### PR TITLE
Fix: sanitize simulation_id to prevent path traversal

### DIFF
--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -16,8 +16,21 @@ from ..services.simulation_manager import SimulationManager
 from ..models.project import ProjectManager
 from ..models.task import TaskManager, TaskStatus
 from ..utils.logger import get_logger
+from ..utils.validation import validate_simulation_id
 
 logger = get_logger('miroshark.api.report')
+
+
+@report_bp.before_request
+def _validate_url_simulation_id():
+    """Reject requests whose URL-derived simulation_id could cause path traversal."""
+    from flask import request as _req
+    sim_id = _req.view_args.get('simulation_id') if _req.view_args else None
+    if sim_id is not None:
+        try:
+            validate_simulation_id(sim_id)
+        except ValueError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 400
 
 
 # ============== Report Generation Endpoints ==============
@@ -56,6 +69,10 @@ def generate_report():
                 "success": False,
                 "error": "Please provide simulation_id"
             }), 400
+        try:
+            validate_simulation_id(simulation_id)
+        except ValueError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 400
 
         force_regenerate = data.get('force_regenerate', False)
 
@@ -231,6 +248,11 @@ def get_generate_status():
 
         task_id = data.get('task_id')
         simulation_id = data.get('simulation_id')
+        if simulation_id:
+            try:
+                validate_simulation_id(simulation_id)
+            except ValueError as exc:
+                return jsonify({"success": False, "error": str(exc)}), 400
 
         # If simulation_id is provided, first check if a completed report exists
         if simulation_id:
@@ -472,6 +494,10 @@ def chat_with_report_agent():
                 "success": False,
                 "error": "Please provide simulation_id"
             }), 400
