### PR TITLE
feat: agent persona bulk import (CSV/JSON)

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -499,6 +499,7 @@ def prepare_simulation():
         entity_types_list = data.get('entity_types')
         use_llm_for_profiles = data.get('use_llm_for_profiles', True)
         parallel_profile_count = data.get('parallel_profile_count', 5)
+        skip_profile_generation = data.get('skip_profile_generation', False)
         
         # ========== Get GraphStorage (capture reference before background task starts) ==========
         storage = current_app.extensions.get('neo4j_storage')
@@ -506,23 +507,37 @@ def prepare_simulation():
             raise ValueError("GraphStorage not initialized — check Neo4j connection")
 
         # ========== Synchronously get entity count (before background task starts) ==========
-        # This allows the frontend to get the expected total Agent count immediately after calling prepare
-        try:
-            logger.info(f"Synchronously fetching entity count: graph_id={state.graph_id}")
-            reader = EntityReader(storage)
-            # Quick entity read (no edge info needed, just counting)
-            filtered_preview = reader.filter_defined_entities(
-                graph_id=state.graph_id,
-                defined_entity_types=entity_types_list,
-                enrich_with_edges=False  # Skip edge info for faster processing
-            )
-            # Save entity count to state (for frontend to fetch immediately)
-            state.entities_count = filtered_preview.filtered_count
-            state.entity_types = list(filtered_preview.entity_types)
-            logger.info(f"Expected entity count: {filtered_preview.filtered_count}, types: {filtered_preview.entity_types}")
-        except Exception as e:
-            logger.warning(f"Failed to synchronously get entity count (will retry in background task): {e}")
-            # Failure does not affect subsequent flow, background task will re-fetch
+        # This allows the frontend to get the expected total Agent count immediately after calling prepare.
+        # When skip_profile_generation is True, profiles are already imported — read count from file.
+        if skip_profile_generation:
+            sim_dir_path = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+            reddit_path = os.path.join(sim_dir_path, "reddit_profiles.json")
+            if os.path.exists(reddit_path):
+                try:
+                    with open(reddit_path, 'r', encoding='utf-8') as _f:
+                        _profiles = json.load(_f)
+                    state.entities_count = len(_profiles) if isinstance(_profiles, list) else 0
+                    state.entity_types = ["ImportedAgent"]
+                    logger.info(f"Imported profiles count: {state.entities_count}")
+                except Exception as e:
+                    logger.warning(f"Failed to read imported profiles count: {e}")
+        else:
+            try:
+                logger.info(f"Synchronously fetching entity count: graph_id={state.graph_id}")
+                reader = EntityReader(storage)
+                # Quick entity read (no edge info needed, just counting)
+                filtered_preview = reader.filter_defined_entities(
+                    graph_id=state.graph_id,
+                    defined_entity_types=entity_types_list,
+                    enrich_with_edges=False  # Skip edge info for faster processing
+                )
+                # Save entity count to state (for frontend to fetch immediately)
+                state.entities_count = filtered_preview.filtered_count
+                state.entity_types = list(filtered_preview.entity_types)
+                logger.info(f"Expected entity count: {filtered_preview.filtered_count}, types: {filtered_preview.entity_types}")
+            except Exception as e:
+                logger.warning(f"Failed to synchronously get entity count (will retry in background task): {e}")
+                # Failure does not affect subsequent flow, background task will re-fetch
         
         # Create async task
         task_manager = TaskManager()
@@ -621,7 +636,8 @@ def prepare_simulation():
                     use_llm_for_profiles=use_llm_for_profiles,
                     progress_callback=progress_callback,
                     parallel_profile_count=parallel_profile_count,
-                    storage=storage
+                    storage=storage,
+                    skip_profile_generation=skip_profile_generation,
                 )
                 
                 # Task complete
