### PR TITLE
feat: embeddable simulation widget

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -2759,6 +2759,175 @@ def _compute_quality_diagnostics(simulation_id: str, sim_dir: str):
     }
 
 
+# ============== Embed Widget ==============
+
+@simulation_bp.route('/<simulation_id>/embed-summary', methods=['GET'])
+def get_embed_summary(simulation_id: str):
+    """
+    Return a minimal summary for rendering the embeddable widget.
+
+    Bundles only the fields the embed iframe needs — scenario, round counts,
+    agent count, belief drift sparkline, optional consensus/resolution/health —
+    so a single request powers the read-only widget without the full simulation
+    payload.
+    """
+    try:
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({
+                "success": False,
+                "error": f"Simulation not found: {simulation_id}"
+            }), 404
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+
+        # Scenario & timing
+        config = manager.get_simulation_config(simulation_id)
+        scenario = ""
+        if config:
+            scenario = (config.get("simulation_requirement") or "").strip()
+
+        run_state = SimulationRunner.get_run_state(simulation_id)
+        if run_state:
+            current_round = run_state.current_round
+            total_rounds = run_state.total_rounds if getattr(run_state, 'total_rounds', 0) else 0
+            runner_status = run_state.runner_status.value if hasattr(run_state.runner_status, 'value') else str(run_state.runner_status)
+        else:
+            current_round = 0
+            total_rounds = 0
+            runner_status = "idle"
+
+        if total_rounds == 0 and config:
+            time_config = config.get("time_config", {})
+            minutes_per_round = max(int(time_config.get("minutes_per_round", 60) or 60), 1)
+            hours = int(time_config.get("total_simulation_hours", 0) or 0)
+            total_rounds = int(hours * 60 / minutes_per_round)
+
+        # Belief drift sparkline
+        belief = None
+        trajectory_path = os.path.join(sim_dir, "trajectory.json") if os.path.exists(sim_dir) else None
+        if trajectory_path and os.path.exists(trajectory_path):
+            try:
+                with open(trajectory_path, 'r', encoding='utf-8') as f:
+                    traj = json.load(f)
+
+                rounds = []
+                bullish = []
+                neutral = []
+                bearish = []
+                for snap in traj.get("snapshots", []):
+                    positions = snap.get("belief_positions", {}) or {}
+                    if not positions:
+                        continue
+                    stances = []
+                    for p in positions.values():
+                        if p:
+                            stances.append(sum(p.values()) / len(p))
+                    if not stances:
+                        continue
+                    total = len(stances)
+                    nb = sum(1 for s in stances if s > 0.2)
+                    nbe = sum(1 for s in stances if s < -0.2)
+                    nn = total - nb - nbe
+                    rounds.append(snap.get("round_num", len(rounds)))
+                    bullish.append(round(nb / total * 100, 1))
+                    neutral.append(round(nn / total * 100, 1))
+                    bearish.append(round(nbe / total * 100, 1))
+
+                consensus_round = None
+                consensus_stance = None
+                for i, _ in enumerate(rounds):
+                    if bullish[i] > 50:
+                        consensus_round = rounds[i]
+                        consensus_stance = "bullish"
+                        break
+                    if bearish[i] > 50:
+                        consensus_round = rounds[i]
+                        consensus_stance = "bearish"
+                        break
+
+                if rounds:
+                    belief = {
+                        "rounds": rounds,
+                        "bullish": bullish,
+                        "neutral": neutral,
+                        "bearish": bearish,
+                        "final": {
+                            "bullish": bullish[-1],
+                            "neutral": neutral[-1],
+                            "bearish": bearish[-1],
+                        },
+                        "consensus_round": consensus_round,
+                        "consensus_stance": consensus_stance,
+                    }
+            except Exception as exc:
+                logger.warning(f"Embed summary: failed to parse trajectory for {simulation_id}: {exc}")
+
+        # Quality (cached)
+        quality = None
+        quality_path = os.path.join(sim_dir, "quality.json") if os.path.exists(sim_dir) else None
+        if quality_path and os.path.exists(quality_path):
+            try:
+                with open(quality_path, 'r', encoding='utf-8') as f:
+                    q = json.load(f)
+                quality = {
+                    "health": q.get("health"),
+                    "participation_rate": q.get("participation_rate"),
+                }
+            except Exception:
+                quality = None
+
+        # Resolution (cached)
+        resolution = None
+        resolution_path = os.path.join(sim_dir, "resolution.json") if os.path.exists(sim_dir) else None
+        if resolution_path and os.path.exists(resolution_path):
+            try:
+                with open(resolution_path, 'r', encoding='utf-8') as f:
+                    r = json.load(f)
+                resolution = {
+                    "actual_outcome": r.get("actual_outcome"),
+                    "predicted_consensus": r.get("predicted_consensus"),
+                    "accuracy_score": r.get("accuracy_score"),
+                }
+            except Exception:
+                resolution = None
+
+        created_date = ""
+        try:
+            created_date = (state.created_at or "")[:10]
+        except Exception:
+            pass
+
+        summary = {
+            "simulation_id": simulation_id,
+            "scenario": scenario,
+            "status": state.status.value if hasattr(state.status, 'value') else str(state.status),
+            "runner_status": runner_status,
+            "current_round": current_round,
+            "total_rounds": total_rounds,
+            "profiles_count": state.profiles_count,
+            "created_date": created_date,
+            "parent_simulation_id": state.parent_simulation_id,
+            "belief": belief,
+            "quality": quality,
+            "resolution": resolution,
+        }
+
+        response = jsonify({"success": True, "data": summary})
+        # Widget is read-only and explicitly designed to be embedded anywhere.
+        response.headers["Cache-Control"] = "public, max-age=60"
+        return response
+
+    except Exception as e:
+        logger.error(f"Failed to build embed summary: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
 # ============== Database Query Endpoints ==============
 
 @simulation_bp.route('/<simulation_id>/posts', methods=['GET'])

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -363,3 +363,12 @@ export const getSimulationQuality = (simulationId) => {
   return service.get(`/api/simulation/${simulationId}/quality`)
 }
 
+/**
+ * Get a minimal summary for rendering the embeddable widget.
+ * @param {string} simulationId
+ * @returns {Promise<{simulation_id, scenario, status, current_round, total_rounds, profiles_count, belief, quality, resolution}>}
+ */
+export const getEmbedSummary = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/embed-summary`)
+}
+

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -1,0 +1,496 @@
+<template>
+  <Teleport to="body">
+    <Transition name="embed-dialog">
+      <div v-if="open" class="embed-dialog-overlay" @click.self="$emit('close')">
+        <div class="embed-dialog">
+          <!-- Header -->
+          <div class="embed-dialog-header">
+            <div class="embed-dialog-title">
+              <span class="title-icon">⌘</span>
+              <span>Embed simulation</span>
+              <span class="title-sub">{{ formatSimulationId(simulationId) }}</span>
+            </div>
+            <button class="embed-dialog-close" @click="$emit('close')">×</button>
+          </div>
+
+          <!-- Description -->
+          <p class="embed-dialog-desc">
+            Paste the iframe below into Notion, Substack, Medium, a GitHub README, or any HTML page.
+            The widget loads live from this MiroShark instance and updates automatically as the simulation changes.
+          </p>
+
+          <!-- Size presets -->
+          <div class="embed-size-row">
+            <span class="embed-size-label">Size</span>
+            <div class="embed-size-buttons">
+              <button
+                v-for="preset in sizePresets"
+                :key="preset.name"
+                class="embed-size-btn"
+                :class="{ active: activePreset === preset.name }"
+                @click="activePreset = preset.name"
+              >
+                {{ preset.name }}
+                <span class="embed-size-dim">{{ preset.width }}×{{ preset.height }}</span>
+              </button>
+            </div>
+            <label class="embed-theme-toggle">
+              <span>Theme</span>
+              <select v-model="theme" class="embed-theme-select">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+            </label>
+          </div>
+
+          <!-- Preview -->
+          <div class="embed-preview-wrap" :class="`preview-${activePreset.toLowerCase()}`">
+            <div class="embed-preview-frame" :style="previewStyle">
+              <iframe
+                v-if="embedUrl"
+                :src="embedUrl"
+                :style="iframeStyle"
+                frameborder="0"
+                loading="lazy"
+                title="MiroShark simulation embed preview"
+              ></iframe>
+            </div>
+          </div>
+
+          <!-- Copyable snippets -->
+          <div class="embed-snippets">
+            <div class="snippet-block">
+              <div class="snippet-head">
+                <span class="snippet-label">HTML iframe</span>
+                <button class="snippet-copy-btn" @click="copy('iframe')">
+                  {{ copied === 'iframe' ? '✓ Copied' : 'Copy' }}
+                </button>
+              </div>
+              <pre class="snippet-code"><code>{{ iframeSnippet }}</code></pre>
+            </div>
+
+            <div class="snippet-block">
+              <div class="snippet-head">
+                <span class="snippet-label">Markdown (Notion / Substack auto-embed)</span>
+                <button class="snippet-copy-btn" @click="copy('markdown')">
+                  {{ copied === 'markdown' ? '✓ Copied' : 'Copy' }}
+                </button>
+              </div>
+              <pre class="snippet-code"><code>{{ markdownSnippet }}</code></pre>
+            </div>
+
+            <div class="snippet-block">
+              <div class="snippet-head">
+                <span class="snippet-label">Direct URL</span>
+                <button class="snippet-copy-btn" @click="copy('url')">
+                  {{ copied === 'url' ? '✓ Copied' : 'Copy' }}
+                </button>
+              </div>
+              <pre class="snippet-code"><code>{{ embedUrl }}</code></pre>
+            </div>
+          </div>
+
+          <!-- Hint -->
+          <div class="embed-dialog-hint">
+            <span class="hint-icon">ⓘ</span>
+            The widget reads from this instance's API, so viewers must be able to reach
+            <code>{{ origin }}</code>. For public embeds, deploy MiroShark somewhere reachable from the internet.
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  simulationId: { type: String, required: true }
+})
+
+defineEmits(['close'])
+
+const sizePresets = [
+  { name: 'Compact', width: 480, height: 260 },
+  { name: 'Standard', width: 640, height: 340 },
+  { name: 'Wide', width: 800, height: 420 }
+]
+
+const activePreset = ref('Standard')
+const theme = ref('light')
+const copied = ref('')
+
+const origin = computed(() => {
+  if (typeof window === 'undefined') return ''
+  return window.location.origin
+})
+
+const currentSize = computed(() => {
+  return sizePresets.find(p => p.name === activePreset.value) || sizePresets[1]
+})
+
+const embedUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  const base = `${origin.value}/embed/${props.simulationId}`
+  const params = new URLSearchParams()
+  if (theme.value !== 'light') params.set('theme', theme.value)
+  const query = params.toString()
+  return query ? `${base}?${query}` : base
+})
+
+const iframeSnippet = computed(() => {
+  const { width, height } = currentSize.value
+  return `<iframe src="${embedUrl.value}" width="${width}" height="${height}" frameborder="0" loading="lazy" title="MiroShark simulation"></iframe>`
+})
+
+const markdownSnippet = computed(() => {
+  if (!embedUrl.value) return ''
+  return `[MiroShark simulation ↗](${embedUrl.value})`
+})
+
+const previewStyle = computed(() => {
+  const { width, height } = currentSize.value
+  return {
+    maxWidth: `${width}px`,
+    aspectRatio: `${width} / ${height}`
+  }
+})
+
+const iframeStyle = computed(() => ({
+  width: '100%',
+  height: '100%',
+  border: 'none',
+  borderRadius: '8px'
+}))
+
+const formatSimulationId = (id) => {
+  if (!id) return ''
+  const prefix = id.replace(/^sim_/, '').slice(0, 6)
+  return `SIM_${prefix.toUpperCase()}`
+}
+
+const copy = async (which) => {
+  let text = ''
+  if (which === 'iframe') text = iframeSnippet.value
+  else if (which === 'markdown') text = markdownSnippet.value
+  else if (which === 'url') text = embedUrl.value
+  if (!text) return
+  try {
+    await navigator.clipboard.writeText(text)
+    copied.value = which
+    setTimeout(() => {
+      if (copied.value === which) copied.value = ''
+    }, 1800)
+  } catch (err) {
+    // Fallback: select-able textarea
+    const ta = document.createElement('textarea')
+    ta.value = text
+    document.body.appendChild(ta)
+    ta.select()
+    try { document.execCommand('copy') } catch (_) {}
+    document.body.removeChild(ta)
+    copied.value = which
+    setTimeout(() => {
+      if (copied.value === which) copied.value = ''
+    }, 1800)
+  }
+}
+
+watch(() => props.open, (val) => {
+  if (val) copied.value = ''
+})
+</script>
+
+<style scoped>
+.embed-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 10, 10, 0.55);
+  backdrop-filter: blur(4px);
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.embed-dialog {
+  background: #ffffff;
+  color: #0a0a0a;
+  width: min(720px, 100%);
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  border-radius: 14px;
+  border: 1px solid rgba(10, 10, 10, 0.08);
+  box-shadow: 0 24px 56px rgba(0, 0, 0, 0.25);
+  padding: 22px 24px 20px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.embed-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.embed-dialog-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.005em;
+}
+
+.title-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: rgba(234, 88, 12, 0.12);
+  color: #ea580c;
+  font-size: 13px;
+}
+
+.title-sub {
+  font-size: 11px;
+  font-weight: 500;
+  color: #6b6b6b;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  background: rgba(10, 10, 10, 0.04);
+  border-radius: 999px;
+}
+
+.embed-dialog-close {
+  background: transparent;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
+  color: #6b6b6b;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.embed-dialog-close:hover {
+  background: rgba(10, 10, 10, 0.05);
+  color: #0a0a0a;
+}
+
+.embed-dialog-desc {
+  font-size: 13px;
+  color: #4b4b4b;
+  margin: 6px 0 14px;
+  line-height: 1.5;
+}
+
+.embed-size-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
+.embed-size-label {
+  font-size: 12px;
+  color: #6b6b6b;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.embed-size-buttons {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.embed-size-btn {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 6px 12px;
+  border: 1px solid rgba(10, 10, 10, 0.12);
+  background: #ffffff;
+  color: #0a0a0a;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  transition: all 0.15s;
+}
+
+.embed-size-btn:hover {
+  border-color: rgba(10, 10, 10, 0.3);
+}
+
+.embed-size-btn.active {
+  background: #0a0a0a;
+  color: #ffffff;
+  border-color: #0a0a0a;
+}
+
+.embed-size-dim {
+  font-size: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+}
+
+.embed-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  font-size: 12px;
+  color: #6b6b6b;
+  font-weight: 500;
+}
+
+.embed-theme-select {
+  background: #ffffff;
+  color: #0a0a0a;
+  border: 1px solid rgba(10, 10, 10, 0.12);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.embed-preview-wrap {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(10, 10, 10, 0.03),
+    rgba(10, 10, 10, 0.03) 10px,
+    rgba(10, 10, 10, 0.06) 10px,
+    rgba(10, 10, 10, 0.06) 20px
+  );
+  border: 1px solid rgba(10, 10, 10, 0.08);
+  border-radius: 10px;
+  padding: 14px;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 16px;
+}
+
+.embed-preview-frame {
+  width: 100%;
+  background: #ffffff;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+}
+
+.embed-snippets {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.snippet-block {
+  border: 1px solid rgba(10, 10, 10, 0.08);
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(10, 10, 10, 0.02);
+}
+
+.snippet-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: rgba(10, 10, 10, 0.04);
+  font-size: 11px;
+  font-weight: 600;
+  color: #6b6b6b;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.snippet-copy-btn {
+  background: #0a0a0a;
+  color: #ffffff;
+  border: none;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: opacity 0.15s;
+}
+
+.snippet-copy-btn:hover { opacity: 0.85; }
+
+.snippet-code {
+  margin: 0;
+  padding: 10px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: #1f1f1f;
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: transparent;
+  max-height: 120px;
+  overflow-y: auto;
+}
+
+.embed-dialog-hint {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(234, 88, 12, 0.06);
+  border: 1px solid rgba(234, 88, 12, 0.2);
+  border-radius: 8px;
+  font-size: 12px;
+  color: #4b4b4b;
+  line-height: 1.5;
+}
+
+.hint-icon {
+  flex-shrink: 0;
+  color: #ea580c;
+  font-weight: 700;
+}
+
+.embed-dialog-hint code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  padding: 1px 6px;
+  background: rgba(10, 10, 10, 0.06);
+  border-radius: 4px;
+  font-size: 11px;
+}
+
+/* Transition */
+.embed-dialog-enter-active,
+.embed-dialog-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.embed-dialog-enter-active .embed-dialog,
+.embed-dialog-leave-active .embed-dialog {
+  transition: transform 0.25s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.25s ease;
+}
+
+.embed-dialog-enter-from,
+.embed-dialog-leave-to { opacity: 0; }
+
+.embed-dialog-enter-from .embed-dialog,
+.embed-dialog-leave-to .embed-dialog {
+  transform: translateY(8px) scale(0.98);
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -408,6 +408,20 @@
               </div>
             </div>
 
+            <!-- Embed Section -->
+            <div class="modal-embed-section">
+              <div class="modal-divider">
+                <span class="divider-line"></span>
+                <span class="divider-text">Embed</span>
+                <span class="divider-line"></span>
+              </div>
+
+              <div class="embed-intro">
+                <p class="embed-desc">Drop this simulation into a Notion page, blog post, or README as a live widget — updates automatically as the simulation progresses.</p>
+                <button class="embed-trigger-btn" @click="openEmbedDialog">⌘ Get Embed Code</button>
+              </div>
+            </div>
+
             <!-- Fork Section -->
             <div class="modal-fork-section">
               <div class="modal-divider">
@@ -446,6 +460,13 @@
         </div>
       </Transition>
     </Teleport>
+
+    <!-- Embed Dialog -->
+    <EmbedDialog
+      :open="embedDialogOpen"
+      :simulation-id="embedSimulationId"
+      @close="closeEmbedDialog"
+    />
   </div>
 </template>
 
@@ -453,6 +474,7 @@
 import { ref, computed, onMounted, onUnmounted, onActivated, watch, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { getSimulationHistory, forkSimulation, resolveSimulation, getSimulationQuality } from '../api/simulation'
+import EmbedDialog from './EmbedDialog.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -487,6 +509,20 @@ const forkError = ref('')
 const showResolvePanel = ref(false)
 const resolving = ref(false)
 const resolveError = ref('')
+
+// Embed dialog
+const embedDialogOpen = ref(false)
+const embedSimulationId = ref('')
+
+const openEmbedDialog = () => {
+  if (!selectedProject.value) return
+  embedSimulationId.value = selectedProject.value.simulation_id
+  embedDialogOpen.value = true
+}
+
+const closeEmbedDialog = () => {
+  embedDialogOpen.value = false
+}
 
 // Filtered and sorted project list
 const filteredProjects = computed(() => {
@@ -1960,6 +1996,47 @@ onUnmounted(() => {
   color: #FFB347;
   opacity: 0.8;
   cursor: default;
+}
+
+/* ===== Embed section in modal ===== */
+.modal-embed-section {
+  background: #FAFAFA;
+  padding: 0 0 22px;
+}
+
+.embed-intro {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 34px 0;
+}
+
+.embed-desc {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.4);
+  letter-spacing: 1px;
+  text-align: center;
+  margin: 0;
+}
+
+.embed-trigger-btn {
+  padding: 8px 22px;
+  border: 1px solid rgba(234, 88, 12, 0.45);
+  background: rgba(234, 88, 12, 0.06);
+  color: #EA580C;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 2px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.embed-trigger-btn:hover {
+  border-color: #EA580C;
+  background: rgba(234, 88, 12, 0.12);
 }
 
 /* ===== Fork section in modal ===== */

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -48,6 +48,12 @@ const routes = [
     name: 'Compare',
     component: () => import('../views/ComparisonView.vue'),
     props: true
+  },
+  {
+    path: '/embed/:simulationId',
+    name: 'Embed',
+    component: () => import('../views/EmbedView.vue'),
+    props: true
   }
 ]
 

--- a/frontend/src/views/EmbedView.vue
+++ b/frontend/src/views/EmbedView.vue
@@ -1,0 +1,539 @@
+<template>
+  <div
+    class="embed-widget"
+    :class="[themeClass, { 'chart-only': chartOnly, 'compact': isCompact }]"
+  >
+    <div v-if="loading" class="embed-state">
+      <div class="embed-spinner"></div>
+      <span>Loading simulation…</span>
+    </div>
+
+    <div v-else-if="error" class="embed-state embed-error">
+      <span>{{ error }}</span>
+      <a class="embed-footer-link" :href="simulationUrl" target="_blank" rel="noopener">
+        Open on MiroShark ↗
+      </a>
+    </div>
+
+    <template v-else>
+      <header v-if="!chartOnly" class="embed-header">
+        <div class="embed-scenario" :title="summary.scenario">{{ scenarioTitle }}</div>
+        <div class="embed-meta">
+          <span class="embed-pill status" :class="statusClass">{{ statusLabel }}</span>
+          <span v-if="hasRounds" class="embed-pill">
+            Round {{ summary.current_round }}/{{ summary.total_rounds || summary.current_round }}
+          </span>
+          <span class="embed-pill">{{ summary.profiles_count || 0 }} agents</span>
+          <span v-if="summary.quality && summary.quality.health" class="embed-pill quality" :class="qualityClass">
+            {{ summary.quality.health }}
+          </span>
+        </div>
+      </header>
+
+      <div class="embed-chart-wrap">
+        <svg
+          v-if="hasBelief"
+          class="embed-chart"
+          :viewBox="`0 0 ${CHART_W} ${CHART_H}`"
+          preserveAspectRatio="none"
+          xmlns="http://www.w3.org/2000/svg"
+          role="img"
+          :aria-label="chartAriaLabel"
+        >
+          <path :d="bullishPath" fill="var(--bullish)" opacity="0.85" />
+          <path :d="neutralPath" fill="var(--neutral)" opacity="0.85" />
+          <path :d="bearishPath" fill="var(--bearish)" opacity="0.85" />
+          <line
+            v-if="consensusX !== null"
+            :x1="consensusX" :x2="consensusX"
+            :y1="0" :y2="CHART_H"
+            stroke="var(--consensus-line)"
+            stroke-width="1.5"
+            stroke-dasharray="3,3"
+          />
+        </svg>
+        <div v-else class="embed-empty-chart">
+          <span>No belief trajectory yet</span>
+        </div>
+
+        <div v-if="hasBelief && !chartOnly" class="embed-final-row">
+          <span class="final-chip bullish">
+            <span class="chip-dot"></span>
+            Bullish {{ finalBullish }}%
+          </span>
+          <span class="final-chip neutral">
+            <span class="chip-dot"></span>
+            Neutral {{ finalNeutral }}%
+          </span>
+          <span class="final-chip bearish">
+            <span class="chip-dot"></span>
+            Bearish {{ finalBearish }}%
+          </span>
+        </div>
+      </div>
+
+      <footer v-if="!chartOnly" class="embed-footer">
+        <div class="embed-footer-left">
+          <span v-if="consensusLabel" class="embed-consensus">{{ consensusLabel }}</span>
+          <span v-if="resolutionLabel" class="embed-resolution" :class="resolutionClass">
+            {{ resolutionLabel }}
+          </span>
+        </div>
+        <a class="embed-footer-link" :href="simulationUrl" target="_blank" rel="noopener">
+          Powered by <strong>MiroShark</strong> ↗
+        </a>
+      </footer>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { getEmbedSummary } from '../api/simulation'
+
+const props = defineProps({
+  simulationId: {
+    type: String,
+    default: ''
+  }
+})
+
+const route = useRoute()
+const simulationId = computed(() => props.simulationId || route.params.simulationId)
+
+const theme = computed(() => (route.query.theme === 'dark' ? 'dark' : 'light'))
+const themeClass = computed(() => `theme-${theme.value}`)
+const chartOnly = computed(() => route.query.chart_only === 'true' || route.query.chart_only === '1')
+
+const CHART_W = 640
+const CHART_H = 180
+
+const loading = ref(true)
+const error = ref('')
+const summary = ref(null)
+
+const scenarioTitle = computed(() => {
+  const raw = (summary.value?.scenario || '').trim()
+  if (!raw) return 'Untitled simulation'
+  return raw.length > 140 ? raw.slice(0, 140).trimEnd() + '…' : raw
+})
+
+const simulationUrl = computed(() => {
+  if (!simulationId.value) return '/'
+  return `${window.location.origin}/simulation/${simulationId.value}/start`
+})
+
+const statusLabel = computed(() => {
+  if (!summary.value) return 'Unknown'
+  const s = (summary.value.runner_status || summary.value.status || '').toLowerCase()
+  if (s === 'completed' || s === 'finished' || s === 'stopped') return 'Completed'
+  if (s === 'running' || s === 'in_progress') return 'Running'
+  if (s === 'error' || s === 'failed') return 'Failed'
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : 'Ready'
+})
+
+const statusClass = computed(() => {
+  const s = statusLabel.value.toLowerCase()
+  return `status-${s}`
+})
+
+const hasRounds = computed(() => {
+  if (!summary.value) return false
+  const total = summary.value.total_rounds || 0
+  const current = summary.value.current_round || 0
+  return total > 0 || current > 0
+})
+
+const hasBelief = computed(() => !!summary.value?.belief?.rounds?.length)
+
+const finalBullish = computed(() => summary.value?.belief?.final?.bullish ?? 0)
+const finalNeutral = computed(() => summary.value?.belief?.final?.neutral ?? 0)
+const finalBearish = computed(() => summary.value?.belief?.final?.bearish ?? 0)
+
+const qualityClass = computed(() => {
+  const h = (summary.value?.quality?.health || '').toLowerCase()
+  return `quality-${h || 'unknown'}`
+})
+
+const consensusLabel = computed(() => {
+  const b = summary.value?.belief
+  if (!b?.consensus_round) return ''
+  return `Consensus formed at round ${b.consensus_round} (${b.consensus_stance})`
+})
+
+const resolutionLabel = computed(() => {
+  const r = summary.value?.resolution
+  if (!r) return ''
+  if (r.accuracy_score !== null && r.accuracy_score !== undefined) {
+    if (r.accuracy_score >= 1.0) return `✓ Correct · Actual ${r.actual_outcome}`
+    if (r.accuracy_score <= 0.0) return `✗ Missed · Actual ${r.actual_outcome}`
+    return `~ Split · Actual ${r.actual_outcome}`
+  }
+  return `Actual ${r.actual_outcome}`
+})
+
+const resolutionClass = computed(() => {
+  const r = summary.value?.resolution
+  if (!r || r.accuracy_score === null || r.accuracy_score === undefined) return 'neutral'
+  if (r.accuracy_score >= 1.0) return 'correct'
+  if (r.accuracy_score <= 0.0) return 'wrong'
+  return 'split'
+})
+
+const chartAriaLabel = computed(() => {
+  if (!hasBelief.value) return 'No belief trajectory'
+  return `Belief drift across ${summary.value.belief.rounds.length} rounds`
+})
+
+// Stacked area chart paths — stack order bullish (top), neutral (middle), bearish (bottom).
+// Each row sums to 100, so we paint the three bands as full-width stacked polygons.
+const stackPaths = computed(() => {
+  if (!hasBelief.value) return { bullish: '', neutral: '', bearish: '' }
+
+  const rounds = summary.value.belief.rounds
+  const bu = summary.value.belief.bullish
+  const ne = summary.value.belief.neutral
+  const be = summary.value.belief.bearish
+
+  const n = rounds.length
+  const xStep = n > 1 ? CHART_W / (n - 1) : CHART_W
+  const yFor = (pct) => CHART_H - (pct / 100) * CHART_H
+
+  const pts = (topSeries) => {
+    const top = topSeries.map((v, i) => `${(i * xStep).toFixed(2)},${yFor(v).toFixed(2)}`).join(' ')
+    return top
+  }
+
+  // Running top of each stacked band (cumulative percentage from bottom).
+  const bullishTop = bu.map(() => 100) // bullish always caps at 100
+  const neutralTop = bu.map((_, i) => ne[i] + be[i])
+  const bearishTop = be.map((v) => v)
+
+  const bottomLine = Array(n).fill(0)
+
+  const buildBand = (topSeries, bottomSeries) => {
+    const top = topSeries.map((v, i) => `${(i * xStep).toFixed(2)},${yFor(v).toFixed(2)}`).join(' L ')
+    const bottom = bottomSeries
+      .map((v, i) => `${((n - 1 - i) * xStep).toFixed(2)},${yFor(v).toFixed(2)}`)
+      .join(' L ')
+    return `M ${top} L ${bottom} Z`
+  }
+
+  const reversedBottomFor = (arr) => [...arr].reverse()
+
+  return {
+    bullish: buildBand(bullishTop, reversedBottomFor(neutralTop)),
+    neutral: buildBand(neutralTop, reversedBottomFor(bearishTop)),
+    bearish: buildBand(bearishTop, reversedBottomFor(bottomLine))
+  }
+})
+
+const bullishPath = computed(() => stackPaths.value.bullish)
+const neutralPath = computed(() => stackPaths.value.neutral)
+const bearishPath = computed(() => stackPaths.value.bearish)
+
+const consensusX = computed(() => {
+  const b = summary.value?.belief
+  if (!b?.consensus_round || !b.rounds?.length) return null
+  const idx = b.rounds.indexOf(b.consensus_round)
+  if (idx < 0) return null
+  const n = b.rounds.length
+  const xStep = n > 1 ? CHART_W / (n - 1) : CHART_W
+  return idx * xStep
+})
+
+const isCompact = computed(() => {
+  // Detect narrow iframe — 480×240 preset
+  if (typeof window === 'undefined') return false
+  return window.innerWidth < 520
+})
+
+const fetchData = async () => {
+  if (!simulationId.value) {
+    error.value = 'Missing simulation id'
+    loading.value = false
+    return
+  }
+  try {
+    const res = await getEmbedSummary(simulationId.value)
+    if (res?.success) {
+      summary.value = res.data
+    } else {
+      error.value = res?.error || 'Failed to load simulation'
+    }
+  } catch (err) {
+    error.value = err?.response?.data?.error || err?.message || 'Failed to load simulation'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  fetchData()
+  // Remove body padding set by main app shell styles (if any) so the embed
+  // renders edge-to-edge inside an iframe host.
+  if (typeof document !== 'undefined') {
+    document.body.style.margin = '0'
+    document.body.style.padding = '0'
+    document.documentElement.style.background = 'transparent'
+    document.body.style.background = 'transparent'
+  }
+})
+</script>
+
+<style scoped>
+.embed-widget {
+  --bg: #ffffff;
+  --fg: #0a0a0a;
+  --muted: #6b6b6b;
+  --border: rgba(10, 10, 10, 0.08);
+  --pill-bg: rgba(10, 10, 10, 0.05);
+  --pill-fg: #0a0a0a;
+  --bullish: #0ea5a0;
+  --neutral: #9aa0a6;
+  --bearish: #f07867;
+  --consensus-line: rgba(10, 10, 10, 0.45);
+  --link-color: #ea580c;
+
+  box-sizing: border-box;
+  width: 100%;
+  height: 100vh;
+  min-height: 220px;
+  padding: 16px 18px;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 13px;
+  line-height: 1.45;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.embed-widget.theme-dark {
+  --bg: #0f1115;
+  --fg: #f4f4f5;
+  --muted: #a1a1aa;
+  --border: rgba(244, 244, 245, 0.12);
+  --pill-bg: rgba(244, 244, 245, 0.08);
+  --pill-fg: #f4f4f5;
+  --consensus-line: rgba(244, 244, 245, 0.55);
+}
+
+.embed-widget.chart-only {
+  padding: 8px;
+  gap: 4px;
+}
+
+.embed-widget.compact {
+  font-size: 12px;
+  padding: 12px 14px;
+}
+
+.embed-state {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.embed-error {
+  color: var(--bearish);
+}
+
+.embed-spinner {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--border);
+  border-top-color: var(--fg);
+  border-radius: 50%;
+  animation: embed-spin 0.9s linear infinite;
+}
+
+@keyframes embed-spin {
+  to { transform: rotate(360deg); }
+}
+
+.embed-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.embed-scenario {
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.005em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.embed-widget.compact .embed-scenario {
+  font-size: 13px;
+}
+
+.embed-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.embed-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--pill-bg);
+  color: var(--pill-fg);
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.embed-pill.status.status-completed {
+  background: rgba(14, 165, 160, 0.15);
+  color: var(--bullish);
+}
+
+.embed-pill.status.status-running {
+  background: rgba(234, 88, 12, 0.15);
+  color: var(--link-color);
+}
+
+.embed-pill.status.status-failed {
+  background: rgba(240, 120, 103, 0.15);
+  color: var(--bearish);
+}
+
+.embed-pill.quality.quality-excellent {
+  background: rgba(14, 165, 160, 0.15);
+  color: var(--bullish);
+}
+
+.embed-pill.quality.quality-good {
+  background: rgba(234, 179, 8, 0.15);
+  color: #b45309;
+}
+
+.embed-widget.theme-dark .embed-pill.quality.quality-good {
+  color: #facc15;
+}
+
+.embed-pill.quality.quality-low {
+  background: rgba(240, 120, 103, 0.15);
+  color: var(--bearish);
+}
+
+.embed-chart-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 80px;
+}
+
+.embed-chart {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  background: var(--pill-bg);
+}
+
+.embed-empty-chart {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.embed-final-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.final-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--pill-bg);
+  color: var(--pill-fg);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.chip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.final-chip.bullish .chip-dot { background: var(--bullish); }
+.final-chip.neutral .chip-dot { background: var(--neutral); }
+.final-chip.bearish .chip-dot { background: var(--bearish); }
+
+.embed-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.embed-footer-left {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.embed-consensus {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 55ch;
+}
+
+.embed-resolution {
+  font-weight: 600;
+}
+
+.embed-resolution.correct { color: var(--bullish); }
+.embed-resolution.wrong { color: var(--bearish); }
+.embed-resolution.split { color: var(--muted); }
+
+.embed-footer-link {
+  color: var(--link-color);
+  text-decoration: none;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.embed-footer-link:hover {
+  text-decoration: underline;
+}
+
+.embed-footer-link strong {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+</style>


### PR DESCRIPTION
## What
Adds a read-only, iframe-friendly embed route at \`/embed/:simulationId\` plus a minimal \`GET /api/simulation/:id/embed-summary\` endpoint so any MiroShark simulation can be dropped into Notion, Substack, Medium, or a GitHub README as a live widget. A new **Embed** section in the history modal exposes copyable iframe / Markdown / URL snippets with Compact (480×260), Standard (640×340), and Wide (800×420) size presets and a light/dark theme toggle.

## Why
Share links work, but links require a click. Researchers publishing in Notion or writing up simulation results in a blog post want the belief drift chart and final consensus rendered inline. Today there is no way to do that — every completed simulation stays a private click-through. This closes that gap and turns each share into live inline content that links back to the running instance. Picks up idea #4 from \`repo-actions-2026-04-16\`; ideas #1 (Replay), #2 (Network Graph) and #5 (Quality Diagnostics) from that batch were already shipped.

## Changes
- **backend/app/api/simulation.py** — new \`GET /<sim_id>/embed-summary\` endpoint returning scenario (truncated server-side friendly), status, round / agent counts, final belief distribution, per-round stacked series (bullish / neutral / bearish), consensus round/stance, cached quality health, and cached resolution. One request powers the whole widget — no extra API chatter from the iframe.
- **frontend/src/views/EmbedView.vue** — minimal full-page widget: scenario header, status / round / agent / quality pills, stacked-area SVG belief drift sparkline with a dashed consensus marker, final-round chips, optional resolution badge, "Powered by MiroShark ↗" footer linking back to the run. Supports \`?theme=dark\` and \`?chart_only=true\` query params; forces transparent body so the widget renders cleanly inside any iframe.
- **frontend/src/components/EmbedDialog.vue** — history-modal dialog with live iframe preview, three size presets, light/dark selector, and three copy-to-clipboard snippets (iframe HTML / Markdown auto-embed link / raw URL). Graceful \`document.execCommand\` fallback for clipboard permissions.
- **frontend/src/components/HistoryDatabase.vue** — registers \`EmbedDialog\`, adds an "Embed" section to the simulation detail modal with a trigger button, wires \`openEmbedDialog\` / \`closeEmbedDialog\` around the selected simulation id.
- **frontend/src/api/simulation.js** — \`getEmbedSummary(simulationId)\` helper.
- **frontend/src/router/index.js** — \`/embed/:simulationId\` route.

---
*Built autonomously by Aeon*