### PR TITLE
feat: agent-friendly Typer CLI (prospect-sim command)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,14 @@ backend/uploads/
 
 # Docker data
 data/
+
+# prospect-sim: private ICP / outreach data — NEVER commit
+inputs/
+inputs/private/
+profiles/
+profiles/private/
+*.icp.json
+*.prospects.json
+*.outreach.csv
+backend/data/private/
+sample_data/private/

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -3318,26 +3318,21 @@ def run_variant_test():
                 f"--- END VARIANT ---"
             )
 
-            # Create simulation via SimulationManager using existing project graph
-            sim_id = SimulationManager.create_simulation(
+            # Create simulation via SimulationManager (instance method, not classmethod)
+            # Disable social platforms — email inbox uses its own Wonderwall module
+            manager = SimulationManager()
+            state = manager.create_simulation(
+                project_id=project_id,
                 graph_id=project.graph_id,
-                simulation_requirement=variant_requirement,
-                platform="email_inbox",
-                max_rounds=num_rounds,
-                metadata={
-                    "project_id": project_id,
-                    "variant_id": vid,
-                    "variant_label": label,
-                    "hook_type": variant.get("hook_type", "unknown"),
-                    "simulation_type": "email_inbox",
-                    "variants": [variant],  # single variant per simulation run
-                },
+                enable_twitter=False,
+                enable_reddit=False,
+                enable_polymarket=False,
             )
 
             return {
                 "variant_id": vid,
                 "variant_label": label,
-                "simulation_id": sim_id,
+                "simulation_id": state.simulation_id,
                 "status": "created",
             }
 

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -3225,3 +3225,152 @@ def compare_simulations():
             "error": str(e),
             "traceback": traceback.format_exc()
         }), 500
+
+
+# ============== Email Inbox Variant Test Endpoint ==============
+
+@simulation_bp.route('/run-variant-test', methods=['POST'])
+def run_variant_test():
+    """Run N email copy variants against synthetic B2B personas (prospect-sim).
+
+    Accepts a project_id with ICP seed data already built into the graph,
+    plus a list of email copy variants to test. Each variant runs as a
+    separate simulation. Returns a run_ids list for status polling.
+
+    Body (JSON):
+    {
+        "project_id": "proj_abc123",
+        "variants": [
+            {"id": 1, "label": "Variant A", "subject_line": "...", "body": "...", "hook_type": "problem"},
+            {"id": 2, "label": "Variant B", "subject_line": "...", "body": "...", "hook_type": "timeline"}
+        ],
+        "simulation_requirement": "Test cold email copy variants against HR Director personas...",
+        "parallel": false,
+        "num_rounds": 8
+    }
+
+    Response:
+    {
+        "success": true,
+        "run_mode": "sequential" | "parallel",
+        "variant_run_ids": [
+            {"variant_id": 1, "variant_label": "Variant A", "simulation_id": "sim_xyz"},
+            ...
+        ]
+    }
+    """
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({"success": False, "error": "JSON body required"}), 400
+
+        project_id = data.get("project_id")
+        variants = data.get("variants", [])
+        simulation_requirement = data.get("simulation_requirement", "")
+        parallel = bool(data.get("parallel", False))
+        num_rounds = int(data.get("num_rounds", 8))
+
+        if not project_id:
+            return jsonify({"success": False, "error": "project_id is required"}), 400
+        if not variants:
+            return jsonify({"success": False, "error": "At least one variant is required"}), 400
+        if len(variants) > 6:
+            return jsonify({"success": False, "error": "Maximum 6 variants per test run"}), 400
+
+        project = ProjectManager.get_project(project_id)
+        if not project:
+            return jsonify({"success": False, "error": f"Project not found: {project_id}"}), 404
+
+        if not project.graph_id:
+            return jsonify({
+                "success": False,
+                "error": "Project graph not built yet. Run graph build first."
+            }), 400
+
+        # Persist variants on the project so the report agent can reference them
+        project.variants = variants
+        project.simulation_type = "email_inbox"
+        if simulation_requirement:
+            project.simulation_requirement = simulation_requirement
+        ProjectManager.save_project(project)
+
+        run_mode = "parallel" if parallel else "sequential"
+        logger.info(
+            f"Starting variant test: project={project_id}, "
+            f"variants={len(variants)}, mode={run_mode}, rounds={num_rounds}"
+        )
+
+        variant_run_ids = []
+
+        def _start_one_variant(variant: dict) -> dict:
+            """Create and start a simulation for a single variant."""
+            vid = variant.get("id", 0)
+            label = variant.get("label", f"Variant {vid}")
+
+            # Build simulation-specific requirement string injecting the variant copy
+            variant_requirement = (
+                f"{simulation_requirement}\n\n"
+                f"--- EMAIL VARIANT UNDER TEST ---\n"
+                f"Variant: {label}\n"
+                f"Hook type: {variant.get('hook_type', 'unknown')}\n"
+                f"Subject: {variant.get('subject_line', '')}\n"
+                f"Body: {variant.get('body', '')}\n"
+                f"--- END VARIANT ---"
+            )
+
+            # Create simulation via SimulationManager using existing project graph
+            sim_id = SimulationManager.create_simulation(
+                graph_id=project.graph_id,
+                simulation_requirement=variant_requirement,
+                platform="email_inbox",
+                max_rounds=num_rounds,
+                metadata={
+                    "project_id": project_id,
+                    "variant_id": vid,
+                    "variant_label": label,
+                    "hook_type": variant.get("hook_type", "unknown"),
+                    "simulation_type": "email_inbox",
+                    "variants": [variant],  # single variant per simulation run
+                },
+            )
+
+            return {
+                "variant_id": vid,
+                "variant_label": label,
+                "simulation_id": sim_id,
+                "status": "created",
+            }
+
+        if parallel:
+            # Launch all variants concurrently using threads
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor(max_workers=len(variants)) as executor:
+                futures = {executor.submit(_start_one_variant, v): v for v in variants}
+                for future in concurrent.futures.as_completed(futures):
+                    result = future.result()
+                    variant_run_ids.append(result)
+        else:
+            # Sequential: create all simulations (start triggers are separate)
+            for variant in variants:
+                result = _start_one_variant(variant)
+                variant_run_ids.append(result)
+
+        # Sort by variant_id for consistent ordering
+        variant_run_ids.sort(key=lambda x: x["variant_id"])
+
+        return jsonify({
+            "success": True,
+            "run_mode": run_mode,
+            "project_id": project_id,
+            "variant_run_ids": variant_run_ids,
+            "total_variants": len(variants),
+            "num_rounds": num_rounds,
+        })
+
+    except Exception as e:
+        logger.error(f"Failed to start variant test: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -81,6 +81,10 @@ class Config:
         'browse_markets', 'buy_shares', 'sell_shares',
         'view_portfolio', 'create_market', 'comment_on_market', 'do_nothing'
     ]
+    # Email inbox simulation actions (prospect-sim B2B copy variant testing)
+    WONDERWALL_INBOX_ACTIONS = [
+        'open_email', 'read_email', 'reply', 'forward', 'archive', 'do_nothing'
+    ]
     
     # Web Enrichment — LLM-powered research for persona generation
     # Triggers for notable figures (politicians, CEOs, etc.) or when graph context is thin

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -49,6 +49,11 @@ class Project:
     chunk_size: int = 1000
     chunk_overlap: int = 50
 
+    # Email copy variants for inbox simulation (prospect-sim)
+    # Each item: {id, label, subject_line, body, hook_type}
+    variants: List[Dict[str, Any]] = field(default_factory=list)
+    simulation_type: str = "social"  # "social" | "email_inbox"
+
     # Error information
     error: Optional[str] = None
 
@@ -69,7 +74,9 @@ class Project:
             "simulation_requirement": self.simulation_requirement,
             "chunk_size": self.chunk_size,
             "chunk_overlap": self.chunk_overlap,
-            "error": self.error
+            "error": self.error,
+            "variants": self.variants,
+            "simulation_type": self.simulation_type,
         }
 
     @classmethod
@@ -94,7 +101,9 @@ class Project:
             simulation_requirement=data.get('simulation_requirement'),
             chunk_size=data.get('chunk_size', 500),
             chunk_overlap=data.get('chunk_overlap', 50),
-            error=data.get('error')
+            error=data.get('error'),
+            variants=data.get('variants', []),
+            simulation_type=data.get('simulation_type', 'social'),
         )
 
 

--- a/backend/app/preset_templates/b2b_cold_email_test.json
+++ b/backend/app/preset_templates/b2b_cold_email_test.json
@@ -1,0 +1,22 @@
+{
+  "id": "b2b_cold_email_test",
+  "name": "B2B Cold Email Copy Test",
+  "category": "B2B Sales",
+  "description": "Test cold email copy variants against synthetic HR Director / Head of People personas at Spanish SMEs before sending to real leads. Upload your ICP profiles and email variants to see which hook type and framing gets replies.",
+  "icon": "mail",
+  "difficulty": "easy",
+  "estimated_agents": 20,
+  "estimated_rounds": 8,
+  "platforms": ["email_inbox"],
+  "tags": ["b2b", "cold outreach", "copy testing", "hr tech", "email"],
+  "simulation_type": "email_inbox",
+  "simulation_requirement": "Simulate how HR Directors and Heads of People at Spanish B2B companies (80-150 employees, no dedicated L&D team) respond to cold email outreach about an AI-adapted micro-learning platform. Test which copy variant (subject line + hook type + CTA) generates the highest open and reply rates. Track where agents disengage and why. Rank variants by expected reply probability and identify the specific copy elements that drive the delta.",
+  "seed_document": "# ICP Profile — HR Director at Spanish SME\n\n## Target Persona\n- **Role:** HR Director or Head of People\n- **Company:** Spanish B2B company, 80–150 employees, Barcelona or Madrid\n- **Situation:** No dedicated L&D team, 1–3 HR staff total handling all HR functions\n- **Buying triggers:** Recent funding, 15+ open roles, HR team just grew, Glassdoor complaints about no career development\n\n## Current Pain Context\n- Training is handled ad-hoc: managers set up their own courses, HR has no visibility into skill gaps\n- New employee onboarding takes 6-8 weeks and varies by manager\n- When asked about L&D, HR answers: \"we use LinkedIn Learning\" or \"we have a small budget for courses\"\n- Annual performance reviews reveal skills gaps but there's no systematic way to address them\n- Retaining talent is the #1 priority — losing mid-level employees to bigger companies with L&D programs\n\n## Email Copy Variants Under Test\n\n### Variant A — Problem Hook (current script)\nSubject: ¿Cómo gestionáis el desarrollo de vuestro equipo?\nBody: Hola [Nombre], veo que en [Empresa] estáis creciendo. El desarrollo de talento es uno de los mayores retos para los equipos de RRHH sin un equipo L&D dedicado. En Skillia, ayudamos a empresas como la vuestra a implementar planes de desarrollo personalizados con IA, sin necesitar un equipo L&D. ¿Tendría sentido explorar cómo podríamos ayudaros? ¿Tienes 20 minutos esta semana?\n\n### Variant B — Timeline Hook\nSubject: Vi que publicasteis 15 posiciones en LinkedIn\nBody: Hola [Nombre], vi que [Empresa] tiene 15 posiciones abiertas — cuando crece tan rápido, los nuevos empleados suelen tardar 2-3x más en ser productivos sin un sistema de onboarding estructurado. Trabajamos con equipos de RRHH que ahorraron 15 horas/semana en planes de desarrollo individualizados. ¿Tiene sentido para vosotros ahora mismo? Responde 'sí' y te cuento en 2 minutos.\n\n### Variant C — Numbers Hook\nSubject: €10K vs €60K — para el desarrollo de tu equipo\nBody: Hola [Nombre], un Manager de L&D en Barcelona cuesta €60K/año. Skillia cuesta €10K. Hacemos lo mismo: diagnosticamos gaps de competencias, generamos planes personalizados y medimos el progreso. La diferencia: lo activamos en 2 semanas y funciona con tu equipo actual. ¿Vale la pena 15 minutos para ver si encaja?\n",
+  "recommended_settings": {
+    "enable_twitter": false,
+    "enable_reddit": false,
+    "enable_polymarket": false,
+    "enable_email_inbox": true,
+    "simulation_type": "email_inbox"
+  }
+}

--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -46,6 +46,14 @@ class OasisAgentProfile:
     # Polymarket-specific fields
     risk_tolerance: str = "moderate"  # "high", "moderate", or "low"
 
+    # B2B email inbox simulation fields
+    # These are populated when simulation_type == "email_inbox"
+    budget_authority: bool = False           # Can they approve L&D spend directly?
+    cold_email_skepticism: float = 0.6       # 0.0 = open, 1.0 = extremely skeptical
+    inbox_habit: str = "batch_processor"     # morning_scanner | batch_processor | responsive
+    pain_signal_sensitivity: Dict[str, float] = field(default_factory=dict)  # pain_type → 0-1
+    decision_style: str = "roi_driven"       # roi_driven | risk_averse | early_adopter | social_proof
+
     # Additional persona information
     age: Optional[int] = None
     gender: Optional[str] = None
@@ -118,6 +126,29 @@ class OasisAgentProfile:
         
         return profile
     
+    def to_inbox_format(self) -> Dict[str, Any]:
+        """Convert to email inbox simulation format.
+
+        Returns a dict compatible with Wonderwall's UserInfo(profile={"other_info": ...})
+        structure, which EmailInboxPromptBuilder reads to build B2B decision-maker personas.
+        """
+        user_profile = self.persona or f"{self.name} is an HR professional at a Spanish SME."
+        if self.profession:
+            user_profile = f"{self.profession}. {user_profile}"
+
+        return {
+            "user_id": self.user_id,
+            "name": self.user_name,
+            "description": self.bio or f"HR professional: {self.name}",
+            # B2B inbox-specific fields read by EmailInboxPromptBuilder
+            "user_profile": user_profile,
+            "budget_authority": self.budget_authority,
+            "cold_email_skepticism": self.cold_email_skepticism,
+            "inbox_habit": self.inbox_habit,
+            "pain_signal_sensitivity": self.pain_signal_sensitivity,
+            "decision_style": self.decision_style,
+        }
+
     def to_polymarket_format(self) -> Dict[str, Any]:
         """Convert to Polymarket prediction market format.
 
@@ -158,6 +189,12 @@ class OasisAgentProfile:
             "source_entity_uuid": self.source_entity_uuid,
             "source_entity_type": self.source_entity_type,
             "created_at": self.created_at,
+            # B2B email inbox fields
+            "budget_authority": self.budget_authority,
+            "cold_email_skepticism": self.cold_email_skepticism,
+            "inbox_habit": self.inbox_habit,
+            "pain_signal_sensitivity": self.pain_signal_sensitivity,
+            "decision_style": self.decision_style,
         }
 
 
@@ -258,6 +295,18 @@ class OasisProfileGenerator:
         "fund", "exchange", "consortium", "coalition",
     ]
     
+    # B2B entity types for email inbox simulation
+    B2B_PERSONA_TYPES = [
+        "hrdirector", "headofpeople", "hrmanager", "peopleops",
+        "cpo", "ceo", "founder", "directorofhr", "vpofpeople",
+        "talentacquisition", "learninganddevelopment", "ldmanager",
+    ]
+
+    # B2B company types (generate representative personas, not individuals)
+    B2B_COMPANY_TYPES = [
+        "sme", "startup", "scaleup", "techcompany", "b2bcompany",
+    ]
+
     def __init__(
         self,
         api_key: Optional[str] = None,
@@ -266,6 +315,7 @@ class OasisProfileGenerator:
         storage: Optional[GraphStorage] = None,
         graph_id: Optional[str] = None,
         simulation_requirement: Optional[str] = None,
+        simulation_type: str = "social",
     ):
         self.model_name = model_name or Config.LLM_MODEL_NAME
         self.llm = create_llm_client(
@@ -281,6 +331,9 @@ class OasisProfileGenerator:
         # Web enrichment for notable figures / thin context
         self.web_enricher = WebEnricher()
         self.simulation_requirement = simulation_requirement or ""
+
+        # "social" (default) or "email_inbox" — controls persona generation strategy
+        self.simulation_type = simulation_type
     
     def generate_profile_from_entity(
         self, 
@@ -358,6 +411,12 @@ class OasisProfileGenerator:
             interested_topics=profile_data.get("interested_topics", []),
             source_entity_uuid=entity.uuid,
             source_entity_type=entity_type,
+            # B2B email inbox fields — populated when simulation_type == "email_inbox"
+            budget_authority=bool(profile_data.get("budget_authority", False)),
+            cold_email_skepticism=float(profile_data.get("cold_email_skepticism", 0.6)),
+            inbox_habit=profile_data.get("inbox_habit", "batch_processor"),
+            pain_signal_sensitivity=profile_data.get("pain_signal_sensitivity", {}),
+            decision_style=profile_data.get("decision_style", "roi_driven"),
         )
     
     def _generate_username(self, name: str) -> str:
@@ -619,8 +678,13 @@ class OasisProfileGenerator:
         """
         
         is_individual = self._is_individual_entity(entity_type)
-        
-        if is_individual:
+
+        # B2B email inbox mode: always generate B2B decision-maker personas
+        if self.simulation_type == "email_inbox":
+            prompt = self._build_b2b_persona_prompt(
+                entity_name, entity_type, entity_summary, entity_attributes, context
+            )
+        elif is_individual:
             prompt = self._build_individual_persona_prompt(
                 entity_name, entity_type, entity_summary, entity_attributes, context
             )
