### PR TITLE
feat: one-click cloud deploy (Railway + Render)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,38 @@ When generating personas for public figures (politicians, CEOs, founders) or whe
 
 ## Quick Start
 
+### One-Click Cloud Deploy
+
+Deploy MiroShark to the cloud in under 3 minutes — no local setup required.
+
+**Before you deploy, create:**
+1. A free [Neo4j Aura](https://neo4j.com/cloud/aura-free/) instance — grab the `NEO4J_URI` (starts with `neo4j+s://`) and password from the dashboard.
+2. An [OpenRouter](https://openrouter.ai/) API key — used for LLM calls and embeddings. Free credits available on signup.
+
+**Railway** (recommended — includes persistent storage and a free trial):
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/new/template?template=https://github.com/aaronjmars/MiroShark)
+
+After clicking deploy, set these environment variables in the Railway dashboard:
+
+| Variable | Value |
+|---|---|
+| `LLM_API_KEY` | Your OpenRouter key (`sk-or-v1-...`) |
+| `NEO4J_URI` | Your Aura URI (`neo4j+s://...`) |
+| `NEO4J_PASSWORD` | Your Aura password |
+| `EMBEDDING_API_KEY` | Same OpenRouter key |
+| `OPENAI_API_KEY` | Same OpenRouter key |
+
+**Render** (free tier available — 750 hrs/month, spins down after 15 min idle):
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/aaronjmars/MiroShark)
+
+Render reads `render.yaml` automatically. Set the same environment variables above when prompted.
+
+> **Note:** Cloud deploys use OpenRouter for all LLM calls. Ollama is not available in this mode. Both platforms expose MiroShark on a public HTTPS URL — no port forwarding needed.
+
+---
+
 ### Prerequisites
 
 - An OpenAI-compatible API key *(including OpenRouter, OpenAI, Anthropic, etc.)*, Ollama for local inference, **or** Claude Code CLI

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "numReplicas": 1,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,47 @@
+services:
+  - type: web
+    name: miroshark
+    runtime: docker
+    plan: standard
+    dockerfilePath: ./Dockerfile
+    healthCheckPath: /api/health
+    envVars:
+      # LLM — use a cloud provider (Ollama is not available on Render)
+      - key: LLM_PROVIDER
+        value: openai
+      - key: LLM_API_KEY
+        sync: false
+      - key: LLM_BASE_URL
+        value: https://openrouter.ai/api/v1
+      - key: LLM_MODEL_NAME
+        value: qwen/qwen3-235b-a22b-2507
+
+      # Smart model (optional — stronger model for reports and ontology)
+      # - key: SMART_MODEL_NAME
+      #   sync: false
+
+      # Neo4j — use Neo4j Aura free tier (aura.neo4j.io)
+      - key: NEO4J_URI
+        sync: false
+      - key: NEO4J_USER
+        value: neo4j
+      - key: NEO4J_PASSWORD
+        sync: false
+
+      # Embeddings — use cloud provider
+      - key: EMBEDDING_PROVIDER
+        value: openai
+      - key: EMBEDDING_MODEL
+        value: openai/text-embedding-3-small
+      - key: EMBEDDING_BASE_URL
+        value: https://openrouter.ai/api
+      - key: EMBEDDING_API_KEY
+        sync: false
+      - key: EMBEDDING_DIMENSIONS
+        value: "768"
+
+      # CAMEL-AI simulation rounds — same cloud LLM
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: OPENAI_API_BASE_URL
+        value: https://openrouter.ai/api/v1


### PR DESCRIPTION
## What
Add one-click deploy support for Railway and Render — two clicks to get MiroShark running in the cloud with no local setup required.

## Why
MiroShark's current install requires Docker, Neo4j, Node.js 18+, and Python 3.11+ configured correctly — a 15-minute process that stops non-technical users from trying it. One-click deploy collapses this to a 3-click flow and directly drives new user conversion toward the 500-star target.

## Changes
- `railway.json`: Dockerfile-based build config for Railway. Railway reads this to build from the existing `Dockerfile`, then prompts for env vars in the dashboard.
- `render.yaml`: Render web service config with all environment variable slots pre-declared and sensible defaults filled in (OpenRouter endpoints, embedding dimensions). Users only supply their API keys and Neo4j Aura credentials.
- `README.md`: New **One-Click Cloud Deploy** section at the top of Quick Start, with Railway and Render deploy badges, a required-env-vars table, and a setup guide pointing to Neo4j Aura free tier.

---
*Built autonomously by Aeon*