+        try:
+            validate_simulation_id(simulation_id)
+        except ValueError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 400
 
         if not message:
             return jsonify({

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -14,6 +14,7 @@ from flask import request, jsonify, send_file, current_app
 
 from . import simulation_bp
 from ..utils.llm_client import create_smart_llm_client
+from ..utils.validation import validate_simulation_id
 from ..config import Config
 from ..services.entity_reader import EntityReader
 from ..services.oasis_profile_generator import OasisProfileGenerator
@@ -24,6 +25,33 @@ from ..utils.logger import get_logger
 from ..models.project import ProjectManager
 
 logger = get_logger('miroshark.api.simulation')
+
+
+@simulation_bp.before_request
+def _validate_url_simulation_id():
+    """Reject requests whose URL-derived simulation_id could cause path traversal."""
+    from flask import request as _req
+    sim_id = _req.view_args.get('simulation_id') if _req.view_args else None
+    if sim_id is not None:
+        try:
+            validate_simulation_id(sim_id)
+        except ValueError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 400
+
+
+def _get_simulation_id_or_400(data: dict) -> tuple:
+    """Extract and validate simulation_id from POST body.
+
+    Returns (simulation_id, None) on success or (None, error_response) on failure.
+    """
+    simulation_id = data.get('simulation_id')
+    if not simulation_id:
+        return None, (jsonify({"success": False, "error": "Please provide simulation_id"}), 400)
+    try:
+        validate_simulation_id(simulation_id)
+    except ValueError as exc:
+        return None, (jsonify({"success": False, "error": str(exc)}), 400)
+    return simulation_id, None
 
 
 # Interview prompt optimization prefix
@@ -499,13 +527,10 @@ def prepare_simulation():
     try:
         data = request.get_json() or {}
         
-        simulation_id = data.get('simulation_id')
-        if not simulation_id:
-            return jsonify({
-                "success": False,
-                "error": "Please provide simulation_id"
-            }), 400
-        
+        simulation_id, err = _get_simulation_id_or_400(data)
+        if err:
+            return err
+
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
         
@@ -770,7 +795,12 @@ def get_prepare_status():
         
         task_id = data.get('task_id')
         simulation_id = data.get('simulation_id')
-        
+        if simulation_id:
+            try:
+                validate_simulation_id(simulation_id)
+            except ValueError as exc:
+                return jsonify({"success": False, "error": str(exc)}), 400
+
         # If simulation_id is provided, first check if preparation is complete
         if simulation_id:
             is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
@@ -1740,12 +1770,9 @@ def start_simulation():
     try:
         data = request.get_json() or {}
 
-        simulation_id = data.get('simulation_id')
-        if not simulation_id:
-            return jsonify({
-                "success": False,
-                "error": "Please provide simulation_id"
-            }), 400
+        simulation_id, err = _get_simulation_id_or_400(data)
+        if err:
+            return err
 
         platform = data.get('platform', 'parallel')
         max_rounds = data.get('max_rounds')  # Optional: maximum simulation rounds
@@ -1934,13 +1961,10 @@ def stop_simulation():
     try:
         data = request.get_json() or {}
         
-        simulation_id = data.get('simulation_id')
-        if not simulation_id:
-            return jsonify({
-                "success": False,
-                "error": "Please provide simulation_id"
-            }), 400
-        
+        simulation_id, err = _get_simulation_id_or_400(data)
+        if err:
+            return err
+
         run_state = SimulationRunner.stop_simulation(simulation_id)
         
         # Update simulation status
@@ -2659,17 +2683,13 @@ def interview_agent():
     try:
         data = request.get_json() or {}
         
-        simulation_id = data.get('simulation_id')
+        simulation_id, err = _get_simulation_id_or_400(data)
+        if err:
+            return err
         agent_id = data.get('agent_id')
         prompt = data.get('prompt')
         platform = data.get('platform')  # Optional: twitter/reddit/None
         timeout = data.get('timeout', 60)
-        
-        if not simulation_id:
-            return jsonify({
-                "success": False,
-                "error": "Please provide simulation_id"
-            }), 400
         
         if agent_id is None:
             return jsonify({
@@ -2781,16 +2801,12 @@ def interview_agents_batch():
     try:
         data = request.get_json() or {}
 
-        simulation_id = data.get('simulation_id')
+        simulation_id, err = _get_simulation_id_or_400(data)
+        if err:
+            return err
         interviews = data.get('interviews')
         platform = data.get('platform')  # Optional: twitter/reddit/None
         timeout = data.get('timeout', 120)
-
-        if not simulation_id:
-            return jsonify({
-                "success": False,
-                "error": "Please provide simulation_id"
-            }), 400
 
         if not interviews or not isinstance(interviews, list):
             return jsonify({
@@ -2909,16 +2925,12 @@ def get_interview_history():
     try:
         data = request.get_json() or {}
         
-        simulation_id = data.get('simulation_id')
+        simulation_id, err = _get_simulation_id_or_400(data)
+        if err:
+            return err
         platform = data.get('platform')  # If not specified, return history for both platforms
         agent_id = data.get('agent_id')
         limit = data.get('limit', 100)
-        
-        if not simulation_id:
-            return jsonify({
-                "success": False,
-                "error": "Please provide simulation_id"
-            }), 400
 
         history = SimulationRunner.get_interview_history(
             simulation_id=simulation_id,
@@ -2971,13 +2983,9 @@ def get_env_status():
     try:
         data = request.get_json() or {}
         
-        simulation_id = data.get('simulation_id')
-        
-        if not simulation_id:
-            return jsonify({
-                "success": False,
-                "error": "Please provide simulation_id"
-            }), 400
+        simulation_id, err = _get_simulation_id_or_400(data)
+        if err:
+            return err
 
         env_alive = SimulationRunner.check_env_alive(simulation_id)
         
@@ -3017,10 +3025,9 @@ def restart_env():
     """
     try:
         data = request.get_json() or {}
-        simulation_id = data.get('simulation_id')
-
-        if not simulation_id:
-            return jsonify({"success": False, "error": "Please provide simulation_id"}), 400
+        simulation_id, err = _get_simulation_id_or_400(data)
+        if err:
+            return err
 
         # Check if env is already alive
         if SimulationRunner.check_env_alive(simulation_id):
@@ -3094,14 +3101,10 @@ def close_simulation_env():
     try:
         data = request.get_json() or {}
         
-        simulation_id = data.get('simulation_id')
+        simulation_id, err = _get_simulation_id_or_400(data)
+        if err:
+            return err
         timeout = data.get('timeout', 30)
-        
-        if not simulation_id:
-            return jsonify({
-                "success": False,
-                "error": "Please provide simulation_id"
-            }), 400
         
         result = SimulationRunner.close_simulation_env(
             simulation_id=simulation_id,

--- a/backend/app/services/report_agent.py
+++ b/backend/app/services/report_agent.py
@@ -21,6 +21,7 @@ from enum import Enum
 from ..config import Config
 from ..utils.llm_client import LLMClient, create_smart_llm_client
 from ..utils.logger import get_logger
+from ..utils.validation import validate_simulation_id
 from .graph_tools import (
     GraphToolsService,
     SearchResult,
@@ -1372,6 +1373,7 @@ class ReportAgent:
 
     def _get_simulation_dir(self) -> str:
         """Find the simulation directory (tries multiple locations)."""
+        validate_simulation_id(self.simulation_id)
         candidates = [
             os.path.join(Config.UPLOAD_FOLDER, 'simulations', self.simulation_id),
             os.path.join(os.path.dirname(__file__), '..', '..', 'pipeline_test_output', self.simulation_id),

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -14,6 +14,7 @@ from enum import Enum
 
 from ..config import Config
 from ..utils.logger import get_logger
+from ..utils.validation import validate_simulation_id
 from .entity_reader import EntityReader, FilteredEntities
 from .oasis_profile_generator import OasisProfileGenerator, OasisAgentProfile
 from .simulation_config_generator import SimulationConfigGenerator, SimulationParameters
@@ -145,6 +146,7 @@ class SimulationManager:
     
     def _get_simulation_dir(self, simulation_id: str) -> str:
         """Get simulation data directory"""
+        validate_simulation_id(simulation_id)
         sim_dir = os.path.join(self.SIMULATION_DATA_DIR, simulation_id)
         os.makedirs(sim_dir, exist_ok=True)
         return sim_dir

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -20,6 +20,7 @@ from queue import Queue
 
 from ..config import Config
 from ..utils.logger import get_logger
+from ..utils.validation import validate_simulation_id
 from .graph_memory_updater import GraphMemoryManager
 from .simulation_ipc import SimulationIPCClient, CommandType, IPCResponse
 
@@ -253,6 +254,7 @@ class SimulationRunner:
     @classmethod
     def _load_run_state(cls, simulation_id: str) -> Optional[SimulationRunState]:
         """Load run state from file"""
+        validate_simulation_id(simulation_id)
         state_file = os.path.join(cls.RUN_STATE_DIR, simulation_id, "run_state.json")
         if not os.path.exists(state_file):
             return None
@@ -314,6 +316,7 @@ class SimulationRunner:
     @classmethod
     def _save_run_state(cls, state: SimulationRunState):
         """Save run state to file"""
+        validate_simulation_id(state.simulation_id)
         sim_dir = os.path.join(cls.RUN_STATE_DIR, state.simulation_id)
         os.makedirs(sim_dir, exist_ok=True)
         state_file = os.path.join(sim_dir, "run_state.json")

--- a/backend/app/utils/validation.py
+++ b/backend/app/utils/validation.py
@@ -1,0 +1,45 @@
+"""
+Input validation utilities for path-safety and sanitization.
+"""
+
+import re
+
+
+# Allowed pattern: alphanumeric, hyphens, underscores, dots (no slashes, no ..)
+_SAFE_ID_PATTERN = re.compile(r'^[a-zA-Z0-9_\-\.]+$')
+
+
+def validate_simulation_id(simulation_id: str) -> str:
+    """
+    Validate that a simulation_id is safe for use in filesystem paths.
+
+    Rejects any value containing path separators, parent-directory
+    references, or characters outside the allowed set
+    (alphanumeric, hyphen, underscore, dot).
+
+    Args:
+        simulation_id: The raw simulation ID from user input.
+
+    Returns:
+        The validated simulation_id (unchanged if valid).
+
+    Raises:
+        ValueError: If the simulation_id is empty, contains path
+            traversal sequences, or uses disallowed characters.
+    """
+    if not simulation_id:
+        raise ValueError("simulation_id must not be empty")
+
+    if '..' in simulation_id:
+        raise ValueError("simulation_id must not contain '..'")
+
+    if '/' in simulation_id or '\\' in simulation_id:
+        raise ValueError("simulation_id must not contain path separators")
+
+    if not _SAFE_ID_PATTERN.match(simulation_id):
+        raise ValueError(
+            "simulation_id contains invalid characters; "
+            "only alphanumeric, hyphen, underscore, and dot are allowed"
+        )
+
+    return simulation_id


### PR DESCRIPTION
## Summary

- Adds `validate_simulation_id()` helper in `backend/app/utils/validation.py` that rejects path separators (`/`, `\`), parent-directory references (`..`), and any characters outside the `[a-zA-Z0-9_\-.]` set
- Protects all 20 URL-path-parameter endpoints in `simulation_bp` and 2 in `report_bp` via `before_request` hooks that validate `simulation_id` before the route handler runs
- Protects all 10 POST-body extraction points in `simulation.py` (via `_get_simulation_id_or_400` helper) and 3 in `report.py` (via direct `validate_simulation_id` calls)
- Adds defense-in-depth validation in the service layer: `SimulationManager._get_simulation_dir`, `SimulationRunner._load_run_state` / `_save_run_state`, and `ReportAgent._get_simulation_dir`

Closes #27

## Test plan

- [ ] Verify normal simulation IDs (e.g. `sim_abc123`, `sim-test-001`) still work on all endpoints
- [ ] Verify path-traversal payloads (`../../etc`, `sim/../../../passwd`) return 400 on URL-param endpoints
- [ ] Verify path-traversal payloads in POST body `simulation_id` return 400
- [ ] Verify empty/missing `simulation_id` still returns the expected 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)