@@ -666,6 +682,197 @@ def prepare_simulation():
         
     except Exception as e:
         logger.error(f"Failed to start preparation task: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
+@simulation_bp.route('/agents/template', methods=['GET'])
+def get_agents_template():
+    """
+    Download a CSV template for agent bulk import.
+
+    Returns a CSV file with the correct headers and 3 example rows.
+    """
+    template_rows = [
+        ["name", "username", "bio", "persona", "age", "gender", "mbti", "country", "profession", "interested_topics"],
+        [
+            "Alice Chen", "alice_chen",
+            "Software engineer and open-source enthusiast based in San Francisco.",
+            "Alice is a pragmatic technologist who values evidence-based reasoning. She follows tech policy closely and often engages in debates about AI governance and data privacy. Her communication style is direct and backed by data.",
+            "32", "female", "INTJ", "US", "Software Engineer", "AI ethics;open source;climate tech"
+        ],
+        [
+            "Marcus Rivera", "m_rivera",
+            "Journalist covering science and technology for a national outlet.",
+            "Marcus approaches every story with deep skepticism and a commitment to factual accuracy. He is skeptical of corporate PR framing and tries to center underrepresented voices in his reporting.",
+            "41", "male", "ENTP", "US", "Journalist", "science communication;media;technology policy"
+        ],
+        [
+            "Yuki Tanaka", "yuki_t",
+            "Researcher at a public health institute. Amateur cyclist.",
+            "Yuki combines academic rigor with a community-oriented mindset. She is cautious about overstating findings and tends to hedge claims. She engages constructively even with people she disagrees with.",
+            "28", "female", "INFJ", "Japan", "Public Health Researcher", "epidemiology;cycling;urban planning"
+        ],
+    ]
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerows(template_rows)
+    csv_bytes = io.BytesIO(output.getvalue().encode('utf-8'))
+    return send_file(
+        csv_bytes,
+        mimetype='text/csv',
+        as_attachment=True,
+        download_name='agent_import_template.csv'
+    )
+
+
+@simulation_bp.route('/agents/import', methods=['POST'])
+def import_simulation_agents():
+    """
+    Import custom agent personas from a CSV or JSON file.
+
+    Writes reddit_profiles.json and twitter_profiles.csv to the simulation directory.
+    Call /prepare with skip_profile_generation=true afterwards to generate only the
+    simulation config (skipping LLM profile generation).
+
+    Request:
+        multipart/form-data:
+            - simulation_id: str  (required)
+            - file: CSV or JSON file (required)
+              CSV columns: name, username, bio, persona (required);
+                           age, gender, mbti, country, profession, interested_topics (optional)
+              JSON: array of objects with the same fields.
+
+    Returns:
+        { success: true, data: { count: N, preview: [...first 5 agents...] } }
+    """
+    try:
+        simulation_id = request.form.get('simulation_id')
+        if not simulation_id:
+            return jsonify({"success": False, "error": "simulation_id is required"}), 400
+
+        if 'file' not in request.files:
+            return jsonify({"success": False, "error": "file is required"}), 400
+
+        uploaded_file = request.files['file']
+        filename = uploaded_file.filename or ''
+        file_bytes = uploaded_file.read()
+
+        # ── Parse uploaded file ──
+        raw_agents = []
+        if filename.lower().endswith('.json'):
+            import json as _json
+            try:
+                raw_agents = _json.loads(file_bytes.decode('utf-8'))
+                if not isinstance(raw_agents, list):
+                    return jsonify({"success": False, "error": "JSON file must contain an array of agent objects"}), 400
+            except Exception as e:
+                return jsonify({"success": False, "error": f"Invalid JSON: {e}"}), 400
+        elif filename.lower().endswith('.csv'):
+            import csv as _csv
+            reader = _csv.DictReader(io.StringIO(file_bytes.decode('utf-8')))
+            for row in reader:
+                raw_agents.append(dict(row))
+        else:
+            return jsonify({"success": False, "error": "Unsupported file type — upload a .csv or .json file"}), 400
+
+        if not raw_agents:
+            return jsonify({"success": False, "error": "File contains no agent rows"}), 400
+
+        # ── Validate and build OasisAgentProfile objects ──
+        from ..services.oasis_profile_generator import OasisAgentProfile
+        profiles = []
+        errors = []
+        for i, row in enumerate(raw_agents):
+            missing = [f for f in ('name', 'username', 'bio', 'persona') if not row.get(f, '').strip()]
+            if missing:
+                errors.append(f"Row {i + 1}: missing required field(s): {', '.join(missing)}")
+                continue
+
+            # Parse interested_topics — accept semicolon or comma separated string, or list
+            topics_raw = row.get('interested_topics', '')
+            if isinstance(topics_raw, list):
+                topics = [t.strip() for t in topics_raw if t.strip()]
+            else:
+                sep = ';' if ';' in str(topics_raw) else ','
+                topics = [t.strip() for t in str(topics_raw).split(sep) if t.strip()]
+
+            age_val = None
+            try:
+                if row.get('age'):
+                    age_val = int(row['age'])
+            except (ValueError, TypeError):
+                pass
+
+            profile = OasisAgentProfile(
+                user_id=i,
+                user_name=row['username'].strip(),
+                name=row['name'].strip(),
+                bio=row['bio'].strip(),
+                persona=row['persona'].strip(),
+                age=age_val,
+                gender=row.get('gender', '').strip() or None,
+                mbti=row.get('mbti', '').strip() or None,
+                country=row.get('country', '').strip() or None,
+                profession=row.get('profession', '').strip() or None,
+                interested_topics=topics,
+            )
+            profiles.append(profile)
+
+        if not profiles:
+            return jsonify({
+                "success": False,
+                "error": f"No valid agents found. Validation errors: {'; '.join(errors[:5])}"
+            }), 400
+
+        # ── Ensure simulation exists ──
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        os.makedirs(sim_dir, exist_ok=True)
+
+        # ── Write profile files ──
+        from ..services.oasis_profile_generator import OasisProfileGenerator
+        gen = OasisProfileGenerator.__new__(OasisProfileGenerator)  # no LLM client needed
+        gen.save_profiles(
+            profiles=profiles,
+            file_path=os.path.join(sim_dir, "reddit_profiles.json"),
+            platform="reddit"
+        )
+        gen.save_profiles(
+            profiles=profiles,
+            file_path=os.path.join(sim_dir, "twitter_profiles.csv"),
+            platform="twitter"
+        )
+        if state.enable_polymarket:
+            gen.save_profiles(
+                profiles=profiles,
+                file_path=os.path.join(sim_dir, "polymarket_profiles.json"),
+                platform="polymarket"
+            )
+
+        # ── Build preview (first 5 agents) ──
+        preview = [p.to_reddit_format() for p in profiles[:5]]
+
+        logger.info(f"Imported {len(profiles)} agent personas into simulation {simulation_id}")
+        return jsonify({
+            "success": True,
+            "data": {
+                "count": len(profiles),
+                "preview": preview,
+                "warnings": errors[:10] if errors else [],
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"Agent import failed: {e}")
         return jsonify({
             "success": False,
             "error": str(e),

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -14,7 +14,7 @@ from enum import Enum
 
 from ..config import Config
 from ..utils.logger import get_logger
-from .entity_reader import EntityReader, FilteredEntities
+from .entity_reader import EntityReader, EntityNode, FilteredEntities
 from .oasis_profile_generator import OasisProfileGenerator, OasisAgentProfile
 from .simulation_config_generator import SimulationConfigGenerator, SimulationParameters
 
@@ -242,6 +242,7 @@ class SimulationManager:
         progress_callback: Optional[callable] = None,
         parallel_profile_count: int = 3,
         storage: 'GraphStorage' = None,
+        skip_profile_generation: bool = False,
     ) -> SimulationState:
         """
         Prepare simulation environment (fully automated)
@@ -275,130 +276,167 @@ class SimulationManager:
 
             sim_dir = self._get_simulation_dir(simulation_id)
 
-            # ========== Phase 1: Read and filter entities ==========
-            if progress_callback:
-                progress_callback("reading", 0, "Connecting to graph...")
-
-            if not storage:
-                raise ValueError("storage (GraphStorage) is required for prepare_simulation")
-            reader = EntityReader(storage)
-
-            if progress_callback:
-                progress_callback("reading", 30, "Reading node data...")
-            
-            filtered = reader.filter_defined_entities(
-                graph_id=state.graph_id,
-                defined_entity_types=defined_entity_types,
-                enrich_with_edges=True
-            )
-            
-            state.entities_count = filtered.filtered_count
-            state.entity_types = list(filtered.entity_types)
-            
-            if progress_callback:
-                progress_callback(
-                    "reading", 100,
-                    f"Done, {filtered.filtered_count} entities in total",
-                    current=filtered.filtered_count,
-                    total=filtered.filtered_count
-                )
-
-            if filtered.filtered_count == 0:
-                state.status = SimulationStatus.FAILED
-                state.error = "No matching entities found, please check if the graph is built correctly"
-                self._save_simulation_state(state)
-                return state
-            
-            # ========== Phase 2: Generate Agent Profiles ==========
-            total_entities = len(filtered.entities)
-
-            if progress_callback:
-                progress_callback(
-                    "generating_profiles", 0,
-                    "Starting generation...",
-                    current=0,
-                    total=total_entities
-                )
-
-            # Pass graph_id to enable graph retrieval for richer context
-            generator = OasisProfileGenerator(
-                storage=storage,
-                graph_id=state.graph_id,
-                simulation_requirement=simulation_requirement,
-            )
-            
-            def profile_progress(current, total, msg):
+            if skip_profile_generation:
+                # ========== Imported profiles: skip entity reading and profile generation ==========
+                # Profiles were already written by the /agents/import endpoint.
+                # Build minimal stub EntityNode objects from the existing reddit_profiles.json
+                # so that config generation has the entity names and counts it needs.
                 if progress_callback:
                     progress_callback(
-                        "generating_profiles", 
-                        int(current / total * 100), 
-                        msg,
-                        current=current,
-                        total=total,
-                        item_name=msg
+                        "generating_profiles", 100,
+                        "Using imported agent profiles — skipping LLM generation",
+                        current=0, total=0
                     )
-            
-            # Set real-time save file path (prefer Reddit JSON format)
-            realtime_output_path = None
-            realtime_platform = "reddit"
-            if state.enable_reddit:
-                realtime_output_path = os.path.join(sim_dir, "reddit_profiles.json")
-                realtime_platform = "reddit"
-            elif state.enable_twitter:
-                realtime_output_path = os.path.join(sim_dir, "twitter_profiles.csv")
-                realtime_platform = "twitter"
-            
-            profiles = generator.generate_profiles_from_entities(
-                entities=filtered.entities,
-                use_llm=use_llm_for_profiles,
-                progress_callback=profile_progress,
-                graph_id=state.graph_id,  # Pass graph_id for graph retrieval
-                parallel_count=parallel_profile_count,  # Parallel generation count
-                realtime_output_path=realtime_output_path,  # Real-time save path
-                output_platform=realtime_platform  # Output format
-            )
-            
-            state.profiles_count = len(profiles)
-            
-            # Save Profile files (note: Twitter uses CSV format, Reddit uses JSON format)
-            # Reddit profiles were already saved in real-time during generation; save again here to ensure completeness
-            if progress_callback:
-                progress_callback(
-                    "generating_profiles", 95,
-                    "Saving Profile files...",
-                    current=total_entities,
-                    total=total_entities
-                )
-            
-            if state.enable_reddit:
-                generator.save_profiles(
-                    profiles=profiles,
-                    file_path=os.path.join(sim_dir, "reddit_profiles.json"),
-                    platform="reddit"
-                )
-            
-            if state.enable_twitter:
-                # Twitter uses CSV format! This is an OASIS requirement
-                generator.save_profiles(
-                    profiles=profiles,
-                    file_path=os.path.join(sim_dir, "twitter_profiles.csv"),
-                    platform="twitter"
+
+                reddit_profiles_path = os.path.join(sim_dir, "reddit_profiles.json")
+                stub_entities = []
+                if os.path.exists(reddit_profiles_path):
+                    import json as _json
+                    with open(reddit_profiles_path, 'r', encoding='utf-8') as _f:
+                        _imported = _json.load(_f)
+                    for _p in _imported:
+                        stub_entities.append(EntityNode(
+                            uuid=f"imported_{_p.get('user_id', len(stub_entities))}",
+                            name=_p.get('name', _p.get('username', 'Agent')),
+                            labels=["ImportedAgent"],
+                            summary=_p.get('bio', ''),
+                            attributes={
+                                "profession": _p.get('profession', ''),
+                                "country": _p.get('country', ''),
+                            }
+                        ))
+
+                filtered_entities = stub_entities
+                state.entities_count = len(filtered_entities)
+                state.entity_types = ["ImportedAgent"]
+                state.profiles_count = len(filtered_entities)
+            else:
+                # ========== Phase 1: Read and filter entities ==========
+                if progress_callback:
+                    progress_callback("reading", 0, "Connecting to graph...")
+
+                if not storage:
+                    raise ValueError("storage (GraphStorage) is required for prepare_simulation")
+                reader = EntityReader(storage)
+
+                if progress_callback:
+                    progress_callback("reading", 30, "Reading node data...")
+
+                filtered = reader.filter_defined_entities(
+                    graph_id=state.graph_id,
+                    defined_entity_types=defined_entity_types,
+                    enrich_with_edges=True
                 )
 
-            if state.enable_polymarket:
-                generator.save_profiles(
-                    profiles=profiles,
-                    file_path=os.path.join(sim_dir, "polymarket_profiles.json"),
-                    platform="polymarket"
+                state.entities_count = filtered.filtered_count
+                state.entity_types = list(filtered.entity_types)
+
+                if progress_callback:
+                    progress_callback(
+                        "reading", 100,
+                        f"Done, {filtered.filtered_count} entities in total",
+                        current=filtered.filtered_count,
+                        total=filtered.filtered_count
+                    )
+
+                if filtered.filtered_count == 0:
+                    state.status = SimulationStatus.FAILED
+                    state.error = "No matching entities found, please check if the graph is built correctly"
+                    self._save_simulation_state(state)
+                    return state
+
+                # ========== Phase 2: Generate Agent Profiles ==========
+                total_entities = len(filtered.entities)
+
+                if progress_callback:
+                    progress_callback(
+                        "generating_profiles", 0,
+                        "Starting generation...",
+                        current=0,
+                        total=total_entities
+                    )
+
+                # Pass graph_id to enable graph retrieval for richer context
+                generator = OasisProfileGenerator(
+                    storage=storage,
+                    graph_id=state.graph_id,
+                    simulation_requirement=simulation_requirement,
                 )
-            
-            if progress_callback:
-                progress_callback(
-                    "generating_profiles", 100,
-                    f"Done, {len(profiles)} Profiles in total",
-                    current=len(profiles),
-                    total=len(profiles)
+
+                def profile_progress(current, total, msg):
+                    if progress_callback:
+                        progress_callback(
+                            "generating_profiles",
+                            int(current / total * 100),
+                            msg,
+                            current=current,
+                            total=total,
+                            item_name=msg
+                        )
+
+                # Set real-time save file path (prefer Reddit JSON format)
+                realtime_output_path = None
+                realtime_platform = "reddit"
+                if state.enable_reddit:
+                    realtime_output_path = os.path.join(sim_dir, "reddit_profiles.json")
+                    realtime_platform = "reddit"
+                elif state.enable_twitter:
+                    realtime_output_path = os.path.join(sim_dir, "twitter_profiles.csv")
+                    realtime_platform = "twitter"
+
+                profiles = generator.generate_profiles_from_entities(
+                    entities=filtered.entities,
+                    use_llm=use_llm_for_profiles,
+                    progress_callback=profile_progress,
+                    graph_id=state.graph_id,  # Pass graph_id for graph retrieval
+                    parallel_count=parallel_profile_count,  # Parallel generation count
+                    realtime_output_path=realtime_output_path,  # Real-time save path
+                    output_platform=realtime_platform  # Output format
                 )
+
+                state.profiles_count = len(profiles)
+
+                # Save Profile files (note: Twitter uses CSV format, Reddit uses JSON format)
+                # Reddit profiles were already saved in real-time during generation; save again here to ensure completeness
+                if progress_callback:
+                    progress_callback(
+                        "generating_profiles", 95,
+                        "Saving Profile files...",
+                        current=total_entities,
+                        total=total_entities
+                    )
+
+                if state.enable_reddit:
+                    generator.save_profiles(
+                        profiles=profiles,
+                        file_path=os.path.join(sim_dir, "reddit_profiles.json"),
+                        platform="reddit"
+                    )
+
+                if state.enable_twitter:
+                    # Twitter uses CSV format! This is an OASIS requirement
+                    generator.save_profiles(
+                        profiles=profiles,
+                        file_path=os.path.join(sim_dir, "twitter_profiles.csv"),
+                        platform="twitter"
+                    )
+
+                if state.enable_polymarket:
+                    generator.save_profiles(
+                        profiles=profiles,
+                        file_path=os.path.join(sim_dir, "polymarket_profiles.json"),
+                        platform="polymarket"
+                    )
+
+                if progress_callback:
+                    progress_callback(
+                        "generating_profiles", 100,
+                        f"Done, {len(profiles)} Profiles in total",
+                        current=len(profiles),
+                        total=len(profiles)
+                    )
+
+                filtered_entities = filtered.entities
 
             # ========== Phase 3: LLM-powered simulation config generation ==========
             if progress_callback:
@@ -425,7 +463,7 @@ class SimulationManager:
                 graph_id=state.graph_id,
                 simulation_requirement=simulation_requirement,
                 document_text=document_text,
-                entities=filtered.entities,
+                entities=filtered_entities,
                 enable_twitter=state.enable_twitter,
                 enable_reddit=state.enable_reddit
             )

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -226,3 +226,26 @@ export const getInfluenceLeaderboard = (simulationId) => {
   return service.get(`/api/simulation/${simulationId}/influence`)
 }
 
+/**
+ * Import custom agent personas from a CSV or JSON file
+ * @param {string} simulationId
+ * @param {File} file - CSV or JSON file
+ * @returns {Promise<{count: number, preview: Array, warnings: Array}>}
+ */
+export const importAgents = (simulationId, file) => {
+  const formData = new FormData()
+  formData.append('simulation_id', simulationId)
+  formData.append('file', file)
+  return service.post('/api/simulation/agents/import', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  })
+}
+
+/**
+ * Download CSV template for agent bulk import
+ * @returns {Promise} Blob response containing the CSV template
+ */
+export const downloadAgentTemplate = () => {
+  return service.get('/api/simulation/agents/template', { responseType: 'blob' })
+}
+

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -61,6 +61,50 @@
             Combines context to automatically invoke tools, organize entities and relationships from the knowledge graph, initialize simulated individuals, and assign them unique behaviors and memories based on reality seeds
           </p>
 
+          <!-- Import mode toggle (only shown before preparation starts) -->
+          <div v-if="phase === 1 && profiles.length === 0 && !importLoading" class="import-toggle-row">
+            <label class="switch-control">
+              <input type="checkbox" v-model="importMode">
+              <span class="switch-track"></span>
+              <span class="switch-label">{{ importMode ? 'Import Custom Agents' : 'Auto-generate from Graph' }}</span>
+            </label>
+            <button v-if="!importMode" class="template-link" @click="handleDownloadTemplate">↓ CSV Template</button>
+          </div>
+
+          <!-- File upload area (import mode) -->
+          <div v-if="importMode && phase === 1 && !importCount" class="import-upload-area">
+            <div
+              class="drop-zone"
+              :class="{ 'drag-over': importDragOver, 'has-file': importFile }"
+              @dragover.prevent="importDragOver = true"
+              @dragleave="importDragOver = false"
+              @drop.prevent="onImportDrop"
+            >
+              <template v-if="importFile">
+                <span class="drop-filename">{{ importFile.name }}</span>
+                <span class="drop-filesize">{{ (importFile.size / 1024).toFixed(1) }} KB</span>
+              </template>
+              <template v-else>
+                <span class="drop-hint">Drop CSV or JSON here, or</span>
+                <label class="drop-browse">
+                  browse
+                  <input type="file" accept=".csv,.json" @change="onImportFileSelect" style="display:none">
+                </label>
+              </template>
+            </div>
+            <p v-if="importError" class="import-error">{{ importError }}</p>
+            <div class="import-actions">
+              <button class="action-btn primary" :disabled="!importFile || importLoading" @click="handleImportAndPrepare">
+                {{ importLoading ? 'Uploading...' : 'Import & Continue →' }}
+              </button>
+              <button class="template-link" @click="handleDownloadTemplate">↓ Download CSV Template</button>
+            </div>
+            <p class="import-format-hint">
+              Required CSV columns: <code>name, username, bio, persona</code>
+              — Optional: <code>age, gender, mbti, country, profession, interested_topics</code>
+            </p>
+          </div>
+
           <!-- Profiles Stats -->
           <div v-if="profiles.length > 0" class="stats-grid">
             <div class="stat-card">
@@ -670,7 +714,9 @@ import {
   getSimulationProfilesRealtime,
   getSimulationConfig,
   getSimulationConfigRealtime,
-  getRunStatus
+  getRunStatus,
+  importAgents,
+  downloadAgentTemplate
 } from '../api/simulation'
 
 const props = defineProps({
@@ -694,6 +740,14 @@ const expectedTotal = ref(null)
 const simulationConfig = ref(null)
 const selectedProfile = ref(null)
 const showProfilesDetail = ref(true)
+
+// Import mode state
+const importMode = ref(false)         // true = use file upload instead of graph generation
+const importFile = ref(null)          // selected File object
+const importDragOver = ref(false)     // drag-over highlight
+const importLoading = ref(false)      // uploading in progress
+const importError = ref('')           // validation / upload error
+const importCount = ref(0)            // number of agents successfully imported
 
 // Log deduplication: track last logged key info
 let lastLoggedMessage = ''
@@ -805,6 +859,75 @@ const selectProfile = (profile) => {
   selectedProfile.value = profile
 }
 
+// ── Import mode helpers ──
+
+const onImportFileSelect = (event) => {
+  const file = event.target.files[0]
+  if (file) setImportFile(file)
+}
+
+const onImportDrop = (event) => {
+  importDragOver.value = false
+  const file = event.dataTransfer.files[0]
+  if (file) setImportFile(file)
+}
+
+const setImportFile = (file) => {
+  const allowed = ['.csv', '.json']
+  const ext = file.name.slice(file.name.lastIndexOf('.')).toLowerCase()
+  if (!allowed.includes(ext)) {
+    importError.value = 'Only .csv and .json files are supported.'
+    return
+  }
+  importFile.value = file
+  importError.value = ''
+}
+
+const handleImportAndPrepare = async () => {
+  if (!importFile.value) {
+    importError.value = 'Please select a CSV or JSON file first.'
+    return
+  }
+  importLoading.value = true
+  importError.value = ''
+  try {
+    addLog(`Uploading ${importFile.value.name}...`)
+    const res = await importAgents(props.simulationId, importFile.value)
+    if (!res.success) {
+      importError.value = res.error || 'Import failed.'
+      addLog(`✗ Import failed: ${res.error}`)
+      importLoading.value = false
+      return
+    }
+    importCount.value = res.data.count
+    if (res.data.warnings?.length) {
+      res.data.warnings.forEach(w => addLog(`⚠ ${w}`))
+    }
+    addLog(`✓ Imported ${res.data.count} agent personas`)
+    // Proceed to config generation (skip profile generation in /prepare)
+    await startPrepareSimulation()
+  } catch (err) {
+    importError.value = err.message || 'Upload error.'
+    addLog(`✗ Import error: ${err.message}`)
+  } finally {
+    importLoading.value = false
+  }
+}
+
+const handleDownloadTemplate = async () => {
+  try {
+    const res = await downloadAgentTemplate()
+    const url = URL.createObjectURL(new Blob([res], { type: 'text/csv' }))
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'agent_import_template.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  } catch (err) {
+    addLog(`✗ Template download failed: ${err.message}`)
+  }
+}
+
 // Automatically start simulation preparation
 const startPrepareSimulation = async () => {
   if (!props.simulationId) {
@@ -823,7 +946,8 @@ const startPrepareSimulation = async () => {
     const res = await prepareSimulation({
       simulation_id: props.simulationId,
       use_llm_for_profiles: true,
-      parallel_profile_count: 5
+      parallel_profile_count: 5,
+      skip_profile_generation: importMode.value
     })
     
     if (res.success && res.data) {
@@ -1125,7 +1249,10 @@ onMounted(async () => {
     }
 
     addLog('Step 2 Agent Setup Initializing')
-    startPrepareSimulation()
+    // Only auto-start if not in import mode (import mode waits for file upload)
+    if (!importMode.value) {
+      startPrepareSimulation()
+    }
   }
 })
 
@@ -2673,6 +2800,116 @@ onUnmounted(() => {
 
 .highlight-tip:hover {
   text-decoration: underline;
+}
+
+/* Import mode styles */
+.import-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  background: var(--color-gray);
+  border: 2px solid rgba(10,10,10,0.08);
+}
+
+.template-link {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: #FF6B1A;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  margin-left: auto;
+}
+
+.template-link:hover { opacity: 0.7; }
+
+.import-upload-area {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.drop-zone {
+  border: 2px dashed rgba(10,10,10,0.2);
+  padding: 28px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: var(--color-gray);
+  transition: all 0.2s;
+  cursor: pointer;
+}
+
+.drop-zone.drag-over {
+  border-color: #FF6B1A;
+  background: rgba(255,107,26,0.05);
+}
+
+.drop-zone.has-file {
+  border-color: #43C165;
+  background: rgba(67,193,101,0.05);
+  flex-direction: column;
+  gap: 4px;
+}
+
+.drop-hint {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: rgba(10,10,10,0.5);
+}
+
+.drop-browse {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: #FF6B1A;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.drop-filename {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: #0A0A0A;
+}
+
+.drop-filesize {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(10,10,10,0.4);
+}
+
+.import-error {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: #FF4444;
+  margin: 0;
+}
+
+.import-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.import-format-hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: rgba(10,10,10,0.4);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.import-format-hint code {
+  background: rgba(10,10,10,0.06);
+  padding: 1px 4px;
+  color: rgba(10,10,10,0.6);
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## What
Researchers and simulation practitioners can now upload their own agent cohorts directly into MiroShark instead of relying solely on LLM-generated profiles from the knowledge graph.

## Why
Research teams often have predefined agent cohorts — demographically calibrated profiles from survey data, fictional character sets for media research, or role-based archetypes from organizational models. Requiring them to reconstruct personas from a document every time blocked serious research use and forced artificial document construction. This feature unblocks that segment by accepting CSV or JSON agent definitions and injecting them directly into the simulation pipeline.

## Changes
- `backend/app/api/simulation.py`: New `GET /api/simulation/agents/template` endpoint that returns a downloadable CSV template with correct headers and 3 example rows. New `POST /api/simulation/agents/import` endpoint that accepts multipart form data (simulation_id + CSV or JSON file), validates required fields (name, username, bio, persona), builds OasisAgentProfile objects, writes reddit_profiles.json / twitter_profiles.csv / polymarket_profiles.json to the simulation directory, and returns a preview of the first 5 imported agents. Also adds `skip_profile_generation` parameter support to the existing `POST /api/simulation/prepare` endpoint.
- `backend/app/services/simulation_manager.py`: Added `skip_profile_generation: bool = False` parameter to `prepare_simulation`. When True, skips entity reading and LLM profile generation, loads existing profile files, creates stub EntityNode objects from the imported profiles, and passes them to config generation — so the LLM still generates a tailored simulation config based on the imported agent names and bios.
- `frontend/src/api/simulation.js`: Added `importAgents(simulationId, file)` and `downloadAgentTemplate()` API functions.
- `frontend/src/components/Step2EnvSetup.vue`: Added import mode toggle in Step 02 (before preparation starts). When toggled on: shows a drag-and-drop / file picker for CSV or JSON, a "Download CSV Template" link, an "Import & Continue" button that uploads the file, then triggers prepare with `skip_profile_generation: true`. Imported agent previews appear in the same profile cards as LLM-generated agents.

---
*Built autonomously by Aeon*