### PR TITLE
feat: agent demographic breakdown panel

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4803,3 +4803,432 @@ def get_interaction_network(simulation_id: str):
             "error": str(e),
             "traceback": traceback.format_exc()
         }), 500
+
+
+# ============== Demographic Breakdown ==============
+
+# Age buckets in display order. "unknown" is appended at the end when populated.
+_DEMO_AGE_BUCKETS = ["<18", "18-24", "25-34", "35-44", "45-54", "55+"]
+
+# Entity-type classification (mirrors OasisProfileGenerator's taxonomy).
+_INDIVIDUAL_ENTITY_TYPES = frozenset({
+    "student", "alumni", "professor", "person", "publicfigure",
+    "expert", "faculty", "official", "journalist", "activist",
+    "politician", "scientist", "researcher", "athlete", "artist",
+    "musician", "author", "entrepreneur", "investor", "diplomat",
+    "celebrity", "ceo", "executive", "regulator",
+})
+_INDIVIDUAL_TYPE_KEYWORDS = (
+    "founder", "forecaster", "user", "trader", "influencer",
+    "analyst", "advisor", "leader", "critic", "advocate",
+    "commentator", "blogger", "developer", "engineer",
+)
+_GROUP_ENTITY_TYPES = frozenset({
+    "university", "governmentagency", "organization", "ngo",
+    "mediaoutlet", "company", "institution", "group", "community",
+    "agency", "platform", "network", "protocol", "framework",
+    "fund", "exchange", "consortium", "coalition",
+})
+
+
+def _demo_age_bucket(age) -> str:
+    try:
+        a = int(age)
+    except (TypeError, ValueError):
+        return "unknown"
+    if a < 18:
+        return "<18"
+    if a <= 24:
+        return "18-24"
+    if a <= 34:
+        return "25-34"
+    if a <= 44:
+        return "35-44"
+    if a <= 54:
+        return "45-54"
+    return "55+"
+
+
+def _demo_classify_archetype(entity_type) -> str:
+    if not entity_type:
+        return "unknown"
+    et = str(entity_type).lower().replace(" ", "").replace("_", "")
+    if et in _INDIVIDUAL_ENTITY_TYPES:
+        return "individual"
+    if et in _GROUP_ENTITY_TYPES:
+        return "institutional"
+    for kw in _INDIVIDUAL_TYPE_KEYWORDS:
+        if kw in et:
+            return "individual"
+    return "unknown"
+
+
+def _demo_load_profiles(sim_dir: str) -> list:
+    """Load agent profiles from reddit_profiles.json (primary) or twitter_profiles.csv.
+
+    Returns a list of dicts with normalized demographic fields.
+    """
+    profiles = []
+    reddit_path = os.path.join(sim_dir, "reddit_profiles.json")
+    if os.path.exists(reddit_path):
+        try:
+            with open(reddit_path, 'r', encoding='utf-8') as f:
+                profiles = json.load(f)
+        except Exception as e:
+            logger.warning(f"Failed to load reddit_profiles.json: {e}")
+
+    if not profiles:
+        twitter_path = os.path.join(sim_dir, "twitter_profiles.csv")
+        if os.path.exists(twitter_path):
+            try:
+                with open(twitter_path, 'r', encoding='utf-8') as f:
+                    reader = csv.DictReader(f)
+                    profiles = list(reader)
+            except Exception as e:
+                logger.warning(f"Failed to load twitter_profiles.csv: {e}")
+
+    return profiles if isinstance(profiles, list) else []
+
+
+def _demo_extract_stances(sim_dir: str):
+    """Return (initial_stance_map, final_stance_map), keyed by string agent_id."""
+    initial_map: dict = {}
+    final_map: dict = {}
+    trajectory_path = os.path.join(sim_dir, "trajectory.json")
+    if not os.path.exists(trajectory_path):
+        return initial_map, final_map
+
+    try:
+        with open(trajectory_path, 'r', encoding='utf-8') as f:
+            traj = json.load(f)
+    except Exception:
+        return initial_map, final_map
+
+    snapshots = traj.get("snapshots", [])
+    if not snapshots:
+        return initial_map, final_map
+
+    def _avg_by_agent(snap):
+        out = {}
+        for aid, positions in (snap.get("belief_positions") or {}).items():
+            if positions:
+                out[str(aid)] = sum(positions.values()) / len(positions)
+        return out
+
+    initial_map = _avg_by_agent(snapshots[0])
+    final_map = _avg_by_agent(snapshots[-1])
+    return initial_map, final_map
+
+
+def _demo_bucket_accumulator():
+    return {
+        "count": 0,
+        "stances": [],
+        "deltas": [],
+        "influences": [],
+        "bullish": 0,
+        "neutral": 0,
+        "bearish": 0,
+    }
+
+
+def _demo_finalize_bucket(acc: dict) -> dict:
+    """Convert accumulator lists into summary statistics."""
+    import math as _math
+    n = acc["count"]
+    result = {
+        "count": n,
+        "final_stance_mean": None,
+        "final_stance_std": None,
+        "stance_volatility": None,
+        "influence_mean": None,
+        "bullish_pct": 0.0,
+        "neutral_pct": 0.0,
+        "bearish_pct": 0.0,
+        "dominant_stance": "neutral",
+    }
+    if n <= 0:
+        return result
+
+    if acc["stances"]:
+        mean = sum(acc["stances"]) / len(acc["stances"])
+        var = sum((s - mean) ** 2 for s in acc["stances"]) / len(acc["stances"])
+        result["final_stance_mean"] = round(mean, 3)
+        result["final_stance_std"] = round(_math.sqrt(var), 3)
+
+    if acc["deltas"]:
+        result["stance_volatility"] = round(
+            sum(acc["deltas"]) / len(acc["deltas"]), 3
+        )
+
+    if acc["influences"]:
+        result["influence_mean"] = round(
+            sum(acc["influences"]) / len(acc["influences"]), 2
+        )
+
+    stance_total = acc["bullish"] + acc["neutral"] + acc["bearish"]
+    if stance_total > 0:
+        result["bullish_pct"] = round(acc["bullish"] / stance_total * 100, 1)
+        result["neutral_pct"] = round(acc["neutral"] / stance_total * 100, 1)
+        result["bearish_pct"] = round(acc["bearish"] / stance_total * 100, 1)
+        pcts = [
+            (result["bullish_pct"], "bullish"),
+            (result["neutral_pct"], "neutral"),
+            (result["bearish_pct"], "bearish"),
+        ]
+        pcts.sort(reverse=True)
+        result["dominant_stance"] = pcts[0][1]
+
+    return result
+
+
+def _demo_top_divergence(breakdown: dict):
+    """Pick the most striking subgroup divergence across all dimensions.
+
+    Returns a dict with {dimension, segment_a, segment_b, delta, headline} or None.
+    """
+    best = None
+    dimension_labels = {
+        "by_age_range": "Age",
+        "by_gender": "Gender",
+        "by_country": "Country",
+        "by_archetype": "Actor type",
+        "by_platform": "Primary platform",
+    }
+
+    for dim_key, dim_label in dimension_labels.items():
+        segments = breakdown.get(dim_key, {})
+        entries = [
+            (seg, data)
+            for seg, data in segments.items()
+            if data.get("final_stance_mean") is not None and data.get("count", 0) >= 2
+        ]
+        if len(entries) < 2:
+            continue
+
+        entries.sort(key=lambda x: x[1]["final_stance_mean"], reverse=True)
+        top = entries[0]
+        bottom = entries[-1]
+        delta = round(top[1]["final_stance_mean"] - bottom[1]["final_stance_mean"], 3)
+
+        if delta <= 0.05:
+            continue
+
+        if best is None or delta > best["delta"]:
+            best = {
+                "dimension": dim_label,
+                "dimension_key": dim_key,
+                "segment_a": top[0],
+                "segment_a_mean": top[1]["final_stance_mean"],
+                "segment_b": bottom[0],
+                "segment_b_mean": bottom[1]["final_stance_mean"],
+                "delta": delta,
+                "headline": (
+                    f"{dim_label.lower()}: {top[0]} agents landed {delta} more bullish "
+                    f"than {bottom[0]} agents on average."
+                ),
+            }
+
+    return best
+
+
+@simulation_bp.route('/<simulation_id>/demographics', methods=['GET'])
+def get_demographic_breakdown(simulation_id: str):
+    """
+    Cross-tab agent demographics (age range, gender, country, archetype, primary
+    platform) against final stance, stance volatility, and influence score.
+
+    Uses data that already exists — persona JSON + trajectory.json + action logs —
+    so no extra collection is required. Results are cached in demographics.json
+    inside the simulation directory.
+    """
+    try:
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        if not os.path.exists(sim_dir):
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        force_refresh = request.args.get('refresh', '').lower() in ('1', 'true', 'yes')
+        cache_path = os.path.join(sim_dir, "demographics.json")
+        if os.path.exists(cache_path) and not force_refresh:
+            with open(cache_path, 'r', encoding='utf-8') as f:
+                return jsonify({"success": True, "data": json.load(f)})
+
+        profiles = _demo_load_profiles(sim_dir)
+        if not profiles:
+            return jsonify({
+                "success": True,
+                "data": None,
+                "message": "No agent profiles available yet."
+            })
+
+        initial_stance, final_stance = _demo_extract_stances(sim_dir)
+        influence_ranked = _compute_influence_ranked(simulation_id) or []
+        influence_by_name = {
+            a.get('agent_name'): a.get('influence_score', 0)
+            for a in influence_ranked
+            if a.get('agent_name')
+        }
+        primary_platform_by_name = {}
+        for a in influence_ranked:
+            name = a.get('agent_name')
+            platforms = a.get('platforms') or []
+            if name and platforms:
+                primary_platform_by_name[name] = platforms[0]
+
+        # Prepare bucket containers
+        buckets = {
+            "by_age_range": {b: _demo_bucket_accumulator() for b in _DEMO_AGE_BUCKETS},
+            "by_gender": {},
+            "by_country": {},
+            "by_archetype": {
+                "individual": _demo_bucket_accumulator(),
+                "institutional": _demo_bucket_accumulator(),
+            },
+            "by_platform": {},
+        }
+        buckets["by_age_range"]["unknown"] = _demo_bucket_accumulator()
+        buckets["by_archetype"]["unknown"] = _demo_bucket_accumulator()
+
+        agents_in_profiles = 0
+        agents_with_stance = 0
+
+        for p in profiles:
+            if not isinstance(p, dict):
+                continue
+            agents_in_profiles += 1
+
+            user_id = p.get('user_id') or p.get('agent_id') or p.get('id')
+            user_name = (
+                p.get('user_name')
+                or p.get('username')
+                or p.get('name')
+                or ''
+            )
+
+            age_bucket = _demo_age_bucket(p.get('age'))
+            gender_raw = p.get('gender') or 'unknown'
+            gender = str(gender_raw).strip().lower() or 'unknown'
+            country_raw = p.get('country') or 'unknown'
+            country = str(country_raw).strip() or 'unknown'
+            archetype = _demo_classify_archetype(p.get('source_entity_type'))
+            primary_platform = primary_platform_by_name.get(user_name) or 'inactive'
+
+            # Lookup stance + delta
+            stance_val = None
+            delta_val = None
+            if user_id is not None:
+                key = str(user_id)
+                if key in final_stance:
+                    stance_val = final_stance[key]
+                    agents_with_stance += 1
+                    if key in initial_stance:
+                        delta_val = abs(stance_val - initial_stance[key])
+
+            influence = influence_by_name.get(user_name)
+
+            if gender not in buckets["by_gender"]:
+                buckets["by_gender"][gender] = _demo_bucket_accumulator()
+            if country not in buckets["by_country"]:
+                buckets["by_country"][country] = _demo_bucket_accumulator()
+            if primary_platform not in buckets["by_platform"]:
+                buckets["by_platform"][primary_platform] = _demo_bucket_accumulator()
+
+            target_buckets = [
+                buckets["by_age_range"][age_bucket],
+                buckets["by_gender"][gender],
+                buckets["by_country"][country],
+                buckets["by_archetype"][archetype],
+                buckets["by_platform"][primary_platform],
+            ]
+
+            for b in target_buckets:
+                b["count"] += 1
+                if stance_val is not None:
+                    b["stances"].append(stance_val)
+                    if stance_val > 0.2:
+                        b["bullish"] += 1
+                    elif stance_val < -0.2:
+                        b["bearish"] += 1
+                    else:
+                        b["neutral"] += 1
+                if delta_val is not None:
+                    b["deltas"].append(delta_val)
+                if influence is not None:
+                    b["influences"].append(influence)
+
+        # Drop unknown buckets if empty so UI stays clean
+        for dim in ("by_age_range", "by_archetype"):
+            if buckets[dim].get("unknown", {}).get("count", 0) == 0:
+                buckets[dim].pop("unknown", None)
+
+        def _finalize_dimension(dim_buckets, preferred_order=None):
+            # Finalize each segment to a summary dict.
+            result = {seg: _demo_finalize_bucket(data) for seg, data in dim_buckets.items()}
+
+            if preferred_order is not None:
+                ordered = {k: result[k] for k in preferred_order if k in result}
+                extras = {k: v for k, v in result.items() if k not in ordered}
+                if extras:
+                    sorted_extras = sorted(
+                        extras.items(), key=lambda kv: kv[1]["count"], reverse=True
+                    )
+                    for k, v in sorted_extras:
+                        ordered[k] = v
+                result = ordered
+            else:
+                # Sort by descending count for readability, then alphabetically on ties.
+                result = dict(sorted(
+                    result.items(),
+                    key=lambda kv: (-kv[1]["count"], kv[0]),
+                ))
+            return result
+
+        breakdown = {
+            "by_age_range": _finalize_dimension(
+                buckets["by_age_range"],
+                preferred_order=_DEMO_AGE_BUCKETS + ["unknown"],
+            ),
+            "by_gender": _finalize_dimension(buckets["by_gender"]),
+            "by_country": _finalize_dimension(buckets["by_country"]),
+            "by_archetype": _finalize_dimension(
+                buckets["by_archetype"],
+                preferred_order=["individual", "institutional", "unknown"],
+            ),
+            "by_platform": _finalize_dimension(buckets["by_platform"]),
+        }
+
+        top_divergence = _demo_top_divergence(breakdown)
+
+        # Cap country breakdown to the 10 largest segments to avoid noisy tails.
+        if len(breakdown["by_country"]) > 10:
+            top_countries = list(breakdown["by_country"].items())[:10]
+            breakdown["by_country"] = dict(top_countries)
+
+        result = {
+            "dimensions": breakdown,
+            "top_divergence": top_divergence,
+            "meta": {
+                "total_agents": agents_in_profiles,
+                "agents_with_stance": agents_with_stance,
+                "has_trajectory": bool(final_stance),
+                "source": "reddit_profiles.json" if os.path.exists(
+                    os.path.join(sim_dir, "reddit_profiles.json")
+                ) else "twitter_profiles.csv",
+            },
+        }
+
+        try:
+            with open(cache_path, 'w', encoding='utf-8') as f:
+                json.dump(result, f, indent=2)
+        except Exception:
+            pass
+
+        return jsonify({"success": True, "data": result})
+
+    except Exception as e:
+        logger.error(f"Failed to compute demographic breakdown: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -363,3 +363,15 @@ export const getSimulationQuality = (simulationId) => {
   return service.get(`/api/simulation/${simulationId}/quality`)
 }
 