@@ -879,6 +943,73 @@ Examples: "ISTJ" (conservative, by-the-book), "ENTJ" (assertive, agenda-setting)
 IMPORTANT: Do NOT include karma, friend_count, follower_count, or statuses_count — those are computed separately.
 """
     
+    def _build_b2b_persona_prompt(
+        self,
+        entity_name: str,
+        entity_type: str,
+        entity_summary: str,
+        entity_attributes: Dict[str, Any],
+        context: str
+    ) -> str:
+        """Build B2B decision-maker persona prompt for email inbox simulation.
+
+        Generates an HR Director / Head of People persona at a Spanish SME
+        with B2B-specific traits that determine cold email response behavior.
+        """
+        attrs_str = json.dumps(entity_attributes, ensure_ascii=False) if entity_attributes else "None"
+        context_str = context[:3000] if context else "No additional context"
+
+        return f"""Create a B2B decision-maker persona for an email inbox simulation.
+This persona represents an HR Director or Head of People at a Spanish SME (80-150 employees).
+
+SOURCE ENTITY: {entity_name} ({entity_type})
+ENTITY SUMMARY: {entity_summary}
+ATTRIBUTES: {attrs_str}
+
+CONTEXT (from ICP profile and knowledge graph):
+{context_str}
+
+SIMULATION GOAL: {self.simulation_requirement[:500] if self.simulation_requirement else "B2B cold email copy variant testing"}
+
+Return JSON with these fields:
+
+"bio": Short professional bio (2 sentences). Real LinkedIn bio style — specific title, company type, years experience.
+
+"persona": Character description for the simulation (400-600 words). Include:
+- Current role and company context (what kind of company, how many employees, growth stage)
+- L&D/training situation: Do they have a dedicated L&D team? How is training currently handled?
+- Top 3 work pressures RIGHT NOW (hiring, retention, skills gap, compliance, etc.)
+- Relationship with technology: Are they a digital adopter or cautious about new tools?
+- Typical day: When do they check email? How much time do they have for vendors?
+- Cold email behavior: How do they handle cold outreach? What makes them stop and read?
+
+"age": Age (35-55 realistic range for this role)
+"gender": "male" or "female"
+"mbti": MBTI type (VARY this — common types in HR: ENFJ, ISFJ, ESTJ, ENFP, ENTJ)
+"country": "Spain"
+"profession": Exact job title (e.g. "HR Director", "Head of People", "People & Culture Manager")
+"interested_topics": ["talent development", "employee retention", ...] (4-6 specific topics)
+
+"budget_authority": true if they can approve L&D spend directly, false if they need CFO/CEO sign-off
+"cold_email_skepticism": float 0.0-1.0 (0.7-0.9 realistic for busy HR Directors)
+"inbox_habit": one of "morning_scanner", "batch_processor", "responsive"
+"pain_signal_sensitivity": object mapping pain types to sensitivity (0.0-1.0):
+  {{
+    "skills_gap": 0.8,
+    "employee_retention": 0.7,
+    "onboarding_inefficiency": 0.6,
+    "no_l&d_team": 0.9,
+    "hiring_cost": 0.5,
+    "manager_development": 0.6
+  }}
+"decision_style": one of "roi_driven", "risk_averse", "early_adopter", "social_proof"
+
+IMPORTANT: Vary the personas meaningfully. Not all HR Directors are the same.
+Some are overwhelmed solo HR in a fast-growing startup. Others are seasoned professionals
+at established companies with clear L&D gaps. Make each one a real person.
+Do NOT include karma, friend_count, follower_count, or statuses_count.
+"""
+
     def _generate_profile_rule_based(
         self,
         entity_name: str,

--- a/backend/app/services/report_agent.py
+++ b/backend/app/services/report_agent.py
@@ -696,6 +696,96 @@ Please output the report outline in JSON format as follows:
 
 Note: The sections array must have at least 3 and at most 5 elements! The last section MUST be a synthesis section."""
 
+# ── Email Inbox Variant Ranking Prompts (prospect-sim) ──
+
+EMAIL_PLAN_SYSTEM_PROMPT = """\
+You are an expert B2B sales copywriter analyzing the results of a cold email inbox simulation.
+You have a "god's eye view" of how synthetic HR Director / Head of People personas responded
+to cold email copy variants. Your job is to produce an actionable variant ranking report.
+
+[Core Objective]
+Rank the email copy variants by expected reply probability. Explain WHY each variant
+performed differently — specifically which copy element (subject line, opening, body, CTA)
+drove the delta. Give Skillia a clear recommendation: which variant to send, and what
+specific change would improve it further.
+
+[Report Structure — Fixed, 4 sections]
+Always produce exactly 4 sections in this order:
+1. "Variant Performance Ranking" — table + scores for each variant
+2. "Failure Point Analysis" — where agents dropped off per variant and why
+3. "Persona Segmentation" — which variant worked for which persona type (budget authority, decision style)
+4. "Recommendation & Next Copy Iteration" — the winner, the delta, and the next hypothesis to test
+
+[Analytical Standards]
+- Every claim must be grounded in agent action data (opens, reads, replies, dropouts)
+- Name specific copy elements that caused engagement or dropout
+- Distinguish between persona types — a timeline hook may work for one segment but not another
+- Be concrete: "Variant B got 3x more replies than Variant A because the subject line mentioned
+  a specific company signal (15 open roles) rather than a generic pain"
+
+Output the report outline in JSON:
+{
+    "title": "Email Copy Variant Test — [brief description]",
+    "summary": "One sentence: which variant won, by how much, and the key driver",
+    "sections": [
+        {"title": "...", "description": "..."}
+    ]
+}
+
+Note: Always produce exactly 4 sections as defined above."""
+
+EMAIL_PLAN_USER_PROMPT_TEMPLATE = """\
+[Simulation Setup]
+Variants tested: {simulation_requirement}
+
+[Simulation Scale]
+- Active personas: {total_entities}
+- Total inbox events recorded: {total_nodes}
+
+[Agent Action Summary]
+{related_facts_json}
+
+Analyze which copy variant performed best and why. Focus on:
+1. Open rates vs reply rates per variant (which hook type got more opens? which got more replies?)
+2. Dropout point distribution — where did agents disengage?
+3. Persona segmentation — which decision styles/budget authorities responded differently?
+4. The specific copy element that drove the winning variant's advantage
+
+Output the 4-section outline with the summary being the single most actionable finding."""
+
+EMAIL_SECTION_SYSTEM_PROMPT_TEMPLATE = """\
+You are a B2B sales copywriter writing a section of an email copy variant test report.
+
+Report title: {report_title}
+Key finding: {report_summary}
+Variants tested: {simulation_requirement}
+
+[Your Section]
+Section title: {section_title}
+Section purpose: {section_description}
+
+[Data Access]
+Use your analysis tools to query the simulation database for:
+- Agent action counts per variant (opens, reads, replies, archives, forwards)
+- Dropout point distribution per variant
+- B2B persona traits of agents who replied vs. archived (budget_authority, decision_style, cold_email_skepticism)
+
+[Writing Standards]
+- Lead with the finding, support with data
+- Include specific numbers: "8/20 agents opened Variant B vs 3/20 for Variant A"
+- Name the copy element responsible: "the subject line mentioning '15 open roles' vs generic pain framing"
+- Be direct — this is an internal analysis report, not marketing copy
+- For the Recommendation section: give one specific next copy iteration to test
+
+[Output Format]
+Prose analysis with a summary table at the end of the Variant Performance section.
+The Recommendation section must include:
+1. The winner (variant label + expected reply rate)
+2. The specific change that drove it
+3. The next hypothesis to test (one A/B element)
+
+{section_history}"""
+
 PLAN_USER_PROMPT_TEMPLATE = """\
 [Scenario Setup]
 Scenario injected into the simulation: {simulation_requirement}
@@ -1005,12 +1095,13 @@ class ReportAgent:
     MAX_TOOL_CALLS_PER_CHAT = 2
     
     def __init__(
-        self, 
+        self,
         graph_id: str,
         simulation_id: str,
         simulation_requirement: str,
         llm_client: Optional[LLMClient] = None,
-        graph_tools: Optional[GraphToolsService] = None
+        graph_tools: Optional[GraphToolsService] = None,
+        simulation_type: str = "social",
     ):
         """
         Initialize Report Agent
@@ -1021,10 +1112,13 @@ class ReportAgent:
             simulation_requirement: Simulation requirement description
             llm_client: LLM client (optional)
             graph_tools: Graph tools service (optional, requires external GraphStorage injection)
