### PR TITLE
feat: one-click article generator from simulation results

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -9,10 +9,11 @@ import csv
 import json
 import traceback
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from flask import request, jsonify, send_file, current_app
 
 from . import simulation_bp
+from ..utils.llm_client import create_smart_llm_client
 from ..config import Config
 from ..services.entity_reader import EntityReader
 from ..services.oasis_profile_generator import OasisProfileGenerator
@@ -3562,6 +3563,181 @@ def resolve_simulation(simulation_id: str):
 
     except Exception as e:
         logger.error(f"Failed to resolve simulation: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
+# ============== Article Generator ==============
+
+@simulation_bp.route('/<simulation_id>/article', methods=['POST'])
+def generate_simulation_article(simulation_id: str):
+    """
+    Generate a 400-600 word publishable article brief from simulation results.
+
+    Returns a Substack-style article with abstract, key findings, market dynamics,
+    implications, and a caveats paragraph. Result is cached in generated_article.json
+    inside the simulation directory so re-opening the drawer does not re-call the LLM.
+
+    Request body (JSON, optional):
+        {
+            "force_regenerate": false,    // Re-generate even if cached
+            "share_url": "https://..."    // Optional share permalink to append
+        }
+
+    Returns:
+        {
+            "success": true,
+            "data": {
+                "article_text": "...",
+                "cached": false
+            }
+        }
+    """
+    try:
+        body = request.get_json(silent=True) or {}
+        force_regenerate = body.get('force_regenerate', False)
+        share_url = body.get('share_url', '')
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        if not os.path.exists(sim_dir):
+            return jsonify({
+                "success": False,
+                "error": f"Simulation not found: {simulation_id}"
+            }), 404
+
+        # --- Cache check ---
+        cache_path = os.path.join(sim_dir, 'generated_article.json')
+        if not force_regenerate and os.path.exists(cache_path):
+            try:
+                with open(cache_path, 'r', encoding='utf-8') as f:
+                    cached = json.load(f)
+                return jsonify({
+                    "success": True,
+                    "data": {
+                        "article_text": cached.get('article_text', ''),
+                        "cached": True
+                    }
+                })
+            except Exception:
+                pass  # corrupt cache — fall through to regenerate
+
+        # --- Gather context ---
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        config = manager.get_simulation_config(simulation_id)
+
+        scenario = ''
+        if config:
+            scenario = config.get('simulation_requirement', '')
+        if not scenario and state:
+            scenario = getattr(state, 'simulation_requirement', '') or ''
+
+        run_state = SimulationRunner.get_run_state(simulation_id)
+        total_rounds = 0
+        agent_count = 0
+        if run_state:
+            total_rounds = run_state.current_round
+        if state:
+            agent_count = state.profiles_count
+
+        # Top 5 most active rounds from timeline
+        timeline = SimulationRunner.get_timeline(simulation_id)
+        top_rounds = sorted(timeline, key=lambda r: r['total_actions'], reverse=True)[:5]
+        top_rounds_summary = ', '.join(
+            f"round {r['round_num']} ({r['total_actions']} actions)"
+            for r in top_rounds
+        )
+
+        # Top 3 influence leaders
+        leaders = _compute_influence_ranked(simulation_id, top_n=3)
+        leader_lines = []
+        for agent in leaders:
+            name = agent.get('agent_name', 'Unknown')
+            score = agent.get('score', 0)
+            posts = agent.get('posts_created', 0)
+            engagement = agent.get('engagement_received', 0)
+            leader_lines.append(
+                f"- {name}: influence score {score}, {posts} posts, {engagement} engagements received"
+            )
+        leaders_text = '\n'.join(leader_lines) if leader_lines else 'No agent data available.'
+
+        # Market price from Polymarket DB (if enabled)
+        market_summary = ''
+        polymarket_db = os.path.join(sim_dir, 'polymarket', 'polymarket.db')
+        if os.path.exists(polymarket_db):
+            try:
+                import sqlite3
+                with sqlite3.connect(polymarket_db) as con:
+                    cur = con.cursor()
+                    tables = {r[0] for r in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+                    if 'market' in tables:
+                        rows = cur.execute("SELECT id, reserve_yes, reserve_no FROM market").fetchall()
+                        market_lines = []
+                        for mid, ry, rn in rows:
+                            total = (ry or 0) + (rn or 0)
+                            price_yes = round((rn / total) * 100, 1) if total > 0 else 50.0
+                            market_lines.append(f"Market {mid}: {price_yes}% YES")
+                        market_summary = '; '.join(market_lines)
+            except Exception:
+                pass
+
+        market_context = (
+            f"\nPrediction market final prices: {market_summary}"
+            if market_summary else ""
+        )
+
+        share_cta = (
+            f"\n\nExplore this simulation yourself: {share_url}"
+            if share_url else ""
+        )
+
+        # --- LLM call ---
+        prompt = f"""You are writing a simulation study brief in the style of a Substack post. Write 400-600 words.
+
+Simulation scenario: {scenario or 'Multi-agent social simulation'}
+Total rounds completed: {total_rounds}
+Total agents: {agent_count}
+Most active rounds: {top_rounds_summary or 'N/A'}{market_context}
+
+Top influence leaders:
+{leaders_text}
+
+Write the article with these sections:
+1. One-sentence abstract (what was simulated and why it matters)
+2. Three bullet-point key findings — be specific, use the data above (active rounds, top agents, market prices if available)
+3. One paragraph on agent dynamics (how did the top agents drive the narrative?)
+4. One paragraph on implications (what does this simulation tell us about the real-world scenario?)
+5. Two-sentence caveat about AI simulation limitations{share_cta}
+
+Return only the article text in Markdown format. Use ## for section headings. Do not include a title — start directly with the abstract."""
+
+        llm = create_smart_llm_client(timeout=120.0)
+        article_text = llm.chat(
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+            max_tokens=1200,
+        )
+
+        # --- Cache result ---
+        try:
+            with open(cache_path, 'w', encoding='utf-8') as f:
+                json.dump({'article_text': article_text, 'generated_at': datetime.now(timezone.utc).isoformat()}, f)
+        except Exception as e:
+            logger.warning(f"Failed to cache generated article for {simulation_id}: {e}")
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "article_text": article_text,
+                "cached": False
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"Failed to generate article for {simulation_id}: {str(e)}")
         return jsonify({
             "success": False,
             "error": str(e),

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -270,3 +270,12 @@ export const resolveSimulation = (simulationId, data) => {
   return service.post(`/api/simulation/${simulationId}/resolve`, data)
 }
 
+/**
+ * Generate a publishable article brief from simulation results (cached).
+ * @param {string} simulationId
+ * @param {Object} options - { force_regenerate?, share_url? }
+ */
+export const generateSimulationArticle = (simulationId, options = {}) => {
+  return service.post(`/api/simulation/${simulationId}/article`, options)
+}
+

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -39,6 +39,16 @@
         ▶ Replay
       </button>
 
+      <!-- Generate Article (when simulation has data) -->
+      <button
+        v-if="phase === 2 && allActions.length > 0"
+        class="action-btn secondary"
+        @click="openArticleDrawer"
+        title="Generate a publishable article brief from simulation results"
+      >
+        ✍ Article
+      </button>
+
       <!-- Influence Leaderboard toggle -->
       <button
         v-if="allActions.length > 0"
@@ -423,6 +433,53 @@
         </div>
       </div>
     </div>
+
+    <!-- Article Drawer Overlay -->
+    <Transition name="article-drawer">
+      <div v-if="showArticleDrawer" class="article-drawer-overlay" @click.self="showArticleDrawer = false">
+        <div class="article-drawer">
+          <div class="article-drawer-header">
+            <span class="article-drawer-title">Generated Article</span>
+            <div class="article-drawer-actions">
+              <button
+                class="article-action-btn"
+                :disabled="isGeneratingArticle || !articleText"
+                @click="copyArticle"
+                :title="articleCopied ? 'Copied!' : 'Copy to clipboard'"
+              >{{ articleCopied ? 'Copied!' : 'Copy' }}</button>
+              <button
+                class="article-action-btn"
+                :disabled="isGeneratingArticle || !articleText"
+                @click="downloadArticle"
+                title="Download as .md"
+              >Download .md</button>
+              <button class="article-close-btn" @click="showArticleDrawer = false">&#x2715;</button>
+            </div>
+          </div>
+
+          <div class="article-drawer-body">
+            <!-- Loading state -->
+            <div v-if="isGeneratingArticle" class="article-loading">
+              <div class="article-loading-spinner"></div>
+              <span>Generating article from simulation data...</span>
+            </div>
+
+            <!-- Error state -->
+            <div v-else-if="articleError" class="article-error">
+              <span class="article-error-msg">{{ articleError }}</span>
+              <button class="article-action-btn" @click="generateArticle">Retry</button>
+            </div>
+
+            <!-- Article content -->
+            <div
+              v-else-if="articleText"
+              class="article-content generated-content"
+              v-html="renderMarkdown(articleText)"
+            ></div>
+          </div>
+        </div>
+      </div>
+    </Transition>
   </div>
 </template>
 
@@ -434,9 +491,11 @@ import {
   stopSimulation,
   resumeSimulation,
   getRunStatus,
-  getRunStatusDetail
+  getRunStatusDetail,
+  generateSimulationArticle
 } from '../api/simulation'
 import { generateReport } from '../api/report'
+import { renderMarkdown } from '../utils/markdown'
 import InfluenceLeaderboard from './InfluenceLeaderboard.vue'
 import BeliefDriftChart from './BeliefDriftChart.vue'
 
@@ -473,6 +532,13 @@ const filteredAgent = ref(null)
 const filteredPlatform = ref(null)
 const showInfluence = ref(false)
 const showBeliefDrift = ref(false)
+
+// Article drawer state
+const showArticleDrawer = ref(false)
+const articleText = ref('')
+const isGeneratingArticle = ref(false)
+const articleError = ref(null)
+const articleCopied = ref(false)
 
 const filterByAgent = (agentName) => {
   filteredAgent.value = filteredAgent.value === agentName ? null : agentName
@@ -1066,6 +1132,53 @@ const tryResumeOrStart = async () => {
   }
 
   doStartSimulation()
+}
+
+const openArticleDrawer = () => {
+  showArticleDrawer.value = true
+  if (!articleText.value && !isGeneratingArticle.value) {
+    generateArticle()
+  }
+}
+
+const generateArticle = async () => {
+  if (!props.simulationId || isGeneratingArticle.value) return
+  isGeneratingArticle.value = true
+  articleError.value = null
+  try {
+    const res = await generateSimulationArticle(props.simulationId)
+    if (res.success && res.data?.article_text) {
+      articleText.value = res.data.article_text
+    } else {
+      articleError.value = res.error || 'Failed to generate article.'
+    }
+  } catch (err) {
+    articleError.value = err?.message || 'Network error generating article.'
+  } finally {
+    isGeneratingArticle.value = false
+  }
+}
+
+const copyArticle = async () => {
+  if (!articleText.value) return
+  try {
+    await navigator.clipboard.writeText(articleText.value)
+    articleCopied.value = true
+    setTimeout(() => { articleCopied.value = false }, 1800)
+  } catch {
+    // clipboard not available
+  }
+}
+
+const downloadArticle = () => {
+  if (!articleText.value) return
+  const blob = new Blob([articleText.value], { type: 'text/markdown;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `simulation-${props.simulationId || 'article'}.md`
+  a.click()
+  URL.revokeObjectURL(url)
 }
 
 onMounted(() => {
@@ -1976,4 +2089,165 @@ onUnmounted(() => {
   animation: spin 0.8s linear infinite;
   margin-right: 6px;
 }
+
+/* ---- Article Drawer ---- */
+.article-drawer-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(10,10,10,0.45);
+  z-index: 200;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.article-drawer {
+  width: 100%;
+  max-width: 780px;
+  max-height: 75vh;
+  background: #FAFAFA;
+  border-top: 2px solid rgba(10,10,10,0.1);
+  border-left: 2px solid rgba(10,10,10,0.08);
+  border-right: 2px solid rgba(10,10,10,0.08);
+  border-radius: 8px 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.article-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.08);
+  background: #F5F5F5;
+  flex-shrink: 0;
+}
+
+.article-drawer-title {
+  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: #0A0A0A;
+}
+
+.article-drawer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.article-action-btn {
+  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid rgba(10,10,10,0.2);
+  border-radius: 3px;
+  cursor: pointer;
+  color: #0A0A0A;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.article-action-btn:hover:not(:disabled) {
+  background: #0A0A0A;
+  color: #FAFAFA;
+  border-color: #0A0A0A;
+}
+
+.article-action-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.article-close-btn {
+  font-size: 14px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: rgba(10,10,10,0.4);
+  line-height: 1;
+  padding: 4px 6px;
+  transition: color 0.15s;
+}
+
+.article-close-btn:hover { color: #0A0A0A; }
+
+.article-drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+}
+
+.article-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 40px 0;
+  color: rgba(10,10,10,0.45);
+  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-size: 12px;
+}
+
+.article-loading-spinner {
+  width: 28px;
+  height: 28px;
+  border: 2px solid rgba(10,10,10,0.12);
+  border-top-color: #FF6B1A;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.article-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 32px 0;
+}
+
+.article-error-msg {
+  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-size: 12px;
+  color: #e53e3e;
+  text-align: center;
+}
+
+.article-content {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.7;
+  color: #0A0A0A;
+}
+
+/* Transition for drawer */
+.article-drawer-enter-active, .article-drawer-leave-active {
+  transition: opacity 0.2s ease;
+}
+.article-drawer-enter-active .article-drawer,
+.article-drawer-leave-active .article-drawer {
+  transition: transform 0.25s ease;
+}
+.article-drawer-enter-from, .article-drawer-leave-to { opacity: 0; }
+.article-drawer-enter-from .article-drawer,
+.article-drawer-leave-to .article-drawer { transform: translateY(100%); }
+
+/* Markdown styles for article content */
+.article-content :deep(.md-h2) { font-size: 1.25em; font-weight: 700; margin: 1.2em 0 0.5em; }
+.article-content :deep(.md-h3) { font-size: 1.1em; font-weight: 700; margin: 1em 0 0.4em; }
+.article-content :deep(.md-p) { margin: 0.6em 0; }
+.article-content :deep(.md-ul) { margin: 0.5em 0 0.5em 1.2em; padding: 0; }
+.article-content :deep(.md-ol) { margin: 0.5em 0 0.5em 1.2em; padding: 0; }
+.article-content :deep(.md-li) { margin: 0.3em 0; list-style-type: disc; }
+.article-content :deep(.md-oli) { margin: 0.3em 0; }
+.article-content :deep(.md-hr) { border: none; border-top: 1px solid rgba(10,10,10,0.1); margin: 1em 0; }
+.article-content :deep(.md-quote) { border-left: 3px solid #FF6B1A; margin: 0.8em 0; padding: 4px 12px; color: rgba(10,10,10,0.6); font-style: italic; }
 </style>


### PR DESCRIPTION
## Summary
- Reimplements the article generator from closed PR #21, built on top of the shared sanitized markdown renderer (#24)
- Backend: `POST /<simulation_id>/article` gathers sim context (scenario, agents, influence leaders, Polymarket prices) and generates a Substack-style article brief via LLM, cached per simulation
- Frontend: slide-up drawer in Step3Simulation with Copy + Download .md actions
- Fixes from #21: SQLite context manager, `datetime.now(timezone.utc)`, no hand-rolled markdown parser, no XSS

## Test plan
- [ ] Run simulation to completion, click "Article" button
- [ ] Verify loading spinner, then rendered article with headings/lists/bold
- [ ] Verify Copy copies raw markdown to clipboard
- [ ] Verify Download saves `.md` file
- [ ] Re-open drawer — should load from cache instantly (no spinner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)