### PR TITLE
feat: config generation timeout and error recovery

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -17,6 +17,7 @@ from ..config import Config
 from ..services.entity_reader import EntityReader
 from ..services.oasis_profile_generator import OasisProfileGenerator
 from ..services.simulation_manager import SimulationManager, SimulationStatus
+from ..services.simulation_config_generator import SimulationConfigGenerator
 from ..services.simulation_runner import SimulationRunner, RunnerStatus
 from ..utils.logger import get_logger
 from ..models.project import ProjectManager
@@ -1230,27 +1231,33 @@ def get_simulation_config_realtime(simulation_id: str):
         is_generating = False
         generation_stage = None
         config_generated = False
-        
+        sim_status = ""
+        config_error = None
+
         state_file = os.path.join(sim_dir, "state.json")
         if os.path.exists(state_file):
             try:
                 with open(state_file, 'r', encoding='utf-8') as f:
                     state_data = json.load(f)
-                    status = state_data.get("status", "")
-                    is_generating = status == "preparing"
+                    sim_status = state_data.get("status", "")
+                    is_generating = sim_status == "preparing"
                     config_generated = state_data.get("config_generated", False)
-                    
+
+                    # Expose error when generation failed
+                    if sim_status == "failed":
+                        config_error = state_data.get("error") or "Config generation failed"
+
                     # Determine current stage
                     if is_generating:
                         if state_data.get("profiles_generated", False):
                             generation_stage = "generating_config"
                         else:
                             generation_stage = "generating_profiles"
-                    elif status == "ready":
+                    elif sim_status == "ready":
                         generation_stage = "completed"
             except Exception:
                 pass
-        
+
         # Build response data
         response_data = {
             "simulation_id": simulation_id,
@@ -1259,6 +1266,8 @@ def get_simulation_config_realtime(simulation_id: str):
             "is_generating": is_generating,
             "generation_stage": generation_stage,
             "config_generated": config_generated,
+            "status": sim_status,
+            "config_error": config_error,
             "config": config
         }
         
@@ -1287,6 +1296,131 @@ def get_simulation_config_realtime(simulation_id: str):
             "error": str(e),
             "traceback": traceback.format_exc()
         }), 500
