### PR TITLE
feat: Agent Interaction Network Graph

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4318,3 +4318,275 @@ def get_director_events(simulation_id: str):
     except Exception as e:
         logger.error(f"Failed to get director events: {e}")
         return jsonify({"success": False, "error": str(e)}), 500
+
+
+@simulation_bp.route('/<simulation_id>/interaction-network', methods=['GET'])
+def get_interaction_network(simulation_id: str):
+    """
+    Build an agent interaction network from simulation action JSONL logs.
+
+    Extracts agent-to-agent edges (likes, reposts, quotes, comments, follows),
+    computes degree centrality, bridge score, and echo chamber metrics.
+    Results are cached in network.json.
+    """
+    import math
+
+    try:
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        if not os.path.exists(sim_dir):
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        cache_path = os.path.join(sim_dir, "network.json")
+        if os.path.exists(cache_path):
+            with open(cache_path, 'r', encoding='utf-8') as f:
+                cached = json.load(f)
+            return jsonify({"success": True, "data": cached})
+
+        INTERACTION_TYPES = frozenset({
+            'LIKE_POST', 'REPOST', 'QUOTE_POST', 'CREATE_COMMENT',
+            'LIKE_COMMENT', 'DISLIKE_POST', 'DISLIKE_COMMENT', 'FOLLOW',
+        })
+
+        agents = {}
+        edges = {}
+
+        def _ensure_agent(name, platform):
+            if name not in agents:
+                agents[name] = {'name': name, 'platforms': set(), 'actions': 0}
+            agents[name]['platforms'].add(platform)
+
+        for platform in ('twitter', 'reddit', 'polymarket'):
+            actions_path = os.path.join(sim_dir, platform, 'actions.jsonl')
+            if not os.path.exists(actions_path):
+                continue
+
+            with open(actions_path, 'r', encoding='utf-8') as fh:
+                for raw_line in fh:
+                    raw_line = raw_line.strip()
+                    if not raw_line:
+                        continue
+                    try:
+                        event = json.loads(raw_line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    if event.get('event_type') in (
+                        'simulation_start', 'round_start', 'round_end', 'simulation_end'
+                    ):
+                        continue
+
+                    agent_name = event.get('agent_name')
+                    if not agent_name:
+                        continue
+
+                    action_type = event.get('action_type', '')
+                    args = event.get('action_args') or {}
+                    _ensure_agent(agent_name, platform)
+                    agents[agent_name]['actions'] += 1
+
+                    if action_type == 'CREATE_POST':
+                        continue
+
+                    if action_type not in INTERACTION_TYPES:
+                        continue
+
+                    target = None
+                    if action_type == 'FOLLOW':
+                        target = args.get('target_user_name')
+                    else:
+                        target = (
+                            args.get('post_author_name')
+                            or args.get('original_author_name')
+                            or args.get('comment_author_name')
+                        )
+
+                    if not target or target == agent_name:
+                        continue
+
+                    _ensure_agent(target, platform)
+
+                    edge_key = (agent_name, target)
+                    if edge_key not in edges:
+                        edges[edge_key] = {
+                            'source': agent_name,
+                            'target': target,
+                            'weight': 0,
+                            'types': {},
+                            'platforms': set(),
+                        }
+                    edges[edge_key]['weight'] += 1
+                    edges[edge_key]['types'][action_type] = edges[edge_key]['types'].get(action_type, 0) + 1
+                    edges[edge_key]['platforms'].add(platform)
+
+        if not agents:
+            return jsonify({
+                "success": True,
+                "data": None,
+                "message": "No interaction data available."
+            })
+
+        # Read stance data from trajectory.json
+        stance_map = {}
+        trajectory_path = os.path.join(sim_dir, "trajectory.json")
+        if os.path.exists(trajectory_path):
+            try:
+                with open(trajectory_path, 'r', encoding='utf-8') as f:
+                    traj = json.load(f)
+                snapshots = traj.get("snapshots", [])
+                if snapshots:
+                    last_snap = snapshots[-1]
+                    for agent_id, positions in last_snap.get("belief_positions", {}).items():
+                        if positions:
+                            avg = sum(positions.values()) / len(positions)
+                            stance_map[agent_id] = avg
+            except Exception:
+                pass
+
+        # Build influence ranking for node sizing
+        ranked = _compute_influence_ranked(simulation_id)
+        influence_map = {a['agent_name']: a['influence_score'] for a in ranked}
+        rank_map = {a['agent_name']: a['rank'] for a in ranked}
+
+        # Map agent names to agent IDs from profiles for stance lookup
+        agent_name_to_stance = {}
+        profiles_path = os.path.join(sim_dir, "profiles.json")
+        if os.path.exists(profiles_path) and stance_map:
+            try:
+                with open(profiles_path, 'r', encoding='utf-8') as f:
+                    profiles = json.load(f)
+                if isinstance(profiles, list):
+                    for p in profiles:
+                        aid = str(p.get('agent_id', p.get('id', '')))
+                        name = p.get('name', p.get('agent_name', ''))
+                        if aid in stance_map and name:
+                            agent_name_to_stance[name] = stance_map[aid]
+            except Exception:
+                pass
+
+        # Compute graph metrics
+        in_degree = {}
+        out_degree = {}
+        cross_platform_edges = 0
+        total_edges = len(edges)
+
+        for edge in edges.values():
+            out_degree[edge['source']] = out_degree.get(edge['source'], 0) + edge['weight']
+            in_degree[edge['target']] = in_degree.get(edge['target'], 0) + edge['weight']
+            if len(edge['platforms']) > 1:
+                cross_platform_edges += 1
+
+        max_possible = max(len(agents) - 1, 1)
+
+        # Build node list
+        nodes = []
+        for name, data in agents.items():
+            total_degree = in_degree.get(name, 0) + out_degree.get(name, 0)
+            stance_val = agent_name_to_stance.get(name)
+            if stance_val is not None:
+                stance = 'bullish' if stance_val > 0.2 else ('bearish' if stance_val < -0.2 else 'neutral')
+            else:
+                stance = 'neutral'
+
+            nodes.append({
+                'id': name,
+                'name': name,
+                'platforms': sorted(data['platforms']),
+                'primary_platform': sorted(data['platforms'])[0] if data['platforms'] else 'unknown',
+                'stance': stance,
+                'influence_score': influence_map.get(name, 0),
+                'rank': rank_map.get(name, len(agents)),
+                'in_degree': in_degree.get(name, 0),
+                'out_degree': out_degree.get(name, 0),
+                'total_degree': total_degree,
+                'degree_centrality': round(total_degree / max_possible, 4) if max_possible > 0 else 0,
+            })
+
+        # Serialize edges
+        edge_list = []
+        for edge in edges.values():
+            edge_list.append({
+                'source': edge['source'],
+                'target': edge['target'],
+                'weight': edge['weight'],
+                'types': edge['types'],
+                'platforms': sorted(edge['platforms']),
+                'is_cross_platform': len(edge['platforms']) > 1,
+            })
+
+        edge_list.sort(key=lambda e: e['weight'], reverse=True)
+
+        # Compute insights
+        top_hub = max(nodes, key=lambda n: n['in_degree']) if nodes else None
+        top_bridge = None
+        if nodes:
+            bridge_scores = []
+            for n in nodes:
+                cross = sum(
+                    1 for e in edge_list
+                    if (e['source'] == n['id'] or e['target'] == n['id']) and e['is_cross_platform']
+                )
+                bridge_scores.append((n, cross))
+            bridge_scores.sort(key=lambda x: x[1], reverse=True)
+            if bridge_scores and bridge_scores[0][1] > 0:
+                top_bridge = {
+                    'agent': bridge_scores[0][0]['name'],
+                    'cross_platform_edges': bridge_scores[0][1],
+                }
+
+        # Platform clustering
+        platform_agents = {}
+        for n in nodes:
+            for p in n['platforms']:
+                platform_agents.setdefault(p, set()).add(n['id'])
+
+        same_platform_edges = 0
+        for e in edge_list:
+            if not e['is_cross_platform']:
+                same_platform_edges += 1
+
+        echo_chamber_score = round(same_platform_edges / total_edges * 100, 1) if total_edges > 0 else 0
+
+        insights = {
+            'top_hub': {
+                'agent': top_hub['name'],
+                'in_degree': top_hub['in_degree'],
+                'description': f"{top_hub['name']} received {top_hub['in_degree']} interactions — more than any other agent.",
+            } if top_hub and top_hub['in_degree'] > 0 else None,
+            'top_bridge': {
+                'agent': top_bridge['agent'],
+                'cross_platform_edges': top_bridge['cross_platform_edges'],
+                'description': f"{top_bridge['agent']} had the highest cross-platform interaction rate ({top_bridge['cross_platform_edges']} cross-platform edges).",
+            } if top_bridge else None,
+            'echo_chamber': {
+                'score': echo_chamber_score,
+                'description': f"{echo_chamber_score}% of interactions were within the same platform." + (
+                    " Agents mostly stayed in their silos." if echo_chamber_score > 80
+                    else " Moderate cross-platform activity." if echo_chamber_score > 50
+                    else " Strong cross-platform engagement."
+                ),
+            },
+            'total_nodes': len(nodes),
+            'total_edges': total_edges,
+        }
+
+        result = {
+            'nodes': nodes,
+            'edges': edge_list,
+            'insights': insights,
+        }
+
+        try:
+            with open(cache_path, 'w', encoding='utf-8') as f:
+                json.dump(result, f, indent=2)
+        except Exception:
+            pass
+
+        return jsonify({"success": True, "data": result})
+
+    except Exception as e:
+        logger.error(f"Failed to compute interaction network: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -329,6 +329,15 @@ export const testPushNotification = (simulationId) => {
 }
 
 /**
+ * Get agent interaction network graph data for a completed simulation.
+ * @param {string} simulationId
+ * @returns {Promise<{nodes: Array, edges: Array, insights: Object}>}
+ */
+export const getInteractionNetwork = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/interaction-network`)
+}
+
+/**
  * Inject a breaking event into a running simulation (Director Mode).
  * @param {string} simulationId
  * @param {Object} data - { event_text: string }

--- a/frontend/src/components/InteractionNetwork.vue
+++ b/frontend/src/components/InteractionNetwork.vue
@@ -1,0 +1,644 @@
+<template>
+  <div class="interaction-network">
+    <!-- Header -->
+    <div class="net-header">
+      <div class="net-title">
+        <span class="net-icon">⬡</span>
+        <span class="net-label">INTERACTION NETWORK</span>
+      </div>
+      <button
+        class="net-export-btn"
+        :disabled="!hasData"
+        @click="downloadPNG"
+        title="Download graph as PNG"
+      >
+        Export PNG ↓
+      </button>
+    </div>
+
+    <!-- Legend -->
+    <div class="net-legend">
+      <span class="legend-item"><span class="legend-dot bullish-dot"></span>Bullish</span>
+      <span class="legend-item"><span class="legend-dot neutral-dot"></span>Neutral</span>
+      <span class="legend-item"><span class="legend-dot bearish-dot"></span>Bearish</span>
+      <span class="legend-sep">|</span>
+      <span class="legend-item"><span class="legend-line twitter-line"></span>Twitter</span>
+      <span class="legend-item"><span class="legend-line reddit-line"></span>Reddit</span>
+      <span class="legend-item"><span class="legend-line cross-line"></span>Cross-platform</span>
+    </div>
+
+    <!-- Platform filter -->
+    <div v-if="hasData" class="net-filters">
+      <label class="filter-check" v-for="p in availablePlatforms" :key="p">
+        <input type="checkbox" :value="p" v-model="activePlatforms" />
+        <span>{{ p === 'twitter' ? 'X' : p === 'reddit' ? 'Reddit' : 'Polymarket' }}</span>
+      </label>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="net-state">
+      <div class="pulse-ring"></div>
+      <span>Computing interaction network...</span>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="net-state net-error-state">{{ error }}</div>
+
+    <!-- No data -->
+    <div v-else-if="!hasData" class="net-state">
+      <span>No interaction data available.</span>
+      <span class="net-hint">Run a simulation to generate agent interactions.</span>
+    </div>
+
+    <!-- Graph -->
+    <div v-else class="net-graph-wrap">
+      <svg
+        ref="svgRef"
+        :viewBox="`0 0 ${W} ${H}`"
+        preserveAspectRatio="xMidYMid meet"
+        class="net-svg"
+        xmlns="http://www.w3.org/2000/svg"
+        @mousemove="onMouseMove"
+        @mouseleave="hoveredNode = null"
+      >
+        <!-- Edges -->
+        <line
+          v-for="(e, i) in visibleEdges"
+          :key="'e' + i"
+          :x1="nodePos[e.source]?.x || 0"
+          :y1="nodePos[e.source]?.y || 0"
+          :x2="nodePos[e.target]?.x || 0"
+          :y2="nodePos[e.target]?.y || 0"
+          :stroke="edgeColor(e)"
+          :stroke-width="edgeWidth(e)"
+          :opacity="hoveredNode ? (e.source === hoveredNode || e.target === hoveredNode ? 0.8 : 0.08) : 0.35"
+          stroke-linecap="round"
+        />
+
+        <!-- Nodes -->
+        <g
+          v-for="n in visibleNodes"
+          :key="'n' + n.id"
+          :transform="`translate(${nodePos[n.id]?.x || 0},${nodePos[n.id]?.y || 0})`"
+          class="net-node"
+          :opacity="hoveredNode ? (n.id === hoveredNode || isNeighbor(n.id) ? 1 : 0.15) : 1"
+          @mouseenter="hoveredNode = n.id"
+        >
+          <circle
+            :r="nodeRadius(n)"
+            :fill="nodeColor(n)"
+            :stroke="n.id === hoveredNode ? 'rgba(10,10,10,0.7)' : 'rgba(10,10,10,0.15)'"
+            :stroke-width="n.id === hoveredNode ? 2 : 1"
+          />
+          <text
+            v-if="nodeRadius(n) >= 6 || n.id === hoveredNode"
+            :y="nodeRadius(n) + 10"
+            text-anchor="middle"
+            fill="rgba(10,10,10,0.5)"
+            :font-size="n.id === hoveredNode ? 10 : 8"
+            font-family="monospace"
+          >{{ n.name.length > 12 ? n.name.slice(0, 11) + '…' : n.name }}</text>
+        </g>
+
+        <!-- Tooltip -->
+        <g v-if="hoveredNode && nodePos[hoveredNode]" :transform="`translate(${tooltipX},${tooltipY})`">
+          <rect
+            x="-4" y="-14"
+            :width="tooltipWidth + 8"
+            height="52"
+            rx="4"
+            fill="rgba(250,250,250,0.95)"
+            stroke="rgba(10,10,10,0.15)"
+            stroke-width="1"
+          />
+          <text x="0" y="0" font-size="10" font-family="monospace" fill="rgba(10,10,10,0.8)" font-weight="bold">
+            {{ hoveredNodeData?.name }}
+          </text>
+          <text x="0" y="13" font-size="9" font-family="monospace" fill="rgba(10,10,10,0.5)">
+            {{ hoveredNodeData?.stance }} · {{ hoveredNodeData?.platforms?.join(', ') }}
+          </text>
+          <text x="0" y="26" font-size="9" font-family="monospace" fill="rgba(10,10,10,0.5)">
+            In: {{ hoveredNodeData?.in_degree }} · Out: {{ hoveredNodeData?.out_degree }} · Rank #{{ hoveredNodeData?.rank }}
+          </text>
+          <text x="0" y="34" font-size="0" fill="transparent">pad</text>
+        </g>
+      </svg>
+    </div>
+
+    <!-- Insights Panel -->
+    <div v-if="hasData && networkData?.insights" class="net-insights">
+      <div v-if="networkData.insights.top_hub" class="insight-card">
+        <span class="insight-label">Top Hub</span>
+        <span class="insight-text">{{ networkData.insights.top_hub.description }}</span>
+      </div>
+      <div v-if="networkData.insights.top_bridge" class="insight-card">
+        <span class="insight-label">Top Bridge</span>
+        <span class="insight-text">{{ networkData.insights.top_bridge.description }}</span>
+      </div>
+      <div v-if="networkData.insights.echo_chamber" class="insight-card">
+        <span class="insight-label">Echo Chamber</span>
+        <span class="insight-text">{{ networkData.insights.echo_chamber.description }}</span>
+      </div>
+      <div class="insight-card stats-row">
+        <span class="insight-stat">{{ networkData.insights.total_nodes }} agents</span>
+        <span class="insight-stat">{{ networkData.insights.total_edges }} interactions</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, nextTick } from 'vue'
+import { getInteractionNetwork } from '../api/simulation'
+
+const props = defineProps({
+  simulationId: { type: String, required: true },
+  visible: { type: Boolean, default: false },
+})
+
+const loading = ref(false)
+const error = ref('')
+const networkData = ref(null)
+const svgRef = ref(null)
+const hoveredNode = ref(null)
+const nodePos = ref({})
+
+const W = 560
+const H = 360
+
+const hasData = computed(() =>
+  networkData.value?.nodes?.length > 0
+)
+
+const availablePlatforms = computed(() => {
+  if (!hasData.value) return []
+  const ps = new Set()
+  for (const n of networkData.value.nodes) {
+    for (const p of n.platforms) ps.add(p)
+  }
+  return [...ps].sort()
+})
+
+const activePlatforms = ref([])
+
+const visibleNodes = computed(() => {
+  if (!hasData.value) return []
+  if (!activePlatforms.value.length) return networkData.value.nodes
+  return networkData.value.nodes.filter(n =>
+    n.platforms.some(p => activePlatforms.value.includes(p))
+  )
+})
+
+const visibleNodeIds = computed(() => new Set(visibleNodes.value.map(n => n.id)))
+
+const visibleEdges = computed(() => {
+  if (!hasData.value) return []
+  const ids = visibleNodeIds.value
+  return networkData.value.edges.filter(e =>
+    ids.has(e.source) && ids.has(e.target)
+  )
+})
+
+const hoveredNodeData = computed(() => {
+  if (!hoveredNode.value || !hasData.value) return null
+  return networkData.value.nodes.find(n => n.id === hoveredNode.value)
+})
+
+const neighborSet = computed(() => {
+  if (!hoveredNode.value || !hasData.value) return new Set()
+  const s = new Set()
+  for (const e of networkData.value.edges) {
+    if (e.source === hoveredNode.value) s.add(e.target)
+    if (e.target === hoveredNode.value) s.add(e.source)
+  }
+  return s
+})
+
+const isNeighbor = (id) => id === hoveredNode.value || neighborSet.value.has(id)
+
+const tooltipX = computed(() => {
+  if (!hoveredNode.value || !nodePos.value[hoveredNode.value]) return 0
+  const x = nodePos.value[hoveredNode.value].x
+  return x > W - 160 ? x - 150 : x + 15
+})
+
+const tooltipY = computed(() => {
+  if (!hoveredNode.value || !nodePos.value[hoveredNode.value]) return 0
+  const y = nodePos.value[hoveredNode.value].y
+  return y > H - 60 ? y - 50 : y + 5
+})
+
+const tooltipWidth = computed(() => {
+  if (!hoveredNodeData.value) return 100
+  return Math.max(hoveredNodeData.value.name.length * 7, 120)
+})
+
+const maxWeight = computed(() => {
+  if (!hasData.value) return 1
+  return Math.max(...networkData.value.edges.map(e => e.weight), 1)
+})
+
+const maxDegree = computed(() => {
+  if (!hasData.value) return 1
+  return Math.max(...networkData.value.nodes.map(n => n.total_degree), 1)
+})
+
+const nodeRadius = (n) => {
+  const base = 4
+  const scale = 12
+  return base + (n.total_degree / maxDegree.value) * scale
+}
+
+const nodeColor = (n) => {
+  const colors = {
+    bullish: 'rgba(20,184,166,0.8)',
+    bearish: 'rgba(239,68,68,0.8)',
+    neutral: 'rgba(148,163,184,0.8)',
+  }
+  return colors[n.stance] || colors.neutral
+}
+
+const edgeColor = (e) => {
+  if (e.is_cross_platform) return 'rgba(139,92,246,0.6)'
+  const p = e.platforms?.[0]
+  if (p === 'twitter') return 'rgba(59,130,246,0.5)'
+  if (p === 'reddit') return 'rgba(249,115,22,0.5)'
+  return 'rgba(148,163,184,0.4)'
+}
+
+const edgeWidth = (e) => {
+  return 0.5 + (e.weight / maxWeight.value) * 3
+}
+
+const onMouseMove = () => {}
+
+const runForceLayout = () => {
+  if (!hasData.value) return
+
+  const nodes = visibleNodes.value
+  const edges = visibleEdges.value
+  const n = nodes.length
+
+  if (n === 0) return
+
+  const pos = {}
+  const vel = {}
+  const cx = W / 2
+  const cy = H / 2
+  const pad = 30
+
+  for (const node of nodes) {
+    const angle = Math.random() * 2 * Math.PI
+    const r = 60 + Math.random() * 80
+    pos[node.id] = { x: cx + Math.cos(angle) * r, y: cy + Math.sin(angle) * r }
+    vel[node.id] = { x: 0, y: 0 }
+  }
+
+  const iterations = 200
+  const repulsionK = 3000
+  const attractionK = 0.015
+  const idealLen = Math.min(W, H) / (Math.sqrt(n) + 1)
+  const damping = 0.85
+  const maxForce = 10
+
+  const edgeSet = new Set()
+  for (const e of edges) {
+    edgeSet.add(e.source + '|' + e.target)
+    edgeSet.add(e.target + '|' + e.source)
+  }
+
+  for (let iter = 0; iter < iterations; iter++) {
+    const temp = 1 - iter / iterations
+
+    for (const a of nodes) {
+      vel[a.id].x = 0
+      vel[a.id].y = 0
+
+      for (const b of nodes) {
+        if (a.id === b.id) continue
+        const dx = pos[a.id].x - pos[b.id].x
+        const dy = pos[a.id].y - pos[b.id].y
+        const dist = Math.sqrt(dx * dx + dy * dy) || 1
+        const force = repulsionK / (dist * dist)
+        const fx = (dx / dist) * Math.min(force, maxForce) * temp
+        const fy = (dy / dist) * Math.min(force, maxForce) * temp
+        vel[a.id].x += fx
+        vel[a.id].y += fy
+      }
+    }
+
+    for (const e of edges) {
+      if (!pos[e.source] || !pos[e.target]) continue
+      const dx = pos[e.target].x - pos[e.source].x
+      const dy = pos[e.target].y - pos[e.source].y
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1
+      const force = (dist - idealLen) * attractionK * (1 + Math.log(e.weight + 1) * 0.3)
+      const fx = (dx / dist) * Math.min(force, maxForce)
+      const fy = (dy / dist) * Math.min(force, maxForce)
+      vel[e.source].x += fx * temp
+      vel[e.source].y += fy * temp
+      vel[e.target].x -= fx * temp
+      vel[e.target].y -= fy * temp
+    }
+
+    // Gravity toward center
+    for (const node of nodes) {
+      const dx = cx - pos[node.id].x
+      const dy = cy - pos[node.id].y
+      vel[node.id].x += dx * 0.001
+      vel[node.id].y += dy * 0.001
+    }
+
+    for (const node of nodes) {
+      pos[node.id].x += vel[node.id].x * damping
+      pos[node.id].y += vel[node.id].y * damping
+      pos[node.id].x = Math.max(pad, Math.min(W - pad, pos[node.id].x))
+      pos[node.id].y = Math.max(pad, Math.min(H - pad, pos[node.id].y))
+    }
+  }
+
+  nodePos.value = { ...pos }
+}
+
+const load = async () => {
+  if (!props.simulationId) return
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await getInteractionNetwork(props.simulationId)
+    if (res.success && res.data) {
+      networkData.value = res.data
+      activePlatforms.value = []
+      await nextTick()
+      runForceLayout()
+    } else if (res.success && !res.data) {
+      networkData.value = null
+    } else {
+      error.value = res.error || 'Failed to load interaction network.'
+    }
+  } catch (err) {
+    error.value = err.message || 'Failed to load interaction network.'
+  } finally {
+    loading.value = false
+  }
+}
+
+const downloadPNG = () => {
+  const svg = svgRef.value
+  if (!svg) return
+  const serializer = new XMLSerializer()
+  const svgStr = serializer.serializeToString(svg)
+  const canvas = document.createElement('canvas')
+  canvas.width = W * 2
+  canvas.height = H * 2
+  const ctx = canvas.getContext('2d')
+  ctx.fillStyle = '#FAFAFA'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  const img = new Image()
+  img.onload = () => {
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+    const a = document.createElement('a')
+    a.download = `interaction-network-${props.simulationId}.png`
+    a.href = canvas.toDataURL('image/png')
+    a.click()
+  }
+  img.src = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svgStr)))
+}
+
+watch(() => props.visible, (val) => { if (val) load() })
+watch(() => props.simulationId, () => { if (props.visible) load() })
+watch(activePlatforms, () => { nextTick(() => runForceLayout()) })
+onMounted(() => { if (props.visible) load() })
+</script>
+
+<style scoped>
+.interaction-network {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  font-family: var(--font-mono);
+  background: var(--background);
+}
+
+/* Header */
+.net-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.08);
+  flex-shrink: 0;
+}
+
+.net-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.net-icon {
+  color: #8b5cf6;
+  font-size: 14px;
+}
+
+.net-label {
+  font-size: 12px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.5);
+}
+
+.net-export-btn {
+  background: none;
+  border: 1px solid rgba(10,10,10,0.15);
+  padding: 4px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 1px;
+  cursor: pointer;
+  color: rgba(10,10,10,0.5);
+  transition: all 0.15s ease;
+}
+
+.net-export-btn:hover:not(:disabled) {
+  border-color: #8b5cf6;
+  color: #8b5cf6;
+}
+
+.net-export-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* Legend */
+.net-legend {
+  display: flex;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.05);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  color: rgba(10,10,10,0.35);
+  letter-spacing: 1px;
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.bullish-dot { background: rgba(20,184,166,0.8); }
+.neutral-dot { background: rgba(148,163,184,0.8); }
+.bearish-dot { background: rgba(239,68,68,0.8); }
+
+.legend-sep {
+  color: rgba(10,10,10,0.15);
+  font-size: 10px;
+}
+
+.legend-line {
+  width: 16px;
+  height: 2px;
+  border-radius: 1px;
+}
+
+.twitter-line { background: rgba(59,130,246,0.7); }
+.reddit-line { background: rgba(249,115,22,0.7); }
+.cross-line { background: rgba(139,92,246,0.7); }
+
+/* Filters */
+.net-filters {
+  display: flex;
+  gap: 12px;
+  padding: 6px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.05);
+  flex-shrink: 0;
+}
+
+.filter-check {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  color: rgba(10,10,10,0.4);
+  letter-spacing: 1px;
+  cursor: pointer;
+}
+
+.filter-check input {
+  accent-color: #8b5cf6;
+}
+
+/* States */
+.net-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 8px;
+  padding: 40px;
+  font-size: 13px;
+  color: rgba(10,10,10,0.35);
+  letter-spacing: 1px;
+  text-align: center;
+}
+
+.net-error-state { color: #dc2626; }
+
+.net-hint {
+  font-size: 11px;
+  color: rgba(10,10,10,0.25);
+}
+
+.pulse-ring {
+  width: 20px;
+  height: 20px;
+  border: 2px solid #8b5cf6;
+  border-radius: 50%;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50%       { transform: scale(1.4); opacity: 0.4; }
+}
+
+/* Graph */
+.net-graph-wrap {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+  min-height: 0;
+}
+
+.net-svg {
+  width: 100%;
+  height: 100%;
+  max-height: 380px;
+  overflow: visible;
+  cursor: crosshair;
+}
+
+.net-node {
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+/* Insights */
+.net-insights {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 16px;
+  border-top: 1px solid rgba(10,10,10,0.06);
+  flex-shrink: 0;
+  overflow-y: auto;
+  max-height: 140px;
+}
+
+.insight-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.insight-label {
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.35);
+}
+
+.insight-text {
+  font-size: 11px;
+  color: rgba(10,10,10,0.6);
+  line-height: 1.4;
+  letter-spacing: 0.3px;
+}
+
+.stats-row {
+  flex-direction: row;
+  gap: 16px;
+  padding-top: 4px;
+  border-top: 1px solid rgba(10,10,10,0.05);
+}
+
+.insight-stat {
+  font-size: 10px;
+  color: rgba(10,10,10,0.3);
+  letter-spacing: 1px;
+}
+</style>

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -54,7 +54,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showInfluence }"
-        @click="showInfluence = !showInfluence; showBeliefDrift = false; showDirector = false"
+        @click="showInfluence = !showInfluence; showBeliefDrift = false; showDirector = false; showNetwork = false"
         title="Agent influence leaderboard"
       >
         ◈ Influence
@@ -65,10 +65,21 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showBeliefDrift }"
-        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false; showDirector = false"
+        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false; showDirector = false; showNetwork = false"
         title="Aggregate belief drift chart"
       >
         ◎ Drift
+      </button>
+
+      <!-- Interaction Network toggle -->
+      <button
+        v-if="allActions.length > 0"
+        class="action-btn secondary"
+        :class="{ active: showNetwork }"
+        @click="showNetwork = !showNetwork; showInfluence = false; showBeliefDrift = false; showDirector = false"
+        title="Agent interaction network graph"
+      >
+        ⬡ Network
       </button>
 
       <!-- Director Mode toggle (only while simulation is running) -->
@@ -76,7 +87,7 @@
         v-if="phase === 1"
         class="action-btn secondary director-btn"
         :class="{ active: showDirector }"
-        @click="showDirector = !showDirector; showInfluence = false; showBeliefDrift = false"
+        @click="showDirector = !showDirector; showInfluence = false; showBeliefDrift = false; showNetwork = false"
         :title="directorEventsTotal >= 10 ? 'Director Mode — max events reached' : 'Director Mode — inject a breaking event into the simulation'"
       >
         ⚡ Director
@@ -188,6 +199,14 @@
       class="influence-overlay"
     />
 
+    <!-- Interaction Network (overlay when toggled) -->
+    <InteractionNetwork
+      v-if="showNetwork"
+      :simulationId="simulationId"
+      :visible="showNetwork"
+      class="influence-overlay"
+    />
+
     <!-- Director Mode Panel (overlay when toggled) -->
     <div v-if="showDirector" class="influence-overlay director-panel">
       <div class="director-header">
@@ -254,7 +273,7 @@
     </div>
 
     <!-- Main Content: Dual Timeline -->
-    <div v-show="!showInfluence && !showBeliefDrift && !showDirector" class="main-content-area" ref="scrollContainer" @scroll="onTimelineScroll">
+    <div v-show="!showInfluence && !showBeliefDrift && !showDirector && !showNetwork" class="main-content-area" ref="scrollContainer" @scroll="onTimelineScroll">
       <!-- Scroll to bottom button -->
       <button
         v-if="showScrollBtn"
@@ -601,6 +620,7 @@ import { generateReport } from '../api/report'
 import { renderMarkdown } from '../utils/markdown'
 import InfluenceLeaderboard from './InfluenceLeaderboard.vue'
 import BeliefDriftChart from './BeliefDriftChart.vue'
+import InteractionNetwork from './InteractionNetwork.vue'
 
 const props = defineProps({
   simulationId: String,
@@ -635,6 +655,7 @@ const filteredAgent = ref(null)
 const filteredPlatform = ref(null)
 const showInfluence = ref(false)
 const showBeliefDrift = ref(false)
+const showNetwork = ref(false)
 
 // Article drawer state
 const showArticleDrawer = ref(false)


### PR DESCRIPTION
## What
Agent Interaction Network Graph — a force-directed network visualization showing how agents interact with each other during simulations. Renders as a new "Network" tab alongside Belief Drift and Influence Leaderboard.

## Why
MiroShark's observability system records every agent-to-agent interaction (replies, likes, reposts, follows, comments) but this interaction structure was never visualized as a graph. The belief drift chart shows temporal dynamics; the leaderboard shows individual rankings; the network graph shows the structural relationships — who talks to whom, where echo chambers form, which agents bridge platforms. For researchers publishing on social simulation, the network graph is a standard analytical figure. Triggered by repo-actions idea #2 (2026-04-16).

## Changes
- **backend/app/api/simulation.py**: New `GET /<simulation_id>/interaction-network` endpoint that reads platform JSONL action logs, extracts agent-to-agent interaction edges (likes, reposts, quotes, comments, follows), builds a weighted directed graph with node metadata (stance from trajectory.json, influence rank, platform affiliations, degree centrality), computes insights (top hub by in-degree, top bridge by cross-platform edges, echo chamber score), and caches results in `network.json`.
- **frontend/src/api/simulation.js**: New `getInteractionNetwork()` API function.
- **frontend/src/components/InteractionNetwork.vue**: New Vue component (644 lines) rendering a force-directed graph using pure SVG — no external graph library. Features: node color by stance (teal=bullish, slate=neutral, coral=bearish), node size by total degree, edge color by platform (blue=Twitter, orange=Reddit, purple=cross-platform), edge thickness by interaction weight, hover highlighting with neighbor isolation, tooltip with agent details (stance, platforms, in/out degree, rank), platform filter checkboxes, insights panel (top hub, top bridge, echo chamber score, totals), and PNG export.
- **frontend/src/components/Step3Simulation.vue**: New "⬡ Network" toggle button in the actions bar. InteractionNetwork component rendered as an overlay (same pattern as BeliefDriftChart and InfluenceLeaderboard). All overlay toggles updated for mutual exclusion.

## How it works
The backend endpoint reads the same `actions.jsonl` files used by the influence leaderboard but extracts pairwise edges instead of per-agent scores. Each engagement action (LIKE_POST, REPOST, etc.) creates a directed edge from the acting agent to the post/comment author. Edges are weighted by interaction count and tagged with platform(s). The endpoint also reads `trajectory.json` for final-round belief positions to color-code nodes by stance, and cross-references the influence ranking for node sizing. Graph metrics (degree centrality, echo chamber score as same-platform edge ratio) are computed in pure Python — no external dependencies. Results are cached as `network.json` for subsequent requests.

The frontend implements a force-directed layout algorithm in JavaScript (200 iterations of repulsion/attraction forces with gravity centering and boundary clamping) — no D3 or external graph library needed. The SVG renders nodes and edges with hover-based highlighting: mousing over a node dims all non-neighbors to 15% opacity, making the local neighborhood instantly visible. Platform filter checkboxes re-run the force layout on the filtered subset.

---
*Built autonomously by Aeon*