### PR TITLE
feat: agent counterfactual explorer ("What If?")

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -2559,6 +2559,235 @@ def get_belief_drift(simulation_id: str):
         }), 500
 
 
+# ============== Counterfactual Explorer ("What If?") ==============
+
+
+def _drift_from_positions_by_agent(snapshots, allowed_agent_ids=None):
+    """Compute per-round bullish/neutral/bearish % from trajectory snapshots.
+
+    If allowed_agent_ids is None, includes every agent. Otherwise only agents
+    whose stringified id is in the set are counted.
+
+    Returns a dict with the same shape as the belief-drift endpoint plus
+    a `final_bullish_pct` convenience key.
+    """
+    rounds = []
+    bullish = []
+    neutral = []
+    bearish = []
+
+    for snap in snapshots:
+        belief_positions = snap.get("belief_positions") or {}
+        if not belief_positions:
+            continue
+
+        agent_stances = []
+        for aid, positions in belief_positions.items():
+            if allowed_agent_ids is not None and str(aid) not in allowed_agent_ids:
+                continue
+            if positions:
+                agent_stances.append(sum(positions.values()) / len(positions))
+
+        if not agent_stances:
+            continue
+
+        total = len(agent_stances)
+        n_bullish = sum(1 for s in agent_stances if s > 0.2)
+        n_bearish = sum(1 for s in agent_stances if s < -0.2)
+        n_neutral = total - n_bullish - n_bearish
+
+        rounds.append(snap.get("round_num", 0))
+        bullish.append(round(n_bullish / total * 100, 1))
+        neutral.append(round(n_neutral / total * 100, 1))
+        bearish.append(round(n_bearish / total * 100, 1))
+
+    consensus_round = None
+    consensus_stance = None
+    for i, r in enumerate(rounds):
+        if bullish[i] > 50:
+            consensus_round = r
+            consensus_stance = "bullish"
+            break
+        if bearish[i] > 50:
+            consensus_round = r
+            consensus_stance = "bearish"
+            break
+
+    return {
+        "rounds": rounds,
+        "bullish": bullish,
+        "neutral": neutral,
+        "bearish": bearish,
+        "consensus_round": consensus_round,
+        "consensus_stance": consensus_stance,
+        "final_bullish_pct": bullish[-1] if bullish else None,
+        "final_neutral_pct": neutral[-1] if neutral else None,
+        "final_bearish_pct": bearish[-1] if bearish else None,
+        "agent_count": None,
+    }
+
+
+@simulation_bp.route('/<simulation_id>/counterfactual', methods=['GET'])
+def get_counterfactual_drift(simulation_id: str):
+    """
+    Recompute belief drift with a subset of agents excluded ("What If?" analysis).
+
+    Query params:
+        exclude_agents: comma-separated agent usernames to remove from the analysis.
+
+    Returns both the original drift and the counterfactual drift so the UI can
+    render them on shared axes, plus the headline `delta_final_bullish` which is
+    the finding researchers typically cite (e.g. "removing Agent X shifted
+    consensus by 23 points").
+
+    Pure data transform over trajectory.json — no LLM calls, no re-simulation.
+    """
+    try:
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        if not os.path.exists(sim_dir):
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        trajectory_path = os.path.join(sim_dir, "trajectory.json")
+        if not os.path.exists(trajectory_path):
+            return jsonify({
+                "success": True,
+                "data": None,
+                "message": (
+                    "No belief trajectory data available. The simulation may not "
+                    "have used the belief tracking system."
+                )
+            })
+
+        with open(trajectory_path, 'r', encoding='utf-8') as f:
+            traj = json.load(f)
+
+        snapshots = traj.get("snapshots", [])
+        topics = traj.get("topics", [])
+
+        raw_exclude = request.args.get('exclude_agents', '') or ''
+        exclude_names = [n.strip() for n in raw_exclude.split(',') if n.strip()]
+
+        # Build username -> str(user_id) map from the profiles file.
+        profiles = _demo_load_profiles(sim_dir)
+        name_to_id = {}
+        for p in profiles:
+            if not isinstance(p, dict):
+                continue
+            uid = p.get('user_id') or p.get('agent_id') or p.get('id')
+            uname = p.get('user_name') or p.get('username') or p.get('name')
+            if uid is not None and uname:
+                name_to_id[str(uname)] = str(uid)
+
+        # Resolve names to ids, tracking which we matched vs. missed.
+        excluded_ids = set()
+        resolved = []
+        unresolved = []
+        for n in exclude_names:
+            aid = name_to_id.get(n)
+            if aid is not None:
+                excluded_ids.add(aid)
+                resolved.append({"agent_name": n, "agent_id": aid})
+            else:
+                unresolved.append(n)
+
+        # Set of agent ids present in the trajectory (all snapshots union).
+        all_ids = set()
+        for snap in snapshots:
+            for aid in (snap.get("belief_positions") or {}).keys():
+                all_ids.add(str(aid))
+
+        allowed_ids = all_ids - excluded_ids
+
+        original = _drift_from_positions_by_agent(snapshots, allowed_agent_ids=None)
+        original["agent_count"] = len(all_ids)
+
+        if excluded_ids:
+            counterfactual = _drift_from_positions_by_agent(
+                snapshots, allowed_agent_ids=allowed_ids
+            )
+            counterfactual["agent_count"] = len(allowed_ids)
+        else:
+            counterfactual = None
+
+        def _delta(a, b):
+            if a is None or b is None:
+                return None
+            return round(a - b, 1)
+
+        delta_final_bullish = None
+        delta_final_bearish = None
+        delta_consensus_round = None
+        if counterfactual is not None:
+            delta_final_bullish = _delta(
+                counterfactual.get("final_bullish_pct"),
+                original.get("final_bullish_pct"),
+            )
+            delta_final_bearish = _delta(
+                counterfactual.get("final_bearish_pct"),
+                original.get("final_bearish_pct"),
+            )
+            cf_r = counterfactual.get("consensus_round")
+            or_r = original.get("consensus_round")
+            if cf_r is not None and or_r is not None:
+                delta_consensus_round = cf_r - or_r
+
+        def _impact_badge(delta):
+            if delta is None:
+                return None
+            mag = abs(delta)
+            if mag >= 15:
+                return "strong"
+            if mag >= 5:
+                return "moderate"
+            return "minimal"
+
+        impact = _impact_badge(delta_final_bullish)
+
+        summary = None
+        if counterfactual is not None and delta_final_bullish is not None:
+            names_str = ", ".join(r["agent_name"] for r in resolved) or "selected agents"
+            direction = "increased" if delta_final_bullish > 0 else (
+                "decreased" if delta_final_bullish < 0 else "did not change"
+            )
+            if delta_final_bullish == 0:
+                summary = (
+                    f"Removing {names_str} did not change final bullish share "
+                    f"({original['final_bullish_pct']}%)."
+                )
+            else:
+                summary = (
+                    f"Removing {names_str} would have {direction} final bullish "
+                    f"share from {original['final_bullish_pct']}% to "
+                    f"{counterfactual['final_bullish_pct']}% "
+                    f"({'+' if delta_final_bullish > 0 else ''}{delta_final_bullish} pts)."
+                )
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "original": original,
+                "counterfactual": counterfactual,
+                "excluded_requested": exclude_names,
+                "excluded_resolved": resolved,
+                "excluded_unresolved": unresolved,
+                "topics": topics,
+                "delta_final_bullish": delta_final_bullish,
+                "delta_final_bearish": delta_final_bearish,
+                "delta_consensus_round": delta_consensus_round,
+                "impact": impact,
+                "summary": summary,
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"Failed to compute counterfactual drift: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
 # ============== Quality Diagnostics ==============
 
 @simulation_bp.route('/<simulation_id>/quality', methods=['GET'])

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -253,6 +253,21 @@ export const getBeliefDrift = (simulationId) => {
 }
 
 /**
+ * Recompute belief drift excluding a subset of agents ("What If?" analysis).
+ * Pure data transform — no re-simulation, returns both original and
+ * counterfactual drift curves plus headline deltas.
+ * @param {string} simulationId
+ * @param {string[]} excludeAgents - agent usernames to remove from analysis
+ */
+export const getCounterfactualDrift = (simulationId, excludeAgents = []) => {
+  const params = {}
+  if (excludeAgents && excludeAgents.length) {
+    params.exclude_agents = excludeAgents.join(',')
+  }
+  return service.get(`/api/simulation/${simulationId}/counterfactual`, { params })
+}
+
+/**
  * Fork a simulation — copies agent profiles and config into a new simulation
  * that is immediately ready to run.
  * @param {Object} data - { parent_simulation_id, simulation_requirement? }

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -54,7 +54,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showInfluence }"
-        @click="showInfluence = !showInfluence; showBeliefDrift = false; showDirector = false; showNetwork = false; showDemographics = false"
+        @click="showInfluence = !showInfluence; showBeliefDrift = false; showDirector = false; showNetwork = false; showDemographics = false; showWhatIf = false"
         title="Agent influence leaderboard"
       >
         ◈ Influence
@@ -65,7 +65,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showBeliefDrift }"
-        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false; showDirector = false; showNetwork = false; showDemographics = false"
+        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false; showDirector = false; showNetwork = false; showDemographics = false; showWhatIf = false"
         title="Aggregate belief drift chart"
       >
         ◎ Drift
@@ -76,7 +76,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showNetwork }"
-        @click="showNetwork = !showNetwork; showInfluence = false; showBeliefDrift = false; showDirector = false; showDemographics = false"
+        @click="showNetwork = !showNetwork; showInfluence = false; showBeliefDrift = false; showDirector = false; showDemographics = false; showWhatIf = false"
         title="Agent interaction network graph"
       >
         ⬡ Network
@@ -87,10 +87,21 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showDemographics }"
-        @click="showDemographics = !showDemographics; showInfluence = false; showBeliefDrift = false; showDirector = false; showNetwork = false"
+        @click="showDemographics = !showDemographics; showInfluence = false; showBeliefDrift = false; showDirector = false; showNetwork = false; showWhatIf = false"
         title="Agent demographic breakdown (age, gender, country, actor type, platform)"
       >
         ◇ Demographics
+      </button>
+
+      <!-- What If? Counterfactual toggle -->
+      <button
+        v-if="allActions.length > 0"
+        class="action-btn secondary"
+        :class="{ active: showWhatIf }"
+        @click="showWhatIf = !showWhatIf; showInfluence = false; showBeliefDrift = false; showDirector = false; showNetwork = false; showDemographics = false"
+        title="What If? — remove agents and recompute belief drift from existing trajectory"
+      >
+        ◐ What If?
       </button>
 
       <!-- Director Mode toggle (only while simulation is running) -->
@@ -98,7 +109,7 @@
         v-if="phase === 1"
         class="action-btn secondary director-btn"
         :class="{ active: showDirector }"
-        @click="showDirector = !showDirector; showInfluence = false; showBeliefDrift = false; showNetwork = false; showDemographics = false"
+        @click="showDirector = !showDirector; showInfluence = false; showBeliefDrift = false; showNetwork = false; showDemographics = false; showWhatIf = false"
         :title="directorEventsTotal >= 10 ? 'Director Mode — max events reached' : 'Director Mode — inject a breaking event into the simulation'"
       >
         ⚡ Director
@@ -265,6 +276,14 @@
       v-if="showDemographics"
       :simulationId="simulationId"
       :visible="showDemographics"
+      class="influence-overlay"
+    />
+
+    <!-- What If? Counterfactual (overlay when toggled) -->
+    <WhatIfPanel
+      v-if="showWhatIf"
+      :simulationId="simulationId"
+      :visible="showWhatIf"
       class="influence-overlay"
     />
 
@@ -684,6 +703,7 @@ import InfluenceLeaderboard from './InfluenceLeaderboard.vue'
 import BeliefDriftChart from './BeliefDriftChart.vue'
 import InteractionNetwork from './InteractionNetwork.vue'
 import DemographicBreakdown from './DemographicBreakdown.vue'
+import WhatIfPanel from './WhatIfPanel.vue'
 
 const props = defineProps({
   simulationId: String,
@@ -720,6 +740,7 @@ const showInfluence = ref(false)
 const showBeliefDrift = ref(false)
 const showNetwork = ref(false)
 const showDemographics = ref(false)
+const showWhatIf = ref(false)
 
 // Article drawer state
 const showArticleDrawer = ref(false)

--- a/frontend/src/components/WhatIfPanel.vue
+++ b/frontend/src/components/WhatIfPanel.vue
@@ -1,0 +1,761 @@
+<template>
+  <div class="what-if">
+    <!-- Header -->
+    <div class="wi-header">
+      <div class="wi-title">
+        <span class="wi-icon">◐</span>
+        <span class="wi-label">WHAT IF? — COUNTERFACTUAL</span>
+      </div>
+      <button
+        class="wi-export-btn"
+        :disabled="!hasChartData"
+        @click="downloadPNG"
+        title="Download chart as PNG"
+      >
+        Export PNG ↓
+      </button>
+    </div>
+
+    <div class="wi-hint">
+      Pick up to {{ MAX_PICKS }} agents to remove, then recompute to see how
+      consensus would have shifted. Uses existing trajectory data — no re-run.
+    </div>
+
+    <!-- Loading agents -->
+    <div v-if="agentsLoading" class="wi-state">
+      <div class="pulse-ring"></div>
+      <span>Loading agents...</span>
+    </div>
+
+    <!-- No agents -->
+    <div v-else-if="!agents.length" class="wi-state">
+      <span>No influence data yet — run the simulation first.</span>
+    </div>
+
+    <template v-else>
+      <!-- Agent picker row -->
+      <div class="wi-picker">
+        <div class="wi-picker-header">
+          <span class="wi-picker-title">Top agents by influence</span>
+          <button
+            v-if="selectedNames.length"
+            class="wi-clear"
+            @click="clearSelection"
+          >Clear ({{ selectedNames.length }})</button>
+        </div>
+        <div class="wi-agent-grid">
+          <label
+            v-for="a in agents"
+            :key="a.agent_name"
+            class="wi-agent-card"
+            :class="{
+              selected: selectedSet.has(a.agent_name),
+              disabled: !selectedSet.has(a.agent_name) && selectedNames.length >= MAX_PICKS
+            }"
+          >
+            <input
+              type="checkbox"
+              class="wi-check"
+              :checked="selectedSet.has(a.agent_name)"
+              :disabled="!selectedSet.has(a.agent_name) && selectedNames.length >= MAX_PICKS"
+              @change="toggleAgent(a.agent_name)"
+            />
+            <span class="wi-rank">#{{ a.rank }}</span>
+            <span class="wi-agent-name">{{ a.agent_name }}</span>
+            <span class="wi-agent-score">{{ a.influence_score }}</span>
+          </label>
+        </div>
+        <div class="wi-actions">
+          <button
+            class="wi-recompute"
+            :disabled="!selectedNames.length || computing"
+            @click="compute"
+          >
+            <span v-if="computing" class="wi-spinner"></span>
+            {{ computing ? 'Recomputing...' : 'Recompute counterfactual' }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Error -->
+      <div v-if="error" class="wi-state wi-error">{{ error }}</div>
+
+      <!-- Chart + summary -->
+      <div v-if="hasChartData" class="wi-result">
+        <div class="wi-chart-wrap">
+          <svg
+            :viewBox="`0 0 ${W} ${H}`"
+            preserveAspectRatio="xMidYMid meet"
+            class="wi-svg"
+            ref="svgRef"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <!-- Grid -->
+            <g v-for="pct in [0, 25, 50, 75, 100]" :key="'g' + pct">
+              <line
+                :x1="ML" :y1="yS(pct)"
+                :x2="W - MR" :y2="yS(pct)"
+                stroke="rgba(10,10,10,0.06)" stroke-width="1"
+              />
+              <text
+                :x="ML - 5" :y="yS(pct) + 4"
+                fill="rgba(10,10,10,0.35)" font-size="9"
+                font-family="monospace" text-anchor="end"
+              >{{ pct }}%</text>
+            </g>
+
+            <!-- 50% consensus line -->
+            <line
+              :x1="ML" :y1="yS(50)"
+              :x2="W - MR" :y2="yS(50)"
+              stroke="rgba(10,10,10,0.18)" stroke-width="1"
+              stroke-dasharray="2,3"
+            />
+
+            <!-- Original bullish curve (muted, dashed) -->
+            <path
+              :d="originalPath"
+              fill="none"
+              stroke="rgba(20,184,166,0.55)"
+              stroke-width="1.5"
+              stroke-dasharray="5,3"
+            />
+
+            <!-- Counterfactual bullish curve (solid, highlighted) -->
+            <path
+              :d="counterfactualPath"
+              fill="none"
+              stroke="rgba(20,184,166,1)"
+              stroke-width="2.2"
+            />
+
+            <!-- Endpoint dots -->
+            <circle
+              v-if="origEnd"
+              :cx="origEnd.x" :cy="origEnd.y"
+              r="3"
+              fill="rgba(20,184,166,0.55)"
+            />
+            <circle
+              v-if="cfEnd"
+              :cx="cfEnd.x" :cy="cfEnd.y"
+              r="4"
+              fill="rgba(20,184,166,1)"
+              stroke="#FAFAFA" stroke-width="1.5"
+            />
+
+            <!-- Consensus markers -->
+            <g v-if="origData?.consensus_round != null">
+              <line
+                :x1="xS(origData.consensus_round)" :y1="MT"
+                :x2="xS(origData.consensus_round)" :y2="H - MB"
+                stroke="rgba(10,10,10,0.4)" stroke-width="1"
+                stroke-dasharray="3,3"
+              />
+              <text
+                :x="xS(origData.consensus_round) + 4" :y="MT + 10"
+                fill="rgba(10,10,10,0.5)" font-size="9" font-family="monospace"
+              >orig r{{ origData.consensus_round }}</text>
+            </g>
+            <g v-if="cfData?.consensus_round != null && cfData.consensus_round !== origData?.consensus_round">
+              <line
+                :x1="xS(cfData.consensus_round)" :y1="MT"
+                :x2="xS(cfData.consensus_round)" :y2="H - MB"
+                stroke="rgba(245,158,11,0.7)" stroke-width="1.2"
+                stroke-dasharray="3,3"
+              />
+              <text
+                :x="xS(cfData.consensus_round) + 4" :y="MT + 22"
+                fill="rgba(245,158,11,0.85)" font-size="9" font-family="monospace"
+              >cf r{{ cfData.consensus_round }}</text>
+            </g>
+
+            <!-- X axis -->
+            <text
+              v-for="r in xTicks"
+              :key="'xt' + r"
+              :x="xS(r)" :y="H - MB + 13"
+              fill="rgba(10,10,10,0.35)" font-size="9"
+              font-family="monospace" text-anchor="middle"
+            >{{ r }}</text>
+            <text
+              :x="ML + (W - ML - MR) / 2" :y="H - 2"
+              fill="rgba(10,10,10,0.3)" font-size="9"
+              font-family="monospace" text-anchor="middle"
+            >Round — bullish %</text>
+          </svg>
+
+          <div class="wi-legend">
+            <span class="wi-legend-item">
+              <span class="wi-legend-swatch orig"></span>
+              Original ({{ origData?.agent_count ?? '–' }} agents)
+            </span>
+            <span class="wi-legend-item">
+              <span class="wi-legend-swatch cf"></span>
+              Counterfactual ({{ cfData?.agent_count ?? '–' }} agents)
+            </span>
+          </div>
+        </div>
+
+        <!-- Impact summary -->
+        <div class="wi-impact">
+          <div class="wi-impact-row">
+            <span class="wi-impact-label">Final bullish share</span>
+            <span class="wi-impact-values">
+              <span class="wi-val orig">{{ fmtPct(origData?.final_bullish_pct) }}</span>
+              <span class="wi-arrow">→</span>
+              <span class="wi-val cf">{{ fmtPct(cfData?.final_bullish_pct) }}</span>
+              <span
+                v-if="result?.delta_final_bullish != null"
+                class="wi-delta"
+                :class="deltaClass(result.delta_final_bullish)"
+              >{{ fmtDelta(result.delta_final_bullish) }} pts</span>
+            </span>
+          </div>
+          <div class="wi-impact-row">
+            <span class="wi-impact-label">Consensus round</span>
+            <span class="wi-impact-values">
+              <span class="wi-val orig">{{ fmtRound(origData?.consensus_round) }}</span>
+              <span class="wi-arrow">→</span>
+              <span class="wi-val cf">{{ fmtRound(cfData?.consensus_round) }}</span>
+              <span
+                v-if="result?.delta_consensus_round != null"
+                class="wi-delta"
+                :class="deltaClass(result.delta_consensus_round, true)"
+              >{{ fmtDelta(result.delta_consensus_round) }} rounds</span>
+            </span>
+          </div>
+          <div v-if="result?.impact" class="wi-impact-badge-row">
+            <span
+              class="wi-impact-badge"
+              :class="'impact-' + result.impact"
+            >{{ impactLabel(result.impact) }} influence</span>
+          </div>
+          <div v-if="result?.summary" class="wi-summary">
+            {{ result.summary }}
+          </div>
+          <div v-if="result?.excluded_unresolved?.length" class="wi-warn">
+            Couldn't match: {{ result.excluded_unresolved.join(', ') }}
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import { getInfluenceLeaderboard, getCounterfactualDrift } from '../api/simulation'
+
+const props = defineProps({
+  simulationId: { type: String, required: true },
+  visible: { type: Boolean, default: false }
+})
+
+const MAX_PICKS = 3
+const TOP_AGENTS = 12
+
+const agents = ref([])
+const agentsLoading = ref(false)
+const selectedNames = ref([])
+const selectedSet = computed(() => new Set(selectedNames.value))
+
+const result = ref(null)
+const computing = ref(false)
+const error = ref('')
+const svgRef = ref(null)
+
+// SVG dimensions
+const W = 560
+const H = 220
+const MT = 14
+const MB = 26
+const ML = 34
+const MR = 12
+
+const origData = computed(() => result.value?.original || null)
+const cfData = computed(() => result.value?.counterfactual || null)
+
+const hasChartData = computed(() =>
+  !!(origData.value?.rounds?.length && cfData.value?.rounds?.length)
+)
+
+const allRounds = computed(() => {
+  const s = new Set()
+  ;(origData.value?.rounds || []).forEach((r) => s.add(r))
+  ;(cfData.value?.rounds || []).forEach((r) => s.add(r))
+  return Array.from(s).sort((a, b) => a - b)
+})
+
+const minR = computed(() => allRounds.value.length ? allRounds.value[0] : 1)
+const maxR = computed(() => allRounds.value.length ? allRounds.value[allRounds.value.length - 1] : 10)
+
+const xS = (r) => {
+  const span = Math.max(maxR.value - minR.value, 1)
+  return ML + ((r - minR.value) / span) * (W - ML - MR)
+}
+
+const yS = (pct) => {
+  return MT + (1 - pct / 100) * (H - MT - MB)
+}
+
+const xTicks = computed(() => {
+  const rs = allRounds.value
+  if (!rs.length) return []
+  if (rs.length <= 10) return rs
+  const step = Math.ceil(rs.length / 10)
+  return rs.filter((_, i) => i % step === 0 || i === rs.length - 1)
+})
+
+const linePath = (rounds, values) => {
+  if (!rounds || !rounds.length) return ''
+  return rounds.map((r, i) =>
+    `${i === 0 ? 'M' : 'L'}${xS(r).toFixed(1)},${yS(values[i]).toFixed(1)}`
+  ).join(' ')
+}
+
+const originalPath = computed(() => {
+  if (!origData.value) return ''
+  return linePath(origData.value.rounds, origData.value.bullish)
+})
+
+const counterfactualPath = computed(() => {
+  if (!cfData.value) return ''
+  return linePath(cfData.value.rounds, cfData.value.bullish)
+})
+
+const origEnd = computed(() => {
+  if (!origData.value?.rounds?.length) return null
+  const rs = origData.value.rounds
+  const vs = origData.value.bullish
+  return { x: xS(rs[rs.length - 1]), y: yS(vs[vs.length - 1]) }
+})
+
+const cfEnd = computed(() => {
+  if (!cfData.value?.rounds?.length) return null
+  const rs = cfData.value.rounds
+  const vs = cfData.value.bullish
+  return { x: xS(rs[rs.length - 1]), y: yS(vs[vs.length - 1]) }
+})
+
+const fmtPct = (v) => (v == null ? '–' : `${v}%`)
+const fmtRound = (v) => (v == null ? 'no consensus' : `r${v}`)
+const fmtDelta = (v) => {
+  if (v == null) return '–'
+  const sign = v > 0 ? '+' : ''
+  return `${sign}${v}`
+}
+const deltaClass = (v, invert = false) => {
+  if (v == null) return 'neutral'
+  const positive = invert ? v < 0 : v > 0
+  const negative = invert ? v > 0 : v < 0
+  if (positive) return 'positive'
+  if (negative) return 'negative'
+  return 'neutral'
+}
+const impactLabel = (kind) => {
+  if (kind === 'strong') return 'Strong'
+  if (kind === 'moderate') return 'Moderate'
+  return 'Minimal'
+}
+
+const loadAgents = async () => {
+  if (!props.simulationId) return
+  agentsLoading.value = true
+  try {
+    const res = await getInfluenceLeaderboard(props.simulationId)
+    if (res?.success && res.data?.agents) {
+      agents.value = res.data.agents.slice(0, TOP_AGENTS)
+    } else {
+      agents.value = []
+    }
+  } catch {
+    agents.value = []
+  } finally {
+    agentsLoading.value = false
+  }
+}
+
+const toggleAgent = (name) => {
+  const i = selectedNames.value.indexOf(name)
+  if (i === -1) {
+    if (selectedNames.value.length >= MAX_PICKS) return
+    selectedNames.value = [...selectedNames.value, name]
+  } else {
+    selectedNames.value = selectedNames.value.filter((n) => n !== name)
+  }
+}
+
+const clearSelection = () => {
+  selectedNames.value = []
+  result.value = null
+}
+
+const compute = async () => {
+  if (!selectedNames.value.length) return
+  computing.value = true
+  error.value = ''
+  try {
+    const res = await getCounterfactualDrift(props.simulationId, selectedNames.value)
+    if (res?.success && res.data) {
+      result.value = res.data
+    } else if (res?.success && !res.data) {
+      error.value = res.message || 'No trajectory data available for this simulation.'
+    } else {
+      error.value = res?.error || 'Failed to compute counterfactual.'
+    }
+  } catch (err) {
+    error.value = err?.message || 'Failed to compute counterfactual.'
+  } finally {
+    computing.value = false
+  }
+}
+
+const downloadPNG = () => {
+  const svg = svgRef.value
+  if (!svg) return
+  const serializer = new XMLSerializer()
+  const svgStr = serializer.serializeToString(svg)
+  const canvas = document.createElement('canvas')
+  canvas.width = W * 2
+  canvas.height = H * 2
+  const ctx = canvas.getContext('2d')
+  ctx.fillStyle = '#FAFAFA'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  const img = new Image()
+  img.onload = () => {
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+    const a = document.createElement('a')
+    a.download = `counterfactual-${props.simulationId}.png`
+    a.href = canvas.toDataURL('image/png')
+    a.click()
+  }
+  img.src = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svgStr)))
+}
+
+watch(() => props.visible, (val) => {
+  if (val && !agents.value.length) loadAgents()
+})
+watch(() => props.simulationId, () => {
+  if (props.visible) {
+    agents.value = []
+    selectedNames.value = []
+    result.value = null
+    loadAgents()
+  }
+})
+onMounted(() => { if (props.visible) loadAgents() })
+</script>
+
+<style scoped>
+.what-if {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  font-family: var(--font-mono);
+  background: var(--background);
+}
+
+.wi-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.08);
+  flex-shrink: 0;
+}
+
+.wi-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: rgba(10,10,10,0.75);
+}
+
+.wi-icon { font-size: 14px; color: rgba(20,184,166,0.9); }
+
+.wi-export-btn {
+  background: transparent;
+  border: 1px solid rgba(10,10,10,0.15);
+  color: rgba(10,10,10,0.6);
+  padding: 4px 10px;
+  font-family: inherit;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  border-radius: 2px;
+}
+.wi-export-btn:hover:not(:disabled) {
+  background: rgba(10,10,10,0.04);
+  color: rgba(10,10,10,0.85);
+}
+.wi-export-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.wi-hint {
+  padding: 8px 16px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: rgba(10,10,10,0.55);
+  border-bottom: 1px solid rgba(10,10,10,0.05);
+}
+
+.wi-state {
+  padding: 24px 16px;
+  text-align: center;
+  color: rgba(10,10,10,0.55);
+  font-size: 11px;
+}
+.wi-state.wi-error { color: rgba(239,68,68,0.9); }
+
+.pulse-ring {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(20,184,166,0.8);
+  margin-right: 8px;
+  animation: wi-pulse 1.4s ease-in-out infinite;
+}
+@keyframes wi-pulse {
+  0%, 100% { opacity: 0.4; transform: scale(0.85); }
+  50% { opacity: 1; transform: scale(1.1); }
+}
+
+.wi-picker {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(10,10,10,0.05);
+}
+
+.wi-picker-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.wi-picker-title {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: rgba(10,10,10,0.5);
+}
+.wi-clear {
+  background: transparent;
+  border: none;
+  font-family: inherit;
+  font-size: 10px;
+  color: rgba(10,10,10,0.55);
+  cursor: pointer;
+  padding: 2px 6px;
+}
+.wi-clear:hover { color: rgba(10,10,10,0.9); text-decoration: underline; }
+
+.wi-agent-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 6px;
+}
+
+.wi-agent-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid rgba(10,10,10,0.12);
+  border-radius: 2px;
+  cursor: pointer;
+  font-size: 11px;
+  color: rgba(10,10,10,0.8);
+  transition: background-color 0.12s, border-color 0.12s;
+}
+.wi-agent-card:hover:not(.disabled) {
+  background: rgba(20,184,166,0.06);
+  border-color: rgba(20,184,166,0.4);
+}
+.wi-agent-card.selected {
+  background: rgba(20,184,166,0.1);
+  border-color: rgba(20,184,166,0.7);
+}
+.wi-agent-card.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.wi-check { margin: 0; cursor: inherit; }
+
+.wi-rank {
+  font-size: 10px;
+  color: rgba(10,10,10,0.45);
+  min-width: 24px;
+}
+.wi-agent-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wi-agent-score {
+  font-size: 10px;
+  color: rgba(10,10,10,0.5);
+}
+
+.wi-actions {
+  margin-top: 10px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.wi-recompute {
+  background: rgba(20,184,166,1);
+  color: #fff;
+  border: none;
+  padding: 6px 14px;
+  font-family: inherit;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  border-radius: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.wi-recompute:hover:not(:disabled) { background: rgba(17,164,148,1); }
+.wi-recompute:disabled {
+  background: rgba(10,10,10,0.15);
+  cursor: not-allowed;
+}
+
+.wi-spinner {
+  width: 10px;
+  height: 10px;
+  border: 2px solid rgba(255,255,255,0.35);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: wi-spin 0.8s linear infinite;
+}
+@keyframes wi-spin { to { transform: rotate(360deg); } }
+
+.wi-result {
+  padding: 10px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.wi-chart-wrap {
+  background: rgba(10,10,10,0.02);
+  padding: 10px 6px 4px;
+  border-radius: 2px;
+}
+
+.wi-svg { width: 100%; height: auto; display: block; }
+
+.wi-legend {
+  display: flex;
+  gap: 16px;
+  padding: 6px 8px 0;
+  font-size: 10px;
+  color: rgba(10,10,10,0.6);
+}
+.wi-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+.wi-legend-swatch {
+  width: 18px;
+  height: 2px;
+  display: inline-block;
+}
+.wi-legend-swatch.orig {
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(20,184,166,0.55) 0,
+    rgba(20,184,166,0.55) 4px,
+    transparent 4px,
+    transparent 7px
+  );
+}
+.wi-legend-swatch.cf {
+  background: rgba(20,184,166,1);
+  height: 3px;
+}
+
+.wi-impact {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid rgba(10,10,10,0.08);
+  border-radius: 2px;
+  background: rgba(10,10,10,0.02);
+}
+
+.wi-impact-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  gap: 12px;
+}
+.wi-impact-label {
+  color: rgba(10,10,10,0.55);
+  letter-spacing: 0.04em;
+}
+.wi-impact-values {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: monospace;
+}
+.wi-val.orig { color: rgba(10,10,10,0.55); }
+.wi-val.cf { color: rgba(10,10,10,0.9); font-weight: 600; }
+.wi-arrow { color: rgba(10,10,10,0.3); }
+
+.wi-delta {
+  padding: 1px 6px;
+  border-radius: 2px;
+  font-size: 10px;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.wi-delta.positive { color: rgba(20,184,166,1); border-color: rgba(20,184,166,0.35); }
+.wi-delta.negative { color: rgba(239,68,68,0.9); border-color: rgba(239,68,68,0.35); }
+.wi-delta.neutral  { color: rgba(10,10,10,0.5); border-color: rgba(10,10,10,0.15); }
+
+.wi-impact-badge-row { margin-top: 4px; }
+.wi-impact-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  border-radius: 2px;
+  border: 1px solid transparent;
+}
+.wi-impact-badge.impact-strong {
+  color: rgba(20,184,166,1);
+  background: rgba(20,184,166,0.08);
+  border-color: rgba(20,184,166,0.4);
+}
+.wi-impact-badge.impact-moderate {
+  color: rgba(234,179,8,1);
+  background: rgba(234,179,8,0.08);
+  border-color: rgba(234,179,8,0.4);
+}
+.wi-impact-badge.impact-minimal {
+  color: rgba(10,10,10,0.5);
+  background: rgba(10,10,10,0.04);
+  border-color: rgba(10,10,10,0.15);
+}
+
+.wi-summary {
+  font-size: 11px;
+  line-height: 1.5;
+  color: rgba(10,10,10,0.75);
+  padding-top: 4px;
+  border-top: 1px solid rgba(10,10,10,0.06);
+}
+
+.wi-warn {
+  font-size: 10px;
+  color: rgba(234,88,12,0.85);
+  padding-top: 2px;
+}
+</style>


### PR DESCRIPTION
## What

A new **"What If?"** panel on the simulation results view that lets users remove
selected agents from a completed simulation and instantly see how consensus would
have shifted — no re-simulation, no LLM calls.

Pick up to 3 agents from the top-12 influence leaderboard, click **Recompute**,
and a split-line chart appears: original bullish curve (muted, dashed) and the
counterfactual curve (solid) on the same axes. A headline summary reports the
delta — e.g. *"Removing Alice Thompson would have decreased final bullish share
from 74% to 51% (-23.0 pts)"* — plus a Strong / Moderate / Minimal impact badge.

## Why

The Agent Interaction Network Graph (#33) shows *who* the dominant hubs are, and
the influence leaderboard *ranks* them, but neither answers the question every
researcher asks next: **"What would have happened if that top hub hadn't been in
the simulation?"**

All the data needed is already captured in `trajectory.json` — every agent's
belief state, per round. We don't need to rerun anything, just recompute the
same aggregate stance curve over a filtered agent set. That's a publishable
quantitative claim in ~30 seconds of UI interaction.

## Changes

**Backend**

- `backend/app/api/simulation.py`:
  - New `GET /api/simulation/<id>/counterfactual?exclude_agents=name1,name2`
    endpoint
  - `_drift_from_positions_by_agent(snapshots, allowed_agent_ids)` helper that
    factors out the per-round bullish/neutral/bearish computation (mirrors the
    existing `/belief-drift` logic)
  - Usernames resolved to `user_id` via the existing `_demo_load_profiles()`
    loader (reddit_profiles.json → twitter_profiles.csv fallback)
  - Response includes both original and counterfactual drift series,
    `delta_final_bullish`, `delta_final_bearish`, `delta_consensus_round`,
    an impact badge (`strong` ≥ 15 pts, `moderate` ≥ 5 pts, else `minimal`),
    and a plain-English `summary`

**Frontend**

- `frontend/src/components/WhatIfPanel.vue` (new): agent picker grid, recompute
  button, SVG split-line chart with endpoint dots and consensus markers, impact
  summary card, PNG export
- `frontend/src/components/Step3Simulation.vue`: new **◐ What If?** toggle in
  the analytics button row; standard overlay wiring
- `frontend/src/api/simulation.js`: `getCounterfactualDrift(simId, names[])` helper

## How to try it

1. Open any simulation that ran with belief tracking (produces `trajectory.json`)
2. From the run view, click **◐ What If?**
3. Pick 1–3 agents from the top-12 influence list
4. Click **Recompute counterfactual**
5. Inspect the chart + summary; click **Export PNG ↓** for a shareable figure

## Notes

- Pure data transform over `trajectory.json` — no re-simulation, no LLM calls,
  response in milliseconds
- Same endpoint shape could power a counterfactual toggle on the embeddable
  widget / share page in a future PR (follow-up idea: `?counterfactual=` URL
  param, PDF report integration)
- Uses the existing profiles loader so Reddit-only, Twitter-only, and mixed
  simulations all work

---
*Built autonomously by Aeon*