### PR TITLE
feat: LLM provider and model selector UI

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -75,11 +75,12 @@ def create_app(config_class=Config):
         return response
     
     # Register blueprints
-    from .api import graph_bp, simulation_bp, report_bp, templates_bp
+    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp
     app.register_blueprint(graph_bp, url_prefix='/api/graph')
     app.register_blueprint(simulation_bp, url_prefix='/api/simulation')
     app.register_blueprint(report_bp, url_prefix='/api/report')
     app.register_blueprint(templates_bp, url_prefix='/api/templates')
+    app.register_blueprint(settings_bp, url_prefix='/api/settings')
     
     # Health check
     @app.route('/health')

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -8,9 +8,11 @@ graph_bp = Blueprint('graph', __name__)
 simulation_bp = Blueprint('simulation', __name__)
 report_bp = Blueprint('report', __name__)
 templates_bp = Blueprint('templates', __name__)
+settings_bp = Blueprint('settings', __name__)
 
 from . import graph  # noqa: E402, F401
 from . import simulation  # noqa: E402, F401
 from . import report  # noqa: E402, F401
 from . import templates  # noqa: E402, F401
+from . import settings  # noqa: E402, F401
 

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -1,0 +1,134 @@
+"""
+Settings API — runtime LLM configuration management.
+
+GET  /api/settings        — return current active config (masked)
+POST /api/settings        — update config at runtime (no restart required)
+POST /api/settings/test-llm — make a minimal test call and return latency
+"""
+
+import time
+from flask import request, jsonify
+
+from . import settings_bp
+from ..config import Config
+from ..utils.logger import get_logger
+
+logger = get_logger('miroshark.api.settings')
+
+
+def _mask_key(key: str) -> str:
+    """Return only the last 4 characters of an API key."""
+    if not key:
+        return ''
+    return '****' + key[-4:] if len(key) > 4 else '****'
+
+
+@settings_bp.route('', methods=['GET'])
+def get_settings():
+    """Return current active LLM and Neo4j config (API key masked)."""
+    return jsonify({
+        'success': True,
+        'data': {
+            'llm': {
+                'provider': Config.LLM_PROVIDER,
+                'base_url': Config.LLM_BASE_URL,
+                'model_name': Config.LLM_MODEL_NAME,
+                'api_key_masked': _mask_key(Config.LLM_API_KEY or ''),
+                'has_api_key': bool(Config.LLM_API_KEY),
+            },
+            'neo4j': {
+                'uri': Config.NEO4J_URI,
+                'user': Config.NEO4J_USER,
+            },
+        }
+    })
+
+
+@settings_bp.route('', methods=['POST'])
+def update_settings():
+    """
+    Update LLM (and optionally Neo4j) config at runtime.
+
+    Accepted body fields (all optional):
+      llm.provider, llm.base_url, llm.model_name, llm.api_key
+      neo4j.uri, neo4j.user, neo4j.password
+    """
+    body = request.get_json(silent=True) or {}
+
+    llm = body.get('llm', {})
+    neo4j = body.get('neo4j', {})
+
+    if llm.get('provider'):
+        Config.LLM_PROVIDER = llm['provider']
+    if llm.get('base_url'):
+        Config.LLM_BASE_URL = llm['base_url']
+    if llm.get('model_name'):
+        Config.LLM_MODEL_NAME = llm['model_name']
+    if llm.get('api_key'):
+        Config.LLM_API_KEY = llm['api_key']
+
+    if neo4j.get('uri'):
+        Config.NEO4J_URI = neo4j['uri']
+    if neo4j.get('user'):
+        Config.NEO4J_USER = neo4j['user']
+    if neo4j.get('password'):
+        Config.NEO4J_PASSWORD = neo4j['password']
+
+    logger.info(
+        "Settings updated: provider=%s model=%s base_url=%s",
+        Config.LLM_PROVIDER, Config.LLM_MODEL_NAME, Config.LLM_BASE_URL
+    )
+
+    return jsonify({
+        'success': True,
+        'data': {
+            'llm': {
+                'provider': Config.LLM_PROVIDER,
+                'base_url': Config.LLM_BASE_URL,
+                'model_name': Config.LLM_MODEL_NAME,
+                'api_key_masked': _mask_key(Config.LLM_API_KEY or ''),
+                'has_api_key': bool(Config.LLM_API_KEY),
+            }
+        }
+    })
+
+
+@settings_bp.route('/test-llm', methods=['POST'])
+def test_llm():
+    """
+    Make a minimal test call to the current LLM config.
+    Returns { success, model, latency_ms, error }.
+    """
+    try:
+        from ..utils.llm_client import LLMClient
+
+        if Config.LLM_PROVIDER == 'claude-code':
+            return jsonify({
+                'success': True,
+                'model': 'claude-code (local CLI)',
+                'latency_ms': 0,
+                'note': 'claude-code provider does not support connection testing'
+            })
+
+        client = LLMClient()
+        start = time.time()
+        response = client.chat(
+            messages=[{'role': 'user', 'content': 'Reply with only the word OK.'}],
+            temperature=0,
+            max_tokens=8,
+        )
+        latency_ms = round((time.time() - start) * 1000)
+
+        return jsonify({
+            'success': True,
+            'model': client.model,
+            'latency_ms': latency_ms,
+            'response': response.strip()[:100],
+        })
+
+    except Exception as e:
+        logger.warning("LLM test failed: %s", e)
+        return jsonify({
+            'success': False,
+            'error': str(e),
+        }), 200  # Return 200 so the frontend can read the error body