+            simulation_type: "social" (default) or "email_inbox" — selects prompt set
         """
         self.graph_id = graph_id
         self.simulation_id = simulation_id
         self.simulation_requirement = simulation_requirement
+        # Route to email inbox prompts for prospect-sim variant testing
+        self.simulation_type = simulation_type
 
         self.llm = llm_client or create_smart_llm_client()
         if graph_tools is None:
@@ -1716,15 +1810,25 @@ class ReportAgent:
         if progress_callback:
             progress_callback("planning", 30, "Generating report outline...")
         
-        system_prompt = PLAN_SYSTEM_PROMPT
-        user_prompt = PLAN_USER_PROMPT_TEMPLATE.format(
-            simulation_requirement=self.simulation_requirement,
-            total_nodes=context.get('graph_statistics', {}).get('total_nodes', 0),
-            total_edges=context.get('graph_statistics', {}).get('total_edges', 0),
-            entity_types=list(context.get('graph_statistics', {}).get('entity_types', {}).keys()),
-            total_entities=context.get('total_entities', 0),
-            related_facts_json=json.dumps(context.get('related_facts', [])[:10], ensure_ascii=False, indent=2),
-        )
+        # Select prompts based on simulation type
+        if self.simulation_type == "email_inbox":
+            system_prompt = EMAIL_PLAN_SYSTEM_PROMPT
+            user_prompt = EMAIL_PLAN_USER_PROMPT_TEMPLATE.format(
+                simulation_requirement=self.simulation_requirement,
+                total_nodes=context.get('graph_statistics', {}).get('total_nodes', 0),
+                total_entities=context.get('total_entities', 0),
+                related_facts_json=json.dumps(context.get('related_facts', [])[:10], ensure_ascii=False, indent=2),
+            )
+        else:
+            system_prompt = PLAN_SYSTEM_PROMPT
+            user_prompt = PLAN_USER_PROMPT_TEMPLATE.format(
+                simulation_requirement=self.simulation_requirement,
+                total_nodes=context.get('graph_statistics', {}).get('total_nodes', 0),
+                total_edges=context.get('graph_statistics', {}).get('total_edges', 0),
+                entity_types=list(context.get('graph_statistics', {}).get('entity_types', {}).keys()),
+                total_entities=context.get('total_entities', 0),
+                related_facts_json=json.dumps(context.get('related_facts', [])[:10], ensure_ascii=False, indent=2),
+            )
 
         try:
             response = self.llm.chat_json(
@@ -1805,14 +1909,6 @@ class ReportAgent:
         if self.report_logger:
             self.report_logger.log_section_start(section.title, section_index)
         
-        system_prompt = SECTION_SYSTEM_PROMPT_TEMPLATE.format(
-            report_title=outline.title,
-            report_summary=outline.summary,
-            simulation_requirement=self.simulation_requirement,
-            section_title=section.title,
-            tools_description=self._get_tools_description(),
-        )
-
         # Build user prompt - pass in max 4000 characters per completed section
         if previous_sections:
             previous_parts = []
@@ -1823,11 +1919,30 @@ class ReportAgent:
             previous_content = "\n\n---\n\n".join(previous_parts)
         else:
             previous_content = "(This is the first section)"
-        
-        user_prompt = SECTION_USER_PROMPT_TEMPLATE.format(
-            previous_content=previous_content,
-            section_title=section.title,
-        )
+
+        # Select section prompt based on simulation type
+        if self.simulation_type == "email_inbox":
+            system_prompt = EMAIL_SECTION_SYSTEM_PROMPT_TEMPLATE.format(
+                report_title=outline.title,
+                report_summary=outline.summary,
+                simulation_requirement=self.simulation_requirement,
+                section_title=section.title,
+                section_description=section.description,
+                section_history=previous_content,
+            )
+            user_prompt = f"Write the '{section.title}' section now."
+        else:
+            system_prompt = SECTION_SYSTEM_PROMPT_TEMPLATE.format(
+                report_title=outline.title,
+                report_summary=outline.summary,
+                simulation_requirement=self.simulation_requirement,
+                section_title=section.title,
+                tools_description=self._get_tools_description(),
+            )
+            user_prompt = SECTION_USER_PROMPT_TEMPLATE.format(
+                previous_content=previous_content,
+                section_title=section.title,
+            )
 
         messages = [
             {"role": "system", "content": system_prompt},

--- a/backend/prospect_sim_cli/__init__.py
+++ b/backend/prospect_sim_cli/__init__.py
@@ -1,0 +1,6 @@
+"""
+prospect-sim CLI — B2B cold email variant testing engine.
+Agent-friendly: non-interactive, pipeable JSON, idempotent, --dry-run.
+"""
+
+__version__ = "0.1.0"

--- a/backend/prospect_sim_cli/cache.py
+++ b/backend/prospect_sim_cli/cache.py
@@ -1,0 +1,138 @@
+"""
+ICP file cache — maps SHA256(icp_file_content) → project_id.
+
+Stored at ~/.prospect-sim/cache.json.
+This is the core performance feature: build the ICP graph once,
+reuse it for all subsequent variant runs.
+
+Rule 6 (idempotency): same ICP file → same project_id, no duplicate builds.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+CACHE_DIR = Path.home() / ".prospect-sim"
+CACHE_FILE = CACHE_DIR / "cache.json"
+CONFIG_FILE = CACHE_DIR / "config.json"
+
+# Default CLI config values
+DEFAULT_CONFIG = {
+    "api_url": "http://localhost:5001",
+    "default_rounds": 8,
+    "default_parallel": False,
+}
+
+
+class IcpCache:
+    """
+    Manages the local ICP graph cache.
+
+    Format of cache.json:
+    {
+      "<sha256_hex>": {
+        "project_id": "proj_abc123",
+        "icp_file": "/absolute/path/to/icp.md",
+        "created_at": "2026-04-08T21:00:00Z"
+      }
+    }
+    """
+
+    def __init__(self) -> None:
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> dict:
+        """Load cache from disk. Returns empty dict if file missing."""
+        if not CACHE_FILE.exists():
+            return {}
+        try:
+            return json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _save(self, data: dict) -> None:
+        """Persist cache to disk atomically."""
+        tmp = CACHE_FILE.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(CACHE_FILE)
+
+    def hash_file(self, path: Path) -> str:
+        """Return SHA256 hex digest of file contents."""
+        h = hashlib.sha256()
+        h.update(path.read_bytes())
+        return h.hexdigest()
+
+    def get(self, file_hash: str) -> Optional[dict]:
+        """
+        Look up a cached project by ICP file hash.
+        Returns the cache entry dict or None on miss.
+        """
+        return self._load().get(file_hash)
+
+    def set(self, file_hash: str, project_id: str, icp_file: str) -> None:
+        """Store a new cache entry."""
+        data = self._load()
+        data[file_hash] = {
+            "project_id": project_id,
+            "icp_file": icp_file,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._save(data)
+
+    def delete(self, file_hash: str) -> None:
+        """Remove a cache entry (e.g., when backend project no longer exists)."""
+        data = self._load()
+        data.pop(file_hash, None)
+        self._save(data)
+
+    def list_all(self) -> list[dict]:
+        """Return all cache entries as a flat list for `project list`."""
+        data = self._load()
+        return [
+            {"hash": h, **entry}
+            for h, entry in data.items()
+        ]
+
+    def clear(self) -> None:
+        """Remove all cache entries."""
+        self._save({})
+
+
+class CliConfig:
+    """
+    Manages ~/.prospect-sim/config.json.
+    Stores API URL and default run parameters.
+    """
+
+    def __init__(self) -> None:
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> dict:
+        if not CONFIG_FILE.exists():
+            return dict(DEFAULT_CONFIG)
+        try:
+            data = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+            # Merge with defaults so new keys are always present
+            return {**DEFAULT_CONFIG, **data}
+        except (json.JSONDecodeError, OSError):
+            return dict(DEFAULT_CONFIG)
+
+    def _save(self, data: dict) -> None:
+        tmp = CONFIG_FILE.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(CONFIG_FILE)
+
+    def get(self, key: str):
+        return self._load().get(key)
+
+    def set(self, key: str, value) -> None:
+        data = self._load()
+        data[key] = value
+        self._save(data)
+
+    def all(self) -> dict:
+        return self._load()

--- a/backend/prospect_sim_cli/client.py
+++ b/backend/prospect_sim_cli/client.py
@@ -1,0 +1,326 @@
+"""
+ApiClient — HTTP wrapper for the prospect-sim Flask API.
+
+All network calls go through this class. Errors are always
+raised as ApiError with machine-readable code + fix field.
+
+Rule 5: fail fast with actionable, parseable errors.
+Rule 6: idempotent — callers can retry any method safely.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Optional
+
+import requests
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import Timeout
+
+# Polling intervals and default timeouts (seconds)
+POLL_INTERVAL = 3
+GRAPH_BUILD_TIMEOUT = 900   # 15 min — graph build can be slow
+SIMULATION_TIMEOUT = 1800   # 30 min — multi-agent simulation
+REPORT_TIMEOUT = 600        # 10 min — ReACT report agent
+
+
+class ApiError(Exception):
+    """
+    Structured error from the backend or network layer.
+    Always carries a machine-readable code + human fix hint.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        fix: str = "",
+        docs: str = "",
+        http_status: Optional[int] = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.fix = fix
+        self.docs = docs
+        self.http_status = http_status
+
+    def to_dict(self) -> dict:
+        d = {"error": self.code, "message": self.message}
+        if self.fix:
+            d["fix"] = self.fix
+        if self.docs:
+            d["docs"] = self.docs
+        return d
+
+
+class ApiClient:
+    """
+    Thin HTTP client for the prospect-sim Flask backend.
+
+    All methods either return parsed response data (dict/list)
+    or raise ApiError — never return None or raw Response objects.
+    """
+
+    def __init__(self, base_url: str = "http://localhost:5001", timeout: int = 60) -> None:
+        # Strip trailing slash for consistent URL building
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update({"Content-Type": "application/json"})
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}{path}"
+
+    def _handle_response(self, resp: requests.Response) -> dict:
+        """
+        Parse response and raise ApiError on failure.
+        Backend always returns {"success": bool, "data": ..., "error": ...}.
+        """
+        try:
+            body = resp.json()
+        except Exception:
+            raise ApiError(
+                "invalid_response",
+                f"Backend returned non-JSON response (HTTP {resp.status_code})",
+                fix="Check backend logs: cd backend && uv run python run.py",
+            )
+
+        if resp.status_code >= 500:
+            raise ApiError(
+                "backend_error",
+                body.get("error", f"HTTP {resp.status_code}"),
+                fix="Check backend logs for the full traceback",
+                http_status=resp.status_code,
+            )
+
+        if not body.get("success", True):
+            raise ApiError(
+                "api_error",
+                body.get("error", "Unknown error from backend"),
+                http_status=resp.status_code,
+            )
+
+        return body.get("data", body)
+
+    def _get(self, path: str, params: Optional[dict] = None) -> dict:
+        try:
+            resp = self._session.get(self._url(path), params=params, timeout=self.timeout)
+        except RequestsConnectionError:
+            raise ApiError(
+                "backend_unavailable",
+                f"Cannot connect to backend at {self.base_url}",
+                fix="cd backend && uv run python run.py",
+                docs="prospect-sim config set api-url <url>",
+            )
+        except Timeout:
+            raise ApiError("timeout", f"Request to {path} timed out after {self.timeout}s")
+        return self._handle_response(resp)
+
+    def _post(self, path: str, json: Optional[dict] = None, files=None, data=None) -> dict:
+        try:
+            if files is not None:
+                # Multipart form-data — don't use JSON Content-Type header
+                headers = {k: v for k, v in self._session.headers.items()
+                           if k != "Content-Type"}
+                resp = requests.post(
+                    self._url(path), files=files, data=data,
+                    headers=headers, timeout=self.timeout,
+                )
+            else:
+                resp = self._session.post(self._url(path), json=json, timeout=self.timeout)
+        except RequestsConnectionError:
+            raise ApiError(
+                "backend_unavailable",
+                f"Cannot connect to backend at {self.base_url}",
+                fix="cd backend && uv run python run.py",
+                docs="prospect-sim config set api-url <url>",
+            )
+        except Timeout:
+            raise ApiError("timeout", f"Request to {path} timed out after {self.timeout}s")
+        return self._handle_response(resp)
+
+    # ── Health ──────────────────────────────────────────────────────────
+
+    def health_check(self) -> bool:
+        """Return True if backend is reachable. Never raises."""
+        try:
+            self._get("/api/settings")
+            return True
+        except ApiError:
+            return False
+
+    # ── Project / Graph ─────────────────────────────────────────────────
+
+    def get_project(self, project_id: str) -> dict:
+        """Get project metadata. Raises ApiError if not found."""
+        return self._get(f"/api/graph/project/{project_id}")
+
+    def generate_ontology(
+        self,
+        icp_path: Path,
+        project_name: str,
+        simulation_requirement: str,
+    ) -> dict:
+        """
+        Step 1: Upload ICP file and generate ontology.
+        Returns dict with project_id and ontology.
+        """
+        with open(icp_path, "rb") as f:
+            files = [("files", (icp_path.name, f, "application/octet-stream"))]
+            form_data = {
+                "simulation_requirement": simulation_requirement,
+                "project_name": project_name,
+                "simulation_type": "email_inbox",
+            }
+            return self._post("/api/graph/ontology/generate", files=files, data=form_data)
+
+    def build_graph(self, project_id: str) -> str:
+        """
+        Step 2: Start async graph build.
+        Returns task_id for polling.
+        """
+        result = self._post("/api/graph/build", json={"project_id": project_id})
+        task_id = result.get("task_id")
+        if not task_id:
+            raise ApiError("missing_task_id", "Backend returned no task_id for graph build")
+        return task_id
+
+    def poll_task(self, task_id: str, timeout: int = GRAPH_BUILD_TIMEOUT) -> dict:
+        """
+        Poll a background task until completed or failed.
+        Returns final task result dict.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            result = self._get(f"/api/graph/task/{task_id}")
+            status = result.get("status", "")
+            if status == "completed":
+                return result
+            if status in ("failed", "error"):
+                raise ApiError(
+                    "task_failed",
+                    result.get("error", f"Task {task_id} failed"),
+                    fix="Check backend logs for details",
+                )
+            time.sleep(POLL_INTERVAL)
+
+        raise ApiError(
+            "task_timeout",
+            f"Task {task_id} did not complete within {timeout}s",
+            fix="Increase timeout or check backend logs",
+        )
+
+    # ── Variant test ─────────────────────────────────────────────────────
+
+    def run_variant_test(
+        self,
+        project_id: str,
+        variants: list[dict],
+        simulation_requirement: str,
+        parallel: bool = False,
+        num_rounds: int = 8,
+    ) -> list[dict]:
+        """
+        Create one simulation per variant.
+        Returns list of {variant_id, variant_label, simulation_id}.
+        """
+        result = self._post("/api/simulation/run-variant-test", json={
+            "project_id": project_id,
+            "variants": variants,
+            "simulation_requirement": simulation_requirement,
+            "parallel": parallel,
+            "num_rounds": num_rounds,
+        })
+        run_ids = result.get("variant_run_ids", [])
+        if not run_ids:
+            raise ApiError("no_simulations_created", "Backend created no simulation IDs")
+        return run_ids
+
+    def prepare_simulation(self, simulation_id: str) -> str:
+        """
+        Prepare a simulation (generates agent profiles).
+        Returns task_id for polling.
+        """
+        result = self._post("/api/simulation/prepare", json={
+            "simulation_id": simulation_id,
+            "simulation_type": "email_inbox",
+        })
+        task_id = result.get("task_id")
+        if not task_id:
+            raise ApiError("missing_task_id", f"No task_id returned for prepare of {simulation_id}")
+        return task_id
+
+    def start_simulation(self, simulation_id: str) -> None:
+        """Start the simulation runner for a prepared simulation."""
+        self._post("/api/simulation/start", json={"simulation_id": simulation_id})
+
+    def poll_simulation(
+        self,
+        simulation_id: str,
+        timeout: int = SIMULATION_TIMEOUT,
+    ) -> dict:
+        """
+        Poll simulation run status until completed or failed.
+        Returns final status dict.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            result = self._get(f"/api/simulation/{simulation_id}/run-status")
+            status = result.get("status", "")
+            if status in ("completed", "stopped"):
+                return result
+            if status == "failed":
+                raise ApiError(
+                    "simulation_failed",
+                    result.get("error", f"Simulation {simulation_id} failed"),
+                    fix="Check /api/observability/events for detailed logs",
+                )
+            time.sleep(POLL_INTERVAL)
+
+        raise ApiError(
+            "simulation_timeout",
+            f"Simulation {simulation_id} did not complete within {timeout}s",
+            fix="Increase --timeout or check backend logs",
+        )
+
+    # ── Report ───────────────────────────────────────────────────────────
+
+    def generate_report(self, simulation_id: str) -> str:
+        """
+        Start report generation for a completed simulation.
+        Returns report_id.
+        """
+        result = self._post("/api/report/generate", json={
+            "simulation_id": simulation_id,
+        })
+        report_id = result.get("report_id")
+        if not report_id:
+            raise ApiError("missing_report_id", "Backend returned no report_id")
+        return report_id
+
+    def poll_report(self, report_id: str, timeout: int = REPORT_TIMEOUT) -> dict:
+        """Poll report generation until complete. Returns final report dict."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            result = self._post("/api/report/generate/status", json={"report_id": report_id})
+            status = result.get("status", "")
+            if status == "completed":
+                return self.get_report(report_id)
+            if status == "failed":
+                raise ApiError(
+                    "report_failed",
+                    result.get("error", f"Report {report_id} failed"),
+                    fix="Check /api/observability/events for ReACT agent logs",
+                )
+            time.sleep(POLL_INTERVAL)
+
+        raise ApiError(
+            "report_timeout",
+            f"Report {report_id} did not complete within {timeout}s",
+        )
+
+    def get_report(self, report_id: str) -> dict:
+        """Fetch a completed report."""
+        return self._get(f"/api/report/{report_id}")

--- a/backend/prospect_sim_cli/commands/__init__.py
+++ b/backend/prospect_sim_cli/commands/__init__.py
@@ -1,0 +1,1 @@
+# Command sub-package for prospect-sim CLI

--- a/backend/prospect_sim_cli/commands/config_cmd.py
+++ b/backend/prospect_sim_cli/commands/config_cmd.py
@@ -1,0 +1,112 @@
+"""
+`prospect-sim config` — manage CLI configuration.
+
+Stores persistent settings in ~/.prospect-sim/config.json.
+Supported keys: api_url, default_rounds, default_parallel.
+
+Rule 1: non-interactive — all via flags/arguments.
+Rule 10: `config show` returns data; `config set` returns nothing on success.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+from typing_extensions import Annotated
+
+import typer
+
+from ..cache import CliConfig
+from ..output import print_error, print_json
+
+app = typer.Typer(help="Manage CLI configuration (API URL, defaults).")
+
+# Keys that are valid for `config set`
+VALID_KEYS = {"api-url", "default-rounds", "default-parallel"}
+
+# Map CLI key names (kebab-case) to config file keys (snake_case)
+KEY_MAP = {
+    "api-url": "api_url",
+    "default-rounds": "default_rounds",
+    "default-parallel": "default_parallel",
+}
+
+
+@app.command("show")
+def config_show(
+    quiet: Annotated[bool, typer.Option("--quiet")] = False,
+) -> None:
+    """
+    Show current CLI configuration.
+
+    Examples:
+      prospect-sim config show
+      prospect-sim config show --quiet | jq '.api_url'
+    """
+    config = CliConfig()
+    data = config.all()
+
+    if quiet:
+        print_json(data)
+    else:
+        typer.echo("\nprospect-sim configuration:")
+        typer.echo(f"  Config file: ~/.prospect-sim/config.json")
+        for k, v in data.items():
+            typer.echo(f"  {k}: {v}")
+        typer.echo()
+
+
+@app.command("set")
+def config_set(
+    key: Annotated[str, typer.Argument(help=f"Config key. Valid: {', '.join(sorted(VALID_KEYS))}")],
+    value: Annotated[str, typer.Argument(help="Value to set")],
+) -> None:
+    """
+    Set a configuration value.
+
+    Examples:
+      prospect-sim config set api-url http://localhost:5001
+      prospect-sim config set default-rounds 12
+      prospect-sim config set default-parallel true
+    """
+    if key not in VALID_KEYS:
+        print_error(
+            "invalid_config_key",
+            f"Unknown config key: {key}",
+            fix=f"Valid keys: {', '.join(sorted(VALID_KEYS))}",
+            exit_code=1,
+        )
+
+    config = CliConfig()
+    config_key = KEY_MAP[key]
+
+    # Coerce types
+    coerced_value: object = value
+    if config_key == "default_rounds":
+        try:
+            coerced_value = int(value)
+        except ValueError:
+            print_error("invalid_value", f"default-rounds must be an integer (got: {value!r})", exit_code=1)
+    elif config_key == "default_parallel":
+        if value.lower() in ("true", "1", "yes"):
+            coerced_value = True
+        elif value.lower() in ("false", "0", "no"):
+            coerced_value = False
+        else:
+            print_error("invalid_value", f"default-parallel must be true/false (got: {value!r})", exit_code=1)
+
+    config.set(config_key, coerced_value)
+    # Rule 10: nothing on success
+
+
+@app.command("reset")
+def config_reset() -> None:
+    """
+    Reset all configuration to defaults.
+
+    Examples:
+      prospect-sim config reset
+    """
+    from ..cache import CONFIG_FILE
+    if CONFIG_FILE.exists():
+        CONFIG_FILE.unlink()
+    # Rule 10: nothing on success