+/**
+ * Get demographic breakdown (age / gender / country / archetype / primary
+ * platform) cross-tabbed against final stance, stance volatility, and
+ * influence.
+ * @param {string} simulationId
+ * @param {Object} options - { refresh?: boolean }
+ */
+export const getDemographicBreakdown = (simulationId, options = {}) => {
+  const params = options.refresh ? { refresh: 'true' } : {}
+  return service.get(`/api/simulation/${simulationId}/demographics`, { params })
+}
+

--- a/frontend/src/components/DemographicBreakdown.vue
+++ b/frontend/src/components/DemographicBreakdown.vue
@@ -1,0 +1,582 @@
+<template>
+  <div class="demographic-breakdown">
+    <!-- Header -->
+    <div class="demo-header">
+      <div class="demo-title">
+        <span class="demo-icon">◇</span>
+        <span class="demo-label">DEMOGRAPHIC BREAKDOWN</span>
+      </div>
+      <div class="demo-header-actions">
+        <span v-if="meta" class="demo-meta">
+          {{ meta.agents_with_stance }}/{{ meta.total_agents }} agents with belief data
+        </span>
+        <button
+          class="demo-export-btn"
+          :disabled="!hasData"
+          @click="refresh"
+          title="Refresh demographic breakdown"
+        >
+          ↻ Refresh
+        </button>
+      </div>
+    </div>
+
+    <!-- Tab bar -->
+    <div v-if="hasData" class="demo-tabs">
+      <button
+        v-for="tab in availableTabs"
+        :key="tab.key"
+        class="demo-tab"
+        :class="{ active: activeTab === tab.key }"
+        @click="activeTab = tab.key"
+      >
+        {{ tab.label }}
+        <span class="demo-tab-count">{{ tabSegmentCount(tab.key) }}</span>
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="demo-state">
+      <div class="pulse-ring"></div>
+      <span>Computing demographic breakdown...</span>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="demo-state demo-error-state">{{ error }}</div>
+
+    <!-- No data -->
+    <div v-else-if="!hasData" class="demo-state">
+      <span>No demographic data available.</span>
+      <span class="demo-hint">Run a simulation to generate agent profiles.</span>
+    </div>
+
+    <!-- Main content -->
+    <div v-else class="demo-content">
+      <!-- Top divergence callout -->
+      <div v-if="topDivergence" class="demo-highlight">
+        <span class="demo-highlight-label">KEY SUBGROUP DYNAMIC</span>
+        <span class="demo-highlight-text">{{ topDivergence.headline }}</span>
+      </div>
+      <div v-else-if="meta && !meta.has_trajectory" class="demo-highlight demo-highlight-muted">
+        <span class="demo-highlight-label">NOTICE</span>
+        <span class="demo-highlight-text">
+          This simulation has no belief trajectory — stance comparisons will be
+          unavailable, but counts and influence remain accurate.
+        </span>
+      </div>
+
+      <!-- Legend -->
+      <div class="demo-legend">
+        <span class="legend-item"><span class="legend-dot bullish-dot"></span>Bullish</span>
+        <span class="legend-item"><span class="legend-dot neutral-dot"></span>Neutral</span>
+        <span class="legend-item"><span class="legend-dot bearish-dot"></span>Bearish</span>
+        <span class="legend-sep">·</span>
+        <span class="legend-item">Stance mean: -1 ↔ +1</span>
+      </div>
+
+      <!-- Segment list for active tab -->
+      <div class="demo-segments">
+        <div
+          v-for="segment in activeSegments"
+          :key="segment.label"
+          class="demo-row"
+        >
+          <div class="demo-row-head">
+            <span class="demo-row-label">{{ formatSegmentLabel(segment.label) }}</span>
+            <span class="demo-row-count">{{ segment.count }} agent{{ segment.count === 1 ? '' : 's' }}</span>
+          </div>
+
+          <!-- Stance distribution bar -->
+          <div class="stance-bar" v-if="hasStanceData(segment)">
+            <div
+              class="stance-seg stance-bullish"
+              :style="{ width: segment.bullish_pct + '%' }"
+              :title="`Bullish: ${segment.bullish_pct}%`"
+            ></div>
+            <div
+              class="stance-seg stance-neutral"
+              :style="{ width: segment.neutral_pct + '%' }"
+              :title="`Neutral: ${segment.neutral_pct}%`"
+            ></div>
+            <div
+              class="stance-seg stance-bearish"
+              :style="{ width: segment.bearish_pct + '%' }"
+              :title="`Bearish: ${segment.bearish_pct}%`"
+            ></div>
+          </div>
+          <div v-else class="stance-bar stance-empty"></div>
+
+          <!-- Metrics row -->
+          <div class="demo-metrics">
+            <span class="metric">
+              <span class="metric-label">mean</span>
+              <span class="metric-value" :class="stanceClass(segment.final_stance_mean)">
+                {{ formatStance(segment.final_stance_mean) }}
+              </span>
+            </span>
+            <span class="metric">
+              <span class="metric-label">σ</span>
+              <span class="metric-value">{{ formatNumber(segment.final_stance_std) }}</span>
+            </span>
+            <span class="metric">
+              <span class="metric-label">volatility</span>
+              <span class="metric-value">{{ formatNumber(segment.stance_volatility) }}</span>
+            </span>
+            <span class="metric">
+              <span class="metric-label">influence</span>
+              <span class="metric-value">{{ formatInfluence(segment.influence_mean) }}</span>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer hint -->
+      <div class="demo-footer-hint">
+        Stance values average each agent's final belief across tracked topics
+        (-1 bearish → +1 bullish). Volatility is the mean absolute change from
+        round 0 to the final round.
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import { getDemographicBreakdown } from '../api/simulation'
+
+const props = defineProps({
+  simulationId: { type: String, required: true },
+  visible: { type: Boolean, default: false },
+})
+
+const loading = ref(false)
+const error = ref('')
+const payload = ref(null)
+const activeTab = ref('by_age_range')
+
+const TABS = [
+  { key: 'by_age_range', label: 'Age' },
+  { key: 'by_gender', label: 'Gender' },
+  { key: 'by_country', label: 'Country' },
+  { key: 'by_archetype', label: 'Actor type' },
+  { key: 'by_platform', label: 'Platform' },
+]
+
+const hasData = computed(() => !!payload.value?.dimensions)
+const meta = computed(() => payload.value?.meta || null)
+const topDivergence = computed(() => payload.value?.top_divergence || null)
+
+const availableTabs = computed(() => {
+  if (!hasData.value) return []
+  return TABS.filter(t => {
+    const dim = payload.value.dimensions[t.key]
+    return dim && Object.keys(dim).length > 0
+  })
+})
+
+const tabSegmentCount = (key) => {
+  if (!hasData.value) return 0
+  const dim = payload.value.dimensions[key]
+  return dim ? Object.keys(dim).length : 0
+}
+
+const activeSegments = computed(() => {
+  if (!hasData.value) return []
+  const dim = payload.value.dimensions[activeTab.value] || {}
+  return Object.entries(dim).map(([label, data]) => ({ label, ...data }))
+})
+
+const hasStanceData = (segment) =>
+  (segment.bullish_pct + segment.neutral_pct + segment.bearish_pct) > 0
+
+const formatSegmentLabel = (raw) => {
+  if (!raw) return 'unknown'
+  const map = {
+    unknown: 'Unknown',
+    individual: 'Individual',
+    institutional: 'Institutional',
+    inactive: 'Inactive',
+    male: 'Male',
+    female: 'Female',
+    other: 'Other',
+    twitter: 'X / Twitter',
+    reddit: 'Reddit',
+    polymarket: 'Polymarket',
+  }
+  return map[raw] || raw
+}
+
+const formatStance = (v) => {
+  if (v === null || v === undefined) return '—'
+  const sign = v > 0 ? '+' : ''
+  return sign + v.toFixed(2)
+}
+
+const formatNumber = (v) => {
+  if (v === null || v === undefined) return '—'
+  return v.toFixed(2)
+}
+
+const formatInfluence = (v) => {
+  if (v === null || v === undefined) return '—'
+  return v.toFixed(0)
+}
+
+const stanceClass = (v) => {
+  if (v === null || v === undefined) return ''
+  if (v > 0.1) return 'stance-val-bullish'
+  if (v < -0.1) return 'stance-val-bearish'
+  return 'stance-val-neutral'
+}
+
+const load = async (opts = {}) => {
+  if (!props.simulationId) return
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await getDemographicBreakdown(props.simulationId, opts)
+    if (res.success && res.data) {
+      payload.value = res.data
+      const first = availableTabs.value[0]
+      if (first && !availableTabs.value.find(t => t.key === activeTab.value)) {
+        activeTab.value = first.key
+      }
+    } else if (res.success && !res.data) {
+      payload.value = null
+    } else {
+      error.value = res.error || 'Failed to load demographic breakdown.'
+    }
+  } catch (err) {
+    error.value = err.message || 'Failed to load demographic breakdown.'
+  } finally {
+    loading.value = false
+  }
+}
+
+const refresh = () => load({ refresh: true })
+
+watch(() => props.visible, (val) => { if (val) load() })
+watch(() => props.simulationId, () => { if (props.visible) load() })
+onMounted(() => { if (props.visible) load() })
+</script>
+
+<style scoped>
+.demographic-breakdown {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  font-family: var(--font-mono);
+  background: var(--background);
+}
+
+.demo-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.08);
+  flex-shrink: 0;
+}
+
+.demo-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.demo-icon {
+  color: #ec4899;
+  font-size: 14px;
+}
+
+.demo-label {
+  font-size: 12px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.5);
+}
+
+.demo-header-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.demo-meta {
+  font-size: 10px;
+  letter-spacing: 1px;
+  color: rgba(10,10,10,0.4);
+}
+
+.demo-export-btn {
+  background: none;
+  border: 1px solid rgba(10,10,10,0.15);
+  padding: 4px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 1px;
+  cursor: pointer;
+  color: rgba(10,10,10,0.5);
+  transition: all 0.15s ease;
+}
+
+.demo-export-btn:hover:not(:disabled) {
+  border-color: #ec4899;
+  color: #ec4899;
+}
+
+.demo-export-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.demo-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 12px;
+  border-bottom: 1px solid rgba(10,10,10,0.05);
+  flex-shrink: 0;
+  overflow-x: auto;
+}
+
+.demo-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 10px 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.4);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.demo-tab:hover {
+  color: rgba(10,10,10,0.7);
+}
+
+.demo-tab.active {
+  color: #ec4899;
+  border-bottom-color: #ec4899;
+}
+
+.demo-tab-count {
+  font-size: 9px;
+  opacity: 0.5;
+  background: rgba(10,10,10,0.06);
+  padding: 1px 5px;
+  border-radius: 8px;
+  letter-spacing: 0;
+}
+
+.demo-tab.active .demo-tab-count {
+  background: rgba(236,72,153,0.15);
+  color: #ec4899;
+  opacity: 1;
+}
+
+.demo-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 8px;
+  color: rgba(10,10,10,0.4);
+  font-size: 12px;
+  letter-spacing: 1px;
+}
+
+.demo-error-state {
+  color: rgba(239,68,68,0.8);
+}
+
+.demo-hint {
+  font-size: 10px;
+  color: rgba(10,10,10,0.3);
+}
+
+.pulse-ring {
+  width: 24px;
+  height: 24px;
+  border: 2px solid rgba(236,72,153,0.15);
+  border-top-color: rgba(236,72,153,0.7);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.demo-content {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  flex: 1;
+  padding: 12px 16px 16px;
+  gap: 14px;
+}
+
+.demo-highlight {
+  background: rgba(236,72,153,0.06);
+  border-left: 3px solid #ec4899;
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.demo-highlight-muted {
+  background: rgba(10,10,10,0.04);
+  border-left-color: rgba(10,10,10,0.2);
+}
+
+.demo-highlight-label {
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: #ec4899;
+  text-transform: uppercase;
+}
+
+.demo-highlight-muted .demo-highlight-label {
+  color: rgba(10,10,10,0.4);
+}
+
+.demo-highlight-text {
+  font-size: 12px;
+  color: rgba(10,10,10,0.8);
+  line-height: 1.5;
+}
+
+.demo-legend {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+  font-size: 10px;
+  color: rgba(10,10,10,0.4);
+  letter-spacing: 1px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.bullish-dot { background: rgba(20,184,166,0.8); }
+.neutral-dot { background: rgba(148,163,184,0.8); }
+.bearish-dot { background: rgba(239,68,68,0.8); }
+
+.legend-sep {
+  color: rgba(10,10,10,0.15);
+}
+
+.demo-segments {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.demo-row {
+  padding: 10px 12px;
+  background: rgba(10,10,10,0.02);
+  border: 1px solid rgba(10,10,10,0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.demo-row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.demo-row-label {
+  font-size: 12px;
+  color: rgba(10,10,10,0.8);
+  letter-spacing: 0.5px;
+}
+
+.demo-row-count {
+  font-size: 10px;
+  color: rgba(10,10,10,0.4);
+  letter-spacing: 1px;
+}
+
+.stance-bar {
+  display: flex;
+  height: 8px;
+  background: rgba(10,10,10,0.04);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.stance-bar.stance-empty {
+  opacity: 0.4;
+}
+
+.stance-seg {
+  height: 100%;
+  transition: width 0.25s ease;
+}
+
+.stance-bullish { background: rgba(20,184,166,0.75); }
+.stance-neutral { background: rgba(148,163,184,0.55); }
+.stance-bearish { background: rgba(239,68,68,0.75); }
+
+.demo-metrics {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding-top: 2px;
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 56px;
+}
+
+.metric-label {
+  font-size: 9px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.35);
+}
+
+.metric-value {
+  font-size: 13px;
+  color: rgba(10,10,10,0.85);
+  letter-spacing: 0.5px;
+}
+
+.stance-val-bullish { color: rgba(13,148,136,0.95); }
+.stance-val-bearish { color: rgba(220,38,38,0.95); }
+.stance-val-neutral { color: rgba(100,116,139,0.9); }
+
+.demo-footer-hint {
+  font-size: 10px;
+  color: rgba(10,10,10,0.35);
+  line-height: 1.6;
+  border-top: 1px solid rgba(10,10,10,0.05);
+  padding-top: 10px;
+  margin-top: 4px;
+}
+</style>

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -54,7 +54,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showInfluence }"
-        @click="showInfluence = !showInfluence; showBeliefDrift = false; showDirector = false; showNetwork = false"
+        @click="showInfluence = !showInfluence; showBeliefDrift = false; showDirector = false; showNetwork = false; showDemographics = false"
         title="Agent influence leaderboard"
       >
         ◈ Influence
@@ -65,7 +65,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showBeliefDrift }"
-        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false; showDirector = false; showNetwork = false"
+        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false; showDirector = false; showNetwork = false; showDemographics = false"
         title="Aggregate belief drift chart"
       >
         ◎ Drift
@@ -76,10 +76,21 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showNetwork }"
-        @click="showNetwork = !showNetwork; showInfluence = false; showBeliefDrift = false; showDirector = false"
+        @click="showNetwork = !showNetwork; showInfluence = false; showBeliefDrift = false; showDirector = false; showDemographics = false"
         title="Agent interaction network graph"
       >
         ⬡ Network
+      </button>
+
+      <!-- Demographic Breakdown toggle -->
+      <button
+        v-if="allActions.length > 0"
+        class="action-btn secondary"
+        :class="{ active: showDemographics }"
+        @click="showDemographics = !showDemographics; showInfluence = false; showBeliefDrift = false; showDirector = false; showNetwork = false"
+        title="Agent demographic breakdown (age, gender, country, actor type, platform)"
+      >
+        ◇ Demographics
       </button>
 
       <!-- Director Mode toggle (only while simulation is running) -->
@@ -87,7 +98,7 @@
         v-if="phase === 1"
         class="action-btn secondary director-btn"
         :class="{ active: showDirector }"
-        @click="showDirector = !showDirector; showInfluence = false; showBeliefDrift = false; showNetwork = false"
+        @click="showDirector = !showDirector; showInfluence = false; showBeliefDrift = false; showNetwork = false; showDemographics = false"
         :title="directorEventsTotal >= 10 ? 'Director Mode — max events reached' : 'Director Mode — inject a breaking event into the simulation'"
       >
         ⚡ Director
@@ -249,6 +260,14 @@
       class="influence-overlay"
     />
 
+    <!-- Demographic Breakdown (overlay when toggled) -->
+    <DemographicBreakdown
+      v-if="showDemographics"
+      :simulationId="simulationId"
+      :visible="showDemographics"
+      class="influence-overlay"
+    />
+
     <!-- Director Mode Panel (overlay when toggled) -->
     <div v-if="showDirector" class="influence-overlay director-panel">
       <div class="director-header">
@@ -315,7 +334,7 @@
     </div>
 
     <!-- Main Content: Dual Timeline -->
-    <div v-show="!showInfluence && !showBeliefDrift && !showDirector && !showNetwork" class="main-content-area" ref="scrollContainer" @scroll="onTimelineScroll">
+    <div v-show="!showInfluence && !showBeliefDrift && !showDirector && !showNetwork && !showDemographics" class="main-content-area" ref="scrollContainer" @scroll="onTimelineScroll">
       <!-- Scroll to bottom button -->
       <button
         v-if="showScrollBtn"
@@ -664,6 +683,7 @@ import { renderMarkdown } from '../utils/markdown'
 import InfluenceLeaderboard from './InfluenceLeaderboard.vue'
 import BeliefDriftChart from './BeliefDriftChart.vue'
 import InteractionNetwork from './InteractionNetwork.vue'
+import DemographicBreakdown from './DemographicBreakdown.vue'
 
 const props = defineProps({
   simulationId: String,
@@ -699,6 +719,7 @@ const filteredPlatform = ref(null)
 const showInfluence = ref(false)
 const showBeliefDrift = ref(false)
 const showNetwork = ref(false)
+const showDemographics = ref(false)
 
 // Article drawer state
 const showArticleDrawer = ref(false)


### PR DESCRIPTION
## What
Adds a **Demographics** tab alongside Influence / Drift / Network that cross-tabs every agent's persona attributes — age range, gender, country, actor type (individual vs institutional), and primary platform — against final stance, stance volatility, and influence score. Uses data that already exists (`reddit_profiles.json` + `trajectory.json` + action logs), so no new collection is required. The most striking cross-segment stance gap across all five dimensions is surfaced as a `KEY SUBGROUP DYNAMIC` callout at the top of the panel.

## Why
The influence leaderboard ranks agents individually; the belief drift chart shows aggregate stance over time. Neither answers the subgroup question researchers actually ask — *did institutional actors land in a different place from individuals? Did one age cohort flip earlier than another? Which platform was most polarized?* Persona data already carries the answer (age / gender / country / \`source_entity_type\`), so the only missing piece was the analytical lens.

Picks up idea #4 from \`repo-actions-2026-04-15.md\`. The Apr 16 batch had only **Multi-Document Mode** outstanding, which was explicitly deferred as a larger standalone PR earlier today, so this run reaches back to the previous batch for a shippable small-effort analytics idea that complements the recently merged **Quality Diagnostics** (#32) and **Interaction Network** (#33).

## Changes
- **backend/app/api/simulation.py** — new \`GET /<sim_id>/demographics\` endpoint + helpers.
  - \`_demo_age_bucket\` / \`_demo_classify_archetype\` (mirrors the \`OasisProfileGenerator\` INDIVIDUAL_ENTITY_TYPES / GROUP_ENTITY_TYPES / INDIVIDUAL_TYPE_KEYWORDS taxonomy).
  - \`_demo_load_profiles\` reads \`reddit_profiles.json\` first, falls back to \`twitter_profiles.csv\` via \`csv.DictReader\`.
  - \`_demo_extract_stances\` pulls both the first-snapshot and final-snapshot \`belief_positions\` from \`trajectory.json\` so volatility can be computed as mean |final − initial|.
  - Reuses \`_compute_influence_ranked\` to attach per-segment influence means and to look up each agent's primary platform.
  - For each of the 5 dimensions it computes per-segment \`final_stance_mean\`, \`final_stance_std\`, \`stance_volatility\`, \`influence_mean\`, and bullish/neutral/bearish percentages. Age buckets follow a stable \`<18 / 18-24 / 25-34 / 35-44 / 45-54 / 55+\` ordering; country is capped at the 10 largest segments; empty \`unknown\` buckets drop out so the UI stays clean.
  - \`_demo_top_divergence\` sweeps all dimensions and returns the largest stance gap between any two segments (≥ 0.05 threshold, ≥ 2 agents per segment) as a plain-English headline.
  - Result is cached in \`<sim_dir>/demographics.json\`; \`?refresh=1\` bypasses the cache.
- **frontend/src/components/DemographicBreakdown.vue** — new overlay (~500 lines). Tab bar across the five dimensions with a count badge per tab, one card per segment showing label + agent count, a stacked bullish/neutral/bearish distribution bar, and four metric columns (mean / σ / volatility / influence). \`KEY SUBGROUP DYNAMIC\` callout for the top divergence, a muted variant when no \`trajectory.json\` is available. Refresh button forces a recompute.
- **frontend/src/components/Step3Simulation.vue** — registers the new component, adds a \`◇ Demographics\` toggle alongside the existing Influence / Drift / Network / Director buttons with matching mutual-exclusion behavior, hides the main feed while it is visible.
- **frontend/src/api/simulation.js** — \`getDemographicBreakdown(simulationId, { refresh })\` helper.

---
*Built autonomously by Aeon.*