### PR TITLE
feat: simulation comparison mode

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -2177,8 +2177,8 @@ def get_agent_stats(simulation_id: str):
 
 # ============== Influence Leaderboard ==============
 
-@simulation_bp.route('/<simulation_id>/influence', methods=['GET'])
-def get_influence_leaderboard(simulation_id: str):
+
+def _compute_influence_ranked(simulation_id, top_n=None):
     """
     Compute agent influence scores from simulation action JSONL logs.
 
@@ -2188,122 +2188,121 @@ def get_influence_leaderboard(simulation_id: str):
         score = engagement_received * 3 + follows_received * 2
                 + platform_count * 5 + posts_created
 
-    Where:
-        engagement_received — likes, reposts, quotes, and comment-likes on the agent's posts
-        follows_received    — number of other agents that followed this agent
-        platform_count      — number of distinct platforms where the agent appeared (max 3)
-        posts_created       — number of original posts created by the agent
+    Returns a list of ranked agent dicts (1-based rank), optionally truncated to top_n.
+    Returns an empty list if the simulation directory does not exist.
+    """
+    sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+    if not os.path.exists(sim_dir):
+        return []
 
+    ENGAGEMENT_TYPES = frozenset({
+        'LIKE_POST', 'REPOST', 'QUOTE_POST', 'LIKE_COMMENT',
+        'CREATE_COMMENT',
+    })
+
+    agents = {}
+
+    def _get_or_create(name):
+        if name not in agents:
+            agents[name] = {
+                'agent_name': name,
+                'posts_created': 0,
+                'engagement_received': 0,
+                'follows_received': 0,
+                'platforms': set(),
+            }
+        return agents[name]
+
+    for platform in ('twitter', 'reddit', 'polymarket'):
+        actions_path = os.path.join(sim_dir, platform, 'actions.jsonl')
+        if not os.path.exists(actions_path):
+            continue
+
+        with open(actions_path, 'r', encoding='utf-8') as fh:
+            for raw_line in fh:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    event = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+
+                if event.get('event_type') in (
+                    'simulation_start', 'round_start', 'round_end', 'simulation_end'
+                ):
+                    continue
+
+                agent_name = event.get('agent_name')
+                if not agent_name:
+                    continue
+
+                actor = _get_or_create(agent_name)
+                actor['platforms'].add(platform)
+
+                action_type = event.get('action_type', '')
+                args = event.get('action_args') or {}
+
+                if action_type == 'CREATE_POST':
+                    actor['posts_created'] += 1
+
+                elif action_type in ENGAGEMENT_TYPES:
+                    author = (
+                        args.get('post_author_name')
+                        or args.get('original_author_name')
+                    )
+                    if author and author != agent_name:
+                        _get_or_create(author)['engagement_received'] += 1
+
+                elif action_type == 'FOLLOW':
+                    target = args.get('target_user_name')
+                    if target:
+                        _get_or_create(target)['follows_received'] += 1
+
+    ranked = []
+    for a in agents.values():
+        platform_count = len(a['platforms'])
+        score = (
+            a['engagement_received'] * 3
+            + a['follows_received'] * 2
+            + platform_count * 5
+            + a['posts_created']
+        )
+        ranked.append({
+            'agent_name': a['agent_name'],
+            'posts_created': a['posts_created'],
+            'engagement_received': a['engagement_received'],
+            'follows_received': a['follows_received'],
+            'platform_count': platform_count,
+            'platforms': sorted(a['platforms']),
+            'influence_score': score,
+        })
+
+    ranked.sort(key=lambda x: x['influence_score'], reverse=True)
+
+    for i, entry in enumerate(ranked):
+        entry['rank'] = i + 1
+
+    return ranked[:top_n] if top_n else ranked
+
+
+@simulation_bp.route('/<simulation_id>/influence', methods=['GET'])
+def get_influence_leaderboard(simulation_id: str):
+    """
+    Compute agent influence scores from simulation action JSONL logs.
     Returns the top 20 agents sorted by score descending.
     """
     try:
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
-
         if not os.path.exists(sim_dir):
             return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
 
-        # Engagement action types that credit the original post author
-        ENGAGEMENT_TYPES = frozenset({
-            'LIKE_POST', 'REPOST', 'QUOTE_POST', 'LIKE_COMMENT',
-            'CREATE_COMMENT',  # replying to a post counts as engagement
-        })
-
-        agents = {}  # agent_name -> mutable stats dict
-
-        def _get_or_create(name):
-            if name not in agents:
-                agents[name] = {
-                    'agent_name': name,
-                    'posts_created': 0,
-                    'engagement_received': 0,
-                    'follows_received': 0,
-                    'platforms': set(),
-                }
-            return agents[name]
-
-        for platform in ('twitter', 'reddit', 'polymarket'):
-            actions_path = os.path.join(sim_dir, platform, 'actions.jsonl')
-            if not os.path.exists(actions_path):
-                continue
-
-            with open(actions_path, 'r', encoding='utf-8') as fh:
-                for raw_line in fh:
-                    raw_line = raw_line.strip()
-                    if not raw_line:
-                        continue
-                    try:
-                        event = json.loads(raw_line)
-                    except json.JSONDecodeError:
-                        continue
-
-                    # Skip bookkeeping events that have no agent
-                    if event.get('event_type') in (
-                        'simulation_start', 'round_start', 'round_end', 'simulation_end'
-                    ):
-                        continue
-
-                    agent_name = event.get('agent_name')
-                    if not agent_name:
-                        continue
-
-                    actor = _get_or_create(agent_name)
-                    actor['platforms'].add(platform)
-
-                    action_type = event.get('action_type', '')
-                    args = event.get('action_args') or {}
-
-                    if action_type == 'CREATE_POST':
-                        actor['posts_created'] += 1
-
-                    elif action_type in ENGAGEMENT_TYPES:
-                        # Credit the original author, not the actor
-                        author = (
-                            args.get('post_author_name')
-                            or args.get('original_author_name')
-                        )
-                        if author and author != agent_name:
-                            _get_or_create(author)['engagement_received'] += 1
-
-                    elif action_type == 'FOLLOW':
-                        target = args.get('target_user_name')
-                        if target:
-                            _get_or_create(target)['follows_received'] += 1
-
-        if not agents:
-            return jsonify({
-                "success": True,
-                "data": {"agents": [], "total_agents": 0}
-            })
-
-        ranked = []
-        for a in agents.values():
-            platform_count = len(a['platforms'])
-            score = (
-                a['engagement_received'] * 3
-                + a['follows_received'] * 2
-                + platform_count * 5
-                + a['posts_created']
-            )
-            ranked.append({
-                'agent_name': a['agent_name'],
-                'posts_created': a['posts_created'],
-                'engagement_received': a['engagement_received'],
-                'follows_received': a['follows_received'],
-                'platform_count': platform_count,
-                'platforms': sorted(a['platforms']),
-                'influence_score': score,
-            })
-
-        ranked.sort(key=lambda x: x['influence_score'], reverse=True)
-
-        # Attach rank (1-based)
-        for i, entry in enumerate(ranked):
-            entry['rank'] = i + 1
+        ranked = _compute_influence_ranked(simulation_id, top_n=20)
 
         return jsonify({
             "success": True,
             "data": {
-                "agents": ranked[:20],
+                "agents": ranked,
                 "total_agents": len(ranked),
             }
         })