+
+
+@simulation_bp.route('/<simulation_id>/config/retry', methods=['POST'])
+def retry_simulation_config(simulation_id: str):
+    """
+    Retry config generation only (profiles already exist).
+
+    Resets the simulation status to 'preparing', then regenerates the
+    simulation_config.json from existing profiles and entities without
+    repeating the (slow) profile generation step.
+
+    Returns:
+        { "success": true, "data": { "simulation_id": "...", "status": "preparing" } }
+    """
+    import threading
+    from ..models.task import TaskManager, TaskStatus
+    from ..config import Config
+
+    try:
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        # Profiles must exist before we can retry config generation
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        profiles_exist = (
+            os.path.exists(os.path.join(sim_dir, "reddit_profiles.json")) or
+            os.path.exists(os.path.join(sim_dir, "twitter_profiles.csv"))
+        )
+        if not profiles_exist:
+            return jsonify({
+                "success": False,
+                "error": "Agent profiles not found — run /prepare first"
+            }), 400
+
+        # Get project data needed for config generation
+        project = ProjectManager.get_project(state.project_id)
+        if not project:
+            return jsonify({"success": False, "error": f"Project not found: {state.project_id}"}), 404
+
+        simulation_requirement = project.simulation_requirement or ""
+        document_text = ProjectManager.get_extracted_text(state.project_id) or ""
+
+        storage = current_app.extensions.get('neo4j_storage')
+        if not storage:
+            return jsonify({"success": False, "error": "GraphStorage not initialized"}), 500
+
+        # Reset state so the frontend polling loop sees "preparing" again
+        state.status = SimulationStatus.PREPARING
+        state.config_generated = False
+        state.error = None
+        manager._save_simulation_state(state)
+
+        task_manager = TaskManager()
+        task_id = task_manager.create_task(
+            task_type="simulation_config_retry",
+            metadata={"simulation_id": simulation_id}
+        )
+
+        def run_config_retry():
+            try:
+                task_manager.update_task(task_id, status=TaskStatus.PROCESSING, progress=0,
+                                         message="Retrying config generation...")
+
+                # Re-read entities for config generation context
+                reader = EntityReader(storage)
+                filtered = reader.filter_defined_entities(
+                    graph_id=state.graph_id,
+                    enrich_with_edges=True
+                )
+
+                config_generator = SimulationConfigGenerator()
+                sim_params = config_generator.generate_config(
+                    simulation_id=simulation_id,
+                    project_id=state.project_id,
+                    graph_id=state.graph_id,
+                    simulation_requirement=simulation_requirement,
+                    document_text=document_text,
+                    entities=filtered.entities,
+                    enable_twitter=state.enable_twitter,
+                    enable_reddit=state.enable_reddit,
+                )
+
+                config_path = os.path.join(sim_dir, "simulation_config.json")
+                with open(config_path, 'w', encoding='utf-8') as f:
+                    f.write(sim_params.to_json())
+
+                # Mark as complete
+                reload_state = manager.get_simulation(simulation_id)
+                if reload_state:
+                    reload_state.config_generated = True
+                    reload_state.config_reasoning = sim_params.generation_reasoning
+                    reload_state.status = SimulationStatus.READY
+                    reload_state.error = None
+                    manager._save_simulation_state(reload_state)
+
+                task_manager.complete_task(task_id, result={"simulation_id": simulation_id})
+                logger.info(f"Config retry complete for {simulation_id}")
+
+            except Exception as e:
+                logger.error(f"Config retry failed for {simulation_id}: {e}")
+                task_manager.fail_task(task_id, str(e))
+                failed_state = manager.get_simulation(simulation_id)
+                if failed_state:
+                    failed_state.status = SimulationStatus.FAILED
+                    failed_state.error = str(e)
+                    manager._save_simulation_state(failed_state)
+
+        thread = threading.Thread(target=run_config_retry, daemon=True)
+        thread.start()
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "simulation_id": simulation_id,
+                "task_id": task_id,
+                "status": "preparing",
+                "message": "Config generation retry started"
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"Failed to start config retry: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
 
 
 @simulation_bp.route('/<simulation_id>/config', methods=['GET'])

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -68,6 +68,14 @@ export const getSimulationConfigRealtime = (simulationId) => {
 }
 
 /**
+ * Retry config generation (profiles must already exist)
+ * @param {string} simulationId
+ */
+export const retrySimulationConfig = (simulationId) => {
+  return requestWithRetry(() => service.post(`/api/simulation/${simulationId}/config/retry`), 2, 1000)
+}
+
+/**
  * List all simulations
  * @param {string} projectId - Optional, filter by project ID
  */

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -114,7 +114,7 @@
       </div>
 
       <!-- Step 03: Generate Simulation Config -->
-      <div class="step-card" :class="{ 'active': phase === 2, 'completed': phase > 2 }">
+      <div class="step-card" :class="{ 'active': phase === 2, 'completed': phase > 2, 'error': configError }">
         <div class="card-header">
           <div class="step-info">
             <span class="step-num">03</span>
@@ -122,6 +122,7 @@
           </div>
           <div class="step-status">
             <span v-if="phase > 2" class="badge success">Completed</span>
+            <span v-else-if="configError" class="badge error">Failed</span>
             <span v-else-if="phase === 2" class="badge processing">Generating</span>
             <span v-else class="badge pending">Waiting</span>
           </div>
@@ -132,7 +133,25 @@
           <p class="description">
             LLM intelligently configures world time flow, recommendation algorithms, each individual's active time periods, posting frequency, event triggers, and other parameters based on simulation requirements and reality seeds
           </p>