--- a/frontend/src/api/settings.js
+++ b/frontend/src/api/settings.js
@@ -1,0 +1,24 @@
+import service from './index'
+
+/**
+ * Get current active settings (API key masked)
+ */
+export const getSettings = () => {
+  return service.get('/api/settings')
+}
+
+/**
+ * Update settings at runtime
+ * @param {Object} data - { llm: { provider, base_url, model_name, api_key }, neo4j: { uri, user, password } }
+ */
+export const updateSettings = (data) => {
+  return service.post('/api/settings', data)
+}
+
+/**
+ * Test the current LLM connection
+ * @returns {Promise<{ success, model, latency_ms, error }>}
+ */
+export const testLlmConnection = () => {
+  return service.post('/api/settings/test-llm')
+}

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -1,0 +1,664 @@
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="settings-overlay" @click.self="$emit('close')">
+      <div class="settings-modal">
+        <!-- Header -->
+        <div class="modal-header">
+          <div class="modal-title">
+            <span class="title-label">⚙ Settings</span>
+          </div>
+          <button class="close-btn" @click="$emit('close')">✕</button>
+        </div>
+
+        <div class="warning-stripe"></div>
+
+        <!-- LLM Configuration -->
+        <section class="settings-section">
+          <div class="section-header">
+            <span class="section-label">LLM Configuration</span>
+            <div
+              class="status-badge"
+              :class="testStatus"
+            >
+              <span class="badge-dot"></span>
+              {{ testStatusText }}
+            </div>
+          </div>
+
+          <!-- Provider -->
+          <div class="field-row">
+            <label class="field-label">Provider</label>
+            <div class="select-wrapper">
+              <select v-model="form.llm.provider" class="field-select">
+                <option value="openai">OpenAI-compatible (OpenRouter, Ollama, etc.)</option>
+                <option value="claude-code">Claude Code (local CLI)</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- Base URL (hidden for claude-code) -->
+          <div v-if="form.llm.provider !== 'claude-code'" class="field-row">
+            <label class="field-label">Base URL</label>
+            <input
+              v-model="form.llm.base_url"
+              class="field-input"
+              type="url"
+              placeholder="https://openrouter.ai/api/v1"
+            />
+          </div>
+
+          <!-- Model selector -->
+          <div v-if="form.llm.provider !== 'claude-code'" class="field-row">
+            <label class="field-label">Model</label>
+            <div class="model-input-group">
+              <div class="select-wrapper model-select-wrapper">
+                <select
+                  v-if="modelList.length > 0"
+                  v-model="form.llm.model_name"
+                  class="field-select"
+                >
+                  <optgroup
+                    v-for="tier in modelTiers"
+                    :key="tier.label"
+                    :label="tier.label"
+                  >
+                    <option
+                      v-for="m in tier.models"
+                      :key="m.id"
+                      :value="m.id"
+                    >
+                      {{ m.name }}
+                    </option>
+                  </optgroup>
+                </select>
+                <input
+                  v-else
+                  v-model="form.llm.model_name"
+                  class="field-input"
+                  type="text"
+                  placeholder="e.g. openai/gpt-4o-mini"
+                />
+              </div>
+              <button
+                class="load-models-btn"
+                :disabled="loadingModels || !isOpenRouter"
+                @click="loadOpenRouterModels"
+                :title="isOpenRouter ? 'Load available models from OpenRouter' : 'Only available for OpenRouter base URL'"
+              >
+                <span v-if="loadingModels">...</span>
+                <span v-else>↻</span>
+              </button>
+            </div>
+            <div v-if="modelLoadError" class="field-error">{{ modelLoadError }}</div>
+          </div>
+
+          <!-- API Key -->
+          <div v-if="form.llm.provider !== 'claude-code'" class="field-row">
+            <label class="field-label">API Key</label>
+            <div class="key-input-group">
+              <input
+                v-model="form.llm.api_key"
+                class="field-input"
+                :type="showKey ? 'text' : 'password'"
+                :placeholder="currentSettings.llm?.api_key_masked || 'sk-...'"
+              />
+              <button class="toggle-key-btn" @click="showKey = !showKey">
+                {{ showKey ? '◉' : '◎' }}
+              </button>
+            </div>
+            <div v-if="currentSettings.llm?.has_api_key && !form.llm.api_key" class="field-hint">
+              Current key: {{ currentSettings.llm.api_key_masked }} — leave blank to keep unchanged
+            </div>
+          </div>
+
+          <!-- Test Connection -->
+          <div v-if="form.llm.provider !== 'claude-code'" class="field-row test-row">
+            <button
+              class="test-btn"
+              :disabled="testing"
+              @click="testConnection"
+            >
+              <span v-if="testing">Testing...</span>
+              <span v-else>Test Connection</span>
+            </button>
+            <div v-if="testResult" class="test-result" :class="testResult.success ? 'ok' : 'fail'">
+              <span v-if="testResult.success">
+                ✓ {{ testResult.model }} — {{ testResult.latency_ms }}ms
+              </span>
+              <span v-else>✗ {{ testResult.error }}</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- Neo4j Configuration -->
+        <section class="settings-section">
+          <div class="section-header">
+            <span class="section-label">Graph Database (Neo4j)</span>
+          </div>
+
+          <div class="field-row">
+            <label class="field-label">URI</label>
+            <input
+              v-model="form.neo4j.uri"
+              class="field-input"
+              type="text"
+              placeholder="bolt://localhost:7687"
+            />
+          </div>
+
+          <div class="field-row">
+            <label class="field-label">User</label>
+            <input
+              v-model="form.neo4j.user"
+              class="field-input"
+              type="text"
+              placeholder="neo4j"
+            />
+          </div>
+
+          <div class="field-row">
+            <label class="field-label">Password</label>
+            <input
+              v-model="form.neo4j.password"
+              class="field-input"
+              type="password"
+              placeholder="Leave blank to keep unchanged"
+            />
+          </div>
+        </section>
+
+        <!-- Footer -->
+        <div class="modal-footer">
+          <div v-if="saveError" class="save-error">{{ saveError }}</div>
+          <div v-if="saveSuccess" class="save-success">✓ Settings saved</div>
+          <div class="footer-actions">
+            <button class="cancel-btn" @click="$emit('close')">Cancel</button>
+            <button class="save-btn" :disabled="saving" @click="saveSettings">
+              <span v-if="saving">Saving...</span>
+              <span v-else>Save Settings →</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { ref, reactive, computed, watch } from 'vue'
+import { getSettings, updateSettings, testLlmConnection } from '../api/settings'
+
+const props = defineProps({
+  open: { type: Boolean, required: true }
+})
+
+const emit = defineEmits(['close'])
+
+// Current settings loaded from backend
+const currentSettings = ref({})
+
+// Form state
+const form = reactive({
+  llm: {
+    provider: 'openai',
+    base_url: '',
+    model_name: '',
+    api_key: '',
+  },
+  neo4j: {
+    uri: '',
+    user: '',
+    password: '',
+  },
+})
+
+// UI state
+const showKey = ref(false)
+const saving = ref(false)
+const saveError = ref('')
+const saveSuccess = ref(false)
+const testing = ref(false)
+const testResult = ref(null)
+const modelList = ref([])
+const loadingModels = ref(false)
+const modelLoadError = ref('')
+
+// Load current settings when panel opens
+watch(() => props.open, async (isOpen) => {
+  if (isOpen) {
+    saveError.value = ''
+    saveSuccess.value = false
+    testResult.value = null
+    await loadCurrentSettings()
+  }
+})
+
+const loadCurrentSettings = async () => {
+  try {
+    const res = await getSettings()
+    if (res.data?.success) {
+      currentSettings.value = res.data.data
+      const llm = res.data.data.llm
+      const neo4j = res.data.data.neo4j
+      form.llm.provider = llm.provider || 'openai'
+      form.llm.base_url = llm.base_url || ''
+      form.llm.model_name = llm.model_name || ''
+      form.llm.api_key = '' // never pre-fill the key
+      form.neo4j.uri = neo4j.uri || ''
+      form.neo4j.user = neo4j.user || ''
+      form.neo4j.password = ''
+    }
+  } catch (e) {
+    // Settings load failure is non-fatal
+  }
+}
+
+// Whether current base URL is OpenRouter
+const isOpenRouter = computed(() =>
+  form.llm.base_url.includes('openrouter.ai')
+)
+
+// Model tiering thresholds (cost per 1M tokens, prompt side)
+const MODEL_TIERS = [
+  { label: 'Fast (< $0.50/M)', max: 0.5 },
+  { label: 'Standard ($0.50–$5/M)', max: 5 },
+  { label: 'Capable (> $5/M)', max: Infinity },
+]
+
+const modelTiers = computed(() => {
+  if (modelList.value.length === 0) return []
+  return MODEL_TIERS.map(tier => ({
+    label: tier.label,
+    models: modelList.value.filter(m => {
+      const price = m.pricing?.prompt ? parseFloat(m.pricing.prompt) * 1_000_000 : 0
+      return price <= tier.max && price > (tier === MODEL_TIERS[0] ? 0 : MODEL_TIERS[MODEL_TIERS.indexOf(tier) - 1].max)
+    })
+  })).filter(t => t.models.length > 0)
+})
+
+const loadOpenRouterModels = async () => {
+  loadingModels.value = true
+  modelLoadError.value = ''
+  try {
+    const res = await fetch('https://openrouter.ai/api/v1/models')
+    const json = await res.json()
+    if (json.data) {
+      modelList.value = json.data
+        .filter(m => m.id && m.name)
+        .sort((a, b) => {
+          const pa = parseFloat(a.pricing?.prompt || 0) * 1_000_000
+          const pb = parseFloat(b.pricing?.prompt || 0) * 1_000_000
+          return pa - pb
+        })
+    }
+  } catch (e) {
+    modelLoadError.value = 'Could not load model list — check your network connection.'
+  } finally {
+    loadingModels.value = false
+  }
+}
+
+const testConnection = async () => {
+  testing.value = true
+  testResult.value = null
+  try {
+    const res = await testLlmConnection()
+    testResult.value = res.data
+  } catch (e) {
+    testResult.value = { success: false, error: e.message }
+  } finally {
+    testing.value = false
+  }
+}
+
+const testStatus = computed(() => {
+  if (!testResult.value) return 'idle'
+  return testResult.value.success ? 'ok' : 'fail'
+})
+
+const testStatusText = computed(() => {
+  if (!testResult.value) return 'Not tested'
+  return testResult.value.success ? 'Connected' : 'Failed'
+})
+
+const saveSettings = async () => {
+  saving.value = true
+  saveError.value = ''
+  saveSuccess.value = false
+  try {
+    const payload = {
+      llm: {
+        provider: form.llm.provider,
+        base_url: form.llm.base_url,
+        model_name: form.llm.model_name,
+      },
+      neo4j: {
+        uri: form.neo4j.uri,
+        user: form.neo4j.user,
+      },
+    }
+    // Only include keys if user typed something
+    if (form.llm.api_key) payload.llm.api_key = form.llm.api_key
+    if (form.neo4j.password) payload.neo4j.password = form.neo4j.password
+
+    const res = await updateSettings(payload)
+    if (res.data?.success) {
+      saveSuccess.value = true
+      currentSettings.value.llm = res.data.data.llm
+      form.llm.api_key = ''
+      form.neo4j.password = ''
+      setTimeout(() => { saveSuccess.value = false }, 3000)
+    } else {
+      saveError.value = res.data?.error || 'Save failed'
+    }
+  } catch (e) {
+    saveError.value = e.message
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style scoped>
+/* ── Modal Overlay ── */
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 10, 10, 0.6);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fade-in 0.15s ease-out;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.settings-modal {
+  background: #FAFAFA;
+  width: 560px;
+  max-width: calc(100vw - 48px);
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+  border: 2px solid rgba(10,10,10,0.12);
+  position: relative;
+  animation: slide-in 0.2s ease-out;
+  font-family: 'Space Mono', 'Courier New', monospace;
+}
+
+@keyframes slide-in {
+  from { transform: translateY(-16px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+/* ── Header ── */
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px;
+  background: #0A0A0A;
+  color: #FAFAFA;
+}
+
+.title-label {
+  font-family: 'Space Mono', monospace;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: rgba(250,250,250,0.5);
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px 8px;
+  transition: color 0.1s;
+}
+.close-btn:hover { color: #FAFAFA; }
+
+/* ── Warning Stripe ── */
+.warning-stripe {
+  height: 6px;
+  background: repeating-linear-gradient(
+    -45deg,
+    #FF6B1A,
+    #FF6B1A 10px,
+    #FAFAFA 10px,
+    #FAFAFA 20px
+  );
+}
+
+/* ── Sections ── */
+.settings-section {
+  padding: 22px;
+  border-bottom: 2px solid rgba(10,10,10,0.08);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.section-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.4);
+}
+
+/* ── Status Badge ── */
+.status-badge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+.badge-dot {
+  width: 7px;
+  height: 7px;
+  background: rgba(10,10,10,0.2);
+  border-radius: 0;
+}
+.status-badge.ok .badge-dot { background: #43C165; }
+.status-badge.fail .badge-dot { background: #FF4444; }
+.status-badge.ok { color: #43C165; }
+.status-badge.fail { color: #FF4444; }
+.status-badge.idle { color: rgba(10,10,10,0.3); }
+
+/* ── Form Fields ── */
+.field-row {
+  margin-bottom: 14px;
+}
+
+.field-label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.5);
+  margin-bottom: 6px;
+}
+
+.field-input {
+  width: 100%;
+  border: 2px solid rgba(10,10,10,0.1);
+  background: #F5F5F5;
+  padding: 8px 11px;
+  font-family: 'Space Mono', monospace;
+  font-size: 13px;
+  color: #0A0A0A;
+  outline: none;
+  transition: border-color 0.1s;
+  box-sizing: border-box;
+}
+.field-input:focus { border-color: #FF6B1A; background: #FAFAFA; }
+.field-input::placeholder { color: rgba(10,10,10,0.3); }
+
+.select-wrapper { position: relative; }
+.field-select {
+  width: 100%;
+  border: 2px solid rgba(10,10,10,0.1);
+  background: #F5F5F5;
+  padding: 8px 11px;
+  font-family: 'Space Mono', monospace;
+  font-size: 13px;
+  color: #0A0A0A;
+  outline: none;
+  cursor: pointer;
+  appearance: auto;
+  transition: border-color 0.1s;
+  box-sizing: border-box;
+}
+.field-select:focus { border-color: #FF6B1A; }
+
+/* ── Model input group ── */
+.model-input-group {
+  display: flex;
+  gap: 6px;
+}
+.model-select-wrapper { flex: 1; min-width: 0; }
+
+.load-models-btn {
+  border: 2px solid rgba(10,10,10,0.1);
+  background: #F5F5F5;
+  padding: 8px 12px;
+  font-family: 'Space Mono', monospace;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.1s;
+  flex-shrink: 0;
+}
+.load-models-btn:hover:not(:disabled) { border-color: #FF6B1A; color: #FF6B1A; }
+.load-models-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+/* ── Key input group ── */
+.key-input-group {
+  display: flex;
+  gap: 6px;
+}
+.key-input-group .field-input { flex: 1; }
+
+.toggle-key-btn {
+  border: 2px solid rgba(10,10,10,0.1);
+  background: #F5F5F5;
+  padding: 8px 12px;
+  font-size: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 0.1s;
+}
+.toggle-key-btn:hover { border-color: #FF6B1A; }
+
+.field-hint {
+  margin-top: 5px;
+  font-size: 11px;
+  color: rgba(10,10,10,0.4);
+  letter-spacing: 0.5px;
+}
+
+.field-error {
+  margin-top: 5px;
+  font-size: 11px;
+  color: #FF4444;
+}
+
+/* ── Test row ── */
+.test-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.test-btn {
+  border: 2px solid rgba(10,10,10,0.12);
+  background: transparent;
+  padding: 8px 16px;
+  font-family: 'Space Mono', monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.1s;
+}
+.test-btn:hover:not(:disabled) { border-color: #FF6B1A; color: #FF6B1A; }
+.test-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+.test-result {
+  font-size: 12px;
+  letter-spacing: 1px;
+}
+.test-result.ok { color: #43C165; }
+.test-result.fail { color: #FF4444; }
+
+/* ── Footer ── */
+.modal-footer {
+  padding: 18px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.footer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.save-error {
+  font-size: 12px;
+  color: #FF4444;
+  letter-spacing: 0.5px;
+}
+
+.save-success {
+  font-size: 12px;
+  color: #43C165;
+  letter-spacing: 1px;
+}
+
+.cancel-btn {
+  border: 2px solid rgba(10,10,10,0.1);
+  background: transparent;
+  padding: 10px 20px;
+  font-family: 'Space Mono', monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  color: rgba(10,10,10,0.5);
+  transition: all 0.1s;
+}
+.cancel-btn:hover { border-color: rgba(10,10,10,0.3); color: #0A0A0A; }
+
+.save-btn {
+  border: 2px solid #0A0A0A;
+  background: #0A0A0A;
+  color: #FAFAFA;
+  padding: 10px 20px;
+  font-family: 'Space Mono', monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.save-btn:hover:not(:disabled) { background: #FF6B1A; border-color: #FF6B1A; }
+.save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+</style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -7,8 +7,13 @@
         <a href="https://github.com/aaronjmars/MiroShark" target="_blank" class="github-link">
           GitHub <span class="arrow">↗</span>
         </a>
+        <button class="settings-btn" @click="settingsOpen = true" title="Settings">
+          ⚙
+        </button>
       </div>
     </nav>
+
+    <SettingsPanel :open="settingsOpen" @close="settingsOpen = false" />
 
     <div class="main-content">
       <!-- Upper Section: Hero Area -->
@@ -230,7 +235,10 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import HistoryDatabase from '../components/HistoryDatabase.vue'
 import TemplateGallery from '../components/TemplateGallery.vue'
+import SettingsPanel from '../components/SettingsPanel.vue'
 import { fetchUrl } from '../api/graph'
+
+const settingsOpen = ref(false)
 
 const router = useRouter()
 
@@ -418,6 +426,19 @@ const startSimulation = () => {
 .github-link:hover { opacity: 1; }
 
 .arrow { font-family: sans-serif; }
+
+.settings-btn {
+  background: none;
+  border: none;
+  color: rgba(250,250,250,0.5);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 0 0 var(--space-md);
+  line-height: 1;
+  transition: var(--transition-fast);
+}
+
+.settings-btn:hover { color: var(--color-orange); }
 
 /* ── Main Content ── */
 .main-content {


### PR DESCRIPTION
## What
Users can now configure their LLM provider, model, and API key directly from the MiroShark UI — no more editing `.env` and restarting the server.

## Why
MiroShark's LLM configuration has always lived entirely in `.env`. Experienced users know where to look; new users don't. With the one-click cloud deploy PR bringing non-technical users to MiroShark, invisible configuration becomes a support burden and a friction point that stops people from successfully running their first simulation.

## Changes
- `backend/app/api/settings.py`: New Flask Blueprint with three endpoints:
  - `GET /api/settings` — returns current active config (provider, base URL, model name, API key masked to last 4 chars)
  - `POST /api/settings` — updates Config class attributes at runtime without server restart; only updates fields that are provided
  - `POST /api/settings/test-llm` — makes a minimal "reply with OK" call to the configured LLM and returns model name + latency in ms
- `backend/app/api/__init__.py`: Registers the `settings_bp` Blueprint
- `backend/app/__init__.py`: Mounts the Blueprint at `/api/settings`
- `frontend/src/api/settings.js`: Three API functions (`getSettings`, `updateSettings`, `testLlmConnection`)
- `frontend/src/components/SettingsPanel.vue`: Full settings modal with:
  - Provider selector (OpenAI-compatible vs Claude Code)
  - Base URL field
  - Model selector: dropdown populated from OpenRouter's public model list (`GET openrouter.ai/api/v1/models`), grouped into Fast/Standard/Capable cost tiers; falls back to a text input if model list is not loaded
  - "↻" button to fetch the model list on demand (only enabled when base URL contains `openrouter.ai`)
  - API key field with show/hide toggle; current key shown as masked value, left blank to keep unchanged
  - "Test Connection" button that calls `/api/settings/test-llm` and shows model + latency
  - Neo4j URI/user/password fields for completeness
  - Save button that commits all changes to the runtime config
- `frontend/src/views/Home.vue`: Gear icon button added to the navbar (right of GitHub link); imports and renders `SettingsPanel`

---
*Built autonomously by Aeon*