### PR TITLE
feat: mid-simulation event injection (Director Mode)

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4219,3 +4219,102 @@ def test_push_notification():
             "success": False,
             "error": str(e),
         }), 500
+
+
+# ============================================================
+# Director Mode — Mid-Simulation Event Injection
+# ============================================================
+
+@simulation_bp.route('/<simulation_id>/director/inject', methods=['POST'])
+def inject_director_event(simulation_id: str):
+    """
+    Inject a breaking event into a running simulation (Director Mode).
+
+    The event is queued and consumed by the simulation loop at the next
+    round boundary. All agents receive the event as context before
+    generating their next round of actions.
+
+    Request (JSON):
+        {
+            "event_text": "Central bank unexpectedly raised rates by 100bps"
+        }
+
+    Returns:
+        {
+            "success": true,
+            "event": { ... },
+            "total_events": 2
+        }
+    """
+    import sys
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../scripts'))
+    from director_events import add_event, get_event_count
+
+    try:
+        data = request.get_json() or {}
+        event_text = (data.get('event_text') or '').strip()
+
+        if not event_text:
+            return jsonify({"success": False, "error": "event_text is required"}), 400
+
+        if len(event_text) > 500:
+            return jsonify({"success": False, "error": "event_text must be under 500 characters"}), 400
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        if not os.path.exists(sim_dir):
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        # Check simulation is running
+        state = SimulationRunner.get_run_state(simulation_id)
+        if not state or state.runner_status not in [RunnerStatus.RUNNING]:
+            return jsonify({"success": False, "error": "Simulation is not currently running"}), 400
+
+        # Enforce max 3 events per simulation
+        total = get_event_count(sim_dir)
+        if total >= 3:
+            return jsonify({"success": False, "error": "Maximum 3 events per simulation reached"}), 400
+
+        current_round = state.current_round or 0
+        event = add_event(sim_dir, event_text, current_round)
+
+        return jsonify({
+            "success": True,
+            "event": event,
+            "total_events": total + 1,
+        })
+
+    except Exception as e:
+        logger.error(f"Failed to inject director event: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@simulation_bp.route('/<simulation_id>/director/events', methods=['GET'])
+def get_director_events(simulation_id: str):
+    """
+    Get all director events (injected + pending) for a simulation.
+
+    Returns:
+        {
+            "success": true,
+            "events": [ ... ],
+            "pending": [ ... ]
+        }
+    """
+    import sys
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../scripts'))
+    from director_events import get_event_history, get_pending_events
+
+    try:
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        if not os.path.exists(sim_dir):
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        return jsonify({
+            "success": True,
+            "events": get_event_history(sim_dir),
+            "pending": get_pending_events(sim_dir),
+        })
+
+    except Exception as e:
+        logger.error(f"Failed to get director events: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500

--- a/backend/scripts/director_events.py
+++ b/backend/scripts/director_events.py
@@ -1,0 +1,187 @@
+"""
+Director Mode — Mid-Simulation Event Injection
+
+Provides file-based event injection for running simulations.
+The API writes events to `{sim_dir}/director_events.json`.
+The simulation loop reads and consumes them at each round boundary.
+"""
+
+import os
+import json
+import tempfile
+from datetime import datetime
+from typing import List, Dict, Any
+
+
+_DIRECTOR_MARKER = "\n\n# BREAKING EVENT"
+
+
+def _events_path(simulation_dir: str) -> str:
+    return os.path.join(simulation_dir, "director_events.json")
+
+
+def _history_path(simulation_dir: str) -> str:
+    return os.path.join(simulation_dir, "director_events_history.json")
+
+
+def _atomic_write_json(path: str, data):
+    """Write JSON atomically via temp file + rename."""
+    dir_name = os.path.dirname(path)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def add_event(simulation_dir: str, event_text: str, round_num: int) -> Dict[str, Any]:
+    """
+    Queue an event for injection at the next round boundary.
+
+    Args:
+        simulation_dir: Path to the simulation data directory.
+        event_text: Plain-text description of the event.
+        round_num: The round the event was submitted during.
+
+    Returns:
+        The event record that was queued.
+    """
+    event = {
+        "id": f"evt_{datetime.now().strftime('%Y%m%d%H%M%S%f')}",
+        "event_text": event_text,
+        "submitted_at_round": round_num,
+        "injected_at_round": None,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    path = _events_path(simulation_dir)
+
+    pending = []
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                pending = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pending = []
+
+    pending.append(event)
+    _atomic_write_json(path, pending)
+
+    return event
+
+
+def consume_pending_events(simulation_dir: str, current_round: int) -> List[Dict[str, Any]]:
+    """
+    Read and clear all pending events. Called by the simulation loop
+    at the start of each round.
+
+    Returns:
+        List of event dicts that should be injected this round.
+    """
+    path = _events_path(simulation_dir)
+
+    if not os.path.exists(path):
+        return []
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            pending = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return []
+
+    if not pending:
+        return []
+
+    consumed = []
+    for evt in pending:
+        evt["injected_at_round"] = current_round
+        consumed.append(evt)
+
+    # Clear pending queue
+    _atomic_write_json(path, [])
+
+    # Append to history
+    _append_history(simulation_dir, consumed)
+
+    return consumed
+
+
+def _append_history(simulation_dir: str, events: List[Dict[str, Any]]):
+    """Append consumed events to the history file."""
+    path = _history_path(simulation_dir)
+    history = []
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                history = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            history = []
+
+    history.extend(events)
+    _atomic_write_json(path, history)
+
+
+def get_event_history(simulation_dir: str) -> List[Dict[str, Any]]:
+    """Return all injected events (history) for this simulation."""
+    path = _history_path(simulation_dir)
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def get_pending_events(simulation_dir: str) -> List[Dict[str, Any]]:
+    """Return events that are queued but not yet injected."""
+    path = _events_path(simulation_dir)
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def get_event_count(simulation_dir: str) -> int:
+    """Return total number of events injected (from history)."""
+    return len(get_event_history(simulation_dir))
+
+
+def inject_director_event_context(agent, event_text: str):
+    """
+    Inject a breaking event into an agent's system message.
+    Uses the same marker-replace pattern as inject_cross_platform_context.
+
+    Args:
+        agent: A SocialAgent instance (has .system_message.content).
+        event_text: The event text to inject.
+    """
+    content = agent.system_message.content
+
+    # Remove previous director event section if present
+    marker_pos = content.find(_DIRECTOR_MARKER)
+    if marker_pos != -1:
+        next_marker = content.find("\n\n# ", marker_pos + len(_DIRECTOR_MARKER))
+        if next_marker != -1:
+            content = content[:marker_pos] + content[next_marker:]
+        else:
+            content = content[:marker_pos]
+
+    event_block = (
+        f"{_DIRECTOR_MARKER}\n"
+        f"BREAKING: {event_text}\n"
+        f"This is a major new development that just occurred. "
+        f"React to this information in your next action — "
+        f"it may change your stance, trading behavior, or what you post about."
+    )
+
+    agent.system_message.content = content + event_block

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -162,6 +162,7 @@ def init_logging_for_simulation(simulation_dir: str):
 from action_logger import SimulationLogManager, PlatformActionLogger, write_simulation_event
 from cross_platform_digest import CrossPlatformLog, inject_cross_platform_context
 from belief_integration import BeliefTracker
+from director_events import consume_pending_events, inject_director_event_context
 from market_media_bridge import (
     MarketMediaBridge,
     inject_market_context,
@@ -1349,6 +1350,14 @@ async def run_twitter_simulation(
                 for _, agent in active_agents:
                     inject_market_context(agent, market_prompt)
 
+        # Director Mode: inject breaking events into agent context
+        director_events = consume_pending_events(simulation_dir, round_num + 1)
+        if director_events:
+            combined_text = " | ".join(e["event_text"] for e in director_events)
+            for _, agent in active_agents:
+                inject_director_event_context(agent, combined_text)
+            log_info(f"Director Mode: injected {len(director_events)} event(s) at round {round_num + 1}")
+
         _round_t0 = datetime.now()
         actions = {agent: LLMAction() for _, agent in active_agents}
         await result.env.step(actions)
@@ -1602,6 +1611,14 @@ async def run_reddit_simulation(
             if market_prompt:
                 for _, agent in active_agents:
                     inject_market_context(agent, market_prompt)
+
+        # Director Mode: inject breaking events into agent context
+        director_events = consume_pending_events(simulation_dir, round_num + 1)
+        if director_events:
+            combined_text = " | ".join(e["event_text"] for e in director_events)
+            for _, agent in active_agents:
+                inject_director_event_context(agent, combined_text)
+            log_info(f"Director Mode: injected {len(director_events)} event(s) at round {round_num + 1}")
 
         actions = {agent: LLMAction() for _, agent in active_agents}
         await result.env.step(actions)

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -328,3 +328,20 @@ export const testPushNotification = (simulationId) => {
   return service.post('/api/simulation/push/test', { simulation_id: simulationId })
 }
 
+/**
+ * Inject a breaking event into a running simulation (Director Mode).
+ * @param {string} simulationId
+ * @param {Object} data - { event_text: string }
+ */
+export const injectDirectorEvent = (simulationId, data) => {
+  return service.post(`/api/simulation/${simulationId}/director/inject`, data)
+}
+
+/**
+ * Get all director events (injected + pending) for a simulation.
+ * @param {string} simulationId
+ */
+export const getDirectorEvents = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/director/events`)
+}
+

--- a/frontend/src/components/BeliefDriftChart.vue
+++ b/frontend/src/components/BeliefDriftChart.vue
@@ -99,6 +99,21 @@
           fill="rgba(10,10,10,0.5)" font-size="9" font-family="monospace"
         >consensus r{{ driftData.consensus_round }}</text>
 
+        <!-- Director event injection markers -->
+        <g v-for="(evt, idx) in eventMarkers" :key="'evt' + idx">
+          <line
+            :x1="xS(evt.round)" :y1="MT"
+            :x2="xS(evt.round)" :y2="H - MB"
+            stroke="rgba(245,158,11,0.7)" stroke-width="1.5"
+            stroke-dasharray="3,2"
+          />
+          <text
+            :x="xS(evt.round) + 4"
+            :y="MT + 12 + idx * 11"
+            fill="rgba(245,158,11,0.8)" font-size="8" font-family="monospace"
+          >⚡ r{{ evt.round }}</text>
+        </g>
+
         <!-- X axis labels -->
         <text
           v-for="r in xTicks"
@@ -135,7 +150,8 @@ import { getBeliefDrift } from '../api/simulation'
 
 const props = defineProps({
   simulationId: { type: String, required: true },
-  visible: { type: Boolean, default: false }
+  visible: { type: Boolean, default: false },
+  directorEvents: { type: Array, default: () => [] }
 })
 
 const loading = ref(false)
@@ -205,6 +221,13 @@ const bullishPath = computed(() => {
   const bot = bearish.map((b, i) => b + neutral[i])
   const top = bot.map((b, i) => b + bullish[i])
   return areaPath(top, bot, rounds)
+})
+
+const eventMarkers = computed(() => {
+  if (!hasData.value || !props.directorEvents?.length) return []
+  return props.directorEvents
+    .filter(e => e.injected_at_round != null)
+    .map(e => ({ round: e.injected_at_round, text: e.event_text }))
 })
 
 const load = async () => {

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -54,7 +54,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showInfluence }"
-        @click="showInfluence = !showInfluence; showBeliefDrift = false"
+        @click="showInfluence = !showInfluence; showBeliefDrift = false; showDirector = false"
         title="Agent influence leaderboard"
       >
         ◈ Influence
@@ -65,10 +65,22 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showBeliefDrift }"
-        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false"
+        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false; showDirector = false"
         title="Aggregate belief drift chart"
       >
         ◎ Belief Drift
+      </button>
+
+      <!-- Director Mode toggle (only while simulation is running) -->
+      <button
+        v-if="phase === 1"
+        class="action-btn secondary director-btn"
+        :class="{ active: showDirector }"
+        @click="showDirector = !showDirector; showInfluence = false; showBeliefDrift = false"
+        :title="directorEventsTotal >= 3 ? 'Director Mode — max events reached' : 'Director Mode — inject a breaking event into the simulation'"
+      >
+        ⚡ Director
+        <span v-if="directorEventsTotal > 0" class="director-badge">{{ directorEventsTotal }}/3</span>
       </button>
 
       <!-- Resume (when paused/stopped/failed with partial data) -->
@@ -192,11 +204,77 @@
       v-if="showBeliefDrift"
       :simulationId="simulationId"
       :visible="showBeliefDrift"
+      :directorEvents="directorEventHistory"
       class="influence-overlay"
     />
 
+    <!-- Director Mode Panel (overlay when toggled) -->
+    <div v-if="showDirector" class="influence-overlay director-panel">
+      <div class="director-header">
+        <div class="director-title">
+          <span class="director-icon">⚡</span>
+          <span class="director-label">DIRECTOR MODE</span>
+        </div>
+        <span class="director-hint">Inject a breaking event — all agents receive it at the next round boundary</span>
+      </div>
+
+      <div class="director-form">
+        <textarea
+          v-model="directorEventText"
+          class="director-input"
+          placeholder="Describe the event (e.g. 'Central bank unexpectedly raised rates by 100bps')..."
+          maxlength="500"
+          :disabled="directorEventsTotal >= 3 || isInjectingEvent"
+          rows="3"
+        ></textarea>
+        <div class="director-form-footer">
+          <span class="director-char-count">{{ directorEventText.length }}/500</span>
+          <button
+            class="director-inject-btn"
+            :disabled="!directorEventText.trim() || directorEventsTotal >= 3 || isInjectingEvent"
+            @click="handleInjectEvent"
+          >
+            <span v-if="isInjectingEvent" class="loading-spinner-small"></span>
+            {{ isInjectingEvent ? 'Injecting...' : directorEventsTotal >= 3 ? 'Max events reached' : 'Inject Event' }}
+          </button>
+        </div>
+        <div v-if="directorError" class="director-error">{{ directorError }}</div>
+      </div>
+
+      <!-- Event History -->
+      <div v-if="directorEventHistory.length > 0" class="director-history">
+        <div class="director-history-title">Injected Events</div>
+        <div
+          v-for="evt in directorEventHistory"
+          :key="evt.id"
+          class="director-event-card"
+        >
+          <div class="director-event-header">
+            <span class="director-event-badge">⚡ ROUND {{ evt.injected_at_round || evt.submitted_at_round }}</span>
+            <span class="director-event-time">{{ formatEventTime(evt.timestamp) }}</span>
+          </div>
+          <div class="director-event-text">{{ evt.event_text }}</div>
+        </div>
+      </div>
+
+      <!-- Pending Events -->
+      <div v-if="directorPendingEvents.length > 0" class="director-history">
+        <div class="director-history-title">Pending (will inject next round)</div>
+        <div
+          v-for="evt in directorPendingEvents"
+          :key="evt.id"
+          class="director-event-card pending"
+        >
+          <div class="director-event-header">
+            <span class="director-event-badge pending-badge">◌ QUEUED</span>
+          </div>
+          <div class="director-event-text">{{ evt.event_text }}</div>
+        </div>
+      </div>
+    </div>
+
     <!-- Main Content: Dual Timeline -->
-    <div v-show="!showInfluence && !showBeliefDrift" class="main-content-area" ref="scrollContainer" @scroll="onTimelineScroll">
+    <div v-show="!showInfluence && !showBeliefDrift && !showDirector" class="main-content-area" ref="scrollContainer" @scroll="onTimelineScroll">
       <!-- Scroll to bottom button -->
       <button
         v-if="showScrollBtn"
@@ -221,6 +299,20 @@
           <span class="filter-count">{{ chronologicalActions.length }} events</span>
         </div>
         <button class="filter-clear" @click="clearAgentFilter">Clear</button>
+      </div>
+
+      <!-- Director Event Banners (inline in timeline) -->
+      <div
+        v-for="evt in directorEventHistory"
+        :key="'director-' + evt.id"
+        class="director-timeline-banner"
+      >
+        <div class="director-banner-line"></div>
+        <div class="director-banner-content">
+          <span class="director-banner-icon">⚡</span>
+          <span class="director-banner-text">BREAKING — Round {{ evt.injected_at_round }}: {{ evt.event_text }}</span>
+        </div>
+        <div class="director-banner-line"></div>
       </div>
 
       <!-- Timeline Feed -->
@@ -517,6 +609,8 @@ import {
   generateSimulationArticle,
   getVapidPublicKey,
   subscribePush,
+  injectDirectorEvent,
+  getDirectorEvents,
 } from '../api/simulation'
 import { generateReport } from '../api/report'
 import { renderMarkdown } from '../utils/markdown'
@@ -562,6 +656,15 @@ const showArticleDrawer = ref(false)
 const articleText = ref('')
 const isGeneratingArticle = ref(false)
 
+// Director Mode state
+const showDirector = ref(false)
+const directorEventText = ref('')
+const directorEventHistory = ref([])
+const directorPendingEvents = ref([])
+const directorEventsTotal = ref(0)
+const isInjectingEvent = ref(false)
+const directorError = ref(null)
+
 // Push notification state
 const pushSupported = typeof window !== 'undefined' &&
   'Notification' in window &&
@@ -587,6 +690,53 @@ const filterByPlatform = (platform) => {
 
 const clearPlatformFilter = () => {
   filteredPlatform.value = null
+}
+
+// Director Mode methods
+const handleInjectEvent = async () => {
+  if (!directorEventText.value.trim() || directorEventsTotal.value >= 3) return
+  isInjectingEvent.value = true
+  directorError.value = null
+  try {
+    const res = await injectDirectorEvent(props.simulationId, {
+      event_text: directorEventText.value.trim()
+    })
+    if (res.data?.success) {
+      directorEventText.value = ''
+      directorEventsTotal.value = res.data.total_events
+      await loadDirectorEvents()
+    } else {
+      directorError.value = res.data?.error || 'Failed to inject event'
+    }
+  } catch (err) {
+    directorError.value = err.response?.data?.error || err.message || 'Failed to inject event'
+  } finally {
+    isInjectingEvent.value = false
+  }
+}
+
+const loadDirectorEvents = async () => {
+  if (!props.simulationId) return
+  try {
+    const res = await getDirectorEvents(props.simulationId)
+    if (res.data?.success) {
+      directorEventHistory.value = res.data.events || []
+      directorPendingEvents.value = res.data.pending || []
+      directorEventsTotal.value = directorEventHistory.value.length + directorPendingEvents.value.length
+    }
+  } catch {
+    // Silently ignore — events will load on next poll
+  }
+}
+
+const formatEventTime = (timestamp) => {
+  if (!timestamp) return ''
+  try {
+    const d = new Date(timestamp)
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return ''
+  }
 }
 
 const copySimId = () => {
@@ -1034,6 +1184,11 @@ const fetchRunStatusDetail = async () => {
     }
   } catch (err) {
     console.warn('Failed to get detailed status:', err)
+  }
+
+  // Also refresh director events while simulation is running
+  if (phase.value === 1) {
+    loadDirectorEvents()
   }
 }
 
@@ -2387,5 +2542,227 @@ onUnmounted(() => {
 }
 .notify-label {
   font-family: var(--font-mono, 'Space Mono', monospace);
+}
+
+/* Director Mode */
+.director-btn.active {
+  border-color: #f59e0b;
+  color: #f59e0b;
+}
+
+.director-badge {
+  margin-left: 4px;
+  padding: 1px 5px;
+  background: rgba(245, 158, 11, 0.15);
+  border-radius: 3px;
+  font-size: 10px;
+  color: #f59e0b;
+}
+
+.director-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  font-family: var(--font-mono, 'Space Mono', monospace);
+  background: var(--background, #FAFAFA);
+}
+
+.director-header {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.08);
+}
+
+.director-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.director-icon {
+  font-size: 14px;
+  color: #f59e0b;
+}
+
+.director-label {
+  font-size: 12px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.5);
+}
+
+.director-hint {
+  font-size: 11px;
+  color: rgba(10,10,10,0.35);
+  letter-spacing: 0.5px;
+}
+
+.director-form {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.08);
+}
+
+.director-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid rgba(10,10,10,0.12);
+  background: rgba(10,10,10,0.02);
+  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-size: 12px;
+  color: #0a0a0a;
+  resize: none;
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+
+.director-input:focus {
+  border-color: #f59e0b;
+}
+
+.director-input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.director-form-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.director-char-count {
+  font-size: 10px;
+  color: rgba(10,10,10,0.3);
+  letter-spacing: 1px;
+}
+
+.director-inject-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: #f59e0b;
+  border: none;
+  color: #fff;
+  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-size: 11px;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.director-inject-btn:hover:not(:disabled) {
+  background: #d97706;
+}
+
+.director-inject-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.director-error {
+  margin-top: 8px;
+  font-size: 11px;
+  color: #dc2626;
+  letter-spacing: 0.5px;
+}
+
+.director-history {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.05);
+}
+
+.director-history-title {
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.35);
+  margin-bottom: 8px;
+}
+
+.director-event-card {
+  padding: 10px 12px;
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  background: rgba(245, 158, 11, 0.04);
+  margin-bottom: 6px;
+}
+
+.director-event-card.pending {
+  border-color: rgba(10,10,10,0.1);
+  background: rgba(10,10,10,0.02);
+  border-style: dashed;
+}
+
+.director-event-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.director-event-badge {
+  font-size: 10px;
+  letter-spacing: 1px;
+  color: #f59e0b;
+  font-weight: 600;
+}
+
+.pending-badge {
+  color: rgba(10,10,10,0.35);
+}
+
+.director-event-time {
+  font-size: 10px;
+  color: rgba(10,10,10,0.3);
+}
+
+.director-event-text {
+  font-size: 12px;
+  color: rgba(10,10,10,0.7);
+  line-height: 1.5;
+  letter-spacing: 0.3px;
+}
+
+/* Director Timeline Banner */
+.director-timeline-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  margin: 4px 0;
+}
+
+.director-banner-line {
+  flex: 1;
+  height: 1px;
+  background: rgba(245, 158, 11, 0.3);
+}
+
+.director-banner-content {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  flex-shrink: 0;
+}
+
+.director-banner-icon {
+  font-size: 12px;
+  color: #f59e0b;
+}
+
+.director-banner-text {
+  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-size: 10px;
+  color: #b45309;
+  letter-spacing: 0.5px;
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
## What

Director Mode lets users inject breaking events into running simulations. During a live simulation, click the **⚡ Director** button, type an event (e.g. "Central bank unexpectedly raised rates by 100bps"), and all agents receive it as context at the next round boundary — affecting their posts, trades, and stance shifts in real time.

This is the experimental control primitive that transforms MiroShark from "what do agents say about document X" into "what do agents say about document X **when Y happens at round N**."

## Why

Every computational social science paper that uses multi-agent simulation needs stimulus injection — the ability to introduce external shocks mid-stream and observe the system's response. Until now, MiroShark ran single-track simulations with no mid-stream disruption capability. Director Mode closes this gap, making MiroShark viable for perturbation-based research questions (e.g. "how does an EU AI Act debate change when three MEPs reverse their vote in round 5?"). This was the #1 idea from repo-actions and the highest-impact feature for research users.

## Changes

### Backend
- **`backend/scripts/director_events.py`** (new): File-based event queue with atomic writes via temp-file-and-rename. Provides `add_event()`, `consume_pending_events()`, `inject_director_event_context()`, and history tracking. Max 3 events per simulation enforced at the API layer.
- **`backend/scripts/run_parallel_simulation.py`**: Both Twitter and Reddit simulation loops now call `consume_pending_events()` at each round boundary (after cross-platform/market context injection, before `env.step()`). Consumed events are injected into every active agent's system message using the same marker-replace pattern as cross-platform digests.
- **`backend/app/api/simulation.py`**: Two new endpoints — `POST /<sim_id>/director/inject` (queue an event, validates simulation is running, enforces 3-event limit) and `GET /<sim_id>/director/events` (returns injected history + pending queue).

### Frontend
- **`frontend/src/api/simulation.js`**: Added `injectDirectorEvent()` and `getDirectorEvents()` API client functions.
- **`frontend/src/components/Step3Simulation.vue`**: Director Mode button in action bar (amber, visible only while simulation is running). Director panel overlay with textarea input, character counter (500 max), inject button, event history cards, and pending event display. Director event banners rendered as horizontal dividers in the timeline feed. Events are polled alongside the existing status polling interval.
- **`frontend/src/components/BeliefDriftChart.vue`**: Accepts `directorEvents` prop. Renders amber dashed vertical lines at injection rounds with ⚡ markers, matching the existing consensus line pattern.

---
*Built autonomously by Aeon*