-          
+
+          <!-- Config Error Panel -->
+          <div v-if="configError" class="config-error-panel">
+            <div class="config-error-title">Config Generation Failed</div>
+            <div class="config-error-msg">{{ configError }}</div>
+            <div class="config-error-hint">
+              Common causes: OpenRouter API key invalid or quota exceeded, model name not found, network timeout.
+              Check your <code>.env</code> values for <code>OPENROUTER_API_KEY</code> and <code>OPENROUTER_MODEL</code>.
+            </div>
+            <button
+              class="retry-config-btn"
+              :disabled="isConfigRetrying"
+              @click="handleConfigRetry"
+            >
+              <span v-if="isConfigRetrying" class="loading-spinner-small"></span>
+              {{ isConfigRetrying ? 'Retrying...' : 'Retry Config Generation' }}
+            </button>
+          </div>
+
           <!-- Config Preview -->
           <div v-if="simulationConfig" class="config-detail-panel">
             <!-- Time Configuration -->
@@ -670,6 +689,7 @@ import {
   getSimulationProfilesRealtime,
   getSimulationConfig,
   getSimulationConfigRealtime,
+  retrySimulationConfig,
   getRunStatus
 } from '../api/simulation'
 
@@ -694,6 +714,12 @@ const expectedTotal = ref(null)
 const simulationConfig = ref(null)
 const selectedProfile = ref(null)
 const showProfilesDetail = ref(true)
+const configError = ref(null)       // Error message when config generation fails
+const isConfigRetrying = ref(false) // True while retry is in progress
+
+// Config polling timeout: stop after 90 seconds with no result
+const CONFIG_POLL_TIMEOUT_MS = 90000
+let configPollStartTime = null
 
 // Log deduplication: track last logged key info
 let lastLoggedMessage = ''
