### PR TITLE
feat: URL document ingestion — paste URLs as simulation input

### DIFF
--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -54,17 +54,61 @@ def get_project(project_id: str):
 
 
 
+# ============== URL Fetch API ==============
+
+@graph_bp.route('/fetch-url', methods=['POST'])
+def fetch_url():
+    """
+    Fetch a URL and extract readable text for use as a simulation document.
+
+    Request (JSON):
+        { "url": "https://example.com/article" }
+
+    Returns:
+        {
+            "success": true,
+            "data": {
+                "title": "Article Title",
+                "text": "Extracted plain text...",
+                "url": "https://example.com/article",
+                "char_count": 4200
+            }
+        }
+    """
+    try:
+        data = request.get_json() or {}
+        url = data.get('url', '').strip()
+
+        if not url:
+            return jsonify({"success": False, "error": "url is required"}), 400
+
+        from ..utils.url_fetcher import fetch_url_text
+        result = fetch_url_text(url)
+
+        return jsonify({"success": True, "data": result})
+
+    except ValueError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
+    except Exception as e:
+        logger.error(f"URL fetch error: {e}")
+        return jsonify({
+            "success": False,
+            "error": f"Failed to fetch URL: {str(e)}"
+        }), 500
+
+
 # ============== API 1: Upload files and generate ontology ==============
 
 @graph_bp.route('/ontology/generate', methods=['POST'])
 def generate_ontology():
     """
-    API 1: Upload files and analyze to generate ontology definition
+    API 1: Upload files and/or URL-fetched texts, then analyze to generate ontology.
 
     Request format: multipart/form-data
 
     Parameters:
-        files: Uploaded files (PDF/MD/TXT), multiple allowed
+        files: Uploaded files (PDF/MD/TXT), multiple allowed (optional if url_docs provided)
+        url_docs: JSON-encoded list of {title, url, text} objects fetched via /fetch-url (optional)
         simulation_requirement: Simulation requirement description (required)
         project_name: Project name (optional)
         additional_context: Additional notes (optional)
@@ -85,30 +129,43 @@ def generate_ontology():
         }
     """
     try:
+        import json as _json
+
         logger.info("=== Starting ontology generation ===")
 
         # Get parameters
         simulation_requirement = request.form.get('simulation_requirement', '')
         project_name = request.form.get('project_name', 'Unnamed Project')
         additional_context = request.form.get('additional_context', '')
-        
+        url_docs_raw = request.form.get('url_docs', '')
+
         logger.debug(f"Project name: {project_name}")
         logger.debug(f"Simulation requirement: {simulation_requirement[:100]}...")
-        
+
         if not simulation_requirement:
             return jsonify({
                 "success": False,
                 "error": "Please provide a simulation requirement description (simulation_requirement)"
             }), 400
-        
+
+        # Parse URL docs (pre-fetched via /fetch-url)
+        url_docs = []
+        if url_docs_raw:
+            try:
+                url_docs = _json.loads(url_docs_raw)
+            except Exception:
+                logger.warning("Failed to parse url_docs field, ignoring")
+
         # Get uploaded files
         uploaded_files = request.files.getlist('files')
-        if not uploaded_files or all(not f.filename for f in uploaded_files):
+        has_files = uploaded_files and any(f.filename for f in uploaded_files)
+
+        if not has_files and not url_docs:
             return jsonify({
                 "success": False,
-                "error": "Please upload at least one document file"
+                "error": "Please upload at least one document file or provide URL documents"
             }), 400
-        
+
         # Create project
         project = ProjectManager.create_project(name=project_name)
         project.simulation_requirement = simulation_requirement
@@ -117,26 +174,42 @@ def generate_ontology():
         # Save files and extract text
         document_texts = []
         all_text = ""
-        
+
         for file in uploaded_files:
             if file and file.filename and allowed_file(file.filename):
                 # Save file to project directory
                 file_info = ProjectManager.save_file_to_project(
-                    project.project_id, 
-                    file, 
+                    project.project_id,
+                    file,
                     file.filename
                 )
                 project.files.append({
                     "filename": file_info["original_filename"],
                     "size": file_info["size"]
                 })
