### PR TITLE
refactor: extract shared sanitized markdown renderer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "axios": "^1.13.2",
         "d3": "^7.9.0",
+        "dompurify": "^3.3.3",
+        "marked": "^18.0.0",
         "vue": "^3.5.24",
         "vue-router": "^4.6.3"
       },
@@ -858,6 +860,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.2.tgz",
@@ -1457,6 +1466,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1770,6 +1788,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "axios": "^1.13.2",
     "d3": "^7.9.0",
+    "dompurify": "^3.3.3",
+    "marked": "^18.0.0",
     "vue": "^3.5.24",
     "vue-router": "^4.6.3"
   },

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -48,7 +48,7 @@
               
               <div class="section-body" v-show="!collapsedSections.has(idx)">
                 <!-- Completed Content -->
-                <div v-if="generatedSections[idx + 1]" class="generated-content" v-html="renderMarkdown(generatedSections[idx + 1])"></div>
+                <div v-if="generatedSections[idx + 1]" class="generated-content" v-html="renderMarkdown(generatedSections[idx + 1], { stripLeadingH2: true })"></div>
                 
                 <!-- Loading State -->
                 <div v-else-if="currentSectionIndex === idx + 1" class="loading-state">
@@ -414,6 +414,7 @@ import { ref, computed, watch, onMounted, onUnmounted, nextTick, h, reactive } f
 import { useRouter } from 'vue-router'
 import { getAgentLog, getConsoleLog } from '../api/report'
 import { exportSimulationData } from '../api/simulation'
+import { renderMarkdown } from '../utils/markdown'
 
 const router = useRouter()
 
