### PR TITLE
fix(embedding): read Config lazily so POST /api/settings takes effect

### DIFF
--- a/backend/app/storage/embedding_service.py
+++ b/backend/app/storage/embedding_service.py
@@ -33,22 +33,46 @@ class EmbeddingService:
         max_retries: int = 3,
         timeout: int = 30,
     ):
-        self.provider = (provider or Config.EMBEDDING_PROVIDER).lower()
-        self.model = model or Config.EMBEDDING_MODEL
-        self.base_url = (base_url or Config.EMBEDDING_BASE_URL).rstrip('/')
-        self.api_key = api_key or Config.EMBEDDING_API_KEY
-        self.dimensions = dimensions or Config.EMBEDDING_DIMENSIONS
+        # Explicit overrides (rare — tests, alternate pipelines). When None,
+        # every property below falls through to Config at call time, so
+        # POST /api/settings edits take effect without a restart.
+        self._provider_override = provider.lower() if provider else None
+        self._model_override = model
+        self._base_url_override = base_url.rstrip('/') if base_url else None
+        self._api_key_override = api_key
+        self._dimensions_override = dimensions
         self.max_retries = max_retries
         self.timeout = timeout
-
-        if self.provider == 'openai':
-            self._embed_url = f"{self.base_url}/v1/embeddings"
-        else:
-            self._embed_url = f"{self.base_url}/api/embed"
 
         # Simple in-memory cache (text -> embedding vector)
         self._cache: dict[str, List[float]] = {}
         self._cache_max_size = 2000
+
+    @property
+    def provider(self) -> str:
+        return (self._provider_override or Config.EMBEDDING_PROVIDER).lower()
+
+    @property
+    def model(self) -> str:
+        return self._model_override or Config.EMBEDDING_MODEL
+
+    @property
+    def base_url(self) -> str:
+        return (self._base_url_override or Config.EMBEDDING_BASE_URL).rstrip('/')
+
+    @property
+    def api_key(self) -> str:
+        return self._api_key_override or Config.EMBEDDING_API_KEY
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions_override or Config.EMBEDDING_DIMENSIONS
+
+    @property
+    def _embed_url(self) -> str:
+        if self.provider == 'openai':
+            return f"{self.base_url}/v1/embeddings"
+        return f"{self.base_url}/api/embed"
 
     def embed(self, text: str) -> List[float]:
         """


### PR DESCRIPTION
## Summary

`EmbeddingService` captured `provider`/`model`/`base_url`/`api_key`/`dimensions` in `__init__`. The service is a long-lived singleton (constructed once when `Neo4jStorage` is initialized at app startup), so any later updates via `POST /api/settings` were silently ignored — the old client kept hitting whatever `EMBEDDING_BASE_URL` was set when the process booted, with the startup-time `api_key`.

This PR converts those attributes to `@property` so every call reads `Config` fresh. Explicit constructor args still work (tests, alternate pipelines) and take precedence over `Config`.

## Real-world impact

- Any deploy where the backend starts with placeholder/empty embedding env vars and the user sets real ones via `POST /api/settings` later: first sim after startup sent embeddings to the wrong endpoint, graph semantic search silently fell back to local string match.
- In my fork on Railway I was seeing **~239 failed 401 embedding calls per run** hitting `api.openai.com` with an OpenRouter key until a restart — that's what prompted the investigation.

## Behavior

- **No change** when `EmbeddingService` is instantiated with explicit values, or when `Config` values never change after startup.
- **Fix applies** only to the runtime-update path via `POST /api/settings`.

## Test plan

- [x] Cold boot → `GET /api/settings` returns current `embedding.base_url`
- [x] `POST /api/settings` with new `embedding.base_url` → next `embed()` call hits the new URL without a restart
- [x] Existing tests that construct `EmbeddingService(base_url='http://...')` still override Config

## File changed

- `backend/app/storage/embedding_service.py` — +34 / -10