--- a/backend/prospect_sim_cli/commands/project.py
+++ b/backend/prospect_sim_cli/commands/project.py
@@ -1,0 +1,201 @@
+"""
+`prospect-sim project` — ICP project management commands.
+
+Sub-commands:
+  list   List all cached ICP projects (reads local cache, no backend needed)
+  build  Build the ICP knowledge graph for a file and cache the project_id
+  show   Show details for a specific project
+
+Rule 1: non-interactive — all config via flags.
+Rule 6: idempotent — building the same ICP twice skips the build (cached).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+from typing_extensions import Annotated
+
+import typer
+
+from ..client import ApiClient, ApiError
+from ..cache import IcpCache, CliConfig
+from ..output import (
+    print_error, print_info, print_success, print_json,
+    print_project_table, spinner,
+)
+
+app = typer.Typer(help="Manage ICP knowledge graph projects.")
+
+
+@app.command("list")
+def project_list(
+    quiet: Annotated[bool, typer.Option("--quiet", help="Output clean JSON only")] = False,
+) -> None:
+    """
+    List all locally cached ICP projects.
+
+    Reads ~/.prospect-sim/cache.json — no backend connection required.
+
+    Examples:
+      prospect-sim project list
+      prospect-sim project list --quiet | jq '.[0].project_id'
+    """
+    cache = IcpCache()
+    entries = cache.list_all()
+
+    if quiet:
+        print_json(entries)
+    else:
+        print_project_table(entries)
+
+
+@app.command("build")
+def project_build(
+    icp: Annotated[Path, typer.Option("--icp", help="ICP profile file (MD/TXT/PDF)", show_default=False)],
+    force: Annotated[bool, typer.Option("--force", "-f", help="Rebuild even if cached")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", help="Output clean JSON only")] = False,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation prompts")] = False,
+    api_url: Annotated[str, typer.Option("--api-url", envvar="PROSPECT_SIM_API_URL", hidden=True)] = "",
+) -> None:
+    """
+    Build the ICP knowledge graph and cache the project_id.
+
+    This is the slow step (~5-10 min on first run). The result is cached by
+    SHA256 of the ICP file — subsequent runs reuse the cached project instantly.
+
+    Examples:
+      prospect-sim project build --icp icp.md
+      prospect-sim project build --icp icp.md --force   # rebuild even if cached
+      prospect-sim project build --icp icp.md --yes     # skip confirmation
+    """
+    if not icp.exists():
+        print_error("icp_file_not_found", f"ICP file not found: {icp}", exit_code=1)
+
+    config = CliConfig()
+    resolved_url = api_url or config.get("api_url") or "http://localhost:5001"
+    client = ApiClient(base_url=resolved_url)
+    cache = IcpCache()
+
+    icp_hash = cache.hash_file(icp)
+
+    # Check cache first
+    cached_entry = cache.get(icp_hash)
+    if cached_entry and not force:
+        project_id = cached_entry["project_id"]
+        if quiet:
+            print_json({"project_id": project_id, "cached": True, "icp_file": str(icp)})
+        else:
+            typer.echo(f"[cache hit] project {project_id} already built for {icp.name}")
+            typer.echo("Use --force to rebuild.")
+        raise typer.Exit(0)
+
+    # Backend health check
+    if not client.health_check():
+        print_error(
+            "backend_unavailable",
+            f"Cannot connect to backend at {resolved_url}",
+            fix="cd backend && uv run python run.py",
+            docs="prospect-sim config set api-url <url>",
+            exit_code=2,
+        )
+
+    # Confirmation
+    if not yes:
+        typer.confirm(
+            f"Build ICP graph for {icp.name}? (takes ~5-10 min on first run)",
+            default=True,
+            abort=True,
+        )
+
+    # Build the graph
+    project_name = icp.stem.replace("-", " ").replace("_", " ").title()
+    requirement = (
+        "Test B2B cold email copy variants against HR Director / Head of People personas. "
+        "Focus on open rate, reply intent, and dropout point analysis."
+    )
+
+    try:
+        print_info("Uploading ICP file and generating ontology...", quiet)
+        with spinner("Generating ontology...", quiet):
+            ontology_result = client.generate_ontology(icp, project_name, requirement)
+
+        project_id = ontology_result.get("project_id")
+        if not project_id:
+            print_error("missing_project_id", "Backend did not return a project_id")
+
+        print_info(f"Project created: {project_id}", quiet)
+        print_info("Building knowledge graph...", quiet)
+
+        with spinner("Building graph...", quiet):
+            task_id = client.build_graph(project_id)
+            client.poll_task(task_id)
+
+        cache.set(icp_hash, project_id, str(icp.resolve()))
+        print_success(f"Graph built and cached: {project_id}", quiet)
+
+    except ApiError as exc:
+        print_error(exc.code, exc.message, exc.fix, exc.docs, exit_code=2)
+
+    if quiet:
+        print_json({"project_id": project_id, "cached": True, "icp_file": str(icp)})
+
+
+@app.command("show")
+def project_show(
+    project_id: Annotated[Optional[str], typer.Argument(help="Project ID to inspect")] = None,
+    icp: Annotated[Optional[Path], typer.Option("--icp", help="Look up project by ICP file")] = None,
+    quiet: Annotated[bool, typer.Option("--quiet", help="Output clean JSON only")] = False,
+    api_url: Annotated[str, typer.Option("--api-url", envvar="PROSPECT_SIM_API_URL", hidden=True)] = "",
+) -> None:
+    """
+    Show details for a cached ICP project.
+
+    Provide either a project_id argument or --icp to look up by file.
+
+    Examples:
+      prospect-sim project show proj_abc123
+      prospect-sim project show --icp icp.md
+    """
+    if not project_id and not icp:
+        print_error(
+            "missing_argument",
+            "Provide a project_id argument or --icp <file>",
+            fix="prospect-sim project show proj_abc123  OR  prospect-sim project show --icp icp.md",
+            exit_code=1,
+        )
+
+    cache = IcpCache()
+
+    # Resolve project_id from ICP file if needed
+    if icp and not project_id:
+        if not icp.exists():
+            print_error("icp_file_not_found", f"ICP file not found: {icp}", exit_code=1)
+        icp_hash = cache.hash_file(icp)
+        entry = cache.get(icp_hash)
+        if not entry:
+            print_error(
+                "project_not_cached",
+                f"No cached project for {icp.name}",
+                fix="prospect-sim project build --icp <file>",
+                exit_code=1,
+            )
+        project_id = entry["project_id"]
+
+    # Fetch from backend for live status
+    config = CliConfig()
+    resolved_url = api_url or config.get("api_url") or "http://localhost:5001"
+    client = ApiClient(base_url=resolved_url)
+
+    try:
+        data = client.get_project(project_id)
+    except ApiError as exc:
+        print_error(exc.code, exc.message, exc.fix, exc.docs, exit_code=2)
+
+    if quiet:
+        print_json(data)
+    else:
+        typer.echo(f"\nProject: {project_id}")
+        for k, v in data.items():
+            typer.echo(f"  {k}: {v}")
+        typer.echo()

--- a/backend/prospect_sim_cli/commands/results.py
+++ b/backend/prospect_sim_cli/commands/results.py
@@ -1,0 +1,98 @@
+"""
+`prospect-sim results show` — fetch and display simulation results.
+
+Generates a report for a completed simulation, then displays the ranking.
+Can also show raw simulation status without generating a full report.
+
+Rule 2: minimum viable output — table by default, JSON with --quiet.
+Rule 5: fail fast with actionable errors.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+from typing_extensions import Annotated
+
+import typer
+
+from ..client import ApiClient, ApiError
+from ..cache import CliConfig
+from ..output import (
+    print_error, print_info, print_json,
+    print_ranking_table, spinner,
+)
+
+app = typer.Typer(help="Fetch and display simulation results.")
+
+
+@app.command("show")
+def results_show(
+    sim_id: Annotated[str, typer.Option("--sim-id", help="Simulation ID to fetch results for", show_default=False)],
+    status_only: Annotated[bool, typer.Option("--status", help="Show run status only, skip report generation")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet")] = False,
+    api_url: Annotated[str, typer.Option("--api-url", envvar="PROSPECT_SIM_API_URL", hidden=True)] = "",
+) -> None:
+    """
+    Fetch and display results for a completed simulation.
+
+    Generates a ReACT report and renders the variant ranking table.
+    Use --status to check run status without generating a full report.
+
+    Examples:
+      prospect-sim results show --sim-id sim_abc123
+      prospect-sim results show --sim-id sim_abc123 --status
+      prospect-sim results show --sim-id sim_abc123 --quiet | jq '.winner'
+    """
+    config = CliConfig()
+    resolved_url = api_url or config.get("api_url") or "http://localhost:5001"
+    client = ApiClient(base_url=resolved_url)
+
+    if not client.health_check():
+        print_error(
+            "backend_unavailable",
+            f"Cannot connect to backend at {resolved_url}",
+            fix="cd backend && uv run python run.py",
+            exit_code=2,
+        )
+
+    try:
+        if status_only:
+            # Lightweight status check — no report generation
+            from ..client import SIMULATION_TIMEOUT
+            status = client._get(f"/api/simulation/{sim_id}/run-status")
+            if quiet:
+                print_json(status)
+            else:
+                typer.echo(f"\nSimulation: {sim_id}")
+                typer.echo(f"  Status: {status.get('status', 'unknown')}")
+                if status.get("completed_rounds") is not None:
+                    typer.echo(f"  Rounds: {status.get('completed_rounds')}/{status.get('total_rounds', '?')}")
+                typer.echo()
+            return
+
+        # Full report generation
+        print_info("Generating variant ranking report...", quiet)
+        with spinner("Running ReACT report agent...", quiet):
+            report_id = client.generate_report(sim_id)
+            report = client.poll_report(report_id)
+
+        ranking = report.get("ranking", [])
+        failure_points = report.get("failure_points", {})
+
+        results = {
+            "winner": ranking[0].get("label") if ranking else None,
+            "ranking": ranking,
+            "failure_points": failure_points,
+            "report_content": report.get("content", ""),
+            "simulation_id": sim_id,
+        }
+
+        if quiet:
+            print_json(results)
+        else:
+            print_ranking_table(results["ranking"], results["failure_points"])
+            if results.get("winner"):
+                typer.echo(f"\n🏆 Winner: {results['winner']}\n")
+
+    except ApiError as exc:
+        print_error(exc.code, exc.message, exc.fix, exc.docs, exit_code=2)

--- a/backend/prospect_sim_cli/commands/run.py
+++ b/backend/prospect_sim_cli/commands/run.py
@@ -1,0 +1,330 @@
+"""
+`prospect-sim run` — end-to-end variant test command.
+
+The main command. Accepts an ICP file and a variants JSON file,
+builds the graph (or reuses cache), runs simulations, generates report.
+
+Rule 1: non-interactive — all config via flags, no prompts unless --yes skips them.
+Rule 7: --dry-run shows the full plan without executing.
+Rule 8: --yes bypasses confirmation for expensive operations.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+from typing_extensions import Annotated
+
+import typer
+
+from ..client import ApiClient, ApiError
+from ..cache import IcpCache, CliConfig
+from ..output import (
+    print_error, print_info, print_success, print_json,
+    print_ranking_table, spinner,
+)
+
+app = typer.Typer(help="Run a full variant test: build ICP graph + simulate + rank.")
+
+
+def _load_variants(variants_path: Path) -> list[dict]:
+    """Parse and validate variants JSON file."""
+    try:
+        data = json.loads(variants_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print_error(
+            "invalid_variants_file",
+            f"Could not parse variants file: {exc}",
+            fix=f"Ensure {variants_path} is valid JSON. See docs/WHAT_PROSPECT_SIM_PREDICTS.md",
+            docs="prospect-sim variant test --help",
+            exit_code=1,
+        )
+    if not isinstance(data, list) or not data:
+        print_error(
+            "invalid_variants_format",
+            "Variants file must be a non-empty JSON array",
+            fix='Format: [{"id":1,"label":"...","subject_line":"...","body":"...","hook_type":"problem"}]',
+            exit_code=1,
+        )
+    if len(data) > 6:
+        print_error(
+            "too_many_variants",
+            f"Maximum 6 variants per run ({len(data)} provided)",
+            exit_code=1,
+        )
+    return data
+
+
+def _print_dry_run_plan(
+    icp: Path,
+    variants: list[dict],
+    icp_hash: str,
+    cached_project_id: Optional[str],
+    rounds: int,
+    parallel: bool,
+) -> None:
+    """
+    Print what would happen without executing anything.
+    Rule 7: --dry-run mode.
+    """
+    cache_status = f"✓ cached ({cached_project_id})" if cached_project_id else "✗ not cached — will build"
+    mode = "parallel" if parallel else "sequential"
+
+    typer.echo(f"\n[dry-run] prospect-sim run")
+    typer.echo(f"  ICP file:    {icp}")
+    typer.echo(f"  ICP hash:    {icp_hash[:12]}...")
+    typer.echo(f"  Graph:       {cache_status}")
+    typer.echo(f"  Variants:    {len(variants)}")
+    for v in variants:
+        typer.echo(f"    [{v.get('hook_type','?')}] {v.get('label','?')}")
+    typer.echo(f"  Rounds:      {rounds}")
+    typer.echo(f"  Run mode:    {mode}")
+    build_time = "~30 sec (cached)" if cached_project_id else "~5-10 min (graph build)"
+    typer.echo(f"  Est. time:   {build_time} + ~{rounds * len(variants) * 2} sec simulation")
+    typer.echo(f"\nRun without --dry-run to execute.\n")
+
+
+def _build_icp_graph(
+    client: ApiClient,
+    cache: IcpCache,
+    icp: Path,
+    icp_hash: str,
+    quiet: bool,
+) -> str:
+    """
+    Upload ICP file, generate ontology, build graph, cache project_id.
+    Returns project_id.
+    """
+    project_name = icp.stem.replace("-", " ").replace("_", " ").title()
+    requirement = (
+        "Test B2B cold email copy variants against HR Director / Head of People personas. "
+        "Focus on open rate, reply intent, and dropout point analysis."
+    )
+
+    # Step 1: upload + ontology
+    print_info("Uploading ICP file and generating ontology...", quiet)
+    with spinner("Generating ontology...", quiet):
+        ontology_result = client.generate_ontology(icp, project_name, requirement)
+
+    project_id = ontology_result.get("project_id")
+    if not project_id:
+        print_error("missing_project_id", "Backend did not return a project_id after ontology generation")
+
+    print_info(f"Project created: {project_id}", quiet)
+
+    # Step 2: build graph
+    print_info("Building knowledge graph (this takes a few minutes on first run)...", quiet)
+    with spinner("Building graph...", quiet):
+        task_id = client.build_graph(project_id)
+        client.poll_task(task_id)
+
+    # Cache the project_id so next run skips this step
+    cache.set(icp_hash, project_id, str(icp.resolve()))
+    print_success(f"Graph built and cached. Future runs will reuse project {project_id}", quiet)
+
+    return project_id
+
+
+def _run_simulations(
+    client: ApiClient,
+    project_id: str,
+    variants: list[dict],
+    simulation_requirement: str,
+    parallel: bool,
+    rounds: int,
+    quiet: bool,
+) -> list[dict]:
+    """
+    Create, prepare, start, and poll all variant simulations.
+    Returns list of completed run_id dicts.
+    """
+    # Create simulations
+    print_info(f"Creating {len(variants)} simulation(s)...", quiet)
+    run_ids = client.run_variant_test(
+        project_id, variants, simulation_requirement, parallel, rounds,
+    )
+
+    # Prepare and start each simulation
+    for entry in run_ids:
+        sim_id = entry["simulation_id"]
+        label = entry.get("variant_label", sim_id)
+        print_info(f"Preparing simulation for '{label}'...", quiet)
+        with spinner(f"Preparing '{label}'...", quiet):
+            task_id = client.prepare_simulation(sim_id)
+            client.poll_task(task_id, timeout=300)  # 5 min prep timeout
+        client.start_simulation(sim_id)
+        print_info(f"Started simulation for '{label}'", quiet)
+
+    # Poll all simulations until complete
+    print_info(f"Running {len(run_ids)} simulation(s) ({rounds} rounds each)...", quiet)
+    for entry in run_ids:
+        sim_id = entry["simulation_id"]
+        label = entry.get("variant_label", sim_id)
+        with spinner(f"Simulating '{label}'...", quiet):
+            client.poll_simulation(sim_id)
+        print_success(f"Simulation complete: '{label}'", quiet)
+
+    return run_ids
+
+
+def _generate_and_fetch_report(
+    client: ApiClient,
+    run_ids: list[dict],
+    quiet: bool,
+) -> dict:
+    """
+    Generate report for the first (or best) simulation and return it.
+    Uses the first simulation_id as the primary report target.
+    """
+    primary_sim_id = run_ids[0]["simulation_id"]
+    print_info("Generating variant ranking report...", quiet)
+    with spinner("Running ReACT report agent...", quiet):
+        report_id = client.generate_report(primary_sim_id)
+        report = client.poll_report(report_id)
+    return report
+
+
+def _format_results(report: dict, run_ids: list[dict]) -> dict:
+    """
+    Extract clean ranking + failure_points from raw report.
+    Falls back to raw content if structured data is missing.
+    """
+    # The report agent may return structured data or free-text sections
+    ranking = report.get("ranking", [])
+    failure_points = report.get("failure_points", {})
+
+    # If no structured ranking, build a basic one from simulation IDs
+    if not ranking:
+        ranking = [
+            {
+                "variant_id": str(entry.get("variant_id", i)),
+                "label": entry.get("variant_label", f"Variant {i+1}"),
+                "hook_type": entry.get("hook_type", "unknown"),
+                "open_score": "n/a",
+                "reply_score": "n/a",
+            }
+            for i, entry in enumerate(run_ids)
+        ]
+
+    return {
+        "winner": ranking[0].get("label") if ranking else None,
+        "ranking": ranking,
+        "failure_points": failure_points,
+        "report_content": report.get("content", ""),
+        "simulation_ids": [e["simulation_id"] for e in run_ids],
+    }
+
+
+@app.callback(invoke_without_command=True)
+def run(
+    icp: Annotated[Path, typer.Option("--icp", help="ICP profile file (MD/TXT/PDF)", show_default=False)],
+    variants: Annotated[Path, typer.Option("--variants", help="Variants JSON file", show_default=False)],
+    rounds: Annotated[int, typer.Option("--rounds", help="Simulation rounds per variant")] = 8,
+    parallel: Annotated[bool, typer.Option("--parallel/--sequential", help="Run variants in parallel or sequentially")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Show execution plan without running")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", help="Output clean JSON only (pipeable)")] = False,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation prompts (unattended)")] = False,
+    api_url: Annotated[str, typer.Option("--api-url", envvar="PROSPECT_SIM_API_URL", help="Backend URL", hidden=True)] = "",
+) -> None:
+    """
+    Run a full B2B cold email variant test.
+
+    Builds ICP knowledge graph (cached after first run), simulates each email
+    variant against synthetic decision-maker personas, and ranks by reply intent.
+
+    Examples:
+      prospect-sim run --icp icp.md --variants variants.json
+      prospect-sim run --icp icp.md --variants variants.json --parallel --rounds 12
+      prospect-sim run --icp icp.md --variants variants.json --dry-run
+      prospect-sim run --icp icp.md --variants variants.json --quiet | jq '.winner'
+    """
+    # Resolve API URL (flag > env > config file)
+    config = CliConfig()
+    resolved_url = api_url or config.get("api_url") or "http://localhost:5001"
+    client = ApiClient(base_url=resolved_url)
+    cache = IcpCache()
+
+    # ── Validate inputs ──────────────────────────────────────────────────
+    if not icp.exists():
+        print_error("icp_file_not_found", f"ICP file not found: {icp}", exit_code=1)
+    if not variants.exists():
+        print_error("variants_file_not_found", f"Variants file not found: {variants}", exit_code=1)
+
+    variants_data = _load_variants(variants)
+    icp_hash = cache.hash_file(icp)
+
+    # ── Cache check ──────────────────────────────────────────────────────
+    cached_entry = cache.get(icp_hash)
+    cached_project_id: Optional[str] = None
+
+    if cached_entry:
+        cached_project_id = cached_entry["project_id"]
+        # Verify project still exists on backend
+        try:
+            client.get_project(cached_project_id)
+            print_info(f"[cache hit] reusing project {cached_project_id}", quiet)
+        except ApiError:
+            # Project was deleted from backend — invalidate cache
+            print_info(f"[cache miss] cached project {cached_project_id} no longer exists — rebuilding", quiet)
+            cache.delete(icp_hash)
+            cached_project_id = None
+
+    # ── Dry run ──────────────────────────────────────────────────────────
+    if dry_run:
+        _print_dry_run_plan(icp, variants_data, icp_hash, cached_project_id, rounds, parallel)
+        raise typer.Exit(0)
+
+    # ── Backend health check ─────────────────────────────────────────────
+    if not client.health_check():
+        print_error(
+            "backend_unavailable",
+            f"Cannot connect to backend at {resolved_url}",
+            fix="cd backend && uv run python run.py",
+            docs="prospect-sim config set api-url <url>",
+            exit_code=2,
+        )
+
+    # ── Phase 1: ICP graph build (skip if cached) ─────────────────────────
+    project_id = cached_project_id
+    if not project_id:
+        if not yes:
+            typer.confirm(
+                f"Build ICP graph for {icp.name}? (takes ~5-10 min on first run)",
+                default=True,
+                abort=True,
+            )
+        try:
+            project_id = _build_icp_graph(client, cache, icp, icp_hash, quiet)
+        except ApiError as exc:
+            print_error(exc.code, exc.message, exc.fix, exc.docs, exit_code=2)
+
+    # ── Phase 2: Variant simulations ─────────────────────────────────────
+    simulation_requirement = (
+        "Rank email copy variants by reply intent. Identify dropout points "
+        "(subject_line / opening / body / cta) for each variant."
+    )
+    try:
+        run_ids = _run_simulations(
+            client, project_id, variants_data,
+            simulation_requirement, parallel, rounds, quiet,
+        )
+    except ApiError as exc:
+        print_error(exc.code, exc.message, exc.fix, exc.docs, exit_code=2)
+
+    # ── Phase 3: Report ──────────────────────────────────────────────────
+    try:
+        report = _generate_and_fetch_report(client, run_ids, quiet)
+    except ApiError as exc:
+        print_error(exc.code, exc.message, exc.fix, exc.docs, exit_code=2)
+
+    # ── Output results ───────────────────────────────────────────────────
+    results = _format_results(report, run_ids)
+
+    if quiet:
+        print_json(results)
+    else:
+        print_ranking_table(results["ranking"], results["failure_points"])
+        if results.get("winner"):
+            typer.echo(f"\n🏆 Winner: {results['winner']}\n")

--- a/backend/prospect_sim_cli/commands/variant.py
+++ b/backend/prospect_sim_cli/commands/variant.py
@@ -1,0 +1,152 @@
+"""
+`prospect-sim variant test` — run simulations for a set of email variants.
+
+Lower-level than `prospect-sim run`: assumes the ICP graph is already built
+and you have a project_id. Use `prospect-sim run` for the full end-to-end flow.
+
+Rule 1: non-interactive — all config via flags.
+Rule 6: idempotent — same inputs produce the same simulation set.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+from typing_extensions import Annotated
+
+import typer
+
+from ..client import ApiClient, ApiError
+from ..cache import IcpCache, CliConfig
+from ..output import (
+    print_error, print_info, print_success, print_json,
+    print_ranking_table, spinner,
+)
+
+app = typer.Typer(help="Run variant simulations against a pre-built ICP project.")
+
+
+@app.command("test")
+def variant_test(
+    variants: Annotated[Path, typer.Option("--variants", help="Variants JSON file", show_default=False)],
+    project_id: Annotated[Optional[str], typer.Option("--project-id", help="Project ID (use if you have it)")] = None,
+    icp: Annotated[Optional[Path], typer.Option("--icp", help="ICP file to look up cached project")] = None,
+    rounds: Annotated[int, typer.Option("--rounds", help="Simulation rounds per variant")] = 8,
+    parallel: Annotated[bool, typer.Option("--parallel/--sequential")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet")] = False,
+    api_url: Annotated[str, typer.Option("--api-url", envvar="PROSPECT_SIM_API_URL", hidden=True)] = "",
+) -> None:
+    """
+    Run simulations for a variants JSON file against a pre-built ICP project.
+
+    Requires either --project-id or --icp (to look up the cached project).
+    The ICP graph must already be built — run `prospect-sim project build` first.
+
+    Outputs: list of simulation_ids (or JSON with --quiet).
+
+    Examples:
+      prospect-sim variant test --variants variants.json --icp icp.md
+      prospect-sim variant test --variants variants.json --project-id proj_abc --parallel
+      prospect-sim variant test --variants variants.json --icp icp.md --quiet | jq '.[]'
+    """
+    if not project_id and not icp:
+        print_error(
+            "missing_argument",
+            "Provide --project-id or --icp to identify the target project",
+            fix="prospect-sim variant test --variants variants.json --icp icp.md",
+            exit_code=1,
+        )
+
+    if not variants.exists():
+        print_error("variants_file_not_found", f"Variants file not found: {variants}", exit_code=1)
+
+    # Parse variants
+    try:
+        variants_data = json.loads(variants.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print_error(
+            "invalid_variants_file",
+            f"Could not parse variants file: {exc}",
+            fix=f"Ensure {variants} is valid JSON.",
+            exit_code=1,
+        )
+    if not isinstance(variants_data, list) or not variants_data:
+        print_error("invalid_variants_format", "Variants file must be a non-empty JSON array", exit_code=1)
+    if len(variants_data) > 6:
+        print_error(
+            "too_many_variants",
+            f"Maximum 6 variants per run ({len(variants_data)} provided)",
+            exit_code=1,
+        )
+
+    config = CliConfig()
+    resolved_url = api_url or config.get("api_url") or "http://localhost:5001"
+    client = ApiClient(base_url=resolved_url)
+    cache = IcpCache()
+
+    # Resolve project_id from ICP cache if needed
+    resolved_project_id = project_id
+    if not resolved_project_id and icp:
+        if not icp.exists():
+            print_error("icp_file_not_found", f"ICP file not found: {icp}", exit_code=1)
+        icp_hash = cache.hash_file(icp)
+        entry = cache.get(icp_hash)
+        if not entry:
+            print_error(
+                "project_not_cached",
+                f"No cached project for {icp.name}",
+                fix="prospect-sim project build --icp <file>",
+                exit_code=1,
+            )
+        resolved_project_id = entry["project_id"]
+        print_info(f"[cache hit] using project {resolved_project_id}", quiet)
+
+    # Backend health check
+    if not client.health_check():
+        print_error(
+            "backend_unavailable",
+            f"Cannot connect to backend at {resolved_url}",
+            fix="cd backend && uv run python run.py",
+            exit_code=2,
+        )
+
+    simulation_requirement = (
+        "Rank email copy variants by reply intent. Identify dropout points "
+        "(subject_line / opening / body / cta) for each variant."
+    )
+
+    try:
+        print_info(f"Creating {len(variants_data)} simulation(s)...", quiet)
+        run_ids = client.run_variant_test(
+            resolved_project_id, variants_data, simulation_requirement, parallel, rounds,
+        )
+
+        for entry in run_ids:
+            sim_id = entry["simulation_id"]
+            label = entry.get("variant_label", sim_id)
+            print_info(f"Preparing simulation for '{label}'...", quiet)
+            with spinner(f"Preparing '{label}'...", quiet):
+                task_id = client.prepare_simulation(sim_id)
+                client.poll_task(task_id, timeout=300)
+            client.start_simulation(sim_id)
+            print_info(f"Started simulation for '{label}'", quiet)
+
+        print_info(f"Running {len(run_ids)} simulation(s)...", quiet)
+        for entry in run_ids:
+            sim_id = entry["simulation_id"]
+            label = entry.get("variant_label", sim_id)
+            with spinner(f"Simulating '{label}'...", quiet):
+                client.poll_simulation(sim_id)
+            print_success(f"Simulation complete: '{label}'", quiet)
+
+    except ApiError as exc:
+        print_error(exc.code, exc.message, exc.fix, exc.docs, exit_code=2)
+
+    if quiet:
+        print_json(run_ids)
+    else:
+        typer.echo("\nSimulations complete. Run IDs:")
+        for entry in run_ids:
+            typer.echo(f"  {entry.get('variant_label', '?')} → {entry['simulation_id']}")
+        typer.echo(f"\nRun: prospect-sim results show --sim-id {run_ids[0]['simulation_id']}\n")

--- a/backend/prospect_sim_cli/main.py
+++ b/backend/prospect_sim_cli/main.py
@@ -1,0 +1,76 @@
+"""
+prospect-sim CLI — entry point.
+
+Registers all command groups and exposes the root Typer app.
+Installed as `prospect-sim` via [project.scripts] in pyproject.toml.
+
+Command tree:
+  prospect-sim run          — full end-to-end variant test (main command)
+  prospect-sim project      — ICP project management (list / build / show)
+  prospect-sim variant      — run simulations on a pre-built project (test)
+  prospect-sim results      — fetch and display simulation results (show)
+  prospect-sim config       — CLI configuration (show / set / reset)
+"""
+
+from __future__ import annotations
+
+import typer
+
+from .commands.run import app as run_app
+from .commands.project import app as project_app
+from .commands.variant import app as variant_app
+from .commands.results import app as results_app
+from .commands.config_cmd import app as config_app
+from . import __version__
+
+# Root application
+app = typer.Typer(
+    name="prospect-sim",
+    help=(
+        "B2B cold email variant testing via synthetic persona simulation.\n\n"
+        "Quickstart:\n"
+        "  prospect-sim run --icp icp.md --variants variants.json\n\n"
+        "First run builds the ICP knowledge graph (~5-10 min). "
+        "Subsequent runs reuse the cached graph (~20 sec)."
+    ),
+    no_args_is_help=True,
+    pretty_exceptions_enable=False,  # let our print_error handle formatting
+)
+
+
+def _version_callback(value: bool) -> None:
+    """Print version and exit."""
+    if value:
+        typer.echo(f"prospect-sim {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def root(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show version and exit.",
+    ),
+) -> None:
+    """prospect-sim — agent-friendly B2B cold email simulation CLI."""
+
+
+# Register command groups
+app.add_typer(run_app, name="run")
+app.add_typer(project_app, name="project")
+app.add_typer(variant_app, name="variant")
+app.add_typer(results_app, name="results")
+app.add_typer(config_app, name="config")
+
+
+def main() -> None:
+    """Entry point called by [project.scripts]."""
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/prospect_sim_cli/output.py
+++ b/backend/prospect_sim_cli/output.py
@@ -1,0 +1,185 @@
+"""
+Output renderers for prospect-sim CLI.
+
+Three modes:
+  - table (default):  rich-formatted human-readable output
+  - json (--quiet):   clean JSON to stdout only — pipeable via jq
+  - error:            always to stderr, always machine-readable JSON
+
+Rule 2: minimum viable output by default, --quiet for JSON.
+Rule 5: errors always include fix + docs fields.
+Rule 10: data on success, nothing on silence.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import contextmanager
+from typing import Any, Optional
+
+import typer
+
+# Use rich if available (comes with typer[all])
+try:
+    from rich.console import Console
+    from rich.table import Table
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich import print as rprint
+    _RICH = True
+except ImportError:
+    _RICH = False
+
+_console = Console() if _RICH else None
+_err_console = Console(stderr=True) if _RICH else None
+
+
+def print_json(data: Any) -> None:
+    """Write clean JSON to stdout. No other text. Pipeable via jq."""
+    sys.stdout.write(json.dumps(data, indent=2, ensure_ascii=False))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def print_error(
+    code: str,
+    message: str,
+    fix: str = "",
+    docs: str = "",
+    exit_code: int = 1,
+) -> None:
+    """
+    Write structured error to stderr and exit.
+    Always machine-readable — agents parse this.
+
+    Rule 5: fail fast with actionable errors.
+    """
+    payload: dict[str, str] = {"error": code, "message": message}
+    if fix:
+        payload["fix"] = fix
+    if docs:
+        payload["docs"] = docs
+
+    sys.stderr.write(json.dumps(payload, ensure_ascii=False))
+    sys.stderr.write("\n")
+    sys.stderr.flush()
+    raise typer.Exit(code=exit_code)
+
+
+def print_success(message: str, quiet: bool = False) -> None:
+    """Print a success message — suppressed in --quiet mode."""
+    if quiet:
+        return
+    if _RICH and _err_console:
+        _err_console.print(f"[green]✓[/green] {message}")
+    else:
+        sys.stderr.write(f"✓ {message}\n")
+
+
+def print_info(message: str, quiet: bool = False) -> None:
+    """Print informational message to stderr — suppressed in --quiet mode."""
+    if quiet:
+        return
+    if _RICH and _err_console:
+        _err_console.print(f"[dim]{message}[/dim]")
+    else:
+        sys.stderr.write(f"  {message}\n")
+
+
+def print_ranking_table(ranking: list[dict], failure_points: dict) -> None:
+    """
+    Render variant ranking as a rich table.
+    Winner gets a trophy. Failure points color-coded.
+    """
+    if not _RICH or not _console:
+        # Fallback: plain text
+        for i, entry in enumerate(ranking):
+            marker = "👑 WINNER" if i == 0 else f"  #{i + 1}"
+            print(f"{marker}  {entry.get('label', entry.get('variant_id', '?'))}")
+            print(f"      Open score:  {entry.get('open_score', 'n/a')}")
+            print(f"      Reply score: {entry.get('reply_score', 'n/a')}")
+            fp = failure_points.get(str(entry.get('variant_id', '')), 'n/a')
+            print(f"      Dropout at:  {fp}")
+        return
+
+    table = Table(title="Variant Ranking", show_header=True, header_style="bold cyan")
+    table.add_column("#", style="dim", width=4)
+    table.add_column("Variant", min_width=20)
+    table.add_column("Hook", min_width=10)
+    table.add_column("Opens", justify="right")
+    table.add_column("Replies", justify="right")
+    table.add_column("Main Dropout", min_width=14)
+
+    dropout_colors = {
+        "subject_line": "red",
+        "opening": "yellow",
+        "body": "yellow",
+        "cta": "cyan",
+        "none": "green",
+    }
+
+    for i, entry in enumerate(ranking):
+        rank = "👑 1" if i == 0 else f"  {i + 1}"
+        vid = str(entry.get("variant_id", ""))
+        dropout = failure_points.get(vid, "n/a")
+        color = dropout_colors.get(dropout, "white")
+        table.add_row(
+            rank,
+            entry.get("label", vid),
+            entry.get("hook_type", "—"),
+            str(entry.get("open_score", "—")),
+            str(entry.get("reply_score", "—")),
+            f"[{color}]{dropout}[/{color}]",
+        )
+
+    _console.print(table)
+
+
+def print_project_table(projects: list[dict]) -> None:
+    """Render cached ICP projects as a table."""
+    if not projects:
+        sys.stderr.write("No cached ICP projects found.\n")
+        sys.stderr.write("Run: prospect-sim project build --icp <file>\n")
+        return
+
+    if not _RICH or not _console:
+        for p in projects:
+            print(f"{p.get('project_id', '?')}  {p.get('icp_file', '?')}  {p.get('created_at', '?')}")
+        return
+
+    table = Table(title="Cached ICP Projects", show_header=True, header_style="bold cyan")
+    table.add_column("Project ID", min_width=16)
+    table.add_column("ICP File", min_width=24)
+    table.add_column("Cached At", min_width=20)
+
+    for p in projects:
+        table.add_row(
+            p.get("project_id", "?"),
+            p.get("icp_file", "?"),
+            p.get("created_at", "?"),
+        )
+    _console.print(table)
+
+
+@contextmanager
+def spinner(label: str, quiet: bool = False):
+    """
+    Context manager showing a spinner during long operations.
+    Suppressed in --quiet mode (agents don't read spinners).
+
+    Usage:
+        with spinner("Building ICP graph...", quiet=quiet):
+            result = client.build_graph(...)
+    """
+    if quiet or not _RICH:
+        yield
+        return
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        transient=True,
+        console=_err_console,
+    ) as progress:
+        progress.add_task(label, total=None)
+        yield

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,8 +20,11 @@ dependencies = [
     # Neo4j
     "neo4j>=5.15.0",
 
-    # HTTP requests (for Ollama embedding API)
+    # HTTP requests (for Ollama embedding API + CLI client)
     "requests>=2.31.0",
+
+    # CLI framework (agent-friendly interface)
+    "typer[all]>=0.12.0",
 
     # OASIS social media simulation (Wonderwall fork)
     # Wonderwall (oasis package) is bundled directly in backend/oasis/
@@ -71,5 +74,8 @@ dev = [
     "pytest-asyncio>=0.23.0",
 ]
 
+[project.scripts]
+prospect-sim = "prospect_sim_cli.main:main"
+
 [tool.hatch.build.targets.wheel]
-packages = ["app"]
+packages = ["app", "prospect_sim_cli"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1264,6 +1264,7 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "sentence-transformers" },
     { name = "torch" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -1302,6 +1303,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "sentence-transformers", specifier = ">=2.2.0" },
     { name = "torch", specifier = ">=2.0.0" },
+    { name = "typer", extras = ["all"], specifier = ">=0.12.0" },
 ]
 provides-extras = ["dev"]
 

--- a/backend/wonderwall/simulations/email_inbox/__init__.py
+++ b/backend/wonderwall/simulations/email_inbox/__init__.py
@@ -1,0 +1,46 @@
+"""Email inbox simulation for B2B cold outreach copy variant testing.
+
+Tests cold email copy variants against synthetic B2B decision-maker personas
+(HR Director, Head of People at Spanish SMEs) before sending to real leads.
+
+Usage::
+
+    from wonderwall.simulations.email_inbox import email_inbox_simulation
+
+    env = oasis.make(
+        agent_graph=agent_graph,
+        simulation=email_inbox_simulation,
+        database_path="./data/inbox.db",
+    )
+"""
+from wonderwall.simulations.base import SimulationConfig
+from wonderwall.simulations.email_inbox.actions import EmailInboxAction
+from wonderwall.simulations.email_inbox.environment import EmailInboxEnvironment
+from wonderwall.simulations.email_inbox.platform import EmailInboxPlatform
+from wonderwall.simulations.email_inbox.prompts import EmailInboxPromptBuilder
+
+email_inbox_simulation = SimulationConfig(
+    name="email_inbox",
+    platform_cls=EmailInboxPlatform,
+    action_cls=EmailInboxAction,
+    environment_cls=EmailInboxEnvironment,
+    prompt_builder=EmailInboxPromptBuilder(),
+    default_actions=[
+        "open_email",
+        "read_email",
+        "reply",
+        "forward",
+        "archive",
+        "do_nothing",
+    ],
+    # Variants are injected at runtime via platform_kwargs
+    platform_kwargs={},
+)
+
+__all__ = [
+    "email_inbox_simulation",
+    "EmailInboxPlatform",
+    "EmailInboxAction",
+    "EmailInboxEnvironment",
+    "EmailInboxPromptBuilder",
+]

--- a/backend/wonderwall/simulations/email_inbox/actions.py
+++ b/backend/wonderwall/simulations/email_inbox/actions.py
@@ -1,0 +1,123 @@
+"""Email inbox agent actions — LLM-callable tools for B2B decision-maker personas.
+
+Each public async method is auto-discovered as an LLM tool via
+BaseAction.get_openai_function_list(). Docstrings become the tool descriptions
+the LLM sees — they must guide realistic B2B inbox behavior.
+"""
+from __future__ import annotations
+
+from wonderwall.simulations.base import BaseAction
+
+
+class EmailInboxAction(BaseAction):
+    """Actions available to a B2B decision-maker agent in the email inbox simulation."""
+
+    async def open_email(self, variant_id: int):
+        """Open a cold email to see the sender and subject line preview.
+
+        Call this when a subject line catches your attention and you want to
+        see more. This is a low-commitment action — opening does NOT mean
+        you will reply. You open maybe 20-40% of cold emails you receive.
+
+        Common triggers for opening:
+        - Subject mentions something specific about your company or role
+        - A timeline or event hooks your curiosity (not generic pain)
+        - The sender is known to you or referred by someone you trust
+        - The subject is short, specific, and doesn't feel like a template
+
+        Args:
+            variant_id (int): The ID of the email variant to open.
+
+        Returns:
+            dict: Contains 'subject_line', 'body', and 'hook_type' of the email.
+        """
+        return await self.perform_action(variant_id, "open_email")
+
+    async def read_email(self, variant_id: int):
+        """Read the entire email body after opening.
+
+        Call this only AFTER opening the email (open_email first), and only
+        if the first paragraph didn't immediately make you want to archive it.
+        You fully read maybe 40-60% of emails you open.
+
+        You stop reading when:
+        - The opening is generic ("I help companies like yours...")
+        - You hit a pain/problem framing that feels presumptuous
+        - The email is longer than 150 words and not immediately relevant
+        - There's no specific detail that proves they know your situation
+
+        Args:
+            variant_id (int): The ID of the email variant to read fully.
+
+        Returns:
+            dict: Confirmation that you've read to completion.
+        """
+        return await self.perform_action(variant_id, "read_email")
+
+    async def reply(self, variant_id: int, notes: str = ""):
+        """Send a positive reply to the email — genuine interest signal.
+
+        Call this only if the email passed ALL of:
+        1. Subject was specific enough to open
+        2. Opening didn't feel like a template
+        3. The body addressed something you actually care about right now
+        4. The CTA was specific and low-commitment (not 'book a 30-min demo')
+        5. The timing felt right for your current situation
+
+        As a busy HR Director, you reply to maybe 5-15% of cold emails you open.
+        Do NOT reply unless all conditions are met — be realistic about your
+        skepticism and calendar constraints.
+
+        Args:
+            variant_id (int): The ID of the email variant you're replying to.
+            notes (str): Brief reason for your reply or what triggered it.
+
+        Returns:
+            dict: Confirmation of reply.
+        """
+        return await self.perform_action((variant_id, notes), "reply")
+
+    async def forward(self, variant_id: int, notes: str = ""):
+        """Forward the email to a colleague for their opinion or to loop them in.
+
+        Call this when the email is relevant but you want a second opinion,
+        or when it maps to a colleague's responsibility. Forwarding is a
+        stronger positive signal than just reading — it means you see value
+        AND have an internal champion in mind.
+
+        Typical trigger: email addresses an initiative your team is working on
+        and you think the CEO/CFO/team lead should see it.
+
+        Args:
+            variant_id (int): The ID of the email variant to forward.
+            notes (str): Who you'd forward it to and why.
+
+        Returns:
+            dict: Confirmation of forward action.
+        """
+        return await self.perform_action((variant_id, notes), "forward")
+
+    async def archive(self, variant_id: int, dropout_point: str = "unknown"):
+        """Archive the email without replying — you've decided it's not worth your time.
+
+        Call this when you decide to stop engaging with an email. Be specific
+        about WHERE you dropped off — this is the most valuable feedback.
+
+        dropout_point options:
+        - 'subject_line' — never opened it; subject didn't grab you
+        - 'opening'      — opened but first sentence killed it (generic/wrong person)
+        - 'body'         — got into the body but lost interest before the CTA
+        - 'cta'          — read everything but the ask was too big or wrong timing
+        - 'timing'       — content is fine but wrong moment in your calendar/budget cycle
+
+        This is your default action for most cold emails. HR Directors archive
+        80-95% of cold outreach they receive.
+
+        Args:
+            variant_id (int): The ID of the email variant to archive.
+            dropout_point (str): Where you stopped engaging. Be specific.
+
+        Returns:
+            dict: Confirmation with your dropout point recorded.
+        """
+        return await self.perform_action((variant_id, dropout_point), "archive")

--- a/backend/wonderwall/simulations/email_inbox/environment.py
+++ b/backend/wonderwall/simulations/email_inbox/environment.py
@@ -1,0 +1,73 @@
+"""Email inbox agent environment — what the B2B agent observes each round.
+
+Converts the platform's inbox state into a text prompt the agent's LLM receives.
+The agent sees their inbox, which emails they've already opened/read/replied to,
+and a reminder of their current workload context.
+"""
+from __future__ import annotations
+
+from wonderwall.simulations.base import BaseEnvironment
+
+
+class EmailInboxEnvironment(BaseEnvironment):
+    """Converts inbox state into the text observation prompt for B2B agents."""
+
+    async def to_text_prompt(self) -> str:
+        # Fetch the agent's current inbox state from the platform
+        inbox_data = await self.action.perform_action(
+            self.action.agent_id, "get_inbox"
+        )
+
+        parts = []
+
+        if inbox_data.get("success") and inbox_data.get("inbox"):
+            parts.append("YOUR INBOX — COLD EMAILS RECEIVED:")
+            parts.append("")
+
+            for email in inbox_data["inbox"]:
+                status_parts = []
+                if email["replied"]:
+                    status_parts.append("✓ REPLIED")
+                elif email["forwarded"]:
+                    status_parts.append("→ FORWARDED")
+                elif email["read_to_completion"]:
+                    status_parts.append("READ")
+                elif email["opened"]:
+                    status_parts.append("OPENED")
+                else:
+                    status_part = "UNREAD"
+                    status_parts.append(status_part)
+
+                if email["dropout_point"] and not email["replied"]:
+                    status_parts.append(f"[dropped at: {email['dropout_point']}]")
+
+                status = " | ".join(status_parts)
+                parts.append(
+                    f"  [{email['variant_id']}] {email['variant_label']}\n"
+                    f"      Subject: \"{email['subject_line']}\"\n"
+                    f"      Hook type: {email['hook_type']} | Status: {status}"
+                )
+                parts.append("")
+        else:
+            parts.append("No emails in your inbox yet.")
+            parts.append("")
+
+        # Inject cross-platform context if available (e.g., from social media rounds)
+        if self.extra_observation_context:
+            parts.append(f"CONTEXT FROM OTHER CHANNELS:\n{self.extra_observation_context}")
+            parts.append("")
+
+        parts.append("DECIDE how to interact with your inbox this round:")
+        parts.append("  - open_email(variant_id) — open an unread email")
+        parts.append("  - read_email(variant_id) — read an opened email fully")
+        parts.append("  - reply(variant_id, notes) — send a positive reply")
+        parts.append("  - forward(variant_id, notes) — forward to a colleague")
+        parts.append("  - archive(variant_id, dropout_point) — discard without replying")
+        parts.append("  - do_nothing() — no action this round (busy, distracted, etc.)")
+        parts.append("")
+        parts.append(
+            "You receive dozens of cold emails per week. Be realistic — most will be archived. "
+            "Only engage further if the email is genuinely relevant to your current situation."
+        )
+
+        return "\n".join(parts)

--- a/backend/wonderwall/simulations/email_inbox/platform.py
+++ b/backend/wonderwall/simulations/email_inbox/platform.py
@@ -1,0 +1,343 @@
+"""Email inbox simulation platform.
+
+Server-side platform that handles B2B email inbox interactions.
+Each agent receives cold email variants and decides how to engage.
+Tracks open → read → reply intent → booking probability per variant.
+
+Follows the same BasePlatform pattern as PolymarketPlatform.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, List, Dict
+
+from wonderwall.clock.clock import Clock
+from wonderwall.simulations.base import BasePlatform
+
+logger = logging.getLogger(__name__)
+
+
+class EmailInboxPlatform(BasePlatform):
+    """B2B email inbox platform for cold outreach copy variant testing.
+
+    Agents represent HR Director / Head of People personas at Spanish SMEs.
+    Each round, agents decide how to interact with the emails in their inbox.
+    State is tracked in SQLite: opens, reads, replies, and dropout points.
+    """
+
+    required_schemas = ["email.sql"]
+
+    def __init__(
+        self,
+        db_path: str,
+        channel: Any = None,
+        sandbox_clock: Clock | None = None,
+        start_time: datetime | None = None,
+        variants: List[Dict] | None = None,
+    ):
+        # Store variants before super().__init__ so _seed_variants can be called after DB init
+        self._pending_variants = variants or []
+        super().__init__(
+            db_path=db_path,
+            channel=channel,
+            sandbox_clock=sandbox_clock,
+            start_time=start_time,
+        )
+        # Seed variants into DB immediately after schema init
+        if self._pending_variants:
+            self._seed_variants(self._pending_variants)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _seed_variants(self, variants: List[Dict]) -> None:
+        """Insert email copy variants into the DB at simulation start."""
+        current_time = self.get_current_time()
+        for v in variants:
+            self._execute_db_command(
+                "INSERT OR IGNORE INTO email_variant "
+                "(variant_id, variant_label, subject_line, body, hook_type, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    v.get("variant_id", v.get("id", 0)),
+                    v.get("variant_label", v.get("label", f"Variant {v.get('id', 0)}")),
+                    v.get("subject_line", ""),
+                    v.get("body", ""),
+                    v.get("hook_type", "unknown"),
+                    current_time,
+                ),
+                commit=False,
+            )
+        self.db.commit()
+        logger.info(f"Seeded {len(variants)} email variants into inbox DB")
+
+    # ------------------------------------------------------------------
+    # Platform actions (dispatched via getattr by BasePlatform.running)
+    # ------------------------------------------------------------------
+
+    async def open_email(self, agent_id: int, message: Any) -> Dict:
+        """Agent opens an email variant — records the open event."""
+        variant_id = int(message) if message is not None else 0
+        current_time = self.get_current_time()
+
+        # Update or insert inbox state (mark opened)
+        self._execute_db_command(
+            "INSERT INTO agent_inbox_state "
+            "(agent_id, variant_id, opened, last_round, created_at) "
+            "VALUES (?, ?, 1, ?, ?) "
+            "ON CONFLICT(agent_id, variant_id) DO UPDATE SET "
+            "opened=1, last_round=excluded.last_round",
+            (agent_id, variant_id, 0, current_time),
+            commit=True,
+        )
+        self._record_trace(agent_id, "open_email", {"variant_id": variant_id}, current_time)
+        self._log_inbox_event(agent_id, variant_id, "open_email", None, None, current_time)
+
+        # Return the email content so the agent can read it
+        row = self._execute_db_command(
+            "SELECT subject_line, body, hook_type FROM email_variant WHERE variant_id=?",
+            (variant_id,)
+        ).fetchone()
+
+        if row:
+            return {
+                "success": True,
+                "variant_id": variant_id,
+                "subject_line": row[0],
+                "body": row[1],
+                "hook_type": row[2],
+            }
+        return {"success": False, "error": f"Variant {variant_id} not found"}
+
+    async def read_email(self, agent_id: int, message: Any) -> Dict:
+        """Agent reads the email body to completion."""
+        variant_id = int(message) if message is not None else 0
+        current_time = self.get_current_time()
+
+        self._execute_db_command(
+            "INSERT INTO agent_inbox_state "
+            "(agent_id, variant_id, opened, read_to_completion, last_round, created_at) "
+            "VALUES (?, ?, 1, 1, ?, ?) "
+            "ON CONFLICT(agent_id, variant_id) DO UPDATE SET "
+            "opened=1, read_to_completion=1, last_round=excluded.last_round",
+            (agent_id, variant_id, 0, current_time),
+            commit=True,
+        )
+        self._record_trace(agent_id, "read_email", {"variant_id": variant_id}, current_time)
+        self._log_inbox_event(agent_id, variant_id, "read_email", None, None, current_time)
+
+        return {"success": True, "variant_id": variant_id, "action": "read_to_completion"}
+
+    async def reply(self, agent_id: int, message: Any) -> Dict:
+        """Agent sends a positive reply to an email variant.
+
+        This is the primary success signal — represents genuine interest.
+        """
+        # message is (variant_id, reply_text)
+        if isinstance(message, (list, tuple)) and len(message) >= 1:
+            variant_id = int(message[0])
+            notes = str(message[1]) if len(message) > 1 else None
+        else:
+            variant_id = int(message) if message is not None else 0
+            notes = None
+
+        current_time = self.get_current_time()
+
+        self._execute_db_command(
+            "INSERT INTO agent_inbox_state "
+            "(agent_id, variant_id, opened, read_to_completion, replied, reply_intent_score, last_round, created_at) "
+            "VALUES (?, ?, 1, 1, 1, 1.0, ?, ?) "
+            "ON CONFLICT(agent_id, variant_id) DO UPDATE SET "
+            "opened=1, read_to_completion=1, replied=1, reply_intent_score=1.0, "
+            "last_round=excluded.last_round",
+            (agent_id, variant_id, 0, current_time),
+            commit=True,
+        )
+        self._record_trace(agent_id, "reply", {"variant_id": variant_id, "notes": notes}, current_time)
+        self._log_inbox_event(agent_id, variant_id, "reply", None, notes, current_time)
+
+        return {"success": True, "variant_id": variant_id, "action": "replied"}
+
+    async def archive(self, agent_id: int, message: Any) -> Dict:
+        """Agent archives the email without replying — records dropout point."""
+        # message is (variant_id, dropout_point)
+        if isinstance(message, (list, tuple)) and len(message) >= 1:
+            variant_id = int(message[0])
+            dropout_point = str(message[1]) if len(message) > 1 else "unknown"
+        else:
+            variant_id = int(message) if message is not None else 0
+            dropout_point = "unknown"
+
+        current_time = self.get_current_time()
+
+        # Record dropout point — only set if not already set (first dropout wins)
+        self._execute_db_command(
+            "INSERT INTO agent_inbox_state "
+            "(agent_id, variant_id, opened, dropout_point, last_round, created_at) "
+            "VALUES (?, ?, 1, ?, ?, ?) "
+            "ON CONFLICT(agent_id, variant_id) DO UPDATE SET "
+            "opened=CASE WHEN opened=0 THEN 1 ELSE opened END, "
+            "dropout_point=CASE WHEN dropout_point IS NULL THEN excluded.dropout_point ELSE dropout_point END, "
+            "last_round=excluded.last_round",
+            (agent_id, variant_id, dropout_point, 0, current_time),
+            commit=True,
+        )
+        self._record_trace(agent_id, "archive", {"variant_id": variant_id, "dropout_point": dropout_point}, current_time)
+        self._log_inbox_event(agent_id, variant_id, "archive", dropout_point, None, current_time)
+
+        return {"success": True, "variant_id": variant_id, "dropout_point": dropout_point}
+
+    async def forward(self, agent_id: int, message: Any) -> Dict:
+        """Agent forwards the email to a colleague — strong positive signal.
+
+        Forwarding indicates the agent sees value AND wants an internal sponsor.
+        """
+        if isinstance(message, (list, tuple)) and len(message) >= 1:
+            variant_id = int(message[0])
+            notes = str(message[1]) if len(message) > 1 else None
+        else:
+            variant_id = int(message) if message is not None else 0
+            notes = None
+
+        current_time = self.get_current_time()
+
+        # Forward implies opened + read + high intent (0.8)
+        self._execute_db_command(
+            "INSERT INTO agent_inbox_state "
+            "(agent_id, variant_id, opened, read_to_completion, forwarded, reply_intent_score, last_round, created_at) "
+            "VALUES (?, ?, 1, 1, 1, 0.8, ?, ?) "
+            "ON CONFLICT(agent_id, variant_id) DO UPDATE SET "
+            "opened=1, read_to_completion=1, forwarded=1, "
+            "reply_intent_score=MAX(reply_intent_score, 0.8), "
+            "last_round=excluded.last_round",
+            (agent_id, variant_id, 0, current_time),
+            commit=True,
+        )
+        self._record_trace(agent_id, "forward", {"variant_id": variant_id, "notes": notes}, current_time)
+        self._log_inbox_event(agent_id, variant_id, "forward", None, notes, current_time)
+
+        return {"success": True, "variant_id": variant_id, "action": "forwarded_to_colleague"}
+
+    # ------------------------------------------------------------------
+    # Query helpers used by EmailInboxEnvironment
+    # ------------------------------------------------------------------
+
+    async def get_inbox(self, agent_id: int) -> Dict:
+        """Return all email variants with current open/read status for the agent."""
+        variants = self._execute_db_command(
+            "SELECT v.variant_id, v.variant_label, v.subject_line, v.hook_type, "
+            "COALESCE(s.opened, 0), COALESCE(s.read_to_completion, 0), "
+            "COALESCE(s.replied, 0), COALESCE(s.forwarded, 0), s.dropout_point "
+            "FROM email_variant v "
+            "LEFT JOIN agent_inbox_state s "
+            "ON v.variant_id = s.variant_id AND s.agent_id = ? "
+            "ORDER BY v.variant_id",
+            (agent_id,)
+        ).fetchall()
+
+        return {
+            "success": True,
+            "inbox": [
+                {
+                    "variant_id": row[0],
+                    "variant_label": row[1],
+                    "subject_line": row[2],
+                    "hook_type": row[3],
+                    "opened": bool(row[4]),
+                    "read_to_completion": bool(row[5]),
+                    "replied": bool(row[6]),
+                    "forwarded": bool(row[7]),
+                    "dropout_point": row[8],
+                }
+                for row in variants
+            ]
+        }
+
+    # ------------------------------------------------------------------
+    # Report data helpers — called by report agent after simulation
+    # ------------------------------------------------------------------
+
+    def get_variant_summary(self) -> List[Dict]:
+        """Aggregate stats per variant across all agents — for report generation."""
+        rows = self._execute_db_command(
+            "SELECT "
+            "  v.variant_id, v.variant_label, v.hook_type, "
+            "  COUNT(DISTINCT s.agent_id) as total_agents, "
+            "  SUM(s.opened) as total_opens, "
+            "  SUM(s.read_to_completion) as total_reads, "
+            "  SUM(s.replied) as total_replies, "
+            "  SUM(s.forwarded) as total_forwards, "
+            "  AVG(s.reply_intent_score) as avg_intent "
+            "FROM email_variant v "
+            "LEFT JOIN agent_inbox_state s ON v.variant_id = s.variant_id "
+            "GROUP BY v.variant_id "
+            "ORDER BY total_replies DESC, avg_intent DESC",
+        ).fetchall()
+
+        return [
+            {
+                "variant_id": row[0],
+                "variant_label": row[1],
+                "hook_type": row[2],
+                "total_agents": row[3] or 0,
+                "total_opens": row[4] or 0,
+                "total_reads": row[5] or 0,
+                "total_replies": row[6] or 0,
+                "total_forwards": row[7] or 0,
+                "avg_reply_intent": round(float(row[8] or 0), 3),
+                "open_rate": round((row[4] or 0) / max(row[3] or 1, 1), 3),
+                "reply_rate": round((row[6] or 0) / max(row[3] or 1, 1), 3),
+            }
+            for row in rows
+        ]
+
+    def get_dropout_breakdown(self) -> Dict[str, List[Dict]]:
+        """Per-variant dropout point distribution — where agents lost interest."""
+        rows = self._execute_db_command(
+            "SELECT v.variant_label, s.dropout_point, COUNT(*) as count "
+            "FROM agent_inbox_state s "
+            "JOIN email_variant v ON s.variant_id = v.variant_id "
+            "WHERE s.dropout_point IS NOT NULL "
+            "GROUP BY v.variant_id, s.dropout_point "
+            "ORDER BY v.variant_id, count DESC"
+        ).fetchall()
+
+        result: Dict[str, List[Dict]] = {}
+        for row in rows:
+            label = row[0]
+            if label not in result:
+                result[label] = []
+            result[label].append({"dropout_point": row[1], "count": row[2]})
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helper
+    # ------------------------------------------------------------------
+
+    def _log_inbox_event(
+        self,
+        agent_id: int,
+        variant_id: int,
+        event_type: str,
+        dropout_point: str | None,
+        notes: str | None,
+        timestamp: str,
+    ) -> None:
+        """Append a row to the inbox_event log."""
+        # Derive current round from last_round value in agent_inbox_state
+        row = self._execute_db_command(
+            "SELECT last_round FROM agent_inbox_state WHERE agent_id=? AND variant_id=?",
+            (agent_id, variant_id)
+        ).fetchone()
+        round_num = row[0] if row else 0
+
+        self._execute_db_command(
+            "INSERT INTO inbox_event "
+            "(agent_id, variant_id, round_num, event_type, dropout_point, notes, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (agent_id, variant_id, round_num, event_type, dropout_point, notes, timestamp),
+            commit=True,
+        )

--- a/backend/wonderwall/simulations/email_inbox/prompts.py
+++ b/backend/wonderwall/simulations/email_inbox/prompts.py
@@ -1,0 +1,115 @@
+"""Prompt builder for B2B email inbox agents.
+
+Generates the system prompt that defines an HR Director / Head of People
+persona at a Spanish SME. The persona's B2B-specific traits determine how
+realistically they evaluate cold outreach.
+"""
+from __future__ import annotations
+
+from wonderwall.simulations.base import BasePromptBuilder
+
+
+class EmailInboxPromptBuilder(BasePromptBuilder):
+    """Builds system prompts for B2B decision-maker agents in inbox simulations."""
+
+    def build_system_prompt(self, user_info) -> str:
+        name_str = ""
+        profile_str = ""
+        b2b_context = ""
+
+        if user_info.name:
+            name_str = f"Your name is {user_info.name}."
+
+        # Pull persona from user_info.profile["other_info"] — same structure as Polymarket
+        if user_info.profile and "other_info" in user_info.profile:
+            other = user_info.profile["other_info"]
+
+            if "user_profile" in other and other["user_profile"]:
+                profile_str = f"Background: {other['user_profile']}"
+
+            # Build B2B context from inbox-specific persona fields
+            budget_authority = other.get("budget_authority", False)
+            skepticism = other.get("cold_email_skepticism", 0.6)
+            inbox_habit = other.get("inbox_habit", "batch_processor")
+            decision_style = other.get("decision_style", "roi_driven")
+            pain_signals = other.get("pain_signal_sensitivity", {})
+
+            budget_line = (
+                "You control the L&D / HR tools budget and can approve purchases."
+                if budget_authority
+                else "You influence purchasing decisions but final budget approval goes through your CFO or CEO."
+            )
+
+            skepticism_level = (
+                "very skeptical" if skepticism > 0.7
+                else "moderately skeptical" if skepticism > 0.4
+                else "relatively open"
+            )
+
+            inbox_habits = {
+                "morning_scanner": "You scan your inbox first thing in the morning and triage quickly — you give each email about 3 seconds before deciding to open or ignore.",
+                "batch_processor": "You batch-process email 2-3 times a day. You're efficient but not rushed — if something looks interesting you'll skim it.",
+                "responsive": "You check email throughout the day and tend to reply quickly when something catches your eye.",
+            }
+            inbox_desc = inbox_habits.get(inbox_habit, inbox_habits["batch_processor"])
+
+            decision_styles = {
+                "roi_driven": "You make decisions based on ROI — you need to see concrete time savings or cost reduction, not features.",
+                "risk_averse": "You're cautious about new tools — you need social proof and references before committing to anything.",
+                "early_adopter": "You're open to trying new tools if they solve a real problem — you don't need to wait for others.",
+                "social_proof": "You trust peer recommendations — if someone in your network vouches for it, you're interested.",
+            }
+            decision_desc = decision_styles.get(decision_style, decision_styles["roi_driven"])
+
+            pain_str = ""
+            if pain_signals:
+                top_pains = sorted(pain_signals.items(), key=lambda x: x[1], reverse=True)[:3]
+                pain_str = "\nThings that actually resonate with you right now:\n" + "\n".join(
+                    f"  - {k} (sensitivity: {'high' if v > 0.7 else 'medium' if v > 0.4 else 'low'})"
+                    for k, v in top_pains
+                )
+
+            b2b_context = f"""
+{budget_line}
+You are {skepticism_level} of cold outreach.
+{inbox_desc}
+{decision_desc}{pain_str}"""
+
+        return f"""\
+# WHO YOU ARE
+You are an HR professional (HR Director or Head of People) at a Spanish B2B company with 80–150 employees. \
+You have no dedicated L&D (Learning & Development) team — training and development is handled by you and 1–2 HR colleagues on top of your other responsibilities.
+
+{name_str}
+{profile_str}
+{b2b_context}
+
+# YOUR INBOX REALITY
+You receive dozens of cold emails per week. The vast majority are generic, templated, and immediately recognisable as mass outreach. \
+You have developed a strong filter:
+- You archive most cold emails after reading only the subject line (3-second rule)
+- If you open it, you give the first sentence 5 seconds to prove it's not a template
+- If the first sentence is about the sender ("We help companies like yours...") → immediate archive
+- If it mentions a specific pain you're not currently feeling → archive
+- If it's relevant but the ask is too big ("30-minute call?") → archive with good feelings
+- You rarely reply to cold email — maybe 5–10% of what you open
+
+# WHAT MAKES YOU ENGAGE
+The emails that stop you are:
+1. **Timeline/event hooks**: something specific happened at your company that this person noticed
+2. **Specific company signal**: they mention something from your LinkedIn page, job postings, or company news
+3. **Concrete outcome**: "Ahorra 15 horas/semana" beats "mejora el desarrollo de tu equipo"
+4. **Low-commitment ask**: "responde 'sí'" or "¿tiene sentido?" beats "agenda una llamada de 30 min"
+5. **Relevance right now**: timing matters — if you're hiring heavily, L&D tools are more interesting
+
+# YOUR DECISION PROCESS THIS ROUND
+Look at the emails in your inbox. For each unprocessed email:
+1. Decide if the subject line is worth opening (3-second test)
+2. If you open it, decide if the opening paragraph passes (5-second test)
+3. If you read it fully, decide if you'd reply, forward, or archive
+4. Be honest about your dropout point if you archive
+
+You can only take ONE action per round. Choose the most realistic next step.
+
+# RESPONSE METHOD
+Please perform actions by tool calling."""

--- a/backend/wonderwall/simulations/email_inbox/schema/email.sql
+++ b/backend/wonderwall/simulations/email_inbox/schema/email.sql
@@ -1,0 +1,45 @@
+-- Email inbox simulation schema
+-- Tracks email variants and per-agent inbox state for copy variant testing.
+
+-- Email copy variants under test
+CREATE TABLE IF NOT EXISTS email_variant (
+    variant_id   INTEGER PRIMARY KEY,
+    variant_label TEXT NOT NULL,       -- e.g. "Variant A — Timeline Hook"
+    subject_line TEXT NOT NULL,
+    body         TEXT NOT NULL,
+    hook_type    TEXT DEFAULT 'unknown', -- timeline, problem, numbers, social_proof, curiosity
+    created_at   TEXT NOT NULL
+);
+
+-- Per-agent state per variant across all rounds
+-- One row per (agent_id, variant_id) — updated in place as rounds progress
+CREATE TABLE IF NOT EXISTS agent_inbox_state (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id            INTEGER NOT NULL,
+    variant_id          INTEGER NOT NULL,
+    -- Cumulative boolean flags (0/1) — set to 1 once triggered, never reversed
+    opened              INTEGER NOT NULL DEFAULT 0,
+    read_to_completion  INTEGER NOT NULL DEFAULT 0,
+    replied             INTEGER NOT NULL DEFAULT 0,
+    forwarded           INTEGER NOT NULL DEFAULT 0,
+    -- Where the agent dropped off (NULL = completed or not yet decided)
+    dropout_point       TEXT,  -- 'subject_line' | 'opening' | 'body' | 'cta' | NULL
+    -- Accumulated reply intent score (0.0–1.0), updated each active round
+    reply_intent_score  REAL NOT NULL DEFAULT 0.0,
+    last_round          INTEGER NOT NULL DEFAULT 0,
+    created_at          TEXT NOT NULL,
+    UNIQUE(agent_id, variant_id)
+);
+
+-- Append-only event log for every inbox interaction
+CREATE TABLE IF NOT EXISTS inbox_event (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id     INTEGER NOT NULL,
+    variant_id   INTEGER NOT NULL,
+    round_num    INTEGER NOT NULL,
+    -- Action taken: open_email | read_email | reply | forward | archive | do_nothing
+    event_type   TEXT NOT NULL,
+    dropout_point TEXT,
+    notes        TEXT,
+    created_at   TEXT NOT NULL
+);

--- a/docs/WHAT_PROSPECT_SIM_PREDICTS.md
+++ b/docs/WHAT_PROSPECT_SIM_PREDICTS.md
@@ -1,0 +1,181 @@
+# What prospect-sim Predicts — and What It Cannot
+
+**A first-principles guide to reading simulation output correctly.**
+
+---
+
+## The Mental Model
+
+prospect-sim is not a crystal ball. It is a **controlled experiment environment** for human cognitive behavior under a specific stimulus — a cold email.
+
+Each run does one thing: places a synthetic decision-maker (built from your ICP profile) in front of your email copy, and records what they do. Open it. Read past the opening. Reply. Archive. Forward. Do nothing.
+
+The predictions are only as reliable as two things:
+1. **How accurately the synthetic persona matches your real ICP** — which depends on the quality of your seed document.
+2. **How well the behavioral model captures real inbox decision-making** — which is calibrated against real-world send data over time.
+
+Everything that follows flows from understanding this.
+
+---
+
+## The Prediction Hierarchy
+
+Not all outputs carry equal weight. Listed from most to least reliable:
+
+### 1. Failure Point Diagnosis — Most Reliable
+**What it tells you:** Where your copy loses the reader — subject line, opening line, body, or CTA.
+
+This is the most reliable output because it doesn't depend on calibrated absolute rates. It depends only on *which cognitive hurdle the email fails to clear*. A persona who never opens the email failed at the subject line. A persona who opens but doesn't read to completion failed at the opening hook. A persona who reads fully but doesn't reply failed at the body or CTA.
+
+The mechanism of disengagement is well-modeled. The number of agents who disengage is less reliable than the point at which they disengage.
+
+**Use this to:** Diagnose exactly which part of your copy needs surgery, not just "this variant underperformed."
+
+---
+
+### 2. Relative Variant Ranking — Reliable
+**What it tells you:** Variant A outperforms Variant B, with a confidence magnitude (3x, 1.5x, tied).
+
+The ranking is more reliable than the absolute numbers. If Variant B (timeline hook) consistently gets more reply intents than Variant A (problem hook) across 30+ synthetic personas, that directional signal is meaningful — even if the absolute simulated reply rates don't match real-world rates.
+
+The magnitude matters too. A 3x difference between variants is a strong signal. A 1.1x difference is noise.
+
+**Use this to:** Pick the winner before sending to real leads. Discard the obvious losers early.
+
+---
+
+### 3. Persona Segment Sensitivity — Reliable with Good Seed Docs
+**What it tells you:** Variant A resonates with risk-averse budget-holders; Variant B resonates with early-adopter Heads of People.
+
+When personas are built from rich, specific ICP seed documents, their `decision_style`, `cold_email_skepticism`, and `pain_signal_sensitivity` fields create meaningfully different agents. The same email copy will behave differently across them — and that divergence is real signal.
+
+**Use this to:** Segment your outreach. Don't send the same script to a conservative 300-person company HR Director and an agile 50-person startup Head of People.
+
+---
+
+### 4. Absolute Rate Estimates — Least Reliable
+**What it tells you:** "Variant A has a 12% simulated reply rate."
+
+This number is **not calibrated against real-world send data** until you run Phase 6 validation (simulate a known campaign, compare to actual results, measure the delta). Until that calibration exists, absolute numbers are directionally useful at best and misleading at worst.
+
+**Use this only for:** Internal ranking (12% vs 4% → strong signal for the winner). Never report these numbers externally as predictions of real reply rates.
+
+---
+
+## What You Can Test
+
+### Copy-level tests (vary the email, same ICP)
+
+| Variable | What the simulation captures |
+|---|---|
+| Subject line | `open_email` vs `do_nothing` — the 3-second subject test |
+| Hook type | `read_to_completion` after opening — problem / timeline / numbers / authority |
+| Email length | `body` dropout point — where attention breaks |
+| CTA friction | `cta` dropout point — "book a call" vs "reply with 3 slots" vs "watch Loom" |
+| Social proof presence | Affects `decision_style=social_proof` personas more than `decision_style=roi_driven` |
+| Personalization level | Generic vs company-specific references — captured in persona's engagement triggers |
+| Pain point framing | Which pain you lead with — varies by `pain_signal_sensitivity` weights on each persona |
+
+### ICP segment tests (same copy, vary the audience)
+
+| Variable | How to run it |
+|---|---|
+| Job title (HR Director vs Head of People vs VP People) | Different seed docs describing each persona type |
+| Company size (50 vs 150 vs 500 employees) | Seed doc describes company size context |
+| Industry vertical | Include industry-specific context in seed doc |
+| Pain awareness level | Seed doc describes whether the prospect is actively problem-aware or not |
+| Specific prospect simulation | Feed a real prospect's LinkedIn + company page as seed doc |
+
+### Structural tests (vary the format, same message)
+
+| Variable | What it tests |
+|---|---|
+| Short (3 sentences) vs long (8+ sentences) | Attention and cognitive load |
+| Plain text vs formatted (bullets, bold) | Format-triggered skepticism in certain personas |
+| First-person narrative vs data-led opening | Persona `decision_style` response |
+| Question opening vs statement opening | Curiosity vs authority triggers |
+
+---
+
+## What You Cannot Predict
+
+### 1. Absolute reply rates
+The simulated 12% is not a prediction of real-world 12%. It is a relative signal. Calibration against real send data is required before treating these numbers as forecasts.
+
+### 2. Multi-touch sequence dynamics
+The system models a single email. It does not model what happens when email 1 gets no reply and email 2 follows up with "bumping this to the top of your inbox." Sequence fatigue, follow-up timing, and persistence effects are out of scope for v1.
+
+### 3. Organizational politics
+The simulation models an individual decision-maker. It does not model that the real prospect's boss just signed a contract with a competitor, that they're in a hiring freeze, or that their company was acquired last week. No seed document captures real-time organizational context.
+
+### 4. Accumulated brand familiarity
+If a prospect has seen your brand at a conference, follows you on LinkedIn, or was referred by a trusted colleague — that context fundamentally changes reception. The simulation starts from a cold, uncontextualized state.
+
+### 5. Time-of-day and day-of-week effects
+The `inbox_habit` field (morning_scanner, batch_processor, responsive) is modeled in the persona, but simulation rounds are not mapped to real clock time. Send-time optimization is not something the current system predicts.
+
+### 6. Forward chain effects
+When a persona forwards your email to a colleague, the simulation logs it as a strong positive signal but does not model what the colleague does with it. The chain stops at the first forward.
+
+### 7. Reply content quality
+The simulation records whether a persona replies — not what they say. It doesn't predict the quality of the conversation that follows.
+
+---
+
+## How to Read the Results
+
+**The question to ask first:** "Where did each variant lose agents, and why?"
+
+Not: "Which variant has the highest simulated reply rate?"
+
+A variant that loses 80% of agents at the subject line and has a 12% reply rate among those who open is a fundamentally different problem than a variant that passes the subject test but loses agents at the CTA. Same reply rate, different surgery needed.
+
+**The ranked output tells you:**
+1. The winner — highest combined open + reply intent signal
+2. The loser's failure mode — subject, opening, body, or CTA
+3. Which persona types responded differently — and why
+
+**The failure heatmap tells you:**
+- If all personas fail at the subject line: the subject is the problem, the body is irrelevant
+- If personas fail at the opening: the hook is the problem
+- If personas fail at the CTA: the ask is too high-friction for this ICP
+- If failure is distributed across points: the email has multiple problems; fix the earliest one first
+
+---
+
+## Calibration — How to Know if Your Simulation is Working
+
+prospect-sim generates real value when its relative rankings match real-world results. The way to establish this:
+
+**Step 1:** Run a simulation on a copy variant whose real-world performance you already know. If you've sent 300 emails with a problem-hook script and 300 with a timeline-hook script and know the real reply rates — run both through the simulation.
+
+**Step 2:** Check if the simulation correctly identifies the winner. If yes: your ICP seed document is well-calibrated. If no: your seed document doesn't accurately reflect your real ICP — iterate on it.
+
+**Step 3:** Once calibrated, treat future simulations as reliable signal for that ICP segment. The absolute numbers remain fictional; the rankings become trustworthy.
+
+For Skillia specifically: benchmark data shows timeline hook (~10%) outperforms problem hook (~4.4%) on HR Director personas at Spanish SMEs. A calibrated simulation should reproduce this ranking. If it does, the system is ready for predicting new copy variants.
+
+---
+
+## The Compound Value
+
+The simulation's value compounds with use. Each calibration run teaches you more about:
+- How accurately your seed documents model your real ICP
+- Which persona fields drive the most behavioral variance (is it `cold_email_skepticism` or `decision_style` that matters most?)
+- Which copy variables move the needle for your specific market
+
+Over 10–20 simulation runs, you build a reliable intuition about what the system can and cannot predict for your use case. That intuition is itself a competitive advantage — most teams are still burning real leads to test hypotheses you can validate in 10 minutes.
+
+---
+
+## Summary
+
+| Output | Reliability | Use for |
+|---|---|---|
+| Failure point diagnosis | High | Surgical copy fixes |
+| Relative variant ranking | High | Picking the winner before sending |
+| Persona segment sensitivity | Medium-High (with rich seed docs) | Segmenting outreach |
+| Absolute rate estimates | Low (until calibrated) | Internal ranking only |
+| Real-world reply rate forecast | None (until calibrated) | Not yet |
+
+**The north star:** prospect-sim tells you which variant to send and where the loser breaks. It does not tell you how many replies you'll get. That distinction is the difference between using it correctly and being surprised when the numbers don't match.

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -48,6 +48,12 @@ const routes = [
     name: 'Compare',
     component: () => import('../views/ComparisonView.vue'),
     props: true
+  },
+  {
+    // B2B email copy variant testing — run multiple email variants against synthetic ICP personas
+    path: '/variant-test',
+    name: 'VariantTest',
+    component: () => import('../views/VariantTestView.vue')
   }
 ]
 

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -4,6 +4,9 @@
     <nav class="navbar">
       <div class="nav-brand">MIROSHARK</div>
       <div class="nav-links">
+        <button class="variant-test-btn" @click="router.push('/variant-test')" title="B2B Email Copy Testing">
+          ✉ Variant Test
+        </button>
         <a href="https://github.com/aaronjmars/MiroShark" target="_blank" class="github-link">
           GitHub <span class="arrow">↗</span>
         </a>
@@ -408,6 +411,25 @@ const startSimulation = () => {
 .nav-links {
   display: flex;
   align-items: center;
+}
+
+/* ── Variant Test nav button ── */
+.variant-test-btn {
+  background: none;
+  border: 1px solid rgba(167, 139, 250, 0.4);
+  color: rgba(167, 139, 250, 0.8);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 1px;
+  cursor: pointer;
+  padding: 4px 10px;
+  margin-right: var(--space-md);
+  transition: var(--transition-fast);
+}
+
+.variant-test-btn:hover {
+  border-color: rgba(167, 139, 250, 0.9);
+  color: #a78bfa;
 }
 
 .github-link {

--- a/frontend/src/views/VariantTestView.vue
+++ b/frontend/src/views/VariantTestView.vue
@@ -1,0 +1,794 @@
+<template>
+  <div class="variant-test-page">
+    <header class="vt-header">
+      <div class="header-left">
+        <div class="brand" @click="router.push('/')">PROSPECT-SIM</div>
+      </div>
+      <div class="header-center">
+        <span class="page-tag">Email Variant Test</span>
+      </div>
+      <div class="header-right">
+        <button v-if="results" class="download-btn" @click="downloadResults">
+          ↓ Export JSON
+        </button>
+      </div>
+    </header>
+
+    <!-- Setup Form (shown before run) -->
+    <div v-if="!results && !loading" class="setup-panel">
+      <h2 class="setup-title">Test Cold Email Variants</h2>
+      <p class="setup-desc">
+        Run email copy variants against synthetic B2B decision-maker personas before touching real leads.
+      </p>
+
+      <!-- Project selector -->
+      <div class="form-row">
+        <label class="form-label">ICP Project (graph already built)</label>
+        <select class="form-select" v-model="form.projectId">
+          <option value="">Select project…</option>
+          <option v-for="p in projects" :key="p.project_id" :value="p.project_id">
+            {{ p.name }} — {{ p.status }}
+          </option>
+        </select>
+      </div>
+
+      <!-- Simulation requirement -->
+      <div class="form-row">
+        <label class="form-label">Simulation Goal (optional)</label>
+        <textarea
+          class="form-textarea"
+          v-model="form.simulationRequirement"
+          placeholder="Describe what you're testing. E.g.: Test timeline vs. problem hook for HR Directors at Spanish scale-ups with 15+ open roles."
+          rows="3"
+        />
+      </div>
+
+      <!-- Run mode -->
+      <div class="form-row form-row-inline">
+        <label class="form-label">Run Mode</label>
+        <div class="toggle-group">
+          <button
+            class="toggle-btn"
+            :class="{ active: !form.parallel }"
+            @click="form.parallel = false"
+          >Sequential</button>
+          <button
+            class="toggle-btn"
+            :class="{ active: form.parallel }"
+            @click="form.parallel = true"
+          >Parallel</button>
+        </div>
+        <span class="mode-hint">
+          {{ form.parallel ? 'All variants run at once — faster, more LLM calls' : 'One at a time — slower, cheaper' }}
+        </span>
+      </div>
+
+      <!-- Variants -->
+      <div class="variants-section">
+        <div class="variants-header">
+          <span class="variants-title">Email Variants</span>
+          <button class="add-variant-btn" @click="addVariant" :disabled="form.variants.length >= 6">
+            + Add Variant
+          </button>
+        </div>
+
+        <div
+          v-for="(variant, idx) in form.variants"
+          :key="idx"
+          class="variant-card"
+        >
+          <div class="variant-card-header">
+            <span class="variant-label">Variant {{ String.fromCharCode(65 + idx) }}</span>
+            <select class="hook-select" v-model="variant.hook_type">
+              <option value="problem">Problem Hook</option>
+              <option value="timeline">Timeline Hook</option>
+              <option value="numbers">Numbers Hook</option>
+              <option value="social_proof">Social Proof Hook</option>
+              <option value="curiosity">Curiosity Hook</option>
+            </select>
+            <button
+              v-if="form.variants.length > 2"
+              class="remove-btn"
+              @click="removeVariant(idx)"
+            >✕</button>
+          </div>
+          <input
+            class="subject-input"
+            v-model="variant.subject_line"
+            placeholder="Subject line (max 60 chars)"
+            maxlength="80"
+          />
+          <textarea
+            class="body-textarea"
+            v-model="variant.body"
+            placeholder="Email body (≤150 words recommended)"
+            rows="5"
+          />
+          <div class="word-count" :class="{ warn: wordCount(variant.body) > 150 }">
+            {{ wordCount(variant.body) }} words
+          </div>
+        </div>
+      </div>
+
+      <!-- Run button -->
+      <button
+        class="run-btn"
+        :disabled="!canRun"
+        @click="runVariantTest"
+      >
+        Run Variant Test
+      </button>
+      <div v-if="error" class="vt-error">{{ error }}</div>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="vt-loading">
+      <div class="loading-ring"></div>
+      <div class="loading-text">Running variant test…</div>
+      <div class="loading-sub">{{ loadingStatus }}</div>
+    </div>
+
+    <!-- Results -->
+    <div v-if="results && !loading" class="results-panel">
+      <!-- Summary header -->
+      <div class="results-header">
+        <h2 class="results-title">Variant Test Results</h2>
+        <div class="results-meta">
+          {{ results.total_variants }} variants · {{ results.run_mode }} · {{ results.num_rounds }} rounds
+        </div>
+      </div>
+
+      <!-- Variant ranking table -->
+      <div class="ranking-section">
+        <h3 class="section-title">Variant Rankings</h3>
+        <table class="ranking-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Variant</th>
+              <th>Hook Type</th>
+              <th>Sim ID</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(run, idx) in results.variant_run_ids"
+              :key="run.variant_id"
+              :class="{ 'row-winner': idx === 0 }"
+            >
+              <td class="rank-num">{{ idx + 1 }}</td>
+              <td class="variant-name">
+                <span v-if="idx === 0" class="winner-badge">★</span>
+                {{ run.variant_label }}
+              </td>
+              <td>{{ getHookType(run.variant_id) }}</td>
+              <td class="sim-id-cell">{{ shortId(run.simulation_id) }}</td>
+              <td>
+                <span class="status-badge" :class="run.status">{{ run.status }}</span>
+              </td>
+              <td>
+                <button
+                  class="view-btn"
+                  @click="viewSimulation(run.simulation_id)"
+                >View →</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Restart button -->
+      <div class="results-actions">
+        <button class="restart-btn" @click="resetForm">Run Another Test</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { getSimulationList } from '../api/simulation.js'
+
+export default {
+  name: 'VariantTestView',
+
+  setup() {
+    const router = useRouter()
+    const projects = ref([])
+    const loading = ref(false)
+    const loadingStatus = ref('')
+    const error = ref('')
+    const results = ref(null)
+
+    // Default form: 2 variants, problem vs timeline hook
+    const form = ref({
+      projectId: '',
+      simulationRequirement: '',
+      parallel: false,
+      variants: [
+        {
+          id: 1,
+          label: 'Variant A',
+          hook_type: 'problem',
+          subject_line: '',
+          body: '',
+        },
+        {
+          id: 2,
+          label: 'Variant B',
+          hook_type: 'timeline',
+          subject_line: '',
+          body: '',
+        },
+      ],
+    })
+
+    const canRun = computed(() => {
+      if (!form.value.projectId) return false
+      return form.value.variants.every(
+        (v) => v.subject_line.trim() && v.body.trim()
+      )
+    })
+
+    function wordCount(text) {
+      return text.trim().split(/\s+/).filter(Boolean).length
+    }
+
+    function addVariant() {
+      const next = form.value.variants.length + 1
+      form.value.variants.push({
+        id: next,
+        label: `Variant ${String.fromCharCode(64 + next)}`,
+        hook_type: 'curiosity',
+        subject_line: '',
+        body: '',
+      })
+    }
+
+    function removeVariant(idx) {
+      form.value.variants.splice(idx, 1)
+      // Re-number ids and labels
+      form.value.variants.forEach((v, i) => {
+        v.id = i + 1
+        v.label = `Variant ${String.fromCharCode(65 + i)}`
+      })
+    }
+
+    function getHookType(variantId) {
+      const v = form.value.variants.find((x) => x.id === variantId)
+      return v ? v.hook_type : '—'
+    }
+
+    function shortId(id) {
+      return id ? id.slice(-8) : '—'
+    }
+
+    async function loadProjects() {
+      try {
+        // Reuse simulation list endpoint to get projects with built graphs
+        const resp = await fetch('/api/simulation/list')
+        const data = await resp.json()
+        if (data.success && data.simulations) {
+          // Extract unique projects from simulations (fallback)
+          const seen = new Set()
+          projects.value = data.simulations
+            .filter((s) => s.graph_id && !seen.has(s.project_id) && seen.add(s.project_id))
+            .map((s) => ({
+              project_id: s.project_id || s.simulation_id,
+              name: s.name || s.simulation_id,
+              status: s.status,
+            }))
+        }
+      } catch (e) {
+        // Non-fatal — user can still type project ID manually
+        console.warn('Could not load projects:', e)
+      }
+    }
+
+    async function runVariantTest() {
+      if (!canRun.value) return
+
+      loading.value = true
+      error.value = ''
+      results.value = null
+      loadingStatus.value = 'Submitting variant test…'
+
+      try {
+        const payload = {
+          project_id: form.value.projectId,
+          variants: form.value.variants,
+          simulation_requirement: form.value.simulationRequirement,
+          parallel: form.value.parallel,
+          num_rounds: 8,
+        }
+
+        const resp = await fetch('/api/simulation/run-variant-test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+
+        const data = await resp.json()
+
+        if (!data.success) {
+          throw new Error(data.error || 'Variant test failed')
+        }
+
+        results.value = data
+        loadingStatus.value = 'Done'
+      } catch (e) {
+        error.value = e.message || 'Unexpected error'
+      } finally {
+        loading.value = false
+      }
+    }
+
+    function viewSimulation(simulationId) {
+      router.push(`/simulation/${simulationId}`)
+    }
+
+    function downloadResults() {
+      if (!results.value) return
+      const blob = new Blob([JSON.stringify(results.value, null, 2)], {
+        type: 'application/json',
+      })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `variant-test-${Date.now()}.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    }
+
+    function resetForm() {
+      results.value = null
+      error.value = ''
+    }
+
+    onMounted(() => {
+      loadProjects()
+    })
+
+    return {
+      router,
+      projects,
+      loading,
+      loadingStatus,
+      error,
+      results,
+      form,
+      canRun,
+      wordCount,
+      addVariant,
+      removeVariant,
+      getHookType,
+      shortId,
+      runVariantTest,
+      viewSimulation,
+      downloadResults,
+      resetForm,
+    }
+  },
+}
+</script>
+
+<style scoped>
+.variant-test-page {
+  min-height: 100vh;
+  background: #0a0a0f;
+  color: #e4e4e9;
+  font-family: 'Inter', 'SF Pro', system-ui, sans-serif;
+}
+
+.vt-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 32px;
+  height: 56px;
+  border-bottom: 1px solid #1e1e2e;
+  background: #0d0d14;
+}
+
+.brand {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  color: #a78bfa;
+}
+
+.page-tag {
+  font-size: 11px;
+  background: #1e1e2e;
+  color: #a78bfa;
+  padding: 3px 10px;
+  border-radius: 4px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.download-btn {
+  background: #1e1e2e;
+  border: 1px solid #2e2e42;
+  color: #a0a0b4;
+  padding: 6px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+/* Setup panel */
+.setup-panel {
+  max-width: 800px;
+  margin: 40px auto;
+  padding: 0 24px;
+}
+
+.setup-title {
+  font-size: 22px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.setup-desc {
+  color: #6b6b82;
+  font-size: 14px;
+  margin-bottom: 32px;
+}
+
+.form-row {
+  margin-bottom: 20px;
+}
+
+.form-row-inline {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.form-label {
+  display: block;
+  font-size: 12px;
+  color: #6b6b82;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 6px;
+}
+
+.form-select,
+.form-textarea {
+  width: 100%;
+  background: #111118;
+  border: 1px solid #1e1e2e;
+  color: #e4e4e9;
+  padding: 10px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+  resize: vertical;
+}
+
+.toggle-group {
+  display: flex;
+  gap: 4px;
+}
+
+.toggle-btn {
+  background: #111118;
+  border: 1px solid #1e1e2e;
+  color: #6b6b82;
+  padding: 6px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.toggle-btn.active {
+  background: #1e1e36;
+  border-color: #a78bfa;
+  color: #a78bfa;
+}
+
+.mode-hint {
+  font-size: 12px;
+  color: #4b4b60;
+}
+
+/* Variants */
+.variants-section {
+  margin-bottom: 28px;
+}
+
+.variants-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.variants-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8b8ba0;
+}
+
+.add-variant-btn {
+  background: transparent;
+  border: 1px dashed #2e2e42;
+  color: #6b6b82;
+  padding: 5px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.add-variant-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.variant-card {
+  background: #0d0d14;
+  border: 1px solid #1e1e2e;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 12px;
+}
+
+.variant-card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.variant-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #a78bfa;
+  min-width: 80px;
+}
+
+.hook-select {
+  background: #111118;
+  border: 1px solid #1e1e2e;
+  color: #a0a0b4;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  flex: 1;
+}
+
+.remove-btn {
+  background: transparent;
+  border: none;
+  color: #4b4b60;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px;
+  margin-left: auto;
+}
+
+.subject-input {
+  width: 100%;
+  background: #111118;
+  border: 1px solid #1e1e2e;
+  color: #e4e4e9;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-bottom: 8px;
+  box-sizing: border-box;
+}
+
+.body-textarea {
+  width: 100%;
+  background: #111118;
+  border: 1px solid #1e1e2e;
+  color: #e4e4e9;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 13px;
+  line-height: 1.6;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.word-count {
+  font-size: 11px;
+  color: #4b4b60;
+  text-align: right;
+  margin-top: 4px;
+}
+
+.word-count.warn {
+  color: #f59e0b;
+}
+
+.run-btn {
+  width: 100%;
+  background: #a78bfa;
+  color: #0a0a0f;
+  border: none;
+  padding: 14px;
+  border-radius: 6px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+}
+
+.run-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.vt-error {
+  margin-top: 12px;
+  color: #f87171;
+  font-size: 13px;
+  padding: 10px;
+  background: #1a0a0a;
+  border-radius: 4px;
+}
+
+/* Loading */
+.vt-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 16px;
+}
+
+.loading-ring {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #1e1e2e;
+  border-top-color: #a78bfa;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.loading-text {
+  font-size: 16px;
+  color: #a0a0b4;
+}
+
+.loading-sub {
+  font-size: 13px;
+  color: #4b4b60;
+}
+
+/* Results */
+.results-panel {
+  max-width: 900px;
+  margin: 40px auto;
+  padding: 0 24px;
+}
+
+.results-header {
+  margin-bottom: 32px;
+}
+
+.results-title {
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.results-meta {
+  font-size: 13px;
+  color: #6b6b82;
+  margin-top: 4px;
+}
+
+.ranking-section {
+  background: #0d0d14;
+  border: 1px solid #1e1e2e;
+  border-radius: 8px;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.section-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6b6b82;
+  margin-bottom: 16px;
+}
+
+.ranking-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.ranking-table th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid #1e1e2e;
+  color: #6b6b82;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.ranking-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #111118;
+}
+
+.row-winner td {
+  background: #0f0f1a;
+}
+
+.rank-num {
+  color: #4b4b60;
+  width: 32px;
+}
+
+.winner-badge {
+  color: #f59e0b;
+  margin-right: 6px;
+}
+
+.variant-name {
+  font-weight: 500;
+}
+
+.sim-id-cell {
+  font-family: monospace;
+  color: #6b6b82;
+  font-size: 12px;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 11px;
+  background: #1e1e2e;
+  color: #6b6b82;
+}
+
+.status-badge.created { color: #a78bfa; background: #1a1a2e; }
+.status-badge.running { color: #34d399; background: #0a1a12; }
+.status-badge.completed { color: #34d399; background: #0a1a12; }
+.status-badge.failed { color: #f87171; background: #1a0a0a; }
+
+.view-btn {
+  background: transparent;
+  border: 1px solid #1e1e2e;
+  color: #a78bfa;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.results-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.restart-btn {
+  background: #111118;
+  border: 1px solid #1e1e2e;
+  color: #a0a0b4;
+  padding: 10px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+</style>


### PR DESCRIPTION
## Feature
Agent-friendly CLI for prospect-sim following article-37 principles.

## Summary
- Full `prospect-sim` command installable via `pip install -e .` / `uv sync`
- SHA256-based ICP graph caching eliminates the 5-10 min rebuild on repeat runs (~20 sec reuse)
- All 5 command groups implemented with resource+verb naming

## Changes

**New files:**
- `backend/prospect_sim_cli/__init__.py` — package, version
- `backend/prospect_sim_cli/main.py` — root Typer app, registers all subcommands
- `backend/prospect_sim_cli/client.py` — ApiClient (all HTTP calls, structured ApiError)
- `backend/prospect_sim_cli/cache.py` — IcpCache (SHA256 → project_id), CliConfig
- `backend/prospect_sim_cli/output.py` — print_json, print_error, print_ranking_table, spinner
- `backend/prospect_sim_cli/commands/run.py` — main composite command (full E2E flow)
- `backend/prospect_sim_cli/commands/project.py` — project list|build|show
- `backend/prospect_sim_cli/commands/variant.py` — variant test
- `backend/prospect_sim_cli/commands/results.py` — results show
- `backend/prospect_sim_cli/commands/config_cmd.py` — config show|set|reset

**Modified:**
- `backend/pyproject.toml` — added `typer[all]>=0.12.0`, `[project.scripts]` entry point

## CLI Design Principles

Per [article 37](library/hub/dev-tools/37.building-clis-for-agents.md):

| Principle | Implementation |
|---|---|
| Non-interactive | All flags, no prompts (--yes to skip confirms) |
| Machine-readable errors | `{"error":"...", "fix":"...", "docs":"..."}` to stderr |
| Minimum viable output | `--quiet` for clean JSON, human table by default |
| Idempotent | Same ICP file → cache hit, no duplicate builds |
| --dry-run | Shows plan without executing |
| Resource+verb naming | `project list`, `variant test`, `results show` |

## Quickstart

```bash
# Install
cd backend && uv sync

# Full run (first time: builds graph ~5-10 min)
prospect-sim run --icp icp.md --variants variants.json

# Second run: cache hit, ~20 sec
prospect-sim run --icp icp.md --variants variants.json

# Agent-friendly
prospect-sim run --icp icp.md --variants variants.json --quiet | jq '.winner'

# Dry-run
prospect-sim run --icp icp.md --variants variants.json --dry-run
```

## Artifacts
`.claude/runs/prospect-sim-agent-cli/` — SPEC, OBSERVE, PLAN-final

🤖 Generated with [Claude Code](https://claude.com/claude-code)