@@ -1913,111 +1914,6 @@ const truncateText = (text, maxLen) => {
   if (!text) return ''
   if (text.length <= maxLen) return text
   return text.substring(0, maxLen) + '...'
-}
-
-const renderMarkdown = (content) => {
-  if (!content) return ''
-  
-  // Remove leading level-2 heading (## xxx), since section title is already displayed outside
-  let processedContent = content.replace(/^##\s+.+\n+/, '')
-  
-  // Process code blocks
-  let html = processedContent.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre class="code-block"><code>$2</code></pre>')
-  
-  // Process inline code
-  html = html.replace(/`([^`]+)`/g, '<code class="inline-code">$1</code>')
-  
-  // Process headings
-  html = html.replace(/^#### (.+)$/gm, '<h5 class="md-h5">$1</h5>')
-  html = html.replace(/^### (.+)$/gm, '<h4 class="md-h4">$1</h4>')
-  html = html.replace(/^## (.+)$/gm, '<h3 class="md-h3">$1</h3>')
-  html = html.replace(/^# (.+)$/gm, '<h2 class="md-h2">$1</h2>')
-  
-  // Process blockquotes
-  html = html.replace(/^> (.+)$/gm, '<blockquote class="md-quote">$1</blockquote>')
-  
-  // Process lists - support sub-lists
-  html = html.replace(/^(\s*)- (.+)$/gm, (match, indent, text) => {
-    const level = Math.floor(indent.length / 2)
-    return `<li class="md-li" data-level="${level}">${text}</li>`
-  })
-  html = html.replace(/^(\s*)(\d+)\. (.+)$/gm, (match, indent, num, text) => {
-    const level = Math.floor(indent.length / 2)
-    return `<li class="md-oli" data-level="${level}">${text}</li>`
-  })
-
-  // Wrap unordered lists
-  html = html.replace(/(<li class="md-li"[^>]*>.*?<\/li>\s*)+/g, '<ul class="md-ul">$&</ul>')
-  // Wrap ordered lists
-  html = html.replace(/(<li class="md-oli"[^>]*>.*?<\/li>\s*)+/g, '<ol class="md-ol">$&</ol>')
-
-  // Clean up all whitespace between list items
-  html = html.replace(/<\/li>\s+<li/g, '</li><li')
-  // Clean up whitespace after list opening tags
-  html = html.replace(/<ul class="md-ul">\s+/g, '<ul class="md-ul">')
-  html = html.replace(/<ol class="md-ol">\s+/g, '<ol class="md-ol">')
-  // Clean up whitespace before list closing tags
-  html = html.replace(/\s+<\/ul>/g, '</ul>')
-  html = html.replace(/\s+<\/ol>/g, '</ol>')
-  
-  // Process bold and italic
-  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-  html = html.replace(/\*(.+?)\*/g, '<em>$1</em>')
-  html = html.replace(/_(.+?)_/g, '<em>$1</em>')
-  
-  // Process horizontal rules
-  html = html.replace(/^---$/gm, '<hr class="md-hr">')
-  
-  // Process line breaks - empty lines become paragraph breaks, single newlines become <br>
-  html = html.replace(/\n\n/g, '</p><p class="md-p">')
-  html = html.replace(/\n/g, '<br>')
-  
-  // Wrap in paragraphs
-  html = '<p class="md-p">' + html + '</p>'
-  
-  // Clean up empty paragraphs
-  html = html.replace(/<p class="md-p"><\/p>/g, '')
-  html = html.replace(/<p class="md-p">(<h[2-5])/g, '$1')
-  html = html.replace(/(<\/h[2-5]>)<\/p>/g, '$1')
-  html = html.replace(/<p class="md-p">(<ul|<ol|<blockquote|<pre|<hr)/g, '$1')
-  html = html.replace(/(<\/ul>|<\/ol>|<\/blockquote>|<\/pre>)<\/p>/g, '$1')
-  // Clean up <br> tags before/after block-level elements
-  html = html.replace(/<br>\s*(<ul|<ol|<blockquote)/g, '$1')
-  html = html.replace(/(<\/ul>|<\/ol>|<\/blockquote>)\s*<br>/g, '$1')
-  // Clean up <p><br> followed by block-level elements (caused by extra blank lines)
-  html = html.replace(/<p class="md-p">(<br>\s*)+(<ul|<ol|<blockquote|<pre|<hr)/g, '$2')
-  // Clean up consecutive <br> tags
-  html = html.replace(/(<br>\s*){2,}/g, '<br>')
-  // Clean up <br> between block-level element closing tags and paragraph opening tags
-  html = html.replace(/(<\/ol>|<\/ul>|<\/blockquote>)<br>(<p|<div)/g, '$1$2')
-
-  // Fix numbering for non-consecutive ordered lists: when single-item <ol> blocks are separated by paragraph content, keep numbering incremental
-  const tokens = html.split(/(<ol class="md-ol">(?:<li class="md-oli"[^>]*>[\s\S]*?<\/li>)+<\/ol>)/g)
-  let olCounter = 0
-  let inSequence = false
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i].startsWith('<ol class="md-ol">')) {
-      const liCount = (tokens[i].match(/<li class="md-oli"/g) || []).length
-      if (liCount === 1) {
-        olCounter++
-        if (olCounter > 1) {
-          tokens[i] = tokens[i].replace('<ol class="md-ol">', `<ol class="md-ol" start="${olCounter}">`)
-        }
-        inSequence = true
-      } else {
-        olCounter = 0
-        inSequence = false
-      }
-    } else if (inSequence) {
-      if (/<h[2-5]/.test(tokens[i])) {
-        olCounter = 0
-        inSequence = false
-      }
-    }
-  }
-  html = tokens.join('')
-
-  return html
 }
 
 const getTimelineItemClass = (log, idx, total) => {

--- a/frontend/src/components/Step5Interaction.vue
+++ b/frontend/src/components/Step5Interaction.vue
@@ -48,7 +48,7 @@
               
               <div class="section-body" v-show="!collapsedSections.has(idx)">
                 <!-- Completed Content -->
-                <div v-if="generatedSections[idx + 1]" class="generated-content" v-html="renderMarkdown(generatedSections[idx + 1])"></div>
+                <div v-if="generatedSections[idx + 1]" class="generated-content" v-html="renderMarkdown(generatedSections[idx + 1], { stripLeadingH2: true })"></div>
                 
                 <!-- Loading State -->
                 <div v-else-if="currentSectionIndex === idx + 1" class="loading-state">
@@ -486,6 +486,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { chatWithReport, getReport, getAgentLog } from '../api/report'
 import { interviewAgents, getSimulationProfilesRealtime, getSimulationActions } from '../api/simulation'
+import { renderMarkdown } from '../utils/markdown'
 
 const props = defineProps({
   reportId: String,
@@ -671,93 +672,6 @@ const formatTime = (timestamp) => {
   } catch {
     return ''
   }
-}
-
-const renderMarkdown = (content) => {
-  if (!content) return ''
-  
-  let processedContent = content.replace(/^##\s+.+\n+/, '')
-  let html = processedContent.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre class="code-block"><code>$2</code></pre>')
-  html = html.replace(/`([^`]+)`/g, '<code class="inline-code">$1</code>')
-  html = html.replace(/^#### (.+)$/gm, '<h5 class="md-h5">$1</h5>')
-  html = html.replace(/^### (.+)$/gm, '<h4 class="md-h4">$1</h4>')
-  html = html.replace(/^## (.+)$/gm, '<h3 class="md-h3">$1</h3>')
-  html = html.replace(/^# (.+)$/gm, '<h2 class="md-h2">$1</h2>')
-  html = html.replace(/^> (.+)$/gm, '<blockquote class="md-quote">$1</blockquote>')
-  
-  // Process lists - support sublists
-  html = html.replace(/^(\s*)- (.+)$/gm, (match, indent, text) => {
-    const level = Math.floor(indent.length / 2)
-    return `<li class="md-li" data-level="${level}">${text}</li>`
-  })
-  html = html.replace(/^(\s*)(\d+)\. (.+)$/gm, (match, indent, num, text) => {
-    const level = Math.floor(indent.length / 2)
-    return `<li class="md-oli" data-level="${level}">${text}</li>`
-  })
-  
-  // Wrap unordered lists
-  html = html.replace(/(<li class="md-li"[^>]*>.*?<\/li>\s*)+/g, '<ul class="md-ul">$&</ul>')
-  // Wrap ordered lists
-  html = html.replace(/(<li class="md-oli"[^>]*>.*?<\/li>\s*)+/g, '<ol class="md-ol">$&</ol>')
-  
-  // Clean up all whitespace between list items
-  html = html.replace(/<\/li>\s+<li/g, '</li><li')
-  // Clean up whitespace after list opening tags
-  html = html.replace(/<ul class="md-ul">\s+/g, '<ul class="md-ul">')
-  html = html.replace(/<ol class="md-ol">\s+/g, '<ol class="md-ol">')
-  // Clean up whitespace before list closing tags
-  html = html.replace(/\s+<\/ul>/g, '</ul>')
-  html = html.replace(/\s+<\/ol>/g, '</ol>')
-  
-  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-  html = html.replace(/\*(.+?)\*/g, '<em>$1</em>')
-  html = html.replace(/_(.+?)_/g, '<em>$1</em>')
-  html = html.replace(/^---$/gm, '<hr class="md-hr">')
-  html = html.replace(/\n\n/g, '</p><p class="md-p">')
-  html = html.replace(/\n/g, '<br>')
-  html = '<p class="md-p">' + html + '</p>'
-  html = html.replace(/<p class="md-p"><\/p>/g, '')
-  html = html.replace(/<p class="md-p">(<h[2-5])/g, '$1')
-  html = html.replace(/(<\/h[2-5]>)<\/p>/g, '$1')
-  html = html.replace(/<p class="md-p">(<ul|<ol|<blockquote|<pre|<hr)/g, '$1')
-  html = html.replace(/(<\/ul>|<\/ol>|<\/blockquote>|<\/pre>)<\/p>/g, '$1')
-  // Clean up <br> tags before and after block-level elements
-  html = html.replace(/<br>\s*(<ul|<ol|<blockquote)/g, '$1')
-  html = html.replace(/(<\/ul>|<\/ol>|<\/blockquote>)\s*<br>/g, '$1')
-  // Clean up <p><br> followed by block-level elements (caused by extra blank lines)
-  html = html.replace(/<p class="md-p">(<br>\s*)+(<ul|<ol|<blockquote|<pre|<hr)/g, '$2')
-  // Clean up consecutive <br> tags
-  html = html.replace(/(<br>\s*){2,}/g, '<br>')
-  // Clean up <br> before paragraph opening tags following block-level elements
-  html = html.replace(/(<\/ol>|<\/ul>|<\/blockquote>)<br>(<p|<div)/g, '$1$2')
-
-  // Fix numbering for non-consecutive ordered lists: maintain incrementing numbers when single-item <ol> blocks are separated by paragraph content
-  const tokens = html.split(/(<ol class="md-ol">(?:<li class="md-oli"[^>]*>[\s\S]*?<\/li>)+<\/ol>)/g)
-  let olCounter = 0
-  let inSequence = false
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i].startsWith('<ol class="md-ol">')) {
-      const liCount = (tokens[i].match(/<li class="md-oli"/g) || []).length
-      if (liCount === 1) {
-        olCounter++
-        if (olCounter > 1) {
-          tokens[i] = tokens[i].replace('<ol class="md-ol">', `<ol class="md-ol" start="${olCounter}">`)
-        }
-        inSequence = true
-      } else {
-        olCounter = 0
-        inSequence = false
-      }
-    } else if (inSequence) {
-      if (/<h[2-5]/.test(tokens[i])) {
-        olCounter = 0
-        inSequence = false
-      }
-    }
-  }
-  html = tokens.join('')
-
-  return html
 }
 
 // Chat Methods

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -1,0 +1,82 @@
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
+
+// Track ordered/unordered context so listitem can apply the right class
+let _ordered = false
+
+const renderer = {
+  heading({ tokens, depth }) {
+    const text = this.parser.parseInline(tokens)
+    // Existing convention: # -> h2.md-h2, ## -> h3.md-h3, etc.
+    const level = depth + 1
+    return `<h${level} class="md-h${level}">${text}</h${level}>\n`
+  },
+
+  paragraph({ tokens }) {
+    const body = this.parser.parseInline(tokens)
+    return `<p class="md-p">${body}</p>\n`
+  },
+
+  list(token) {
+    const { ordered, start, items } = token
+    _ordered = ordered
+    let body = ''
+    for (let i = 0; i < items.length; i++) {
+      body += this.listitem(items[i])
+    }
+    _ordered = false
+
+    const tag = ordered ? 'ol' : 'ul'
+    const cls = ordered ? 'md-ol' : 'md-ul'
+    const startAttr = (ordered && start !== 1) ? ` start="${start}"` : ''
+    return `<${tag} class="${cls}"${startAttr}>${body}</${tag}>\n`
+  },
+
+  listitem(item) {
+    const cls = _ordered ? 'md-oli' : 'md-li'
+    const body = this.parser.parse(item.tokens, false)
+    return `<li class="${cls}">${body}</li>`
+  },
+
+  blockquote({ tokens }) {
+    const body = this.parser.parse(tokens)
+    return `<blockquote class="md-quote">${body}</blockquote>\n`
+  },
+
+  code({ text }) {
+    return `<pre class="code-block"><code>${text}</code></pre>\n`
+  },
+
+  codespan({ text }) {
+    return `<code class="inline-code">${text}</code>`
+  },
+
+  hr() {
+    return `<hr class="md-hr">\n`
+  }
+}
+
+marked.use({ renderer, breaks: true })
+
+/**
+ * Render markdown to sanitized HTML with CSS classes matching the app's design system.
+ *
+ * @param {string} content  Raw markdown string
+ * @param {Object} [options]
+ * @param {boolean} [options.stripLeadingH2=false]  Remove leading ## heading
+ *   (used when the section title is displayed externally)
+ * @returns {string} Sanitized HTML
+ */
+export function renderMarkdown(content, { stripLeadingH2 = false } = {}) {
+  if (!content) return ''
+
+  let processed = content
+  if (stripLeadingH2) {
+    processed = processed.replace(/^##\s+.+\n+/, '')
+  }
+
+  const html = marked.parse(processed)
+  return DOMPurify.sanitize(html, {
+    ADD_ATTR: ['start']
+  })
+}


### PR DESCRIPTION
## Summary
- Replace 2 duplicated hand-rolled regex markdown parsers (~190 lines) with a shared `frontend/src/utils/markdown.js` using `marked` + `DOMPurify`
- Eliminates XSS vulnerability across all 6 `v-html` sites that render LLM-generated content
- Custom `marked` renderer preserves existing CSS class names (`md-h2`, `md-p`, `md-ul`, `md-oli`, etc.) so all scoped component styles continue to work unchanged

## Test plan
- [ ] Generate a report (Step4) — verify sections render with headings, lists, bold, code blocks
- [ ] Chat with agents (Step5) — verify markdown renders in messages
- [ ] Confirm DOMPurify strips `<script>` / `onerror` from injected content

🤖 Generated with [Claude Code](https://claude.com/claude-code)