@@ -991,6 +1017,8 @@ const fetchProfilesRealtime = async () => {
 
 // Config polling
 const startConfigPolling = () => {
+  configError.value = null
+  configPollStartTime = Date.now()
   configTimer = setInterval(fetchConfigRealtime, 2000)
 }
 
@@ -1003,13 +1031,30 @@ const stopConfigPolling = () => {
 
 const fetchConfigRealtime = async () => {
   if (!props.simulationId) return
-  
+
+  // Client-side timeout: give up after CONFIG_POLL_TIMEOUT_MS
+  if (configPollStartTime && Date.now() - configPollStartTime > CONFIG_POLL_TIMEOUT_MS) {
+    stopConfigPolling()
+    configError.value = 'Config generation timed out after 90 seconds. The LLM may be unresponsive or overloaded.'
+    addLog('✗ Config generation timed out (90s). Use "Retry Config" to try again.')
+    return
+  }
+
   try {
     const res = await getSimulationConfigRealtime(props.simulationId)
-    
+
     if (res.success && res.data) {
       const data = res.data
-      
+
+      // Backend reported a generation failure
+      if (data.config_error || data.status === 'failed') {
+        stopConfigPolling()
+        const reason = data.config_error || 'Generation failed — check your OpenRouter API key and model name'
+        configError.value = reason
+        addLog(`✗ Config generation failed: ${reason}`)
+        return
+      }
+
       // Output config generation stage log (avoid duplicates)
       if (data.generation_stage && data.generation_stage !== lastLoggedConfigStage) {
         lastLoggedConfigStage = data.generation_stage
@@ -1019,7 +1064,7 @@ const fetchConfigRealtime = async () => {
           addLog('Calling LLM to generate simulation configuration parameters...')
         }
       }
-      
+
       // If config has been generated
       if (data.config_generated && data.config) {
         simulationConfig.value = data.config
@@ -1033,19 +1078,19 @@ const fetchConfigRealtime = async () => {
           addLog(`  ├─ Hot topics: ${data.summary.hot_topics_count}`)
           addLog(`  └─ Platform config: Twitter ${data.summary.has_twitter_config ? '✓' : '✗'}, Reddit ${data.summary.has_reddit_config ? '✓' : '✗'}`)
         }
-        
+
         // Show time configuration details
         if (data.config.time_config) {
           const tc = data.config.time_config
           addLog(`Time config: ${tc.minutes_per_round} minutes per round, ${Math.floor((tc.total_simulation_hours * 60) / tc.minutes_per_round)} rounds total`)
         }
-        
+
         // Show event configuration
         if (data.config.event_config?.narrative_direction) {
           const narrative = data.config.event_config.narrative_direction
           addLog(`Narrative direction: ${narrative.length > 50 ? narrative.substring(0, 50) + '...' : narrative}`)
         }
-        
+
         stopConfigPolling()
         phase.value = 4
         addLog('✓ Environment setup complete, ready to start simulation')
@@ -1054,6 +1099,30 @@ const fetchConfigRealtime = async () => {
     }
   } catch (err) {
     console.warn('Failed to get config:', err)
+  }
+}
+
+const handleConfigRetry = async () => {
+  if (!props.simulationId || isConfigRetrying.value) return
+  isConfigRetrying.value = true
+  configError.value = null
+  lastLoggedConfigStage = ''
+  addLog('Retrying config generation...')
+
+  try {
+    const res = await retrySimulationConfig(props.simulationId)
+    if (res.success) {
+      addLog('Config retry started — waiting for LLM...')
+      startConfigPolling()
+    } else {
+      configError.value = res.error || 'Retry failed — check backend logs'
+      addLog(`✗ Retry failed: ${res.error || 'unknown error'}`)
+    }
+  } catch (err) {
+    configError.value = err.message || 'Retry request failed'
+    addLog(`✗ Retry error: ${err.message}`)
+  } finally {
+    isConfigRetrying.value = false
   }
 }
 
@@ -1232,6 +1301,77 @@ onUnmounted(() => {
 .badge.processing { background: #FF6B1A; color: #FAFAFA; }
 .badge.pending { background: var(--color-gray); color: rgba(10,10,10,0.4); }
 .badge.accent { background: rgba(255,107,26,0.1); color: #FF6B1A; }
+.badge.error { background: #FF4444; color: #FAFAFA; }
+
+.step-card.error { border-color: rgba(255,68,68,0.3); }
+
+.config-error-panel {
+  border: 2px solid #FF4444;
+  background: rgba(255,68,68,0.04);
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.config-error-title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  color: #FF4444;
+  margin-bottom: 8px;
+}
+
+.config-error-msg {
+  font-size: 13px;
+  color: rgba(10,10,10,0.7);
+  margin-bottom: 8px;
+  word-break: break-word;
+}
+
+.config-error-hint {
+  font-size: 12px;
+  color: rgba(10,10,10,0.5);
+  margin-bottom: 14px;
+  line-height: 1.6;
+}
+
+.config-error-hint code {
+  font-family: var(--font-mono);
+  background: rgba(10,10,10,0.06);
+  padding: 1px 4px;
+  font-size: 11px;
+}
+
+.retry-config-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  background: #FF4444;
+  color: #FAFAFA;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.retry-config-btn:hover:not(:disabled) { background: #E03C3C; }
+.retry-config-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.loading-spinner-small {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-top-color: #FAFAFA;
+  animation: spin 0.8s linear infinite;
+}
+
 
 .card-content {
   /* No extra padding - uses step-card's padding */


### PR DESCRIPTION
## What
Fixes issue #8 — users stuck forever on step 3 (\"Generate Simulation Configuration\") with the frontend polling `/api/simulation/:id/config/realtime` indefinitely and no error message.

## Why
The config generation step calls the LLM (OpenRouter) to build simulation parameters. If the LLM call fails (bad API key, quota exceeded, timeout, invalid model name), the backend writes `status: \"failed\"` to `state.json` but the frontend never checked for this — it only stopped polling on success. Users had no way to know what went wrong or how to recover.

## Changes
- `backend/app/api/simulation.py`: `get_simulation_config_realtime` now returns `config_error` and `status` fields from `state.json` so the frontend gets the actual error reason. New `POST /<simulation_id>/config/retry` endpoint regenerates only the config (skipping the slow profile generation step) by loading existing profiles and re-running `SimulationConfigGenerator`.
- `frontend/src/api/simulation.js`: Added `retrySimulationConfig()` export.
- `frontend/src/components/Step2EnvSetup.vue`: Config polling now stops after 90s with a timeout message. If the backend reports `status: failed` or `config_error`, polling stops immediately and shows an error panel with the failure reason, an actionable hint about `OPENROUTER_API_KEY` / `OPENROUTER_MODEL`, and a **Retry Config Generation** button. The retry button calls the new endpoint and restarts the polling loop.

---
*Built autonomously by Aeon — closes #8*