@@ -3102,78 +3101,6 @@ def compare_simulations():
             m = SimulationManager()
             return m.get_simulation(sim_id)
 
-        def _load_influence(sim_id):
-            """Inline influence computation (reuses logic from get_influence_leaderboard)."""
-            sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, sim_id)
-            if not os.path.exists(sim_dir):
-                return []
-
-            ENGAGEMENT_TYPES = frozenset({
-                'LIKE_POST', 'REPOST', 'QUOTE_POST', 'LIKE_COMMENT', 'CREATE_COMMENT',
-            })
-            agents = {}
-
-            def _get_or_create(name):
-                if name not in agents:
-                    agents[name] = {
-                        'agent_name': name,
-                        'posts_created': 0,
-                        'engagement_received': 0,
-                        'follows_received': 0,
-                        'platforms': set(),
-                    }
-                return agents[name]
-
-            for platform in ('twitter', 'reddit', 'polymarket'):
-                path = os.path.join(sim_dir, platform, 'actions.jsonl')
-                if not os.path.exists(path):
-                    continue
-                with open(path, 'r', encoding='utf-8') as fh:
-                    for line in fh:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            ev = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-                        if ev.get('event_type') in ('simulation_start', 'round_start', 'round_end', 'simulation_end'):
-                            continue
-                        name = ev.get('agent_name')
-                        if not name:
-                            continue
-                        actor = _get_or_create(name)
-                        actor['platforms'].add(platform)
-                        atype = ev.get('action_type', '')
-                        args = ev.get('action_args') or {}
-                        if atype == 'CREATE_POST':
-                            actor['posts_created'] += 1
-                        elif atype in ENGAGEMENT_TYPES:
-                            author = args.get('post_author_name') or args.get('original_author_name')
-                            if author and author != name:
-                                _get_or_create(author)['engagement_received'] += 1
-                        elif atype == 'FOLLOW':
-                            target = args.get('target_user_name')
-                            if target:
-                                _get_or_create(target)['follows_received'] += 1
-
-            ranked = []
-            for a in agents.values():
-                pc = len(a['platforms'])
-                score = a['engagement_received'] * 3 + a['follows_received'] * 2 + pc * 5 + a['posts_created']
-                ranked.append({
-                    'agent_name': a['agent_name'],
-                    'posts_created': a['posts_created'],
-                    'engagement_received': a['engagement_received'],
-                    'follows_received': a['follows_received'],
-                    'platform_count': pc,
-                    'influence_score': score,
-                })
-            ranked.sort(key=lambda x: x['influence_score'], reverse=True)
-            for i, e in enumerate(ranked):
-                e['rank'] = i + 1
-            return ranked[:10]
-
         def _load_timeline_summary(sim_id):
             """Load and summarise timeline: per-round total actions, total rounds."""
             timeline = SimulationRunner.get_timeline(sim_id)
@@ -3236,8 +3163,8 @@ def compare_simulations():
         if not state2:
             return jsonify({"success": False, "error": f"Simulation not found: {id2}"}), 404
 
-        influence1 = _load_influence(id1)
-        influence2 = _load_influence(id2)
+        influence1 = _compute_influence_ranked(id1, top_n=10)
+        influence2 = _compute_influence_ranked(id2, top_n=10)
         timeline1 = _load_timeline_summary(id1)
         timeline2 = _load_timeline_summary(id2)
         markets1 = _load_market_prices(id1)

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -3063,3 +3063,238 @@ def export_simulation_data(simulation_id: str):
             "error": str(e),
             "traceback": traceback.format_exc()
         }), 500
