### PR TITLE
feat: post-simulation trace-grounded agent interview

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -3743,3 +3743,346 @@ Return only the article text in Markdown format. Use ## for section headings. Do
             "error": str(e),
             "traceback": traceback.format_exc()
         }), 500
+
+
+# ============== Trace Interview ==============
+
+
+def _build_agent_trace(simulation_id: str, agent_name: str) -> dict:
+    """
+    Build a per-round trace of an agent's simulation activity from action JSONL logs.
+
+    Returns:
+        {
+            'rounds': {round_num: {'posts': [...], 'other_actions': [...]}},
+            'total_posts': int,
+            'total_engagements_received': int,
+            'platforms': [str, ...]
+        }
+    """
+    sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+
+    rounds: dict = {}
+    total_posts = 0
+    total_engagements = 0
+    platforms_active: set = set()
+
+    ENGAGEMENT_TYPES = frozenset({
+        'LIKE_POST', 'REPOST', 'QUOTE_POST', 'LIKE_COMMENT', 'CREATE_COMMENT',
+    })
+
+    for platform in ('twitter', 'reddit'):
+        actions_path = os.path.join(sim_dir, platform, 'actions.jsonl')
+        if not os.path.exists(actions_path):
+            continue
+
+        with open(actions_path, 'r', encoding='utf-8') as fh:
+            for raw_line in fh:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    event = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+
+                if event.get('event_type') in (
+                    'simulation_start', 'round_start', 'round_end', 'simulation_end'
+                ):
+                    continue
+
+                round_num = event.get('round', 0)
+
+                # Track this agent's own actions
+                if event.get('agent_name') == agent_name:
+                    platforms_active.add(platform)
+                    if round_num not in rounds:
+                        rounds[round_num] = {'posts': [], 'other_actions': []}
+
+                    action_type = event.get('action_type', '')
+                    args = event.get('action_args') or {}
+
+                    if action_type == 'CREATE_POST':
+                        content = args.get('content', '')
+                        rounds[round_num]['posts'].append({
+                            'platform': platform,
+                            'content': content,
+                        })
+                        total_posts += 1
+                    elif action_type and action_type != 'DO_NOTHING':
+                        rounds[round_num]['other_actions'].append({
+                            'platform': platform,
+                            'type': action_type,
+                        })
+
+                # Track engagements received by this agent
+                elif event.get('action_type') in ENGAGEMENT_TYPES:
+                    args = event.get('action_args') or {}
+                    target = (
+                        args.get('post_author_name')
+                        or args.get('original_author_name')
+                    )
+                    if target == agent_name:
+                        total_engagements += 1
+
+    return {
+        'rounds': rounds,
+        'total_posts': total_posts,
+        'total_engagements_received': total_engagements,
+        'platforms': sorted(platforms_active),
+    }
+
+
+@simulation_bp.route('/<simulation_id>/agents/<agent_name>/trace-interview', methods=['POST'])
+def trace_interview_agent(simulation_id: str, agent_name: str):
+    """
+    Post-simulation trace-grounded agent interview.
+
+    Does NOT require the simulation environment to be running. Works on completed
+    simulations by injecting the agent's round-by-round simulation trace as LLM context,
+    enabling questions like "Why did you change your position in round 4?".
+
+    Supports multi-turn: pass previous Q&A in the 'history' field to continue the
+    conversation with full context.
+
+    Request body (JSON):
+        {
+            "question": "Why did you post so aggressively in round 3?",
+            "history": [                        // Optional: prior Q&A for multi-turn
+                {"role": "user", "content": "..."},
+                {"role": "assistant", "content": "..."}
+            ]
+        }
+
+    Returns:
+        {
+            "success": true,
+            "data": {
+                "agent_name": "AgentName",
+                "question": "...",
+                "answer": "...",
+                "total_qa": 3           // total Q&A pairs saved for this agent
+            }
+        }
+    """
+    try:
+        body = request.get_json(silent=True) or {}
+        question = (body.get('question') or '').strip()
+        history = body.get('history') or []
+
+        if not question:
+            return jsonify({"success": False, "error": "Please provide a question"}), 400
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        if not os.path.exists(sim_dir):
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        # --- Get simulation scenario ---
+        scenario = ''
+        config = SimulationManager().get_simulation_config(simulation_id)
+        if config:
+            scenario = config.get('simulation_requirement', '') or ''
+
+        # --- Get agent profile ---
+        profile_lines = []
+        profiles_file = os.path.join(sim_dir, 'reddit_profiles.json')
+        if os.path.exists(profiles_file):
+            try:
+                with open(profiles_file, 'r', encoding='utf-8') as f:
+                    profiles = json.load(f)
+                for p in profiles:
+                    pname = p.get('user_name') or p.get('username') or p.get('name') or ''
+                    if pname.lower() == agent_name.lower():
+                        bio = p.get('bio', '')
+                        persona = p.get('persona', '')
+                        profession = p.get('profession', '')
+                        topics = p.get('interested_topics', [])
+                        age = p.get('age', '')
+                        country = p.get('country', '')
+
+                        if bio:
+                            profile_lines.append(f"Bio: {bio}")
+                        if persona and isinstance(persona, str):
+                            profile_lines.append(f"Persona: {persona[:300]}")
+                        elif persona and isinstance(persona, dict):
+                            if persona.get('archetype'):
+                                profile_lines.append(f"Archetype: {persona['archetype']}")
+                            if persona.get('bio'):
+                                profile_lines.append(f"Persona bio: {persona['bio'][:200]}")
+                        if profession:
+                            profile_lines.append(f"Profession: {profession}")
+                        if topics:
+                            profile_lines.append(f"Interested topics: {', '.join(str(t) for t in topics[:6])}")
+                        if age:
+                            profile_lines.append(f"Age: {age}")
+                        if country:
+                            profile_lines.append(f"Country: {country}")
+                        break
+            except Exception as e:
+                logger.warning(f"Could not load profile for {agent_name}: {e}")
+
+        profile_summary = '\n'.join(profile_lines) if profile_lines else 'No profile data available.'
+
+        # --- Build simulation trace ---
+        trace = _build_agent_trace(simulation_id, agent_name)
+
+        trace_lines = []
+        for round_num in sorted(trace['rounds'].keys()):
+            round_data = trace['rounds'][round_num]
+            posts = round_data.get('posts', [])
+            other_actions = round_data.get('other_actions', [])
+
+            for post in posts:
+                content = post['content'][:250] if post['content'] else ''
+                if content:
+                    trace_lines.append(f"Round {round_num} [{post['platform']}] POST: \"{content}\"")
+
+            if other_actions:
+                action_types = ', '.join(sorted({a['type'] for a in other_actions}))
+                trace_lines.append(f"Round {round_num}: {action_types}")
+
+        if not trace_lines:
+            trace_text = "No recorded actions found for this agent in this simulation."
+        else:
+            trace_text = '\n'.join(trace_lines)
+
+        # --- Build LLM messages ---
+        system_content = (
+            f"You are {agent_name}, an AI agent who just participated in a multi-agent "
+            f"social media simulation about: \"{scenario or 'a prediction scenario'}\".\n\n"
+            f"Your profile:\n{profile_summary}\n\n"
+            f"Here is everything you did during the simulation, round by round:\n{trace_text}\n\n"
+            f"Answer questions about your simulation experience IN CHARACTER as {agent_name}. "
+            f"Cite specific posts you made and actions you took. Reference exact round numbers "
+            f"when relevant. Be concise (2-4 paragraphs), specific, and stay true to your persona."
+        )
+
+        messages = [{"role": "system", "content": system_content}]
+
+        # Append validated conversation history for multi-turn support
+        for msg in history:
+            if (
+                isinstance(msg, dict)
+                and msg.get('role') in ('user', 'assistant')
+                and isinstance(msg.get('content'), str)
+                and msg['content'].strip()
+            ):
+                messages.append({"role": msg['role'], "content": msg['content']})
+
+        messages.append({"role": "user", "content": question})
+
+        # --- LLM call ---
+        llm = create_smart_llm_client(timeout=90.0)
+        answer = llm.chat(messages=messages, temperature=0.75, max_tokens=800)
+
+        # --- Persist transcript ---
+        interviews_dir = os.path.join(sim_dir, 'interviews')
+        os.makedirs(interviews_dir, exist_ok=True)
+
+        safe_name = ''.join(c if c.isalnum() or c in '-_.' else '_' for c in agent_name)
+        transcript_path = os.path.join(interviews_dir, f'{safe_name}.json')
+
+        transcript = []
+        if os.path.exists(transcript_path):
+            try:
+                with open(transcript_path, 'r', encoding='utf-8') as f:
+                    existing = json.load(f)
+                    transcript = existing.get('qa_pairs', [])
+            except Exception:
+                pass
+
+        transcript.append({
+            'question': question,
+            'answer': answer,
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+        })
+
+        try:
+            with open(transcript_path, 'w', encoding='utf-8') as f:
+                json.dump({
+                    'agent_name': agent_name,
+                    'simulation_id': simulation_id,
+                    'qa_pairs': transcript,
+                    'last_updated': datetime.now(timezone.utc).isoformat(),
+                }, f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            logger.warning(f"Failed to save interview transcript for {agent_name}: {e}")
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "agent_name": agent_name,
+                "question": question,
+                "answer": answer,
+                "total_qa": len(transcript),
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"Trace interview failed for {agent_name} in {simulation_id}: {e}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
+@simulation_bp.route('/<simulation_id>/interviews/<agent_name>', methods=['GET'])
+def get_agent_interview_transcript(simulation_id: str, agent_name: str):
+    """
+    Retrieve the saved interview transcript for an agent.
+
+    Returns the full list of Q&A pairs previously saved for this agent,
+    or an empty transcript if none exists yet.
+
+    Returns:
+        {
+            "success": true,
+            "data": {
+                "agent_name": "AgentName",
+                "qa_pairs": [
+                    {"question": "...", "answer": "...", "timestamp": "..."},
+                    ...
+                ],
+                "total_qa": 3
+            }
+        }
+    """
+    try:
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        if not os.path.exists(sim_dir):
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        safe_name = ''.join(c if c.isalnum() or c in '-_.' else '_' for c in agent_name)
+        transcript_path = os.path.join(sim_dir, 'interviews', f'{safe_name}.json')
+
+        if not os.path.exists(transcript_path):
+            return jsonify({
+                "success": True,
+                "data": {
+                    "agent_name": agent_name,
+                    "qa_pairs": [],
+                    "total_qa": 0,
+                }
+            })
+
+        with open(transcript_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        qa_pairs = data.get('qa_pairs', [])
+        return jsonify({
+            "success": True,
+            "data": {
+                "agent_name": agent_name,
+                "qa_pairs": qa_pairs,
+                "total_qa": len(qa_pairs),
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"Failed to get interview transcript for {agent_name}: {e}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -279,3 +279,28 @@ export const generateSimulationArticle = (simulationId, options = {}) => {
   return service.post(`/api/simulation/${simulationId}/article`, options)
 }
 
+/**
+ * Post-simulation trace-grounded agent interview.
+ * Works on completed simulations without needing the env running.
+ * @param {string} simulationId
+ * @param {string} agentName
+ * @param {Object} data - { question: string, history?: [{role, content}] }
+ */
+export const traceInterviewAgent = (simulationId, agentName, data) => {
+  return service.post(
+    `/api/simulation/${simulationId}/agents/${encodeURIComponent(agentName)}/trace-interview`,
+    data
+  )
+}
+
+/**
+ * Get saved interview transcript for an agent.
+ * @param {string} simulationId
+ * @param {string} agentName
+ */
+export const getAgentInterview = (simulationId, agentName) => {
+  return service.get(
+    `/api/simulation/${simulationId}/interviews/${encodeURIComponent(agentName)}`
+  )
+}
+

--- a/frontend/src/components/InfluenceLeaderboard.vue
+++ b/frontend/src/components/InfluenceLeaderboard.vue
@@ -16,6 +16,80 @@
       </button>
     </div>
 
+    <!-- Interview Modal -->
+    <teleport to="body">
+      <div v-if="interviewAgent" class="iv-overlay" @click.self="closeInterview">
+        <div class="iv-modal">
+          <!-- Modal Header -->
+          <div class="iv-header">
+            <div class="iv-agent-info">
+              <div class="iv-avatar">{{ interviewAgent.agent_name[0].toUpperCase() }}</div>
+              <div>
+                <div class="iv-name">{{ interviewAgent.agent_name }}</div>
+                <div class="iv-meta">
+                  Rank #{{ interviewAgent.rank }} · {{ interviewAgent.influence_score }} pts
+                  · {{ interviewAgent.posts_created }} posts
+                </div>
+              </div>
+            </div>
+            <button class="iv-close" @click="closeInterview">✕</button>
+          </div>
+
+          <!-- Chat thread -->
+          <div class="iv-thread" ref="threadEl">
+            <div v-if="!interviewHistory.length && !interviewLoading" class="iv-empty">
+              Ask {{ interviewAgent.agent_name }} about their simulation experience.
+              Try: "Why did you post so much in the early rounds?" or "What changed your mind?"
+            </div>
+            <div
+              v-for="(qa, i) in interviewHistory"
+              :key="i"
+              class="iv-qa-pair"
+            >
+              <div class="iv-question">
+                <span class="iv-role">You</span>
+                <span class="iv-text">{{ qa.question }}</span>
+              </div>
+              <div class="iv-answer">
+                <span class="iv-role agent">{{ interviewAgent.agent_name }}</span>
+                <span class="iv-text">{{ qa.answer }}</span>
+                <button class="iv-share-btn" @click="shareQA(qa)" title="Copy for sharing">
+                  Share ↗
+                </button>
+              </div>
+            </div>
+            <div v-if="interviewLoading" class="iv-thinking">
+              <div class="iv-dots"><span></span><span></span><span></span></div>
+              <span>{{ interviewAgent.agent_name }} is thinking...</span>
+            </div>
+          </div>
+
+          <!-- Input -->
+          <div class="iv-input-row">
+            <input
+              ref="questionInput"
+              v-model="interviewQuestion"
+              class="iv-input"
+              type="text"
+              placeholder="Ask a question..."
+              :disabled="interviewLoading"
+              @keydown.enter.prevent="submitQuestion"
+            />
+            <button
+              class="iv-send"
+              :disabled="interviewLoading || !interviewQuestion.trim()"
+              @click="submitQuestion"
+            >
+              Ask
+            </button>
+          </div>
+
+          <!-- Error -->
+          <div v-if="interviewError" class="iv-error">{{ interviewError }}</div>
+        </div>
+      </div>
+    </teleport>
+
     <!-- Score legend -->
     <div class="lb-legend">
       <span class="legend-item"><span class="legend-dot engage"></span>Engagement ×3</span>
@@ -90,6 +164,15 @@
             ></div>
           </div>
         </div>
+
+        <!-- Interview button -->
+        <button
+          class="iv-btn"
+          @click.stop="openInterview(agent)"
+          title="Interview this agent about their simulation"
+        >
+          ▶ Interview
+        </button>
       </div>
     </div>
 
@@ -101,8 +184,8 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue'
-import { getInfluenceLeaderboard } from '../api/simulation'
+import { ref, computed, watch, onMounted, nextTick } from 'vue'
+import { getInfluenceLeaderboard, traceInterviewAgent, getAgentInterview } from '../api/simulation'
 
 const props = defineProps({
   simulationId: { type: String, required: true },
@@ -113,6 +196,15 @@ const loading = ref(false)
 const error = ref('')
 const agents = ref([])
 const totalAgents = ref(0)
+
+// Interview state
+const interviewAgent = ref(null)
+const interviewHistory = ref([])
+const interviewQuestion = ref('')
+const interviewLoading = ref(false)
+const interviewError = ref('')
+const threadEl = ref(null)
+const questionInput = ref(null)
 
 const maxScore = computed(() =>
   agents.value.length ? agents.value[0].influence_score : 1
@@ -155,6 +247,89 @@ const exportReport = () => {
   a.download = `influence-report-${props.simulationId}.json`
   a.click()
   URL.revokeObjectURL(url)
+}
+
+// ── Interview ──
+
+const openInterview = async (agent) => {
+  interviewAgent.value = agent
+  interviewHistory.value = []
+  interviewQuestion.value = ''
+  interviewError.value = ''
+
+  // Load existing transcript
+  try {
+    const res = await getAgentInterview(props.simulationId, agent.agent_name)
+    if (res.data?.success && res.data.data.qa_pairs?.length) {
+      interviewHistory.value = res.data.data.qa_pairs
+    }
+  } catch (_) {
+    // No transcript yet — that's fine
+  }
+
+  await nextTick()
+  questionInput.value?.focus()
+  scrollThread()
+}
+
+const closeInterview = () => {
+  interviewAgent.value = null
+  interviewHistory.value = []
+  interviewQuestion.value = ''
+  interviewError.value = ''
+}
+
+const submitQuestion = async () => {
+  const question = interviewQuestion.value.trim()
+  if (!question || interviewLoading.value) return
+
+  interviewLoading.value = true
+  interviewError.value = ''
+  interviewQuestion.value = ''
+
+  try {
+    // Build history for multi-turn context (last 6 exchanges to keep tokens bounded)
+    const history = interviewHistory.value.slice(-6).flatMap(qa => [
+      { role: 'user', content: qa.question },
+      { role: 'assistant', content: qa.answer },
+    ])
+
+    const res = await traceInterviewAgent(props.simulationId, interviewAgent.value.agent_name, {
+      question,
+      history,
+    })
+
+    if (res.data?.success) {
+      interviewHistory.value.push({
+        question,
+        answer: res.data.data.answer,
+        timestamp: new Date().toISOString(),
+      })
+      await nextTick()
+      scrollThread()
+    } else {
+      interviewError.value = res.data?.error || 'Failed to get a response.'
+    }
+  } catch (err) {
+    interviewError.value = err.message || 'Request failed.'
+  } finally {
+    interviewLoading.value = false
+    await nextTick()
+    questionInput.value?.focus()
+  }
+}
+
+const scrollThread = () => {
+  if (threadEl.value) {
+    threadEl.value.scrollTop = threadEl.value.scrollHeight
+  }
+}
+
+const shareQA = (qa) => {
+  const name = interviewAgent.value?.agent_name || 'Agent'
+  const text = `I interviewed ${name} (AI simulation agent)\n\nQ: ${qa.question}\n\nA: ${qa.answer}`
+  const card = text.length > 280 ? text.slice(0, 277) + '...' : text
+  navigator.clipboard.writeText(card).catch(() => {})
 }
 
 // Load when becoming visible or when simulationId changes
@@ -441,6 +616,279 @@ onMounted(() => { if (props.visible) load() })
   letter-spacing: 1px;
   text-align: center;
   border-top: 1px solid rgba(10,10,10,0.05);
+  flex-shrink: 0;
+}
+
+/* ── Interview button ── */
+.iv-btn {
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid rgba(10,10,10,0.15);
+  padding: 3px 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  cursor: pointer;
+  color: rgba(10,10,10,0.45);
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.iv-btn:hover {
+  border-color: var(--color-green, #43C165);
+  color: var(--color-green, #43C165);
+}
+
+/* ── Interview Overlay ── */
+.iv-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10,10,10,0.5);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.iv-modal {
+  background: #FAFAFA;
+  border: 1px solid rgba(10,10,10,0.12);
+  width: 100%;
+  max-width: 580px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-mono);
+  box-shadow: 0 20px 60px rgba(10,10,10,0.25);
+}
+
+/* ── Modal Header ── */
+.iv-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.08);
+  flex-shrink: 0;
+}
+
+.iv-agent-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.iv-avatar {
+  width: 36px;
+  height: 36px;
+  background: rgba(10,10,10,0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+  color: rgba(10,10,10,0.4);
+  flex-shrink: 0;
+}
+
+.iv-name {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--foreground, #0A0A0A);
+}
+
+.iv-meta {
+  font-size: 10px;
+  color: rgba(10,10,10,0.35);
+  letter-spacing: 1px;
+  margin-top: 2px;
+}
+
+.iv-close {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  color: rgba(10,10,10,0.35);
+  padding: 4px 8px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.iv-close:hover {
+  color: rgba(10,10,10,0.8);
+}
+
+/* ── Chat Thread ── */
+.iv-thread {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 200px;
+  max-height: 420px;
+}
+
+.iv-empty {
+  font-size: 12px;
+  color: rgba(10,10,10,0.35);
+  letter-spacing: 0.5px;
+  line-height: 1.6;
+  text-align: center;
+  padding: 24px 8px;
+}
+
+.iv-qa-pair {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.iv-question,
+.iv-answer {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.iv-role {
+  font-size: 9px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.3);
+  font-weight: 600;
+}
+
+.iv-role.agent {
+  color: var(--color-green, #43C165);
+}
+
+.iv-text {
+  font-size: 12px;
+  line-height: 1.65;
+  color: rgba(10,10,10,0.8);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.iv-answer {
+  background: rgba(10,10,10,0.02);
+  border-left: 2px solid var(--color-green, #43C165);
+  padding: 8px 10px;
+}
+
+.iv-share-btn {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 1px;
+  color: rgba(10,10,10,0.3);
+  cursor: pointer;
+  padding: 2px 0;
+  margin-top: 2px;
+  transition: color 0.15s;
+}
+
+.iv-share-btn:hover {
+  color: var(--color-orange, #FF6B1A);
+}
+
+/* ── Loading dots ── */
+.iv-thinking {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 11px;
+  color: rgba(10,10,10,0.35);
+  letter-spacing: 1px;
+  padding: 4px 0;
+}
+
+.iv-dots {
+  display: flex;
+  gap: 4px;
+}
+
+.iv-dots span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-orange, #FF6B1A);
+  animation: iv-bounce 1.2s ease-in-out infinite;
+}
+
+.iv-dots span:nth-child(2) { animation-delay: 0.2s; }
+.iv-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes iv-bounce {
+  0%, 80%, 100% { transform: scale(0.7); opacity: 0.5; }
+  40% { transform: scale(1); opacity: 1; }
+}
+
+/* ── Input Row ── */
+.iv-input-row {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid rgba(10,10,10,0.08);
+  flex-shrink: 0;
+}
+
+.iv-input {
+  flex: 1;
+  background: rgba(10,10,10,0.03);
+  border: 1px solid rgba(10,10,10,0.12);
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--foreground, #0A0A0A);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.iv-input:focus {
+  border-color: var(--color-green, #43C165);
+}
+
+.iv-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.iv-send {
+  background: var(--color-green, #43C165);
+  border: none;
+  padding: 8px 16px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.iv-send:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.iv-send:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* ── Error ── */
+.iv-error {
+  padding: 8px 16px;
+  font-size: 11px;
+  color: var(--color-red, #e53e3e);
+  letter-spacing: 0.5px;
+  border-top: 1px solid rgba(229,62,62,0.15);
   flex-shrink: 0;
 }
 </style>


### PR DESCRIPTION
## What

Add an **Interview** button to every agent row in the Influence Leaderboard. Clicking opens a conversational modal where users can ask agents questions grounded in their actual simulation trace — posts made, engagements taken, round by round.

Unlike the existing Step 5 /interview endpoint (which requires the simulation runtime to be alive), this feature works on any completed simulation with no env restart needed. The agent answers in-character, citing specific posts and round numbers from what they actually did.

Example questions:
- "Why did you post so aggressively in round 3?"
- "What changed your position in round 7?"
- "Which posts got you the most engagement?"

## Why

Persona chat exists (Step 5) but it's simulation-blind — it uses graph context only and requires the environment to be running. This closes that gap: every completed simulation now becomes a conversation. The pattern "I interviewed the AI agent that predicted X — here's what it said" is inherently social-shareable and makes simulation results accessible to non-technical users.

## Changes

- backend/app/api/simulation.py: _build_agent_trace() reads twitter/actions.jsonl + reddit/actions.jsonl per agent. POST /<sim_id>/agents/<agent_name>/trace-interview loads profile from reddit_profiles.json, assembles LLM context (profile + full trace), calls create_smart_llm_client, persists transcript to <sim_dir>/interviews/<agent_name>.json, supports multi-turn via history field. GET /<sim_id>/interviews/<agent_name> returns saved Q&A pairs for transcript continuity.

- frontend/src/api/simulation.js: traceInterviewAgent() and getAgentInterview() API functions.

- frontend/src/components/InfluenceLeaderboard.vue: Interview button on each agent row. Teleport-based modal with agent profile header, scrollable chat thread, multi-turn support (last 6 Q&A sent as history), per-answer Share button (copies 280-char X-ready card to clipboard), animated thinking dots, Enter-key submit.

---
*Built autonomously by Aeon*