### PR TITLE
feat: simulation fork / branch from history view

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -270,6 +270,66 @@ def create_simulation():
         }), 500
 
 
+@simulation_bp.route('/fork', methods=['POST'])
+def fork_simulation():
+    """
+    Fork an existing simulation into a new child simulation.
+
+    Copies agent profiles and configuration from the parent so the child
+    is immediately ready to run.  Optionally accepts a new
+    simulation_requirement to explore a different scenario with the same
+    agent population.
+
+    Request (JSON):
+        {
+            "parent_simulation_id": "sim_xxxx",        // Required
+            "simulation_requirement": "What if..."     // Optional override
+        }
+
+    Returns:
+        {
+            "success": true,
+            "data": { ...simulation state... }
+        }
+    """
+    try:
+        data = request.get_json() or {}
+
+        parent_simulation_id = data.get('parent_simulation_id')
+        if not parent_simulation_id:
+            return jsonify({
+                "success": False,
+                "error": "Please provide parent_simulation_id"
+            }), 400
+
+        simulation_requirement = data.get('simulation_requirement') or None
+
+        manager = SimulationManager()
+        state = manager.fork_simulation(
+            parent_simulation_id=parent_simulation_id,
+            simulation_requirement=simulation_requirement,
+        )
+
+        return jsonify({
+            "success": True,
+            "data": state.to_dict()
+        })
+
+    except ValueError as e:
+        return jsonify({
+            "success": False,
+            "error": str(e)
+        }), 404
+
+    except Exception as e:
+        logger.error(f"Failed to fork simulation: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
 def _check_simulation_prepared(simulation_id: str) -> tuple:
     """
     Check if the simulation has been prepared
@@ -995,6 +1055,9 @@ def get_simulation_history():
             # Get associated report_id (find the latest report for this simulation)
             sim_dict["report_id"] = _get_report_id_for_simulation(sim.simulation_id)
             
+            # Propagate fork lineage fields (already in to_dict but ensure they surface)
+            sim_dict.setdefault("parent_simulation_id", sim.parent_simulation_id)
+
             # Add version number
             sim_dict["version"] = "v1.0.2"
             

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -74,7 +74,11 @@ class SimulationState:
 
     # Error info
     error: Optional[str] = None
-    
+
+    # Fork lineage
+    parent_simulation_id: Optional[str] = None
+    config_diff: Optional[Dict] = None
+
     def to_dict(self) -> Dict[str, Any]:
         """Full state dictionary (for internal use)"""
         return {
@@ -96,6 +100,8 @@ class SimulationState:
             "created_at": self.created_at,
             "updated_at": self.updated_at,
             "error": self.error,
+            "parent_simulation_id": self.parent_simulation_id,
+            "config_diff": self.config_diff,
         }
     
     def to_simple_dict(self) -> Dict[str, Any]:
@@ -188,6 +194,8 @@ class SimulationManager:
             created_at=data.get("created_at", datetime.now().isoformat()),
             updated_at=data.get("updated_at", datetime.now().isoformat()),
             error=data.get("error"),
+            parent_simulation_id=data.get("parent_simulation_id"),
+            config_diff=data.get("config_diff"),
         )
         
         self._simulations[simulation_id] = state
@@ -523,6 +531,104 @@ class SimulationManager:
         with open(config_path, 'r', encoding='utf-8') as f:
             return json.load(f)
     
+    def fork_simulation(
+        self,
+        parent_simulation_id: str,
+        simulation_requirement: Optional[str] = None,
+    ) -> SimulationState:
+        """
+        Fork an existing simulation into a new child simulation.
+
+        Copies all prepared files (profiles, config) from the parent so the
+        child is immediately READY to run without going through the full
+        prepare pipeline again.  The caller may override simulation_requirement
+        to explore a different scenario with the same agent population.
+
+        Args:
+            parent_simulation_id: ID of the simulation to fork from
+            simulation_requirement: Optional new scenario description.
+                                    Defaults to the parent's requirement.
+
+        Returns:
+            New SimulationState with status=READY and parent_simulation_id set
+        """
+        import uuid
+
+        parent = self._load_simulation_state(parent_simulation_id)
+        if not parent:
+            raise ValueError(f"Parent simulation not found: {parent_simulation_id}")
+
+        parent_dir = self._get_simulation_dir(parent_simulation_id)
+
+        # Create new simulation ID and directory
+        new_id = f"sim_{uuid.uuid4().hex[:12]}"
+        new_dir = self._get_simulation_dir(new_id)
+        os.makedirs(new_dir, exist_ok=True)
+
+        # Copy preparation files
+        files_to_copy = [
+            "reddit_profiles.json",
+            "twitter_profiles.csv",
+            "polymarket_profiles.json",
+        ]
+        for fname in files_to_copy:
+            src = os.path.join(parent_dir, fname)
+            if os.path.exists(src):
+                shutil.copy2(src, os.path.join(new_dir, fname))
+
+        # Copy and optionally patch the simulation config
+        config_diff: Dict[str, Any] = {}
+        parent_config_path = os.path.join(parent_dir, "simulation_config.json")
+        if os.path.exists(parent_config_path):
+            with open(parent_config_path, "r", encoding="utf-8") as f:
+                config_data = json.load(f)
+
+            original_requirement = config_data.get("simulation_requirement", "")
+
+            if simulation_requirement and simulation_requirement != original_requirement:
+                config_diff["simulation_requirement"] = {
+                    "from": original_requirement,
+                    "to": simulation_requirement,
+                }
+                config_data["simulation_requirement"] = simulation_requirement
+
+            # Update IDs to point to the new simulation
+            config_data["simulation_id"] = new_id
+
+            new_config_path = os.path.join(new_dir, "simulation_config.json")
+            with open(new_config_path, "w", encoding="utf-8") as f:
+                json.dump(config_data, f, ensure_ascii=False, indent=2)
+        else:
+            if simulation_requirement:
+                config_diff["simulation_requirement"] = {
+                    "from": "",
+                    "to": simulation_requirement,
+                }
+
+        state = SimulationState(
+            simulation_id=new_id,
+            project_id=parent.project_id,
+            graph_id=parent.graph_id,
+            enable_twitter=parent.enable_twitter,
+            enable_reddit=parent.enable_reddit,
+            enable_polymarket=parent.enable_polymarket,
+            status=SimulationStatus.READY,
+            entities_count=parent.entities_count,
+            profiles_count=parent.profiles_count,
+            entity_types=list(parent.entity_types),
+            config_generated=True,
+            config_reasoning=f"Forked from {parent_simulation_id}",
+            parent_simulation_id=parent_simulation_id,
+            config_diff=config_diff if config_diff else None,
+        )
+
+        self._save_simulation_state(state)
+        logger.info(
+            f"Forked simulation: {new_id} from parent={parent_simulation_id}, "
+            f"diff={config_diff}"
+        )
+        return state
+
     def get_run_instructions(self, simulation_id: str) -> Dict[str, str]:
         """Get run instructions"""
         sim_dir = self._get_simulation_dir(simulation_id)

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -243,3 +243,12 @@ export const getInfluenceLeaderboard = (simulationId) => {
   return service.get(`/api/simulation/${simulationId}/influence`)
 }
 
+/**
+ * Fork a simulation — copies agent profiles and config into a new simulation
+ * that is immediately ready to run.
+ * @param {Object} data - { parent_simulation_id, simulation_requirement? }
+ */
+export const forkSimulation = (data) => {
+  return requestWithRetry(() => service.post('/api/simulation/fork', data), 3, 1000)
+}
+

--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -40,6 +40,11 @@
           <span class="card-id">{{ formatSimulationId(project.simulation_id) }}</span>
           <div class="card-status-icons">
             <span
+              v-if="project.parent_simulation_id"
+              class="fork-badge"
+              :title="`Forked from ${formatSimulationId(project.parent_simulation_id)}`"
+            >⑂</span>
+            <span
               class="status-icon"
               :class="{ available: project.project_id, unavailable: !project.project_id }"
               title="Graph Build"
@@ -223,6 +228,41 @@
             <div class="modal-playback-hint">
               <span class="hint-text">Select a step to replay from the simulation history</span>
             </div>
+
+            <!-- Fork Section -->
+            <div class="modal-fork-section">
+              <div class="modal-divider">
+                <span class="divider-line"></span>
+                <span class="divider-text">Fork</span>
+                <span class="divider-line"></span>
+              </div>
+
+              <div v-if="!showForkPanel" class="fork-intro">
+                <p class="fork-desc">Clone this simulation with a new scenario — agent profiles are reused instantly.</p>
+                <button class="fork-trigger-btn" @click="openForkPanel">⑂ Fork Simulation</button>
+                <div v-if="selectedProject.parent_simulation_id" class="fork-lineage-badge">
+                  ⑂ Forked from <span class="fork-parent-id">{{ formatSimulationId(selectedProject.parent_simulation_id) }}</span>
+                </div>
+              </div>
+
+              <div v-else class="fork-form">
+                <label class="fork-label">Scenario (edit to explore a variant)</label>
+                <textarea
+                  v-model="forkRequirement"
+                  class="fork-textarea"
+                  placeholder="Describe the scenario you want to simulate..."
+                  rows="3"
+                ></textarea>
+                <p class="fork-note">Agent profiles will be copied from the parent simulation — no re-preparation needed.</p>
+                <div v-if="forkError" class="fork-error">{{ forkError }}</div>
+                <div class="fork-actions">
+                  <button class="fork-cancel-btn" @click="closeForkPanel" :disabled="forking">Cancel</button>
+                  <button class="fork-submit-btn" @click="executeFork" :disabled="forking">
+                    {{ forking ? 'Forking...' : '⑂ Fork & Open' }}
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </Transition>
@@ -233,7 +273,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, onActivated, watch, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { getSimulationHistory } from '../api/simulation'
+import { getSimulationHistory, forkSimulation } from '../api/simulation'
 
 const router = useRouter()
 const route = useRoute()
@@ -250,6 +290,12 @@ let observer = null
 // Compare mode
 const compareMode = ref(false)
 const compareSelections = ref([])
+
+// Fork mode
+const showForkPanel = ref(false)
+const forkRequirement = ref('')
+const forking = ref(false)
+const forkError = ref('')
 
 const toggleCompareMode = () => {
   if (compareMode.value && compareSelections.value.length === 2) {
@@ -476,6 +522,8 @@ const navigateToProject = (simulation) => {
 // Close modal
 const closeModal = () => {
   selectedProject.value = null
+  showForkPanel.value = false
+  forkError.value = ''
 }
 
 // Navigate to graph build page (Project)
@@ -541,6 +589,45 @@ const goToInteraction = () => {
       params: { reportId: selectedProject.value.report_id }
     })
     closeModal()
+  }
+}
+
+// Open fork panel for selected simulation
+const openForkPanel = () => {
+  forkRequirement.value = selectedProject.value?.simulation_requirement || ''
+  forkError.value = ''
+  showForkPanel.value = true
+}
+
+// Close fork panel
+const closeForkPanel = () => {
+  showForkPanel.value = false
+  forkError.value = ''
+}
+
+// Execute fork
+const executeFork = async () => {
+  if (!selectedProject.value) return
+  forking.value = true
+  forkError.value = ''
+  try {
+    const response = await forkSimulation({
+      parent_simulation_id: selectedProject.value.simulation_id,
+      simulation_requirement: forkRequirement.value || undefined,
+    })
+    if (response.success) {
+      const newSimId = response.data.simulation_id
+      showForkPanel.value = false
+      closeModal()
+      await loadHistory()
+      router.push({ name: 'SimulationRun', params: { simulationId: newSimId } })
+    } else {
+      forkError.value = response.error || 'Fork failed'
+    }
+  } catch (err) {
+    forkError.value = err?.response?.data?.error || err.message || 'Fork failed'
+  } finally {
+    forking.value = false
   }
 }
 
@@ -1508,4 +1595,163 @@ onUnmounted(() => {
 }
 .compare-select-btn:hover { border-color: #FF6B1A; color: #FF6B1A; }
 .compare-select-btn.selected { border-color: #FF6B1A; color: #FF6B1A; background: rgba(255,107,26,0.1); }
+
+/* ===== Fork badge on cards ===== */
+.fork-badge {
+  font-size: 0.8rem;
+  color: #FFB347;
+  opacity: 0.8;
+  cursor: default;
+}
+
+/* ===== Fork section in modal ===== */
+.modal-fork-section {
+  background: #FAFAFA;
+  padding: 0 0 22px;
+}
+
+.fork-intro {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 34px 0;
+}
+
+.fork-desc {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.4);
+  letter-spacing: 1px;
+  text-align: center;
+  margin: 0;
+}
+
+.fork-trigger-btn {
+  padding: 8px 22px;
+  border: 1px solid rgba(255, 179, 71, 0.5);
+  background: rgba(255, 179, 71, 0.06);
+  color: #CC8800;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 2px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.fork-trigger-btn:hover {
+  border-color: #FFB347;
+  background: rgba(255, 179, 71, 0.12);
+}
+
+.fork-lineage-badge {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.4);
+  letter-spacing: 2px;
+}
+
+.fork-parent-id {
+  color: #FFB347;
+  font-weight: 600;
+}
+
+/* Fork form */
+.fork-form {
+  padding: 16px 34px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.fork-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.5);
+  text-transform: uppercase;
+  letter-spacing: 3px;
+}
+
+.fork-textarea {
+  width: 100%;
+  padding: 10px 12px;
+  background: #F5F5F5;
+  border: 1px solid rgba(10, 10, 10, 0.12);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: #0A0A0A;
+  resize: vertical;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+}
+
+.fork-textarea:focus {
+  border-color: #FFB347;
+}
+
+.fork-note {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: rgba(10, 10, 10, 0.35);
+  letter-spacing: 1px;
+  margin: 0;
+}
+
+.fork-error {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: #FF4444;
+  padding: 6px 10px;
+  background: rgba(255, 68, 68, 0.06);
+  border: 1px solid rgba(255, 68, 68, 0.15);
+}
+
+.fork-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.fork-cancel-btn {
+  padding: 8px 16px;
+  border: 1px solid rgba(10, 10, 10, 0.12);
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.5);
+  cursor: pointer;
+  letter-spacing: 2px;
+  transition: all 0.2s;
+}
+
+.fork-cancel-btn:hover:not(:disabled) {
+  border-color: rgba(10, 10, 10, 0.3);
+  color: #0A0A0A;
+}
+
+.fork-submit-btn {
+  padding: 8px 18px;
+  border: 1px solid rgba(255, 179, 71, 0.6);
+  background: rgba(255, 179, 71, 0.08);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: #CC8800;
+  cursor: pointer;
+  letter-spacing: 2px;
+  transition: all 0.2s;
+}
+
+.fork-submit-btn:hover:not(:disabled) {
+  background: rgba(255, 179, 71, 0.18);
+  border-color: #FFB347;
+}
+
+.fork-submit-btn:disabled,
+.fork-cancel-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 </style>


### PR DESCRIPTION
## What
A Fork button in the simulation history modal that lets users clone any existing simulation into a new child simulation — instantly, without going through the full prepare pipeline again.

## Why
The most natural question after seeing a simulation result is \"what would happen if I changed the scenario?\" Previously, users had to start from scratch: re-upload documents, wait for graph building, wait for agent profile generation. This wastes minutes of compute for what should be a one-click experiment. Fork reuses the agent population from the parent and makes a new scenario available to run immediately.

This was the top-ranked idea in the 2026-04-07 repo-actions analysis: \"the 'experiment lineage' workflow that researchers need for systematic exploration — and generates more simulation runs per user, deepening engagement.\"

## Changes
- `backend/app/services/simulation_manager.py`: Added `parent_simulation_id` and `config_diff` fields to `SimulationState`. Added `fork_simulation()` method that copies agent profiles and config from the parent, patches `simulation_requirement` if a new scenario is provided, updates the simulation ID in the config, and returns a `READY` state with lineage metadata.
- `backend/app/api/simulation.py`: Added `POST /api/simulation/fork` endpoint. Updated `/history` response to surface `parent_simulation_id`.
- `frontend/src/api/simulation.js`: Added `forkSimulation()` API helper.
- `frontend/src/components/HistoryDatabase.vue`: Added Fork panel to the simulation history modal — a textarea pre-filled with the parent's scenario (editable), a note explaining profiles are reused, and a \"⑂ Fork & Open\" button that creates the fork and navigates directly to SimulationRun. Added a ⑂ badge on history cards that are forked simulations, with a tooltip showing the parent simulation ID.

## How it works
When the user clicks \"⑂ Fork Simulation\" in the history modal and confirms, `POST /api/simulation/fork` is called with the parent ID and (optionally) a modified scenario text. The backend copies `reddit_profiles.json`, `twitter_profiles.csv`, and `simulation_config.json` from the parent's directory into a new simulation directory, patches the scenario text and simulation ID in the config JSON, and saves a new `state.json` with `status=ready`, `parent_simulation_id` set, and a `config_diff` recording what changed. The frontend then navigates to the SimulationRun page for the new simulation, which is immediately ready to run — no waiting for agent generation.

---
*Built autonomously by Aeon*