-                
+
                 # Extract text
                 text = FileParser.extract_text(file_info["path"])
                 text = TextProcessor.preprocess_text(text)
                 document_texts.append(text)
                 all_text += f"\n\n=== {file_info['original_filename']} ===\n{text}"
-        
+
+        # Incorporate URL-fetched documents
+        for doc in url_docs:
+            title = doc.get('title') or doc.get('url', 'URL Document')
+            text = doc.get('text', '').strip()
+            if not text:
+                continue
+            text = TextProcessor.preprocess_text(text)
+            document_texts.append(text)
+            all_text += f"\n\n=== {title} ===\n{text}"
+            project.files.append({
+                "filename": title,
+                "size": len(text),
+                "url": doc.get('url', '')
+            })
+            logger.info(f"Incorporated URL doc: {title} ({len(text)} chars)")
+
         if not document_texts:
             ProjectManager.delete_project(project.project_id)
             return jsonify({

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -3,6 +3,7 @@ Graph-related API routes
 Uses project context mechanism with server-side persistent state
 """
 
+import json
 import os
 import traceback
 import threading
@@ -129,8 +130,6 @@ def generate_ontology():
         }
     """
     try:
-        import json as _json
-
         logger.info("=== Starting ontology generation ===")
 
         # Get parameters
@@ -152,7 +151,7 @@ def generate_ontology():
         url_docs = []
         if url_docs_raw:
             try:
-                url_docs = _json.loads(url_docs_raw)
+                url_docs = json.loads(url_docs_raw)
             except Exception:
                 logger.warning("Failed to parse url_docs field, ignoring")
 

--- a/backend/app/utils/url_fetcher.py
+++ b/backend/app/utils/url_fetcher.py
@@ -1,0 +1,175 @@
+"""
+URL fetching and text extraction utility for MiroShark document ingestion.
+Fetches a URL and extracts readable article text without extra dependencies.
+"""
+
+import re
+import socket
+import ipaddress
+from html.parser import HTMLParser
+from urllib.parse import urlparse
+
+
+class _TextExtractor(HTMLParser):
+    """Simple HTML parser that strips tags and extracts readable body text."""
+
+    # Tags whose content should be ignored entirely
+    SKIP_TAGS = frozenset({
+        'script', 'style', 'noscript', 'nav', 'footer', 'aside',
+        'form', 'button', 'meta', 'link', 'img', 'svg', 'iframe',
+        'head',
+    })
+
+    # Block-level tags that should introduce a newline when closed
+    BLOCK_TAGS = frozenset({
+        'p', 'div', 'article', 'section', 'main',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'li', 'br', 'tr', 'blockquote', 'pre',
+    })
+
+    def __init__(self):
+        super().__init__()
+        self._parts = []
+        self._skip_depth = 0
+        self._title = ''
+        self._in_title = False
+
+    def handle_starttag(self, tag, attrs):
+        tag = tag.lower()
+        if tag in self.SKIP_TAGS:
+            self._skip_depth += 1
+        if tag == 'title':
+            self._in_title = True
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        if tag in self.SKIP_TAGS:
+            self._skip_depth = max(0, self._skip_depth - 1)
+        if tag == 'title':
+            self._in_title = False
+        if tag in self.BLOCK_TAGS:
+            if self._parts and not self._parts[-1].endswith('\n'):
+                self._parts.append('\n')
+
+    def handle_data(self, data):
+        if self._skip_depth > 0:
+            return
+        text = data.strip()
+        if not text:
+            return
+        if self._in_title:
+            self._title = text
+        else:
+            self._parts.append(text + ' ')
+
+    def get_text(self) -> str:
+        raw = ''.join(self._parts)
+        # Normalize whitespace runs
+        raw = re.sub(r'[ \t]+', ' ', raw)
+        # Collapse 3+ newlines to 2
+        raw = re.sub(r'\n{3,}', '\n\n', raw)
+        return raw.strip()
+
+    def get_title(self) -> str:
+        return self._title.strip()
+
+
+def _block_private_ip(hostname: str) -> None:
+    """
+    Raises ValueError if the hostname resolves to a private/loopback address.
+    Prevents SSRF attacks.
+    """
+    try:
+        ip_str = socket.gethostbyname(hostname)
+        addr = ipaddress.ip_address(ip_str)
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            raise ValueError(
+                f"Requests to private or internal addresses are not allowed ({ip_str})"
+            )
+    except socket.gaierror:
+        # Let requests handle DNS errors
+        pass
+
+
+def fetch_url_text(url: str, timeout: int = 15) -> dict:
+    """
+    Fetch a URL and extract readable text content suitable for simulation input.
+
+    Args:
+        url: The URL to fetch (must be http or https).
+        timeout: Request timeout in seconds.
+
+    Returns:
+        dict with keys:
+            - title (str): Page title or derived from URL
+            - text (str): Extracted plain text content
+            - url (str): The original URL
+            - char_count (int): Length of extracted text
+
+    Raises:
+        ValueError: For invalid URLs, blocked addresses, or unextractable content.
+        requests.exceptions.RequestException: For HTTP/network errors.
+    """
+    import requests
+
+    # Validate scheme
+    parsed = urlparse(url)
+    if parsed.scheme not in ('http', 'https'):
+        raise ValueError(
+            f"Only http and https URLs are supported (got '{parsed.scheme}')"
+        )
+    if not parsed.netloc:
+        raise ValueError("Invalid URL: missing host")
+
+    # Block private/internal addresses (SSRF prevention)
+    host = parsed.netloc.split(':')[0]
+    _block_private_ip(host)
+
+    headers = {
+        'User-Agent': (
+            'Mozilla/5.0 (compatible; MiroShark/1.0; '
+            '+https://github.com/aaronjmars/MiroShark)'
+        ),
+        'Accept': 'text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+    }
+
+    response = requests.get(
+        url, headers=headers, timeout=timeout,
+        allow_redirects=True, stream=False
+    )
+    response.raise_for_status()
+
+    content_type = response.headers.get('content-type', '').lower()
+
+    # Plain text or markdown
+    if 'text/plain' in content_type or url.lower().endswith(('.txt', '.md')):
+        text = response.text
+        title = parsed.path.split('/')[-1] or parsed.netloc
+        return {'title': title, 'text': text, 'url': url, 'char_count': len(text)}
+
+    # Require HTML for everything else
+    if 'text/html' not in content_type and 'application/xhtml' not in content_type:
+        raise ValueError(
+            f"Unsupported content type '{content_type}'. "
+            "Only HTML and plain-text pages can be fetched."
+        )
+
+    parser = _TextExtractor()
+    parser.feed(response.text)
+
+    title = parser.get_title() or parsed.netloc
+    text = parser.get_text()
+
+    if len(text) < 100:
+        raise ValueError(
+            "Could not extract meaningful text from the page. "
+            "The page may require JavaScript or have no readable content."
+        )
+
+    return {
+        'title': title,
+        'text': text,
+        'url': url,
+        'char_count': len(text),
+    }

--- a/backend/app/utils/url_fetcher.py
+++ b/backend/app/utils/url_fetcher.py
@@ -9,6 +9,10 @@ import ipaddress
 from html.parser import HTMLParser
 from urllib.parse import urlparse
 
+import requests
+
+MAX_RESPONSE_BYTES = 5 * 1024 * 1024  # 5 MB
+
 
 class _TextExtractor(HTMLParser):
     """Simple HTML parser that strips tags and extracts readable body text."""
@@ -74,21 +78,74 @@ class _TextExtractor(HTMLParser):
         return self._title.strip()
 
 
-def _block_private_ip(hostname: str) -> None:
-    """
-    Raises ValueError if the hostname resolves to a private/loopback address.
-    Prevents SSRF attacks.
-    """
+def _check_ip(ip_str: str) -> None:
+    """Raises ValueError if the IP is private/loopback/reserved."""
+    addr = ipaddress.ip_address(ip_str)
+    if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+        raise ValueError(
+            f"Requests to private or internal addresses are not allowed ({ip_str})"
+        )
+
+
+def _validate_url(url: str) -> str:
+    """Validate scheme/host and check resolved IP. Returns the hostname."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ('http', 'https'):
+        raise ValueError(
+            f"Only http and https URLs are supported (got '{parsed.scheme}')"
+        )
+    if not parsed.netloc:
+        raise ValueError("Invalid URL: missing host")
+    host = parsed.netloc.split(':')[0]
     try:
-        ip_str = socket.gethostbyname(hostname)
-        addr = ipaddress.ip_address(ip_str)
-        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
-            raise ValueError(
-                f"Requests to private or internal addresses are not allowed ({ip_str})"
-            )
+        _check_ip(socket.gethostbyname(host))
     except socket.gaierror:
-        # Let requests handle DNS errors
-        pass
+        pass  # let requests surface the DNS error
+    return host
+
+
+def _safe_get(url: str, headers: dict, timeout: int) -> requests.Response:
+    """
+    GET with manual redirect following — each hop is IP-checked to prevent
+    SSRF via redirect to internal addresses. Also streams the response and
+    enforces a size cap so a large file can't OOM the server.
+    """
+    max_redirects = 5
+    current_url = url
+
+    for _ in range(max_redirects + 1):
+        _validate_url(current_url)
+
+        resp = requests.get(
+            current_url, headers=headers, timeout=timeout,
+            allow_redirects=False, stream=True,
+        )
+
+        if resp.is_redirect and 'location' in resp.headers:
+            current_url = resp.headers['location']
+            resp.close()
+            continue
+
+        resp.raise_for_status()
+
+        # Enforce size limit while streaming
+        chunks = []
+        downloaded = 0
+        for chunk in resp.iter_content(chunk_size=64 * 1024):
+            downloaded += len(chunk)
+            if downloaded > MAX_RESPONSE_BYTES:
+                resp.close()
+                raise ValueError(
+                    f"Response exceeds {MAX_RESPONSE_BYTES // (1024 * 1024)} MB size limit"
+                )
+            chunks.append(chunk)
+        resp.close()
+
+        # Reconstruct a response-like object with the full content
+        resp._content = b''.join(chunks)
+        return resp
+
+    raise ValueError("Too many redirects")
 
 
 def fetch_url_text(url: str, timeout: int = 15) -> dict:
@@ -110,20 +167,7 @@ def fetch_url_text(url: str, timeout: int = 15) -> dict:
         ValueError: For invalid URLs, blocked addresses, or unextractable content.
         requests.exceptions.RequestException: For HTTP/network errors.
     """
-    import requests
-
-    # Validate scheme
-    parsed = urlparse(url)
-    if parsed.scheme not in ('http', 'https'):
-        raise ValueError(
-            f"Only http and https URLs are supported (got '{parsed.scheme}')"
-        )
-    if not parsed.netloc:
-        raise ValueError("Invalid URL: missing host")
-
-    # Block private/internal addresses (SSRF prevention)
-    host = parsed.netloc.split(':')[0]
-    _block_private_ip(host)
+    _validate_url(url)
 
     headers = {
         'User-Agent': (
@@ -134,12 +178,9 @@ def fetch_url_text(url: str, timeout: int = 15) -> dict:
         'Accept-Language': 'en-US,en;q=0.5',
     }
 
-    response = requests.get(
-        url, headers=headers, timeout=timeout,
-        allow_redirects=True, stream=False
-    )
-    response.raise_for_status()
+    response = _safe_get(url, headers, timeout)
 
+    parsed = urlparse(url)
     content_type = response.headers.get('content-type', '').lower()
 
     # Plain text or markdown

--- a/frontend/src/api/graph.js
+++ b/frontend/src/api/graph.js
@@ -68,3 +68,18 @@ export function getProject(projectId) {
     method: 'get'
   })
 }
+
+/**
+ * Fetch a URL and extract its text content for simulation input
+ * @param {String} url - The URL to fetch
+ * @returns {Promise<{title, text, url, char_count}>}
+ */
+export function fetchUrl(url) {
+  return requestWithRetry(() =>
+    service({
+      url: '/api/graph/fetch-url',
+      method: 'post',
+      data: { url }
+    })
+  )
+}

--- a/frontend/src/store/pendingUpload.js
+++ b/frontend/src/store/pendingUpload.js
@@ -6,14 +6,16 @@ import { reactive } from 'vue'
 
 const state = reactive({
   files: [],
+  urlDocs: [],   // [{title, url, text, char_count}] fetched via /api/graph/fetch-url
   simulationRequirement: '',
   isPending: false,
   templateSeedText: '',
   templateName: ''
 })
 
-export function setPendingUpload(files, requirement) {
+export function setPendingUpload(files, requirement, urlDocs = []) {
   state.files = files
+  state.urlDocs = urlDocs
   state.simulationRequirement = requirement
   state.isPending = true
   state.templateSeedText = ''
@@ -22,6 +24,7 @@ export function setPendingUpload(files, requirement) {
 
 export function setPendingTemplate(requirement, seedText, templateName) {
   state.files = []
+  state.urlDocs = []
   state.simulationRequirement = requirement
   state.isPending = true
   state.templateSeedText = seedText
@@ -31,6 +34,7 @@ export function setPendingTemplate(requirement, seedText, templateName) {
 export function getPendingUpload() {
   return {
     files: state.files,
+    urlDocs: state.urlDocs,
     simulationRequirement: state.simulationRequirement,
     isPending: state.isPending,
     templateSeedText: state.templateSeedText,
@@ -40,6 +44,7 @@ export function getPendingUpload() {
 
 export function clearPendingUpload() {
   state.files = []
+  state.urlDocs = []
   state.simulationRequirement = ''
   state.isPending = false
   state.templateSeedText = ''

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -140,6 +140,43 @@
               </div>
             </div>
 
+            <!-- URL Input Section -->
+            <div class="console-section url-section">
+              <div class="console-header">
+                <span class="console-label">01b / URL Import</span>
+                <span class="console-meta">Paste article or report URL</span>
+              </div>
+              <div class="url-input-row">
+                <input
+                  v-model="urlInput"
+                  class="url-input"
+                  type="url"
+                  placeholder="https://example.com/article"
+                  :disabled="loading || urlFetching"
+                  @keydown.enter.prevent="fetchUrlDoc"
+                />
+                <button
+                  class="url-fetch-btn"
+                  @click="fetchUrlDoc"
+                  :disabled="!urlInput.trim() || loading || urlFetching"
+                >
+                  <span v-if="urlFetching">...</span>
+                  <span v-else>Fetch →</span>
+                </button>
+              </div>
+              <div v-if="urlError" class="url-error">{{ urlError }}</div>
+              <div v-if="urlDocs.length > 0" class="url-doc-list">
+                <div v-for="(doc, index) in urlDocs" :key="index" class="url-doc-item">
+                  <span class="url-doc-icon">◈</span>
+                  <div class="url-doc-info">
+                    <div class="url-doc-title">{{ doc.title }}</div>
+                    <div class="url-doc-meta">{{ doc.char_count.toLocaleString() }} chars · {{ doc.url }}</div>
+                  </div>
+                  <button @click.stop="removeUrlDoc(index)" class="remove-btn">×</button>
+                </div>
+              </div>
+            </div>
+
             <!-- Divider -->
             <div class="console-divider">
               <span>Input Parameters</span>
@@ -193,6 +230,7 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import HistoryDatabase from '../components/HistoryDatabase.vue'
 import TemplateGallery from '../components/TemplateGallery.vue'
+import { fetchUrl } from '../api/graph'
 
 const router = useRouter()
 
@@ -204,6 +242,12 @@ const formData = ref({
 // File list
 const files = ref([])
 
+// URL import state
+const urlInput = ref('')
+const urlDocs = ref([])   // [{title, url, text, char_count}]
+const urlFetching = ref(false)
+const urlError = ref('')
+
 // State
 const loading = ref(false)
 const error = ref('')
@@ -214,7 +258,8 @@ const fileInput = ref(null)
 
 // Computed: whether the form can be submitted
 const canSubmit = computed(() => {
-  return formData.value.simulationRequirement.trim() !== '' && files.value.length > 0
+  return formData.value.simulationRequirement.trim() !== '' &&
+    (files.value.length > 0 || urlDocs.value.length > 0)
 })
 
 // Trigger file selection
@@ -271,14 +316,47 @@ const scrollToBottom = () => {
   })
 }
 
+// Fetch a URL and add it to urlDocs
+const fetchUrlDoc = async () => {
+  const url = urlInput.value.trim()
+  if (!url || urlFetching.value) return
+
+  // Prevent duplicate URLs
+  if (urlDocs.value.some(d => d.url === url)) {
+    urlError.value = 'This URL has already been added.'
+    return
+  }
+
+  urlFetching.value = true
+  urlError.value = ''
+  try {
+    const res = await fetchUrl(url)
+    if (res.success) {
+      urlDocs.value.push(res.data)
+      urlInput.value = ''
+    } else {
+      urlError.value = res.error || 'Failed to fetch URL.'
+    }
+  } catch (err) {
+    urlError.value = err.message || 'Failed to fetch URL.'
+  } finally {
+    urlFetching.value = false
+  }
+}
+
+// Remove a URL document from the list
+const removeUrlDoc = (index) => {
+  urlDocs.value.splice(index, 1)
+}
+
 // Start simulation - navigate immediately, API calls happen on the Process page
 const startSimulation = () => {
   if (!canSubmit.value || loading.value) return
-  
+
   // Store data pending upload
   import('../store/pendingUpload.js').then(({ setPendingUpload }) => {
-    setPendingUpload(files.value, formData.value.simulationRequirement)
-    
+    setPendingUpload(files.value, formData.value.simulationRequirement, urlDocs.value)
+
     // Navigate immediately to Process page (using special identifier for new project)
     router.push({
       name: 'Process',
@@ -878,6 +956,120 @@ const startSimulation = () => {
 @keyframes btn-pulse {
   0%, 100% { border-color: var(--color-black); }
   50% { border-color: var(--color-orange); }
+}
+
+/* ── URL Import Section ── */
+.url-section {
+  padding-top: 0;
+}
+
+.url-input-row {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.url-input {
+  flex: 1;
+  border: var(--border-light);
+  background: var(--color-gray);
+  padding: var(--space-xs) var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--foreground);
+  outline: none;
+  transition: var(--transition-fast);
+  min-width: 0;
+}
+
+.url-input:focus {
+  border-color: var(--color-orange);
+  background: var(--background);
+}
+
+.url-input::placeholder {
+  color: rgba(10,10,10,0.3);
+}
+
+.url-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.url-fetch-btn {
+  background: var(--color-black);
+  color: var(--color-white);
+  border: 2px solid var(--color-black);
+  padding: var(--space-xs) var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: var(--transition-fast);
+  white-space: nowrap;
+}
+
+.url-fetch-btn:hover:not(:disabled) {
+  background: var(--color-orange);
+  border-color: var(--color-orange);
+}
+
+.url-fetch-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.url-error {
+  margin-top: var(--space-xs);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-red);
+}
+
+.url-doc-list {
+  margin-top: var(--space-xs);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.url-doc-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-xs);
+  background: var(--background);
+  padding: var(--space-xs) var(--space-sm);
+  border: var(--border-light);
+  border-left: 3px solid var(--color-green);
+}
+
+.url-doc-icon {
+  color: var(--color-green);
+  font-size: 14px;
+  margin-top: 1px;
+  flex-shrink: 0;
+}
+
+.url-doc-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.url-doc-title {
+  font-family: var(--font-display);
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.url-doc-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(10,10,10,0.35);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* ── Footer ── */

--- a/frontend/src/views/MainView.vue
+++ b/frontend/src/views/MainView.vue
@@ -190,7 +190,8 @@ const handleNewProject = async () => {
   const pending = getPendingUpload()
   const hasFiles = pending.files.length > 0
   const hasTemplate = !!pending.templateSeedText
-  if (!pending.isPending || (!hasFiles && !hasTemplate)) {
+  const hasUrlDocs = pending.urlDocs && pending.urlDocs.length > 0
+  if (!pending.isPending || (!hasFiles && !hasTemplate && !hasUrlDocs)) {
     error.value = 'No pending files found.'
     addLog('Error: No pending files found for new project.')
     return
@@ -202,15 +203,20 @@ const handleNewProject = async () => {
     ontologyProgress.value = { message: 'Uploading and analyzing docs...' }
     addLog(hasTemplate
       ? `Starting from template "${pending.templateName}"...`
-      : 'Starting ontology generation: Uploading files...')
+      : hasUrlDocs && !hasFiles
+        ? `Starting from ${pending.urlDocs.length} URL document(s)...`
+        : 'Starting ontology generation: Uploading files...')
 
     const formData = new FormData()
     if (hasFiles) {
       pending.files.forEach(f => formData.append('files', f))
-    } else {
+    } else if (hasTemplate) {
       const blob = new Blob([pending.templateSeedText], { type: 'text/markdown' })
       const fileName = `${(pending.templateName || 'template').replace(/\s+/g, '_')}.md`
       formData.append('files', blob, fileName)
+    }
+    if (hasUrlDocs) {
+      formData.append('url_docs', JSON.stringify(pending.urlDocs))
     }
     formData.append('simulation_requirement', pending.simulationRequirement)
     


### PR DESCRIPTION
## What
Users can now paste article, press release, or report URLs directly into the MiroShark home screen as simulation input — no file upload required.

## Why
The README describes MiroShark as a tool to \"upload any document\" — but fetching a live article from the web was the single biggest friction point. Before this PR, users had to manually save a web page as a PDF or .txt, then upload it. This change lets anyone paste a URL (e.g. a news article, policy draft, financial report) and start simulating in seconds.

This was the #1 idea from the repo-actions analysis (DX / Small scope) — identified as removing the biggest onboarding friction.

## Changes
- `backend/app/utils/url_fetcher.py`: New utility that fetches a URL using `requests` (already a project dependency), parses HTML with Python's built-in `html.parser`, strips navigation/script/style tags, and returns clean article text + title. Includes SSRF protection (blocks private/loopback IPs, requires http/https scheme).
- `backend/app/api/graph.py`: New `POST /api/graph/fetch-url` endpoint wrapping the utility. Also updated `generate_ontology` to accept an optional `url_docs` form field (JSON array of {title, url, text} objects) alongside file uploads — URL-sourced text flows through the same preprocessing pipeline as uploaded files.
- `frontend/src/api/graph.js`: Added `fetchUrl(url)` API function.
- `frontend/src/store/pendingUpload.js`: Added `urlDocs` array to the pending-upload state and updated `setPendingUpload` / `clearPendingUpload` accordingly.
- `frontend/src/views/Home.vue`: Added "01b / URL Import" section to the console panel — text input, Fetch button, and a live list of fetched URL docs (title, char count, remove button). Updated `canSubmit` to allow submission with either files OR URL docs. Duplicate URL prevention and error display included.
- `frontend/src/views/MainView.vue`: Updated `handleNewProject` to serialize `urlDocs` into FormData as `url_docs` JSON when sending to the backend.

---
*Built autonomously by Aeon*