+
+
+# ============== Simulation Comparison Endpoint ==============
+
+@simulation_bp.route('/compare', methods=['GET'])
+def compare_simulations():
+    """
+    Compare two completed simulations side by side.
+
+    Query parameters:
+        id1: First simulation ID (required)
+        id2: Second simulation ID (required)
+
+    Returns aggregated comparison data from both simulations:
+    - Influence leaderboards (top 10 each)
+    - Per-round activity timelines
+    - Prediction market final prices (from polymarket SQLite if available)
+    - Divergence score (0–1, higher = more divergent outcomes)
+
+    Divergence score methodology:
+        For each agent that appears in the top-10 of both runs, compute the
+        normalized absolute rank difference. Agents present in one run but not
+        the other contribute a penalty of 0.5 per missing agent. The final score
+        is the mean across all compared agents, clamped to [0, 1].
+    """
+    try:
+        id1 = request.args.get('id1', '').strip()
+        id2 = request.args.get('id2', '').strip()
+
+        if not id1 or not id2:
+            return jsonify({"success": False, "error": "Both id1 and id2 are required"}), 400
+
+        if id1 == id2:
+            return jsonify({"success": False, "error": "id1 and id2 must be different simulations"}), 400
+
+        def _load_state(sim_id):
+            m = SimulationManager()
+            return m.get_simulation(sim_id)
+
+        def _load_influence(sim_id):
+            """Inline influence computation (reuses logic from get_influence_leaderboard)."""
+            sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, sim_id)
+            if not os.path.exists(sim_dir):
+                return []
+
+            ENGAGEMENT_TYPES = frozenset({
+                'LIKE_POST', 'REPOST', 'QUOTE_POST', 'LIKE_COMMENT', 'CREATE_COMMENT',
+            })
+            agents = {}
+
+            def _get_or_create(name):
+                if name not in agents:
+                    agents[name] = {
+                        'agent_name': name,
+                        'posts_created': 0,
+                        'engagement_received': 0,
+                        'follows_received': 0,
+                        'platforms': set(),
+                    }
+                return agents[name]
+
+            for platform in ('twitter', 'reddit', 'polymarket'):
+                path = os.path.join(sim_dir, platform, 'actions.jsonl')
+                if not os.path.exists(path):
+                    continue
+                with open(path, 'r', encoding='utf-8') as fh:
+                    for line in fh:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            ev = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if ev.get('event_type') in ('simulation_start', 'round_start', 'round_end', 'simulation_end'):
+                            continue
+                        name = ev.get('agent_name')
+                        if not name:
+                            continue
+                        actor = _get_or_create(name)
+                        actor['platforms'].add(platform)
+                        atype = ev.get('action_type', '')
+                        args = ev.get('action_args') or {}
+                        if atype == 'CREATE_POST':
+                            actor['posts_created'] += 1
+                        elif atype in ENGAGEMENT_TYPES:
+                            author = args.get('post_author_name') or args.get('original_author_name')
+                            if author and author != name:
+                                _get_or_create(author)['engagement_received'] += 1
+                        elif atype == 'FOLLOW':
+                            target = args.get('target_user_name')
+                            if target:
+                                _get_or_create(target)['follows_received'] += 1
+
+            ranked = []
+            for a in agents.values():
+                pc = len(a['platforms'])
+                score = a['engagement_received'] * 3 + a['follows_received'] * 2 + pc * 5 + a['posts_created']
+                ranked.append({
+                    'agent_name': a['agent_name'],
+                    'posts_created': a['posts_created'],
+                    'engagement_received': a['engagement_received'],
+                    'follows_received': a['follows_received'],
+                    'platform_count': pc,
+                    'influence_score': score,
+                })
+            ranked.sort(key=lambda x: x['influence_score'], reverse=True)
+            for i, e in enumerate(ranked):
+                e['rank'] = i + 1
+            return ranked[:10]
+
+        def _load_timeline_summary(sim_id):
+            """Load and summarise timeline: per-round total actions, total rounds."""
+            timeline = SimulationRunner.get_timeline(sim_id)
+            return [
+                {
+                    'round_num': r['round_num'],
+                    'total_actions': r['total_actions'],
+                    'twitter_actions': r['twitter_actions'],
+                    'reddit_actions': r['reddit_actions'],
+                }
+                for r in timeline
+            ]
+
+        def _load_market_prices(sim_id):
+            """
+            Extract per-round YES token prices from the Polymarket SQLite database.
+
+            Reads the AmM reserve table to derive price_yes = reserve_no / (reserve_yes + reserve_no)
+            per round. Returns an empty list if Polymarket was not enabled or the DB does not exist.
+            """
+            sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, sim_id)
+            db_path = os.path.join(sim_dir, 'polymarket', 'polymarket.db')
+            if not os.path.exists(db_path):
+                return []
+            try:
+                import sqlite3
+                con = sqlite3.connect(db_path)
+                cur = con.cursor()
+                # Try to read round-level price snapshots if they exist
+                tables = {r[0] for r in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+                prices = []
+
+                if 'price_history' in tables:
+                    # Custom table we may have written
+                    rows = cur.execute(
+                        "SELECT round_num, market_id, price_yes FROM price_history ORDER BY round_num, market_id"
+                    ).fetchall()
+                    for rn, mid, py in rows:
+                        prices.append({'round_num': rn, 'market_id': mid, 'price_yes': py})
+                elif 'market' in tables:
+                    # Wonderwall market table: id, reserve_yes, reserve_no
+                    rows = cur.execute(
+                        "SELECT id, reserve_yes, reserve_no FROM market"
+                    ).fetchall()
+                    for mid, ry, rn in rows:
+                        total = (ry or 0) + (rn or 0)
+                        price_yes = (rn / total) if total > 0 else 0.5
+                        prices.append({'market_id': mid, 'price_yes': round(price_yes, 4), 'round_num': None})
+                con.close()
+                return prices
+            except Exception:
+                return []
+
+        # Load data for both simulations
+        state1 = _load_state(id1)
+        state2 = _load_state(id2)
+
+        if not state1:
+            return jsonify({"success": False, "error": f"Simulation not found: {id1}"}), 404
+        if not state2:
+            return jsonify({"success": False, "error": f"Simulation not found: {id2}"}), 404
+
+        influence1 = _load_influence(id1)
+        influence2 = _load_influence(id2)
+        timeline1 = _load_timeline_summary(id1)
+        timeline2 = _load_timeline_summary(id2)
+        markets1 = _load_market_prices(id1)
+        markets2 = _load_market_prices(id2)
+
+        # ---- Divergence Score ----
+        # Rank-based divergence: normalized mean absolute rank difference for top-10 agents
+        rank_map1 = {a['agent_name']: a['rank'] for a in influence1}
+        rank_map2 = {a['agent_name']: a['rank'] for a in influence2}
+        all_agents = set(rank_map1) | set(rank_map2)
+        if all_agents:
+            diffs = []
+            for name in all_agents:
+                r1 = rank_map1.get(name, 15)  # penalty: treat absent agents as rank 15
+                r2 = rank_map2.get(name, 15)
+                diffs.append(abs(r1 - r2) / 14.0)  # normalise to [0, 1] (max diff = 14)
+            divergence_score = round(min(1.0, sum(diffs) / len(diffs)), 3)
+        else:
+            divergence_score = 0.0
+
+        # ---- Total activity stats ----
+        def _total_actions(timeline):
+            return sum(r['total_actions'] for r in timeline)
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "id1": id1,
+                "id2": id2,
+                "divergence_score": divergence_score,
+                "sim1": {
+                    "simulation_id": id1,
+                    "status": state1.status.value if state1 else None,
+                    "profiles_count": state1.profiles_count if state1 else 0,
+                    "total_rounds": len(timeline1),
+                    "total_actions": _total_actions(timeline1),
+                    "influence": influence1,
+                    "timeline": timeline1,
+                    "markets": markets1,
+                },
+                "sim2": {
+                    "simulation_id": id2,
+                    "status": state2.status.value if state2 else None,
+                    "profiles_count": state2.profiles_count if state2 else 0,
+                    "total_rounds": len(timeline2),
+                    "total_actions": _total_actions(timeline2),
+                    "influence": influence2,
+                    "timeline": timeline2,
+                    "markets": markets2,
+                },
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"Failed to compare simulations: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -129,6 +129,15 @@ export const getRunStatusDetail = (simulationId) => {
 }
 
 /**
+ * Compare two simulations side by side
+ * @param {string} id1 - First simulation ID
+ * @param {string} id2 - Second simulation ID
+ */
+export const compareSimulations = (id1, id2) => {
+  return service.get('/api/simulation/compare', { params: { id1, id2 } })
+}
+
+/**
  * Get posts in simulation
  * @param {string} simulationId
  * @param {string} platform - 'reddit' | 'twitter'

--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -15,6 +15,12 @@
       <div class="section-line"></div>
       <span class="section-title">Simulation Records</span>
       <div class="section-line"></div>
+      <button
+        v-if="projects.length >= 2"
+        class="compare-mode-btn"
+        :class="{ active: compareMode }"
+        @click="toggleCompareMode"
+      >{{ compareMode ? (compareSelections.length === 2 ? 'Compare →' : `${compareSelections.length}/2 selected`) : '⇄ Compare' }}</button>
     </div>
 
     <!-- Cards container (only shown when projects exist) -->
@@ -89,9 +95,17 @@
             <span class="card-date">{{ formatDate(project.created_at) }}</span>
             <span class="card-time">{{ formatTime(project.created_at) }}</span>
           </div>
-          <span class="card-progress" :class="getProgressClass(project)">
-            <span class="status-dot">●</span> {{ formatRounds(project) }}
-          </span>
+          <div style="display:flex;align-items:center;gap:8px;">
+            <span class="card-progress" :class="getProgressClass(project)">
+              <span class="status-dot">●</span> {{ formatRounds(project) }}
+            </span>
+            <button
+              v-if="compareMode"
+              class="compare-select-btn"
+              :class="{ selected: compareSelections.includes(project.simulation_id) }"
+              @click.stop="toggleCompareSelection(project.simulation_id)"
+            >{{ compareSelections.includes(project.simulation_id) ? '✓' : '+' }}</button>
+          </div>
         </div>
 
         <!-- Bottom decoration line (expands on hover) -->
@@ -232,6 +246,43 @@ const hoveringCard = ref(null)
 const historyContainer = ref(null)
 const selectedProject = ref(null)  // Currently selected project (for modal)
 let observer = null
+
+// Compare mode
+const compareMode = ref(false)
+const compareSelections = ref([])
+
+const toggleCompareMode = () => {
+  if (compareMode.value && compareSelections.value.length === 2) {
+    // Navigate to comparison view
+    router.push({
+      name: 'Compare',
+      params: { id1: compareSelections.value[0], id2: compareSelections.value[1] }
+    })
+    compareMode.value = false
+    compareSelections.value = []
+    return
+  }
+  compareMode.value = !compareMode.value
+  compareSelections.value = []
+}
+
+const toggleCompareSelection = (simId) => {
+  const idx = compareSelections.value.indexOf(simId)
+  if (idx >= 0) {
+    compareSelections.value.splice(idx, 1)
+  } else if (compareSelections.value.length < 2) {
+    compareSelections.value.push(simId)
+  }
+  // Auto-navigate when two are selected
+  if (compareSelections.value.length === 2) {
+    router.push({
+      name: 'Compare',
+      params: { id1: compareSelections.value[0], id2: compareSelections.value[1] }
+    })
+    compareMode.value = false
+    compareSelections.value = []
+  }
+}
 let isAnimating = false  // Animation lock to prevent flickering
 let expandDebounceTimer = null  // Debounce timer
 let pendingState = null  // Target state to be executed
@@ -1421,4 +1472,34 @@ onUnmounted(() => {
   text-align: center;
   line-height: 1.5;
 }
+
+/* Compare mode */
+.compare-mode-btn {
+  padding: 5px 14px;
+  border: 1px solid rgba(10,10,10,0.2);
+  background: transparent;
+  color: rgba(10,10,10,0.5);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: 'Space Mono', monospace;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+.compare-mode-btn:hover { border-color: #FF6B1A; color: #FF6B1A; }
+.compare-mode-btn.active { border-color: #FF6B1A; color: #FF6B1A; background: rgba(255,107,26,0.06); }
+
+.compare-select-btn {
+  padding: 2px 8px;
+  border: 1px solid rgba(10,10,10,0.2);
+  background: transparent;
+  color: rgba(10,10,10,0.4);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: 'Space Mono', monospace;
+  transition: all 0.15s;
+}
+.compare-select-btn:hover { border-color: #FF6B1A; color: #FF6B1A; }
+.compare-select-btn.selected { border-color: #FF6B1A; color: #FF6B1A; background: rgba(255,107,26,0.1); }
 </style>

--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -95,7 +95,7 @@
             <span class="card-date">{{ formatDate(project.created_at) }}</span>
             <span class="card-time">{{ formatTime(project.created_at) }}</span>
           </div>
-          <div style="display:flex;align-items:center;gap:8px;">
+          <div class="card-progress-row">
             <span class="card-progress" :class="getProgressClass(project)">
               <span class="status-dot">●</span> {{ formatRounds(project) }}
             </span>
@@ -1471,6 +1471,12 @@ onUnmounted(() => {
   letter-spacing: 3px;
   text-align: center;
   line-height: 1.5;
+}
+
+.card-progress-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 /* Compare mode */

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -6,6 +6,7 @@ import SimulationRunView from '../views/SimulationRunView.vue'
 import ReportView from '../views/ReportView.vue'
 import InteractionView from '../views/InteractionView.vue'
 import ReplayView from '../views/ReplayView.vue'
+import ComparisonView from '../views/ComparisonView.vue'
 
 const routes = [
   {
@@ -47,6 +48,12 @@ const routes = [
     path: '/replay/:simulationId',
     name: 'Replay',
     component: ReplayView,
+    props: true
+  },
+  {
+    path: '/compare/:id1?/:id2?',
+    name: 'Compare',
+    component: ComparisonView,
     props: true
   }
 ]

--- a/frontend/src/views/ComparisonView.vue
+++ b/frontend/src/views/ComparisonView.vue
@@ -371,13 +371,28 @@ const getRankDeltaTitle = (name, simKey) => {
   return `Rank difference: ${label.replace(/[▲▼]/, '')}`
 }
 
-// Chart point computation
+// Chart point computation — shared Y-axis scale across both timelines
+const sharedChartMax = computed(() => {
+  const t1 = data.value?.sim1?.timeline || []
+  const t2 = data.value?.sim2?.timeline || []
+  const all = [...t1, ...t2].map(r => r.total_actions)
+  return Math.max(...all, 1)
+})
+
+const sharedRoundRange = computed(() => {
+  const t1 = data.value?.sim1?.timeline || []
+  const t2 = data.value?.sim2?.timeline || []
+  const allRounds = [...t1, ...t2].map(r => r.round_num)
+  if (!allRounds.length) return { min: 0, range: 1 }
+  const min = Math.min(...allRounds)
+  const max = Math.max(...allRounds)
+  return { min, range: Math.max(max - min, 1) }
+})
+
 const buildChartPoints = (timeline) => {
   if (!timeline || !timeline.length) return []
-  const maxActions = Math.max(...timeline.map(r => r.total_actions), 1)
-  const minR = timeline[0].round_num
-  const maxR = timeline[timeline.length - 1].round_num
-  const rangeR = Math.max(maxR - minR, 1)
+  const maxActions = sharedChartMax.value
+  const { min: minR, range: rangeR } = sharedRoundRange.value
   return timeline.map(r => ({
     round: r.round_num,
     x: chartPad + ((r.round_num - minR) / rangeR) * (chartW - 2 * chartPad),

--- a/frontend/src/views/ComparisonView.vue
+++ b/frontend/src/views/ComparisonView.vue
@@ -1,0 +1,664 @@
+<template>
+  <div class="comparison-page">
+    <!-- Header -->
+    <header class="cmp-header">
+      <div class="header-left">
+        <div class="brand" @click="router.push('/')">MIROSHARK</div>
+      </div>
+      <div class="header-center">
+        <span class="page-tag">Simulation Comparison</span>
+      </div>
+      <div class="header-right">
+        <button v-if="data" class="download-btn" @click="downloadComparison">
+          ↓ Export JSON
+        </button>
+      </div>
+    </header>
+
+    <!-- Simulation Selector -->
+    <div class="selector-bar">
+      <div class="selector-group">
+        <label class="selector-label">Simulation A</label>
+        <select class="sim-select" v-model="selectedId1" @change="onSelectionChange">
+          <option value="">Select simulation…</option>
+          <option v-for="s in simulations" :key="s.simulation_id" :value="s.simulation_id">
+            {{ formatId(s.simulation_id) }} — {{ s.status }}
+          </option>
+        </select>
+      </div>
+
+      <div class="vs-badge">VS</div>
+
+      <div class="selector-group">
+        <label class="selector-label">Simulation B</label>
+        <select class="sim-select" v-model="selectedId2" @change="onSelectionChange">
+          <option value="">Select simulation…</option>
+          <option v-for="s in simulations" :key="s.simulation_id" :value="s.simulation_id">
+            {{ formatId(s.simulation_id) }} — {{ s.status }}
+          </option>
+        </select>
+      </div>
+
+      <button
+        class="compare-btn"
+        :disabled="!selectedId1 || !selectedId2 || selectedId1 === selectedId2 || loading"
+        @click="runComparison"
+      >
+        <span v-if="loading" class="loading-spinner-small"></span>
+        {{ loading ? 'Comparing…' : 'Compare' }}
+      </button>
+    </div>
+
+    <!-- Error -->
+    <div v-if="error" class="cmp-error">{{ error }}</div>
+
+    <!-- Loading -->
+    <div v-else-if="loading" class="cmp-loading">
+      <div class="loading-ring"></div>
+      <span>Running comparison…</span>
+    </div>
+
+    <!-- Results -->
+    <div v-else-if="data" class="cmp-results">
+
+      <!-- Divergence Banner -->
+      <div class="divergence-banner">
+        <div class="divergence-label">Outcome Divergence Score</div>
+        <div class="divergence-score" :class="divergenceClass">
+          {{ (data.divergence_score * 100).toFixed(1) }}%
+        </div>
+        <div class="divergence-desc">{{ divergenceDescription }}</div>
+      </div>
+
+      <!-- Key Metrics Row -->
+      <div class="metrics-row">
+        <div class="metric-card sim-a">
+          <div class="metric-sim-id">{{ formatId(data.id1) }}</div>
+          <div class="metric-grid">
+            <div class="metric-item">
+              <span class="metric-val">{{ data.sim1.profiles_count }}</span>
+              <span class="metric-lbl">Agents</span>
+            </div>
+            <div class="metric-item">
+              <span class="metric-val">{{ data.sim1.total_rounds }}</span>
+              <span class="metric-lbl">Rounds</span>
+            </div>
+            <div class="metric-item">
+              <span class="metric-val">{{ data.sim1.total_actions.toLocaleString() }}</span>
+              <span class="metric-lbl">Actions</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="metric-card sim-b">
+          <div class="metric-sim-id">{{ formatId(data.id2) }}</div>
+          <div class="metric-grid">
+            <div class="metric-item">
+              <span class="metric-val">{{ data.sim2.profiles_count }}</span>
+              <span class="metric-lbl">Agents</span>
+            </div>
+            <div class="metric-item">
+              <span class="metric-val">{{ data.sim2.total_rounds }}</span>
+              <span class="metric-lbl">Rounds</span>
+            </div>
+            <div class="metric-item">
+              <span class="metric-val">{{ data.sim2.total_actions.toLocaleString() }}</span>
+              <span class="metric-lbl">Actions</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Two-Column Layout -->
+      <div class="two-col-layout">
+
+        <!-- Influence Leaderboard Comparison -->
+        <div class="cmp-section full-width">
+          <div class="section-title">Influence Leaderboard</div>
+          <div class="leaderboard-compare">
+            <div class="lb-col">
+              <div class="lb-header sim-a-color">{{ formatId(data.id1) }}</div>
+              <div
+                v-for="agent in data.sim1.influence"
+                :key="agent.agent_name"
+                class="lb-row"
+              >
+                <span class="lb-rank">#{{ agent.rank }}</span>
+                <span class="lb-name">{{ agent.agent_name }}</span>
+                <span class="lb-score">{{ agent.influence_score }}</span>
+                <span
+                  class="lb-delta"
+                  :class="getRankDeltaClass(agent.agent_name, 'sim1')"
+                  :title="getRankDeltaTitle(agent.agent_name, 'sim1')"
+                >{{ getRankDeltaLabel(agent.agent_name, 'sim1') }}</span>
+              </div>
+              <div v-if="!data.sim1.influence.length" class="lb-empty">No data</div>
+            </div>
+
+            <div class="lb-col">
+              <div class="lb-header sim-b-color">{{ formatId(data.id2) }}</div>
+              <div
+                v-for="agent in data.sim2.influence"
+                :key="agent.agent_name"
+                class="lb-row"
+              >
+                <span class="lb-rank">#{{ agent.rank }}</span>
+                <span class="lb-name">{{ agent.agent_name }}</span>
+                <span class="lb-score">{{ agent.influence_score }}</span>
+                <span
+                  class="lb-delta"
+                  :class="getRankDeltaClass(agent.agent_name, 'sim2')"
+                  :title="getRankDeltaTitle(agent.agent_name, 'sim2')"
+                >{{ getRankDeltaLabel(agent.agent_name, 'sim2') }}</span>
+              </div>
+              <div v-if="!data.sim2.influence.length" class="lb-empty">No data</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Activity Timeline Chart -->
+        <div class="cmp-section full-width" v-if="data.sim1.timeline.length || data.sim2.timeline.length">
+          <div class="section-title">Activity per Round</div>
+          <div class="chart-container">
+            <svg ref="chartSvg" class="activity-chart" :viewBox="`0 0 ${chartW} ${chartH}`" preserveAspectRatio="none">
+              <!-- Grid lines -->
+              <line
+                v-for="i in 5"
+                :key="'h'+i"
+                :x1="chartPad"
+                :x2="chartW - chartPad"
+                :y1="chartPad + ((chartH - 2*chartPad) / 4) * (i-1)"
+                :y2="chartPad + ((chartH - 2*chartPad) / 4) * (i-1)"
+                stroke="#1E1E1E"
+                stroke-width="1"
+              />
+              <!-- Sim A line -->
+              <polyline
+                v-if="chartPoints1.length > 1"
+                :points="chartPoints1.map(p => `${p.x},${p.y}`).join(' ')"
+                fill="none"
+                stroke="#FF6B1A"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <!-- Sim B line -->
+              <polyline
+                v-if="chartPoints2.length > 1"
+                :points="chartPoints2.map(p => `${p.x},${p.y}`).join(' ')"
+                fill="none"
+                stroke="#43C165"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <!-- Dots Sim A -->
+              <circle
+                v-for="p in chartPoints1"
+                :key="'a'+p.round"
+                :cx="p.x" :cy="p.y" r="3"
+                fill="#FF6B1A"
+              />
+              <!-- Dots Sim B -->
+              <circle
+                v-for="p in chartPoints2"
+                :key="'b'+p.round"
+                :cx="p.x" :cy="p.y" r="3"
+                fill="#43C165"
+              />
+            </svg>
+            <div class="chart-legend">
+              <span class="legend-item sim-a-color">● {{ formatId(data.id1) }}</span>
+              <span class="legend-item sim-b-color">● {{ formatId(data.id2) }}</span>
+              <span class="legend-label">Total actions / round</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Market Prices (if available) -->
+        <div
+          class="cmp-section full-width"
+          v-if="data.sim1.markets.length || data.sim2.markets.length"
+        >
+          <div class="section-title">Prediction Market Final Prices</div>
+          <div class="markets-compare">
+            <div class="market-col">
+              <div class="market-col-header sim-a-color">{{ formatId(data.id1) }}</div>
+              <div v-for="m in data.sim1.markets" :key="m.market_id" class="market-row">
+                <span class="market-id">Market {{ m.market_id }}</span>
+                <div class="market-bar-wrap">
+                  <div class="market-bar" :style="{ width: (m.price_yes * 100) + '%', background: '#FF6B1A' }"></div>
+                </div>
+                <span class="market-price">{{ (m.price_yes * 100).toFixed(1) }}% YES</span>
+              </div>
+            </div>
+            <div class="market-col">
+              <div class="market-col-header sim-b-color">{{ formatId(data.id2) }}</div>
+              <div v-for="m in data.sim2.markets" :key="m.market_id" class="market-row">
+                <span class="market-id">Market {{ m.market_id }}</span>
+                <div class="market-bar-wrap">
+                  <div class="market-bar" :style="{ width: (m.price_yes * 100) + '%', background: '#43C165' }"></div>
+                </div>
+                <span class="market-price">{{ (m.price_yes * 100).toFixed(1) }}% YES</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Empty State -->
+    <div v-else-if="!loading && !error" class="cmp-empty">
+      <p>Select two simulations above and click Compare to see the diff.</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { compareSimulations, listSimulations } from '../api/simulation'
+
+const router = useRouter()
+const route = useRoute()
+
+const simulations = ref([])
+const selectedId1 = ref(route.params.id1 || '')
+const selectedId2 = ref(route.params.id2 || '')
+const data = ref(null)
+const loading = ref(false)
+const error = ref(null)
+
+// Chart dimensions
+const chartW = 600
+const chartH = 200
+const chartPad = 20
+
+onMounted(async () => {
+  try {
+    const res = await listSimulations()
+    if (res.data?.success) {
+      simulations.value = res.data.data?.simulations || []
+    }
+  } catch (_) {}
+
+  // Auto-run if IDs provided via URL
+  if (selectedId1.value && selectedId2.value) {
+    await runComparison()
+  }
+})
+
+watch(() => route.params, async (params) => {
+  if (params.id1 && params.id2) {
+    selectedId1.value = params.id1
+    selectedId2.value = params.id2
+    await runComparison()
+  }
+})
+
+const onSelectionChange = () => {
+  // Update URL without triggering navigation
+  if (selectedId1.value && selectedId2.value && selectedId1.value !== selectedId2.value) {
+    router.replace({ name: 'Compare', params: { id1: selectedId1.value, id2: selectedId2.value } })
+  }
+}
+
+const runComparison = async () => {
+  if (!selectedId1.value || !selectedId2.value) return
+  loading.value = true
+  error.value = null
+  data.value = null
+  try {
+    const res = await compareSimulations(selectedId1.value, selectedId2.value)
+    if (res.data?.success) {
+      data.value = res.data.data
+    } else {
+      error.value = res.data?.error || 'Comparison failed'
+    }
+  } catch (err) {
+    error.value = err?.response?.data?.error || err.message || 'Comparison failed'
+  } finally {
+    loading.value = false
+  }
+}
+
+const formatId = (id) => {
+  if (!id) return '—'
+  return id.replace(/^sim_/, '').slice(0, 10) + '…'
+}
+
+const divergenceClass = computed(() => {
+  if (!data.value) return ''
+  const s = data.value.divergence_score
+  if (s < 0.2) return 'low'
+  if (s < 0.5) return 'medium'
+  return 'high'
+})
+
+const divergenceDescription = computed(() => {
+  if (!data.value) return ''
+  const s = data.value.divergence_score
+  if (s < 0.2) return 'Simulations produced very similar influence rankings — comparable outcomes.'
+  if (s < 0.5) return 'Moderate divergence — some agents shifted in relative influence between runs.'
+  return 'High divergence — the two simulations produced substantially different influence outcomes.'
+})
+
+// Rank delta helpers
+const getRankDeltaLabel = (name, simKey) => {
+  const other = simKey === 'sim1' ? data.value?.sim2 : data.value?.sim1
+  if (!other) return ''
+  const myRank = (simKey === 'sim1' ? data.value.sim1 : data.value.sim2)
+    .influence.find(a => a.agent_name === name)?.rank
+  const otherRank = other.influence.find(a => a.agent_name === name)?.rank
+  if (!otherRank) return '—'
+  const delta = otherRank - myRank
+  if (delta === 0) return '='
+  return delta > 0 ? `▲${delta}` : `▼${Math.abs(delta)}`
+}
+
+const getRankDeltaClass = (name, simKey) => {
+  const label = getRankDeltaLabel(name, simKey)
+  if (label.startsWith('▲')) return 'delta-up'
+  if (label.startsWith('▼')) return 'delta-down'
+  return 'delta-equal'
+}
+
+const getRankDeltaTitle = (name, simKey) => {
+  const label = getRankDeltaLabel(name, simKey)
+  if (label === '—') return 'Not in other simulation\'s top 10'
+  if (label === '=') return 'Same rank in both simulations'
+  return `Rank difference: ${label.replace(/[▲▼]/, '')}`
+}
+
+// Chart point computation
+const buildChartPoints = (timeline) => {
+  if (!timeline || !timeline.length) return []
+  const maxActions = Math.max(...timeline.map(r => r.total_actions), 1)
+  const minR = timeline[0].round_num
+  const maxR = timeline[timeline.length - 1].round_num
+  const rangeR = Math.max(maxR - minR, 1)
+  return timeline.map(r => ({
+    round: r.round_num,
+    x: chartPad + ((r.round_num - minR) / rangeR) * (chartW - 2 * chartPad),
+    y: chartH - chartPad - (r.total_actions / maxActions) * (chartH - 2 * chartPad),
+  }))
+}
+
+const chartPoints1 = computed(() => buildChartPoints(data.value?.sim1?.timeline))
+const chartPoints2 = computed(() => buildChartPoints(data.value?.sim2?.timeline))
+
+// Download comparison JSON
+const downloadComparison = () => {
+  if (!data.value) return
+  const blob = new Blob([JSON.stringify(data.value, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `comparison_${selectedId1.value.slice(-6)}_${selectedId2.value.slice(-6)}.json`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+</script>
+
+<style scoped>
+.comparison-page {
+  min-height: 100vh;
+  background: #0A0A0A;
+  color: #FAFAFA;
+  font-family: 'Space Mono', monospace;
+}
+
+.cmp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 32px;
+  border-bottom: 1px solid #1E1E1E;
+}
+.brand {
+  font-family: 'Young Serif', serif;
+  font-size: 18px;
+  color: #FF6B1A;
+  cursor: pointer;
+}
+.page-tag {
+  font-size: 12px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.download-btn {
+  padding: 7px 16px;
+  border: 1px solid #3A3A3A;
+  background: transparent;
+  color: #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-family: inherit;
+  transition: all 0.15s;
+}
+.download-btn:hover {
+  border-color: #FF6B1A;
+  color: #FF6B1A;
+}
+
+/* Selector Bar */
+.selector-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  padding: 20px 32px;
+  border-bottom: 1px solid #1A1A1A;
+  background: #0D0D0D;
+}
+.selector-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+.selector-label {
+  font-size: 11px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.sim-select {
+  padding: 8px 12px;
+  background: #151515;
+  border: 1px solid #2A2A2A;
+  color: #ccc;
+  border-radius: 4px;
+  font-family: 'Space Mono', monospace;
+  font-size: 12px;
+  cursor: pointer;
+  width: 100%;
+}
+.sim-select:focus {
+  outline: none;
+  border-color: #FF6B1A;
+}
+.vs-badge {
+  padding: 8px 14px;
+  border: 1px solid #3A3A3A;
+  border-radius: 4px;
+  color: #555;
+  font-size: 11px;
+  font-weight: bold;
+  letter-spacing: 0.1em;
+  flex-shrink: 0;
+}
+.compare-btn {
+  padding: 9px 24px;
+  background: #FF6B1A;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+.compare-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* Error / Loading / Empty */
+.cmp-error {
+  margin: 32px;
+  padding: 14px;
+  background: rgba(255, 68, 68, 0.1);
+  border: 1px solid #FF4444;
+  border-radius: 6px;
+  color: #FF4444;
+  font-size: 13px;
+}
+.cmp-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 60px;
+  color: #555;
+  font-size: 13px;
+}
+.loading-ring {
+  width: 36px;
+  height: 36px;
+  border: 3px solid #2A2A2A;
+  border-top-color: #FF6B1A;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+.cmp-empty {
+  padding: 60px 32px;
+  text-align: center;
+  color: #444;
+  font-size: 13px;
+}
+
+/* Results */
+.cmp-results {
+  padding: 24px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* Divergence Banner */
+.divergence-banner {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 16px 24px;
+  background: #111;
+  border: 1px solid #2A2A2A;
+  border-radius: 8px;
+}
+.divergence-label { font-size: 11px; color: #555; text-transform: uppercase; letter-spacing: 0.08em; }
+.divergence-score {
+  font-size: 28px;
+  font-weight: bold;
+}
+.divergence-score.low { color: #43C165; }
+.divergence-score.medium { color: #FFB347; }
+.divergence-score.high { color: #FF6B1A; }
+.divergence-desc { font-size: 12px; color: #888; max-width: 400px; line-height: 1.5; }
+
+/* Metrics Row */
+.metrics-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.metric-card {
+  padding: 16px 20px;
+  background: #111;
+  border: 1px solid #2A2A2A;
+  border-radius: 8px;
+}
+.metric-card.sim-a { border-top: 3px solid #FF6B1A; }
+.metric-card.sim-b { border-top: 3px solid #43C165; }
+.metric-sim-id { font-size: 11px; color: #555; margin-bottom: 12px; font-family: 'Space Mono', monospace; }
+.metric-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.metric-item { display: flex; flex-direction: column; gap: 4px; }
+.metric-val { font-size: 20px; color: #FAFAFA; font-weight: bold; }
+.metric-lbl { font-size: 10px; color: #555; text-transform: uppercase; letter-spacing: 0.08em; }
+
+/* Two-column layout */
+.two-col-layout { display: flex; flex-direction: column; gap: 20px; }
+
+/* Section */
+.cmp-section { background: #111; border: 1px solid #2A2A2A; border-radius: 8px; padding: 20px; }
+.cmp-section.full-width { width: 100%; }
+.section-title { font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: #666; margin-bottom: 16px; }
+
+/* Leaderboard */
+.leaderboard-compare { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+.lb-col {}
+.lb-header {
+  font-size: 11px;
+  font-family: 'Space Mono', monospace;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid #2A2A2A;
+}
+.lb-row {
+  display: grid;
+  grid-template-columns: 28px 1fr 50px 36px;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 0;
+  border-bottom: 1px solid #161616;
+  font-size: 12px;
+}
+.lb-rank { color: #555; font-size: 11px; }
+.lb-name { color: #ccc; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.lb-score { color: #888; text-align: right; font-size: 11px; }
+.lb-delta { font-size: 10px; text-align: center; font-weight: bold; }
+.delta-up { color: #43C165; }
+.delta-down { color: #FF6B1A; }
+.delta-equal { color: #555; }
+.lb-empty { color: #444; font-size: 12px; padding: 12px 0; }
+
+/* Chart */
+.chart-container { display: flex; flex-direction: column; gap: 12px; }
+.activity-chart {
+  width: 100%;
+  height: 180px;
+  background: #0D0D0D;
+  border-radius: 4px;
+  border: 1px solid #1E1E1E;
+}
+.chart-legend { display: flex; gap: 20px; font-size: 11px; color: #666; }
+.legend-item { }
+.legend-label { color: #444; margin-left: auto; }
+.sim-a-color { color: #FF6B1A; }
+.sim-b-color { color: #43C165; }
+
+/* Markets */
+.markets-compare { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+.market-col { }
+.market-col-header { font-size: 11px; font-family: 'Space Mono', monospace; margin-bottom: 8px; }
+.market-row { display: flex; align-items: center; gap: 8px; padding: 6px 0; font-size: 11px; }
+.market-id { color: #555; width: 60px; flex-shrink: 0; }
+.market-bar-wrap { flex: 1; height: 8px; background: #1A1A1A; border-radius: 4px; overflow: hidden; }
+.market-bar { height: 100%; border-radius: 4px; transition: width 0.3s; }
+.market-price { width: 70px; text-align: right; color: #ccc; }
+
+/* Loading spinner */
+.loading-spinner-small {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+</style>


### PR DESCRIPTION
## What

Compare two completed simulations side by side to see how different scenarios, agent mixes, or document inputs produce divergent outcomes.

**New route:** `/compare/:id1/:id2` (shareable URL)

## Why

The natural question after running a simulation is "what if I changed the agent mix?" or "how does this framing differ from that one?" Until now, users had to mentally compare two separate report pages with no quantified diff. This adds a dedicated comparison view that answers "how different were the outcomes?" in a single glance. Picked from the repo-actions-2026-04-03 idea #2 — the second highest-impact unbuilt feature after Config Error Recovery (merged as PR #10).

## Changes

- **backend/app/api/simulation.py**: New `GET /api/simulation/compare?id1=&id2=` endpoint — reads influence leaderboards, per-round activity timelines, and Polymarket SQLite prices from both simulations; computes rank-based divergence score (0–1)
- **frontend/src/views/ComparisonView.vue**: New page with simulation picker dropdowns, divergence score banner, side-by-side metrics cards, influence leaderboard comparison with rank delta badges (▲/▼/=), SVG activity timeline chart with two colored series, Polymarket bar comparison, and "Export JSON" download
- **frontend/src/router/index.js**: New `/compare/:id1?/:id2?` route
- **frontend/src/api/simulation.js**: `compareSimulations(id1, id2)` API helper
- **frontend/src/components/HistoryDatabase.vue**: ⇄ Compare button toggles card-selection mode; selecting two cards auto-navigates to the comparison view

---
*Built autonomously by Aeon*