### PR TITLE
feat: add simulation data export to JSON/CSV

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -2734,13 +2734,11 @@ def export_simulation_data(simulation_id: str):
         filename_base = f"miroshark_export_{simulation_id[:12]}_{timestamp}"
 
         if export_format == 'json':
-            tmp = tempfile.NamedTemporaryFile(
-                mode='w', suffix='.json', delete=False, prefix='miroshark_export_'
-            )
-            json.dump(export_data, tmp, indent=2, default=str, ensure_ascii=False)
-            tmp.close()
+            buf = io.BytesIO()
+            buf.write(json.dumps(export_data, indent=2, default=str, ensure_ascii=False).encode('utf-8'))
+            buf.seek(0)
             return send_file(
-                tmp.name,
+                buf,
                 mimetype='application/json',
                 as_attachment=True,
                 download_name=f"{filename_base}.json"
@@ -2757,11 +2755,8 @@ def export_simulation_data(simulation_id: str):
         fieldnames = ['round_num', 'timestamp', 'platform', 'agent_id',
                       'agent_name', 'action_type', 'action_args', 'result', 'success']
 
-        tmp = tempfile.NamedTemporaryFile(
-            mode='w', suffix='.csv', delete=False,
-            prefix='miroshark_export_', newline=''
-        )
-        writer = csv.DictWriter(tmp, fieldnames=fieldnames, extrasaction='ignore')
+        string_buf = io.StringIO()
+        writer = csv.DictWriter(string_buf, fieldnames=fieldnames, extrasaction='ignore')
         writer.writeheader()
         for row in rows:
             row_copy = dict(row)
@@ -2769,10 +2764,12 @@ def export_simulation_data(simulation_id: str):
             if isinstance(row_copy.get('action_args'), dict):
                 row_copy['action_args'] = json.dumps(row_copy['action_args'], ensure_ascii=False)
             writer.writerow(row_copy)
-        tmp.close()
 
+        buf = io.BytesIO()
+        buf.write(string_buf.getvalue().encode('utf-8'))
+        buf.seek(0)
         return send_file(
-            tmp.name,
+            buf,
             mimetype='text/csv',
             as_attachment=True,
             download_name=f"{filename_base}.csv"

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4,7 +4,12 @@ Step 2: Entity reading and filtering, OASIS simulation preparation and execution
 """
 
 import os
+import io
+import csv
+import json
 import traceback
+import tempfile
+from datetime import datetime
 from flask import request, jsonify, send_file, current_app
 
 from . import simulation_bp
@@ -2637,6 +2642,144 @@ def close_simulation_env():
         
     except Exception as e:
         logger.error(f"Failed to shut down environment: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
+# ============== Data Export Endpoints ==============
+
+@simulation_bp.route('/<simulation_id>/export', methods=['GET'])
+def export_simulation_data(simulation_id: str):
+    """
+    Export simulation data as JSON or CSV file download.
+
+    Query parameters:
+        format: Export format — 'json' (default) or 'csv'
+        include: Comma-separated data sections to include.
+                 Options: actions,posts,timeline,agent_stats,metadata
+                 Default: all sections
+
+    Returns:
+        File download (application/json or text/csv)
+    """
+    try:
+        export_format = request.args.get('format', 'json').lower()
+        include_raw = request.args.get('include', 'actions,posts,timeline,agent_stats,metadata')
+        include_sections = {s.strip() for s in include_raw.split(',')}
+
+        if export_format not in ('json', 'csv'):
+            return jsonify({
+                "success": False,
+                "error": "Unsupported format. Use 'json' or 'csv'."
+            }), 400
+
+        export_data = {}
+
+        # --- Metadata ---
+        if 'metadata' in include_sections:
+            manager = SimulationManager()
+            state = manager.get_simulation(simulation_id)
+            run_state = SimulationRunner.get_run_state(simulation_id)
+            export_data['metadata'] = {
+                "simulation_id": simulation_id,
+                "exported_at": datetime.utcnow().isoformat(),
+                "status": state.status.value if state else None,
+                "project_id": state.project_id if state else None,
+                "run_state": run_state.to_dict() if run_state else None,
+            }
+
+        # --- Actions ---
+        if 'actions' in include_sections:
+            actions = SimulationRunner.get_all_actions(simulation_id)
+            export_data['actions'] = [a.to_dict() for a in actions]
+
+        # --- Timeline ---
+        if 'timeline' in include_sections:
+            export_data['timeline'] = SimulationRunner.get_timeline(simulation_id)
+
+        # --- Agent Stats ---
+        if 'agent_stats' in include_sections:
+            export_data['agent_stats'] = SimulationRunner.get_agent_stats(simulation_id)
+
+        # --- Posts (both platforms) ---
+        if 'posts' in include_sections:
+            import sqlite3
+            sim_dir = os.path.join(
+                os.path.dirname(__file__),
+                f'../../uploads/simulations/{simulation_id}'
+            )
+            all_posts = []
+            for platform in ('twitter', 'reddit'):
+                db_path = os.path.join(sim_dir, f"{platform}_simulation.db")
+                if os.path.exists(db_path):
+                    try:
+                        conn = sqlite3.connect(db_path)
+                        conn.row_factory = sqlite3.Row
+                        cursor = conn.cursor()
+                        cursor.execute("SELECT * FROM post ORDER BY created_at DESC")
+                        for row in cursor.fetchall():
+                            post = dict(row)
+                            post['platform'] = platform
+                            all_posts.append(post)
+                        conn.close()
+                    except sqlite3.OperationalError:
+                        pass
+            export_data['posts'] = all_posts
+
+        # --- Build response ---
+        timestamp = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+        filename_base = f"miroshark_export_{simulation_id[:12]}_{timestamp}"
+
+        if export_format == 'json':
+            tmp = tempfile.NamedTemporaryFile(
+                mode='w', suffix='.json', delete=False, prefix='miroshark_export_'
+            )
+            json.dump(export_data, tmp, indent=2, default=str, ensure_ascii=False)
+            tmp.close()
+            return send_file(
+                tmp.name,
+                mimetype='application/json',
+                as_attachment=True,
+                download_name=f"{filename_base}.json"
+            )
+
+        # CSV: flatten actions into a single table (the most useful tabular view)
+        rows = export_data.get('actions', [])
+        if not rows:
+            return jsonify({
+                "success": False,
+                "error": "No action data available to export as CSV"
+            }), 404
+
+        fieldnames = ['round_num', 'timestamp', 'platform', 'agent_id',
+                      'agent_name', 'action_type', 'action_args', 'result', 'success']
+
+        tmp = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.csv', delete=False,
+            prefix='miroshark_export_', newline=''
+        )
+        writer = csv.DictWriter(tmp, fieldnames=fieldnames, extrasaction='ignore')
+        writer.writeheader()
+        for row in rows:
+            row_copy = dict(row)
+            # Serialize nested dicts to JSON strings for CSV
+            if isinstance(row_copy.get('action_args'), dict):
+                row_copy['action_args'] = json.dumps(row_copy['action_args'], ensure_ascii=False)
+            writer.writerow(row_copy)
+        tmp.close()
+
+        return send_file(
+            tmp.name,
+            mimetype='text/csv',
+            as_attachment=True,
+            download_name=f"{filename_base}.csv"
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to export simulation data: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -189,6 +189,18 @@ export const getEnvStatus = (data) => {
 }
 
 /**
+ * Export simulation data as JSON or CSV file download
+ * @param {string} simulationId
+ * @param {string} format - 'json' or 'csv'
+ */
+export const exportSimulationData = (simulationId, format = 'json') => {
+  return service.get(`/api/simulation/${simulationId}/export`, {
+    params: { format },
+    responseType: 'blob'
+  })
+}
+
+/**
  * Batch interview Agents
  * @param {Object} data - { simulation_id, interviews: [{ agent_id, prompt }] }
  */

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -136,6 +136,26 @@
             </svg>
           </button>
 
+          <!-- Export Buttons - shown after completion -->
+          <div v-if="isComplete" class="export-buttons">
+            <button class="export-btn" @click="downloadExport('json')" :disabled="isExporting">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="7 10 12 15 17 10"></polyline>
+                <line x1="12" y1="15" x2="12" y2="3"></line>
+              </svg>
+              <span>{{ isExporting === 'json' ? 'Exporting...' : 'Export JSON' }}</span>
+            </button>
+            <button class="export-btn" @click="downloadExport('csv')" :disabled="isExporting">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="7 10 12 15 17 10"></polyline>
+                <line x1="12" y1="15" x2="12" y2="3"></line>
+              </svg>
+              <span>{{ isExporting === 'csv' ? 'Exporting...' : 'Export CSV' }}</span>
+            </button>
+          </div>
+
           <div class="workflow-divider"></div>
         </div>
 
@@ -393,6 +413,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick, h, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { getAgentLog, getConsoleLog } from '../api/report'
+import { exportSimulationData } from '../api/simulation'
 
 const router = useRouter()
 
@@ -429,6 +450,29 @@ const expandedContent = ref(new Set())
 const expandedLogs = ref(new Set())
 const collapsedSections = ref(new Set())
 const isComplete = ref(false)
+const isExporting = ref(false)
+
+// Export simulation data as JSON or CSV
+const downloadExport = async (format) => {
+  if (!props.simulationId || isExporting.value) return
+  isExporting.value = format
+  try {
+    const response = await exportSimulationData(props.simulationId, format)
+    const blob = new Blob([response], { type: format === 'json' ? 'application/json' : 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `miroshark_export_${props.simulationId.slice(0, 12)}.${format}`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  } catch (err) {
+    console.error('Export failed:', err)
+  } finally {
+    isExporting.value = false
+  }
+}
 const startTime = ref(null)
 const leftPanel = ref(null)
 const rightPanel = ref(null)
@@ -3443,6 +3487,41 @@ watch(() => props.reportId, (newId) => {
 
 .next-step-btn:hover svg {
   transform: translateX(4px);
+}
+
+/* Export Buttons */
+.export-buttons {
+  display: flex;
+  gap: 8px;
+  margin: 8px 20px 0 20px;
+}
+
+.export-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex: 1;
+  padding: 10px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #6B7280;
+  background: #F9FAFB;
+  border: 1px solid #E5E7EB;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.export-btn:hover:not(:disabled) {
+  color: #374151;
+  background: #F3F4F6;
+  border-color: #D1D5DB;
+}
+
+.export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 /* Workflow Empty */


### PR DESCRIPTION
## What

Add the ability to export simulation results as structured JSON or CSV files for downstream analysis in Jupyter, Excel, or BI tools.

**Backend:**
- New `GET /api/simulation/<id>/export?format=json|csv` endpoint
- JSON export includes: actions, posts (Twitter + Reddit), timeline, agent stats, and simulation metadata
- CSV export flattens the action log into a standard tabular format
- Supports selective export via `include` query parameter

**Frontend:**
- "Export JSON" and "Export CSV" buttons appear in the report view after simulation completes
- Buttons trigger browser file download with timestamped filenames

## Why

Users can currently only view simulation results in the web UI. This was identified as the highest-impact small feature in the repo-actions analysis — exporting data unlocks downstream analysis workflows for PR crisis testing, trading signal research, and academic use cases.

## Changes

- `backend/app/api/simulation.py`: Added `/export` endpoint with JSON/CSV support
- `frontend/src/api/simulation.js`: Added `exportSimulationData()` API method
- `frontend/src/components/Step4Report.vue`: Added export buttons, download logic, and styling

---
*Built autonomously by Aeon*