### PR TITLE
feat: browser push notifications on simulation completion

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4089,3 +4089,133 @@ def get_agent_interview_transcript(simulation_id: str, agent_name: str):
             "error": str(e),
             "traceback": traceback.format_exc()
         }), 500
+
+
+# ============== Browser Push Notification Endpoints ==============
+
+@simulation_bp.route('/push/vapid-public-key', methods=['GET'])
+def get_push_vapid_public_key():
+    """
+    Return the VAPID public key for the frontend applicationServerKey.
+
+    The key is generated on first call and cached on disk in
+    uploads/vapid_keys.json. Returns null if pywebpush is not installed.
+
+    Returns:
+        {
+            "success": true,
+            "data": {
+                "public_key": "<url-safe base64 uncompressed EC point>"
+            }
+        }
+    """
+    try:
+        from ..services.push_notification_service import get_vapid_public_key
+        key = get_vapid_public_key()
+        return jsonify({
+            "success": True,
+            "data": {"public_key": key}
+        })
+    except Exception as e:
+        logger.error(f"Failed to get VAPID public key: {e}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500
+
+
+@simulation_bp.route('/push/subscribe', methods=['POST'])
+def subscribe_push_notification():
+    """
+    Store a Web Push subscription for a simulation.
+
+    The subscription is tied to a simulation_id so the backend can fire
+    a notification when that specific simulation completes.
+
+    Request body:
+        {
+            "simulation_id": "sim_xxxx",
+            "subscription": {
+                "endpoint": "https://fcm.googleapis.com/...",
+                "keys": {
+                    "p256dh": "...",
+                    "auth": "..."
+                }
+            }
+        }
+
+    Returns:
+        { "success": true }
+    """
+    try:
+        data = request.get_json(force=True) or {}
+        simulation_id = data.get('simulation_id', '').strip()
+        subscription = data.get('subscription')
+
+        if not simulation_id:
+            return jsonify({"success": False, "error": "simulation_id is required"}), 400
+        if not subscription or not isinstance(subscription, dict):
+            return jsonify({"success": False, "error": "subscription object is required"}), 400
+        if not subscription.get('endpoint'):
+            return jsonify({"success": False, "error": "subscription.endpoint is required"}), 400
+
+        try:
+            validate_simulation_id(simulation_id)
+        except ValueError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 400
+
+        from ..services.push_notification_service import save_subscription
+        save_subscription(simulation_id, subscription)
+
+        return jsonify({"success": True})
+
+    except Exception as e:
+        logger.error(f"Failed to store push subscription: {e}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500
+
+
+@simulation_bp.route('/push/test', methods=['POST'])
+def test_push_notification():
+    """
+    Send a test push notification immediately.
+
+    Useful for verifying that the browser permission and VAPID setup work
+    before waiting for a long simulation to complete.
+
+    Request body:
+        { "simulation_id": "sim_xxxx" }
+
+    Returns:
+        { "success": true }
+    """
+    try:
+        data = request.get_json(force=True) or {}
+        simulation_id = data.get('simulation_id', '').strip()
+
+        if not simulation_id:
+            return jsonify({"success": False, "error": "simulation_id is required"}), 400
+
+        try:
+            validate_simulation_id(simulation_id)
+        except ValueError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 400
+
+        from ..services.push_notification_service import send_push_notification
+        send_push_notification(
+            simulation_id=simulation_id,
+            title="MiroShark — test notification",
+            body="Push notifications are working. You'll be notified when your simulation completes.",
+            url=f'/simulation/{simulation_id}/start',
+        )
+
+        return jsonify({"success": True})
+
+    except Exception as e:
+        logger.error(f"Failed to send test push notification: {e}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500

--- a/backend/app/services/push_notification_service.py
+++ b/backend/app/services/push_notification_service.py
@@ -4,6 +4,7 @@ Manages VAPID keys, push subscriptions, and sends Web Push notifications
 when simulations complete. Uses the pywebpush library (optional dependency).
 """
 
+import fcntl
 import os
 import json
 import base64
@@ -16,6 +17,8 @@ from ..utils.logger import get_logger
 logger = get_logger('miroshark.push_notification')
 
 _UPLOADS_DIR = os.path.join(os.path.dirname(__file__), '../../uploads')
+# SECURITY: contains the VAPID private key in plaintext. Do not expose the
+# uploads/ directory publicly (e.g. via a static file server or open bucket).
 VAPID_KEYS_PATH = os.path.join(_UPLOADS_DIR, 'vapid_keys.json')
 SUBSCRIPTIONS_DIR = os.path.join(_UPLOADS_DIR, 'push_subscriptions')
 
@@ -111,21 +114,27 @@ def save_subscription(simulation_id: str, subscription: Dict[str, Any]) -> None:
     os.makedirs(SUBSCRIPTIONS_DIR, exist_ok=True)
     path = os.path.join(SUBSCRIPTIONS_DIR, f'{simulation_id}.json')
 
-    subscriptions: List[Dict[str, Any]] = []
-    if os.path.exists(path):
+    lock_path = path + '.lock'
+    with open(lock_path, 'w') as lock_f:
+        fcntl.flock(lock_f, fcntl.LOCK_EX)
         try:
-            with open(path, 'r') as f:
-                subscriptions = json.load(f)
-        except Exception:
-            subscriptions = []
+            subscriptions: List[Dict[str, Any]] = []
+            if os.path.exists(path):
+                try:
+                    with open(path, 'r') as f:
+                        subscriptions = json.load(f)
+                except Exception:
+                    subscriptions = []
 
-    # Remove any existing entry for this endpoint (dedup / refresh)
-    endpoint = subscription.get('endpoint', '')
-    subscriptions = [s for s in subscriptions if s.get('endpoint') != endpoint]
-    subscriptions.append({**subscription, 'saved_at': datetime.now().isoformat()})
+            # Remove any existing entry for this endpoint (dedup / refresh)
+            endpoint = subscription.get('endpoint', '')
+            subscriptions = [s for s in subscriptions if s.get('endpoint') != endpoint]
+            subscriptions.append({**subscription, 'saved_at': datetime.now().isoformat()})
 
-    with open(path, 'w') as f:
-        json.dump(subscriptions, f, indent=2)
+            with open(path, 'w') as f:
+                json.dump(subscriptions, f, indent=2)
+        finally:
+            fcntl.flock(lock_f, fcntl.LOCK_UN)
 
     logger.info(f"Stored push subscription for simulation {simulation_id}")
 

--- a/backend/app/services/push_notification_service.py
+++ b/backend/app/services/push_notification_service.py
@@ -1,0 +1,212 @@
+"""
+Browser Push Notification Service
+Manages VAPID keys, push subscriptions, and sends Web Push notifications
+when simulations complete. Uses the pywebpush library (optional dependency).
+"""
+
+import os
+import json
+import base64
+import threading
+from datetime import datetime
+from typing import Dict, Any, Optional, List
+
+from ..utils.logger import get_logger
+
+logger = get_logger('miroshark.push_notification')
+
+_UPLOADS_DIR = os.path.join(os.path.dirname(__file__), '../../uploads')
+VAPID_KEYS_PATH = os.path.join(_UPLOADS_DIR, 'vapid_keys.json')
+SUBSCRIPTIONS_DIR = os.path.join(_UPLOADS_DIR, 'push_subscriptions')
+
+# Cache keys in memory once loaded
+_vapid_keys_cache: Optional[Dict[str, str]] = None
+_cache_lock = threading.Lock()
+
+
+def _get_or_create_vapid_keys() -> Dict[str, str]:
+    """Load VAPID keys from disk, generating them on first use.
+
+    Returns a dict with 'private_key' (PEM string) and 'public_key'
+    (URL-safe base64 uncompressed EC point, no padding) — or an empty
+    dict if pywebpush is not installed.
+    """
+    global _vapid_keys_cache
+
+    with _cache_lock:
+        if _vapid_keys_cache is not None:
+            return _vapid_keys_cache
+
+        os.makedirs(_UPLOADS_DIR, exist_ok=True)
+
+        if os.path.exists(VAPID_KEYS_PATH):
+            try:
+                with open(VAPID_KEYS_PATH, 'r') as f:
+                    _vapid_keys_cache = json.load(f)
+                return _vapid_keys_cache
+            except Exception as exc:
+                logger.warning(f"Failed to read VAPID keys, regenerating: {exc}")
+
+        # Generate new keys
+        try:
+            from py_vapid import Vapid
+            from cryptography.hazmat.primitives.serialization import (
+                Encoding,
+                PublicFormat,
+                PrivateFormat,
+                NoEncryption,
+            )
+
+            vapid = Vapid()
+            vapid.generate_keys()
+
+            private_key_pem = vapid.private_key.private_bytes(
+                encoding=Encoding.PEM,
+                format=PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=NoEncryption(),
+            ).decode()
+
+            public_key_raw = vapid.public_key.public_bytes(
+                encoding=Encoding.X962,
+                format=PublicFormat.UncompressedPoint,
+            )
+            public_key_b64url = base64.urlsafe_b64encode(public_key_raw).rstrip(b'=').decode()
+
+            keys = {
+                'private_key': private_key_pem,
+                'public_key': public_key_b64url,
+            }
+
+            with open(VAPID_KEYS_PATH, 'w') as f:
+                json.dump(keys, f, indent=2)
+
+            _vapid_keys_cache = keys
+            logger.info("Generated new VAPID keys for browser push notifications")
+            return keys
+
+        except ImportError:
+            logger.warning(
+                "pywebpush is not installed — browser push notifications are disabled. "
+                "Run: pip install pywebpush"
+            )
+            _vapid_keys_cache = {}
+            return {}
+        except Exception as exc:
+            logger.error(f"Failed to generate VAPID keys: {exc}")
+            _vapid_keys_cache = {}
+            return {}
+
+
+def get_vapid_public_key() -> Optional[str]:
+    """Return the VAPID public key suitable for the frontend applicationServerKey."""
+    return _get_or_create_vapid_keys().get('public_key')
+
+
+def save_subscription(simulation_id: str, subscription: Dict[str, Any]) -> None:
+    """Persist a push subscription for a simulation.
+
+    Deduplicates by endpoint so re-subscribing from the same browser
+    does not create duplicate entries.
+    """
+    os.makedirs(SUBSCRIPTIONS_DIR, exist_ok=True)
+    path = os.path.join(SUBSCRIPTIONS_DIR, f'{simulation_id}.json')
+
+    subscriptions: List[Dict[str, Any]] = []
+    if os.path.exists(path):
+        try:
+            with open(path, 'r') as f:
+                subscriptions = json.load(f)
+        except Exception:
+            subscriptions = []
+
+    # Remove any existing entry for this endpoint (dedup / refresh)
+    endpoint = subscription.get('endpoint', '')
+    subscriptions = [s for s in subscriptions if s.get('endpoint') != endpoint]
+    subscriptions.append({**subscription, 'saved_at': datetime.now().isoformat()})
+
+    with open(path, 'w') as f:
+        json.dump(subscriptions, f, indent=2)
+
+    logger.info(f"Stored push subscription for simulation {simulation_id}")
+
+
+def send_push_notification(
+    simulation_id: str,
+    title: str,
+    body: str,
+    url: str = '/',
+) -> None:
+    """Fire push notifications to all subscribers of a simulation.
+
+    Runs in a background daemon thread to avoid blocking the simulation
+    monitor. Expired/invalid subscriptions (HTTP 404/410) are pruned.
+    """
+
+    def _send() -> None:
+        try:
+            from pywebpush import webpush, WebPushException
+        except ImportError:
+            logger.warning("pywebpush not installed — skipping push notification")
+            return
+
+        keys = _get_or_create_vapid_keys()
+        if not keys:
+            return
+
+        path = os.path.join(SUBSCRIPTIONS_DIR, f'{simulation_id}.json')
+        if not os.path.exists(path):
+            return
+
+        try:
+            with open(path, 'r') as f:
+                subscriptions: List[Dict[str, Any]] = json.load(f)
+        except Exception as exc:
+            logger.error(f"Failed to load subscriptions for {simulation_id}: {exc}")
+            return
+
+        if not subscriptions:
+            return
+
+        payload = json.dumps({
+            'title': title,
+            'body': body,
+            'url': url,
+            'simulation_id': simulation_id,
+        })
+
+        stale_endpoints = []
+
+        for sub in subscriptions:
+            try:
+                webpush(
+                    subscription_info=sub,
+                    data=payload,
+                    vapid_private_key=keys['private_key'],
+                    vapid_claims={'sub': 'mailto:noreply@miroshark.app'},
+                )
+                logger.info(f"Push notification sent for simulation {simulation_id}")
+            except Exception as exc:
+                # WebPushException is the specific type but we catch broadly for safety
+                status = getattr(getattr(exc, 'response', None), 'status_code', None)
+                if status in (404, 410):
+                    # Subscription expired or unsubscribed — prune it
+                    stale_endpoints.append(sub.get('endpoint'))
+                    logger.info(
+                        f"Pruning stale push subscription for {simulation_id}: {status}"
+                    )
+                else:
+                    logger.warning(f"Push notification failed for {simulation_id}: {exc}")
+
+        # Prune stale subscriptions
+        if stale_endpoints:
+            subscriptions = [
+                s for s in subscriptions if s.get('endpoint') not in stale_endpoints
+            ]
+            try:
+                with open(path, 'w') as f:
+                    json.dump(subscriptions, f, indent=2)
+            except Exception as exc:
+                logger.error(f"Failed to prune stale subscriptions: {exc}")
+
+    thread = threading.Thread(target=_send, daemon=True, name=f'push-{simulation_id}')
+    thread.start()

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -1307,6 +1307,18 @@ class SimulationRunner:
                     except Exception as e:
                         errors.append(f"Failed to delete {dir_name}/actions.jsonl: {str(e)}")
         
+        # Clean up push notification subscriptions for this simulation
+        try:
+            from .push_notification_service import SUBSCRIPTIONS_DIR
+            sub_path = os.path.join(SUBSCRIPTIONS_DIR, f'{simulation_id}.json')
+            lock_path = sub_path + '.lock'
+            for p in (sub_path, lock_path):
+                if os.path.exists(p):
+                    os.remove(p)
+                    cleaned_files.append(os.path.basename(p))
+        except Exception as e:
+            errors.append(f"Failed to clean push subscriptions: {str(e)}")
+
         # Clean up in-memory run state
         if simulation_id in cls._run_states:
             del cls._run_states[simulation_id]

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -589,6 +589,26 @@ class SimulationRunner:
                 state.runner_status = RunnerStatus.COMPLETED
                 state.completed_at = datetime.now().isoformat()
                 logger.info(f"Simulation completed: {simulation_id}")
+
+                # Fire browser push notification to any subscribed clients
+                try:
+                    from .push_notification_service import send_push_notification
+                    rounds = state.current_round or 0
+                    total = state.total_rounds or 0
+                    actions = (state.twitter_actions_count or 0) + (state.reddit_actions_count or 0)
+                    body = (
+                        f"{actions} events across {rounds}/{total} rounds — open MiroShark to view results."
+                        if rounds else
+                        "Open MiroShark to view the results."
+                    )
+                    send_push_notification(
+                        simulation_id=simulation_id,
+                        title="Simulation complete",
+                        body=body,
+                        url=f'/simulation/{simulation_id}/start',
+                    )
+                except Exception as _push_err:
+                    logger.warning(f"Push notification dispatch failed: {_push_err}")
             else:
                 state.runner_status = RunnerStatus.FAILED
                 # Read error info from main log file

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,3 +37,7 @@ python-dotenv>=1.0.0
 
 # Data validation
 pydantic>=2.0.0
+
+# ============= Browser Push Notifications =============
+# Required for Web Push (VAPID key generation + push dispatch)
+pywebpush>=2.0.0

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,70 @@
+/**
+ * MiroShark Service Worker — Browser Push Notifications
+ *
+ * Handles incoming Web Push events and displays browser notifications
+ * when a simulation completes. Notification clicks focus the browser
+ * tab (or open a new one) and navigate to the simulation results.
+ */
+
+const CACHE_NAME = 'miroshark-sw-v1'
+
+// ── Install: skip waiting so the SW activates immediately ────────────────────
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+// ── Activate: claim all clients immediately ──────────────────────────────────
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+// ── Push: show a notification when a simulation completes ───────────────────
+self.addEventListener('push', (event) => {
+  let payload = { title: 'MiroShark', body: 'Simulation update', url: '/' }
+
+  if (event.data) {
+    try {
+      payload = { ...payload, ...event.data.json() }
+    } catch (_) {
+      payload.body = event.data.text()
+    }
+  }
+
+  const options = {
+    body: payload.body,
+    icon: '/favicon.ico',
+    badge: '/favicon.ico',
+    tag: payload.simulation_id ? `sim-${payload.simulation_id}` : 'miroshark',
+    renotify: false,
+    requireInteraction: false,
+    data: { url: payload.url || '/' },
+  }
+
+  event.waitUntil(
+    self.registration.showNotification(payload.title, options)
+  )
+})
+
+// ── Notification click: focus existing tab or open new window ────────────────
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/'
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      // Focus any existing window that is already on this origin
+      for (const client of clientList) {
+        try {
+          const clientUrl = new URL(client.url)
+          if (clientUrl.origin === self.location.origin) {
+            client.navigate(targetUrl)
+            return client.focus()
+          }
+        } catch (_) { /* ignore parse errors */ }
+      }
+      // No matching window — open a new one
+      return self.clients.openWindow(targetUrl)
+    })
+  )
+})

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -6,8 +6,6 @@
  * tab (or open a new one) and navigate to the simulation results.
  */
 
-const CACHE_NAME = 'miroshark-sw-v1'
-
 // ── Install: skip waiting so the SW activates immediately ────────────────────
 self.addEventListener('install', () => {
   self.skipWaiting()

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -304,3 +304,27 @@ export const getAgentInterview = (simulationId, agentName) => {
   )
 }
 
+/**
+ * Get the VAPID public key for Web Push subscriptions.
+ * Returns { data: { public_key: string | null } }
+ */
+export const getVapidPublicKey = () => {
+  return service.get('/api/simulation/push/vapid-public-key')
+}
+
+/**
+ * Store a Web Push subscription for a simulation.
+ * @param {Object} data - { simulation_id, subscription }
+ */
+export const subscribePush = (data) => {
+  return service.post('/api/simulation/push/subscribe', data)
+}
+
+/**
+ * Fire a test push notification immediately (for debugging).
+ * @param {string} simulationId
+ */
+export const testPushNotification = (simulationId) => {
+  return service.post('/api/simulation/push/test', { simulation_id: simulationId })
+}
+

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -105,6 +105,28 @@
       <span class="events-platform">Reddit <span class="events-count">{{ runStatus.reddit_actions_count || 0 }}</span></span>
       <span class="events-slash">/</span>
       <span class="events-platform">Polymarket <span class="events-count">{{ runStatus.polymarket_actions_count || 0 }}</span></span>
+
+      <!-- Notify when done toggle — shown while simulation is running and push is supported -->
+      <template v-if="phase === 1 && pushSupported">
+        <span class="events-divider"></span>
+        <label
+          class="notify-toggle"
+          :class="{ active: pushSubscribed, denied: pushPermission === 'denied' }"
+          :title="pushPermission === 'denied' ? 'Notifications blocked in browser settings' : pushSubscribed ? 'Will notify when done' : 'Notify me when this simulation finishes'"
+        >
+          <input
+            type="checkbox"
+            v-model="notifyWhenDone"
+            @change="onNotifyToggle"
+            :disabled="pushPermission === 'denied' || pushSubscribed"
+            style="display:none"
+          />
+          <span class="notify-icon">{{ pushSubscribed ? '🔔' : '🔕' }}</span>
+          <span class="notify-label">
+            {{ pushSubscribed ? 'Notify on' : pushPermission === 'denied' ? 'Blocked' : 'Notify me' }}
+          </span>
+        </label>
+      </template>
     </div>
 
     <!-- Platform Status Rows -->
@@ -492,7 +514,9 @@ import {
   resumeSimulation,
   getRunStatus,
   getRunStatusDetail,
-  generateSimulationArticle
+  generateSimulationArticle,
+  getVapidPublicKey,
+  subscribePush,
 } from '../api/simulation'
 import { generateReport } from '../api/report'
 import { renderMarkdown } from '../utils/markdown'
@@ -537,6 +561,15 @@ const showBeliefDrift = ref(false)
 const showArticleDrawer = ref(false)
 const articleText = ref('')
 const isGeneratingArticle = ref(false)
+
+// Push notification state
+const pushSupported = typeof window !== 'undefined' &&
+  'Notification' in window &&
+  'serviceWorker' in navigator &&
+  'PushManager' in window
+const pushPermission = ref(typeof window !== 'undefined' && 'Notification' in window ? Notification.permission : 'denied')
+const notifyWhenDone = ref(false)
+const pushSubscribed = ref(false)
 const articleError = ref(null)
 const articleCopied = ref(false)
 
@@ -659,6 +692,8 @@ const resetAllState = () => {
   startError.value = null
   isStarting.value = false
   isStopping.value = false
+  pushSubscribed.value = false
+  notifyWhenDone.value = false
   stopPolling()  // Stop any previously existing polling
 }
 
@@ -720,6 +755,75 @@ const doStartSimulation = async () => {
     isStarting.value = false
   }
 }
+
+// ── Push notifications ────────────────────────────────────────────────────────
+
+/** Convert a URL-safe base64 string to a Uint8Array (required by pushManager.subscribe). */
+function _urlB64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = atob(base64)
+  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)))
+}
+
+/**
+ * Request notification permission, subscribe to Web Push, and send the
+ * subscription to the backend tied to this simulation's ID.
+ */
+const setupPushNotification = async () => {
+  if (!pushSupported || !props.simulationId) return
+
+  try {
+    const permission = await Notification.requestPermission()
+    pushPermission.value = permission
+
+    if (permission !== 'granted') {
+      notifyWhenDone.value = false
+      return
+    }
+
+    // Fetch VAPID public key from backend
+    const keyRes = await getVapidPublicKey()
+    if (!keyRes?.data?.public_key) {
+      console.warn('[MiroShark] Push notifications unavailable — VAPID key missing')
+      notifyWhenDone.value = false
+      return
+    }
+
+    const applicationServerKey = _urlB64ToUint8Array(keyRes.data.public_key)
+
+    // Get the active service worker registration
+    const registration = await navigator.serviceWorker.ready
+
+    // Subscribe (creates or reuses an existing push subscription)
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey,
+    })
+
+    // Send subscription to backend
+    await subscribePush({
+      simulation_id: props.simulationId,
+      subscription: subscription.toJSON(),
+    })
+
+    pushSubscribed.value = true
+    addLog('Push notification registered — you will be notified when this simulation completes')
+  } catch (err) {
+    console.warn('[MiroShark] Push notification setup failed:', err)
+    notifyWhenDone.value = false
+    pushSubscribed.value = false
+  }
+}
+
+/** Called when the "Notify me" toggle changes. */
+const onNotifyToggle = () => {
+  if (notifyWhenDone.value) {
+    setupPushNotification()
+  }
+}
+
+// ── End push notifications ────────────────────────────────────────────────────
 
 // Resume simulation from last completed round
 const handleResume = async () => {
@@ -2250,4 +2354,38 @@ onUnmounted(() => {
 .article-content :deep(.md-oli) { margin: 0.3em 0; }
 .article-content :deep(.md-hr) { border: none; border-top: 1px solid rgba(10,10,10,0.1); margin: 1em 0; }
 .article-content :deep(.md-quote) { border-left: 3px solid #FF6B1A; margin: 0.8em 0; padding: 4px 12px; color: rgba(10,10,10,0.6); font-style: italic; }
+
+/* Push notification toggle inside events-summary bar */
+.notify-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: background 0.15s;
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.4);
+}
+.notify-toggle:hover:not(.denied) {
+  background: rgba(10,10,10,0.06);
+  color: rgba(10,10,10,0.7);
+}
+.notify-toggle.active {
+  color: #FF6B1A;
+}
+.notify-toggle.denied {
+  cursor: default;
+  opacity: 0.5;
+}
+.notify-icon {
+  font-size: 12px;
+  line-height: 1;
+}
+.notify-label {
+  font-family: var(--font-mono, 'Space Mono', monospace);
+}
 </style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,3 +7,10 @@ const app = createApp(App)
 app.use(router)
 
 app.mount('#app')
+
+// Register service worker for browser push notifications
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js').catch((err) => {
+    console.warn('[MiroShark] Service worker registration failed:', err)
+  })
+}


### PR DESCRIPTION
## What

When a MiroShark simulation finishes, the user's browser receives a push notification even if the tab is in the background or minimised. A 🔕/🔔 toggle appears in the events bar while a simulation is running. One click requests permission, subscribes via the Web Push API, and the backend fires the notification the moment the simulation subprocess exits.

## Why

A 50-agent, 15-round simulation on a cloud instance (Railway/Render) takes 4–10 minutes. Users start a run, switch tabs, and forget to check back — the completed simulation goes unnoticed. This is the highest-ROI DX fix for cloud deploy users: no external service required, no polling overhead, and a one-time permission grant that persists across sessions. Picked from the 2026-04-14 repo-actions batch.

## Changes

- `backend/app/services/push_notification_service.py`: VAPID key generation (stored in uploads/vapid_keys.json), push subscription storage (one JSON file per simulation in uploads/push_subscriptions/), and send_push_notification() dispatching via pywebpush in a daemon thread.
- `backend/app/api/simulation.py`: three new endpoints — GET /push/vapid-public-key, POST /push/subscribe, POST /push/test.
- `backend/app/services/simulation_runner.py`: fires push notification after exit_code == 0 in _monitor_simulation with round/action counts in the body.
- `backend/requirements.txt`: pywebpush>=2.0.0 (soft dependency — silently skipped if not installed).
- `frontend/public/sw.js`: service worker handling push events (showNotification) and notificationclick (focus tab or open new window).
- `frontend/src/main.js`: registers service worker on app load.
- `frontend/src/components/Step3Simulation.vue`: toggle in events-summary bar while simulation runs; handles permission request, VAPID key fetch, pushManager.subscribe(), and backend POST. Resets on restart.
- `frontend/src/api/simulation.js`: getVapidPublicKey, subscribePush, testPushNotification API functions.

## How it works

The service worker registers once at app load. When the user clicks the notification toggle, the frontend requests browser permission, fetches the VAPID public key from the backend, calls pushManager.subscribe() with that key, and POSTs the subscription object (endpoint + p256dh + auth) to /push/subscribe tied to the simulation ID. On completion, _monitor_simulation() calls send_push_notification() in a daemon thread — pywebpush signs the payload and delivers it to the browser's push service. The service worker wakes up, reads the JSON payload, and calls showNotification(). Clicking the notification focuses the existing MiroShark tab or opens a new one navigated to the simulation results.

---
*Built autonomously by Aeon*