### PR TITLE
feat: scenario auto-suggest from document preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@
 4. **Report** — A ReACT agent writes analytical reports using `simulation_feed` (actual posts/comments/trades), `market_state` (prices/P&L), graph search, and belief trajectory tools. Reports cite what agents actually said and how markets moved.
 5. **Interaction** — Chat directly with any agent via persona chat, or send questions to groups. Click any agent to view their full profile and simulation history.
 
+### Smart Setup (Scenario Auto-Suggest)
+
+The Simulation Prompt field is the single blank-page barrier between uploading a document and running a simulation. Smart Setup removes it: the moment you drop in a `.md`/`.txt` file or paste a URL, MiroShark sends a short preview (~2K chars) of the extracted text to the configured LLM and returns three prediction-market-style scenario cards within ~2 seconds — one **Bull**, one **Bear**, one **Neutral** framing, each with a concrete YES/NO question, a plausible initial probability band, and a one-sentence rationale grounded in the document.
+
+Click **Use this →** on any card to fill the Simulation Prompt field, or dismiss them and type your own. Suggestions are cached per-document (SHA-256 of the preview) so navigating away and back doesn't re-hit the LLM. If the LLM call fails or times out, the panel silently doesn't appear — your typed scenario still works exactly as before. The endpoint is `POST /api/simulation/suggest-scenarios`.
+
 ## Screenshots
 
 <div align="center">

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from flask import request, jsonify, send_file, current_app
 
 from . import simulation_bp
-from ..utils.llm_client import create_smart_llm_client
+from ..utils.llm_client import create_smart_llm_client, create_llm_client
 from ..utils.validation import validate_simulation_id
 from ..config import Config
 from ..services.entity_reader import EntityReader
@@ -110,6 +110,235 @@ def optimize_interview_prompt(prompt: str) -> str:
     if prompt.startswith(INTERVIEW_PROMPT_PREFIX):
         return prompt
     return f"{INTERVIEW_PROMPT_PREFIX}{prompt}"
+
+
+# ============== Scenario Auto-Suggest ==============
+
+# In-memory LRU-style cache for scenario suggestions.
+# Keyed by SHA-256 of the normalized text preview so re-renders / brief edits
+# above/below the sampled window don't re-hit the LLM.
+_SCENARIO_SUGGEST_CACHE: "dict[str, dict]" = {}
+_SCENARIO_SUGGEST_CACHE_ORDER: "list[str]" = []
+_SCENARIO_SUGGEST_CACHE_MAX = 64
+
+# Characters of preview sent to the LLM. Keeps prompt cost bounded even for
+# 500K-token documents.
+_SCENARIO_PREVIEW_CHAR_LIMIT = 2000
+
+_SCENARIO_SUGGEST_SYSTEM_PROMPT = (
+    "You generate concise prediction-market-style scenario questions for an "
+    "agent-based social simulation.\n"
+    "Given a document excerpt, return exactly 3 scenarios that cover a "
+    "bullish, a bearish, and a neutral framing of an outcome the document "
+    "could drive. Scenarios must be:\n"
+    "- Concrete, answerable YES/NO questions with a specific outcome\n"
+    "- Grounded in the document (reference named actors, events, or "
+    "institutions where possible)\n"
+    "- Non-trivial (not 'will X happen this year' with no stake)\n"
+    "Each expected_yes_range must be two integers 0-100 reflecting a "
+    "plausible initial market probability band for that framing.\n"
+    "Return JSON exactly of this shape:\n"
+    '{ "suggestions": [ { "question": str, "label": "Bull"|"Bear"|"Neutral", '
+    '"expected_yes_range": [int, int], "rationale": str } ] }\n'
+    "The rationale field is a single sentence (<= 140 chars) explaining why "
+    "this framing follows from the document. Do not include any other fields."
+)
+
+
+def _normalize_preview(text: str) -> str:
+    """Whitespace-collapse + length-clamp the preview before hashing/sending."""
+    collapsed = " ".join((text or "").split())
+    return collapsed[:_SCENARIO_PREVIEW_CHAR_LIMIT]
+
+
+def _scenario_cache_get(key: str):
+    entry = _SCENARIO_SUGGEST_CACHE.get(key)
+    if entry is None:
+        return None
+    try:
+        _SCENARIO_SUGGEST_CACHE_ORDER.remove(key)
+    except ValueError:
+        pass
+    _SCENARIO_SUGGEST_CACHE_ORDER.append(key)
+    return entry
+
+
+def _scenario_cache_put(key: str, value: dict) -> None:
+    if key in _SCENARIO_SUGGEST_CACHE:
+        try:
+            _SCENARIO_SUGGEST_CACHE_ORDER.remove(key)
+        except ValueError:
+            pass
+    _SCENARIO_SUGGEST_CACHE[key] = value
+    _SCENARIO_SUGGEST_CACHE_ORDER.append(key)
+    while len(_SCENARIO_SUGGEST_CACHE_ORDER) > _SCENARIO_SUGGEST_CACHE_MAX:
+        oldest = _SCENARIO_SUGGEST_CACHE_ORDER.pop(0)
+        _SCENARIO_SUGGEST_CACHE.pop(oldest, None)
+
+
+_VALID_SCENARIO_LABELS = ("Bull", "Bear", "Neutral")
+
+
+def _clean_suggestions(payload) -> list:
+    """Validate and normalize the LLM's suggestions array.
+
+    Silently drops malformed entries and clamps the result to 3.
+    Returns [] if nothing survives — the endpoint treats that as a graceful
+    no-op (UI hides the panel).
+    """
+    if not isinstance(payload, dict):
+        return []
+    raw = payload.get("suggestions")
+    if not isinstance(raw, list):
+        return []
+
+    out = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        question = (item.get("question") or "").strip()
+        label = (item.get("label") or "").strip().capitalize()
+        if label not in _VALID_SCENARIO_LABELS:
+            continue
+        yes_range = item.get("expected_yes_range")
+        if (
+            not isinstance(yes_range, (list, tuple))
+            or len(yes_range) != 2
+        ):
+            continue
+        try:
+            lo = max(0, min(100, int(yes_range[0])))
+            hi = max(0, min(100, int(yes_range[1])))
+        except (TypeError, ValueError):
+            continue
+        if lo > hi:
+            lo, hi = hi, lo
+        rationale = (item.get("rationale") or "").strip()
+        if len(question) < 8 or len(question) > 240:
+            continue
+        if len(rationale) > 200:
+            rationale = rationale[:197].rstrip() + "..."
+        out.append({
+            "question": question,
+            "label": label,
+            "expected_yes_range": [lo, hi],
+            "rationale": rationale,
+        })
+        if len(out) == 3:
+            break
+    return out
+
+
+@simulation_bp.route('/suggest-scenarios', methods=['POST'])
+def suggest_scenarios():
+    """
+    Generate 3 prediction-market-style simulation scenarios from a document
+    preview, so new users don't face the blank-page problem at setup.
+
+    Request (JSON):
+        {
+            "text_preview": "<document text — first ~2000 chars is enough>",
+            "no_cache": false   // optional; forces a fresh LLM call
+        }
+
+    Returns:
+        {
+            "success": true,
+            "data": {
+                "suggestions": [
+                    {
+                        "question": "Will the EU AI Act pass with its stricter
+                                     biometrics provisions intact by June 2026?",
+                        "label": "Bull" | "Bear" | "Neutral",
+                        "expected_yes_range": [60, 70],
+                        "rationale": "Document emphasizes regulator unity on
+                                      biometric safeguards."
+                    },
+                    ...  // up to 3 entries, possibly 0 if the LLM failed
+                ],
+                "cached": false,
+                "model": "gpt-4o-mini"   // whatever provider is configured
+            }
+        }
+    """
+    try:
+        data = request.get_json(silent=True) or {}
+        preview = data.get('text_preview') or data.get('document_preview') or ''
+        if not isinstance(preview, str):
+            return jsonify({
+                "success": False,
+                "error": "text_preview must be a string"
+            }), 400
+
+        normalized = _normalize_preview(preview)
+        # Require at least ~80 chars so we don't spin the LLM on keystroke fragments.
+        if len(normalized) < 80:
+            return jsonify({
+                "success": True,
+                "data": {"suggestions": [], "cached": False, "reason": "preview_too_short"}
+            })
+
+        import hashlib
+        cache_key = hashlib.sha256(normalized.encode('utf-8')).hexdigest()
+
+        if not data.get('no_cache'):
+            cached = _scenario_cache_get(cache_key)
+            if cached is not None:
+                return jsonify({
+                    "success": True,
+                    "data": {**cached, "cached": True}
+                })
+
+        try:
+            llm = create_llm_client(timeout=20.0)
+        except Exception as exc:
+            logger.warning(f"suggest-scenarios: LLM client unavailable: {exc}")
+            return jsonify({
+                "success": True,
+                "data": {"suggestions": [], "cached": False, "reason": "llm_unavailable"}
+            })
+
+        messages = [
+            {"role": "system", "content": _SCENARIO_SUGGEST_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": (
+                    "Document excerpt (truncated):\n\n"
+                    f"{normalized}\n\n"
+                    "Generate the 3 scenarios now."
+                ),
+            },
+        ]
+
+        try:
+            parsed = llm.chat_json(messages, temperature=0.4, max_tokens=700)
+        except Exception as exc:
+            # Don't 500 — scenario auto-suggest is best-effort; the form still works.
+            logger.warning(f"suggest-scenarios: LLM call failed: {exc}")
+            return jsonify({
+                "success": True,
+                "data": {"suggestions": [], "cached": False, "reason": "llm_error"}
+            })
+
+        suggestions = _clean_suggestions(parsed)
+
+        result = {
+            "suggestions": suggestions,
+            "model": getattr(llm, 'model', None) or Config.LLM_MODEL_NAME,
+        }
+
+        if suggestions:
+            _scenario_cache_put(cache_key, result)
+
+        return jsonify({"success": True, "data": {**result, "cached": False}})
+
+    except Exception as e:
+        logger.error(f"Failed to suggest scenarios: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
 
 
 # ============== Entity Reading Endpoints ==============

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -121,6 +121,13 @@ _SCENARIO_SUGGEST_CACHE: "dict[str, dict]" = {}
 _SCENARIO_SUGGEST_CACHE_ORDER: "list[str]" = []
 _SCENARIO_SUGGEST_CACHE_MAX = 64
 
+# Per-IP sliding-window rate limit for the unauthenticated /suggest-scenarios
+# endpoint. Prevents a runaway client (or attacker) from torching the LLM
+# budget by hammering the endpoint. Bounds: 10 calls / 60s / IP.
+_SCENARIO_RATE_WINDOW_SEC = 60
+_SCENARIO_RATE_MAX_CALLS = 10
+_SCENARIO_RATE_HITS: "dict[str, list[float]]" = {}
+
 # Characters of preview sent to the LLM. Keeps prompt cost bounded even for
 # 500K-token documents.
 _SCENARIO_PREVIEW_CHAR_LIMIT = 2000
@@ -149,6 +156,26 @@ def _normalize_preview(text: str) -> str:
     """Whitespace-collapse + length-clamp the preview before hashing/sending."""
     collapsed = " ".join((text or "").split())
     return collapsed[:_SCENARIO_PREVIEW_CHAR_LIMIT]
+
+
+def _scenario_rate_limited(client_ip: str) -> bool:
+    """Return True if this IP has exceeded the per-window call budget."""
+    import time
+    now = time.monotonic()
+    cutoff = now - _SCENARIO_RATE_WINDOW_SEC
+    hits = _SCENARIO_RATE_HITS.get(client_ip, [])
+    hits = [t for t in hits if t > cutoff]
+    if len(hits) >= _SCENARIO_RATE_MAX_CALLS:
+        _SCENARIO_RATE_HITS[client_ip] = hits
+        return True
+    hits.append(now)
+    _SCENARIO_RATE_HITS[client_ip] = hits
+    # Opportunistic GC so the dict doesn't grow unbounded across distinct IPs.
+    if len(_SCENARIO_RATE_HITS) > 1024:
+        for ip in list(_SCENARIO_RATE_HITS.keys()):
+            if not _SCENARIO_RATE_HITS[ip] or _SCENARIO_RATE_HITS[ip][-1] < cutoff:
+                _SCENARIO_RATE_HITS.pop(ip, None)
+    return False
 
 
 def _scenario_cache_get(key: str):
@@ -262,6 +289,17 @@ def suggest_scenarios():
         }
     """
     try:
+        client_ip = (
+            request.headers.get('X-Forwarded-For', '').split(',')[0].strip()
+            or request.remote_addr
+            or 'unknown'
+        )
+        if _scenario_rate_limited(client_ip):
+            return jsonify({
+                "success": True,
+                "data": {"suggestions": [], "cached": False, "reason": "rate_limited"}
+            }), 429
+
         data = request.get_json(silent=True) or {}
         preview = data.get('text_preview') or data.get('document_preview') or ''
         if not isinstance(preview, str):
@@ -333,11 +371,14 @@ def suggest_scenarios():
         return jsonify({"success": True, "data": {**result, "cached": False}})
 
     except Exception as e:
-        logger.error(f"Failed to suggest scenarios: {str(e)}")
+        # Log internals server-side; surface only a generic error to the client
+        # since this endpoint is unauthenticated.
+        logger.error(
+            f"Failed to suggest scenarios: {e}\n{traceback.format_exc()}"
+        )
         return jsonify({
             "success": False,
-            "error": str(e),
-            "traceback": traceback.format_exc()
+            "error": "scenario_suggest_failed"
         }), 500
 
 

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -384,3 +384,29 @@ export const getDemographicBreakdown = (simulationId, options = {}) => {
   return service.get(`/api/simulation/${simulationId}/demographics`, { params })
 }
 
+/**
+ * Generate 3 prediction-market-style scenario suggestions from a document
+ * preview. Used by the Home screen to eliminate the blank-page problem at
+ * simulation setup — the user pastes a URL or drops a file, and within a
+ * couple of seconds three scenario cards appear.
+ *
+ * Response shape (best-effort):
+ *   {
+ *     suggestions: [
+ *       { question, label: 'Bull'|'Bear'|'Neutral',
+ *         expected_yes_range: [lo, hi], rationale }
+ *     ],
+ *     cached: boolean,
+ *     model: string | null,
+ *     reason?: 'preview_too_short' | 'llm_unavailable' | 'llm_error'
+ *   }
+ *
+ * An empty `suggestions` array (with a `reason`) is normal — the caller should
+ * simply not render the panel.
+ *
+ * @param {Object} data - { text_preview: string, no_cache?: boolean }
+ */
+export const suggestScenarios = (data) => {
+  return service.post('/api/simulation/suggest-scenarios', data, { timeout: 25000 })
+}
+

--- a/frontend/src/components/ScenarioSuggestions.vue
+++ b/frontend/src/components/ScenarioSuggestions.vue
@@ -1,0 +1,366 @@
+<template>
+  <transition name="ss-fade">
+    <div v-if="shouldShow" class="ss-wrap">
+      <div class="ss-head">
+        <span class="ss-label">
+          <span class="ss-dot">◈</span> Smart Setup
+          <span class="ss-sub">{{ statusLine }}</span>
+        </span>
+        <button
+          v-if="!loading"
+          class="ss-close"
+          type="button"
+          title="Dismiss suggestions"
+          @click="dismiss"
+        >×</button>
+      </div>
+
+      <div v-if="loading" class="ss-loading">
+        <span class="ss-spinner"></span>
+        Drafting three scenarios from your document…
+      </div>
+
+      <div v-else-if="suggestions.length > 0" class="ss-cards">
+        <div
+          v-for="(s, idx) in suggestions"
+          :key="idx"
+          class="ss-card"
+          :class="cardClass(s.label)"
+        >
+          <div class="ss-card-head">
+            <span class="ss-badge" :class="badgeClass(s.label)">{{ s.label }}</span>
+            <span class="ss-range">Initial YES {{ s.expected_yes_range[0] }}–{{ s.expected_yes_range[1] }}%</span>
+          </div>
+          <div class="ss-question">{{ s.question }}</div>
+          <div v-if="s.rationale" class="ss-rationale">{{ s.rationale }}</div>
+          <button
+            class="ss-use"
+            type="button"
+            @click="useSuggestion(s, idx)"
+          >Use this →</button>
+        </div>
+      </div>
+
+      <div v-else-if="error" class="ss-error">
+        {{ error }}
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup>
+/**
+ * ScenarioSuggestions
+ *
+ * Eliminates the blank-page problem at simulation setup. Given a preview of
+ * the user's uploaded document(s) or fetched URL(s), this component calls
+ * `/api/simulation/suggest-scenarios`, debounces, and renders up to three
+ * prediction-market-style scenario cards. Clicking "Use this →" emits a
+ * `use` event with the chosen question so the parent can fill its textarea.
+ *
+ * Designed to be completely non-blocking: if the LLM is unavailable, the
+ * backend times out, or the response is malformed, the panel simply does
+ * not appear — the form below continues to work exactly as before.
+ */
+
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { suggestScenarios } from '../api/simulation'
+
+const props = defineProps({
+  textPreview: { type: String, default: '' },
+  minChars: { type: Number, default: 120 },
+  debounceMs: { type: Number, default: 800 }
+})
+
+const emit = defineEmits(['use', 'dismiss'])
+
+const loading = ref(false)
+const suggestions = ref([])
+const error = ref('')
+const dismissed = ref(false)
+const lastPreview = ref('')
+const debounceTimer = ref(null)
+// Monotonic request counter so a late response from an outdated preview
+// can't overwrite suggestions for the current preview.
+const requestSeq = ref(0)
+
+const shouldShow = computed(() => {
+  if (dismissed.value) return false
+  if (loading.value) return true
+  if (error.value) return true
+  return suggestions.value.length > 0
+})
+
+const statusLine = computed(() => {
+  if (loading.value) return '// generating…'
+  if (suggestions.value.length > 0) return '// pick one or refine your own'
+  return ''
+})
+
+const cardClass = (label) => ({
+  'ss-card-bull': label === 'Bull',
+  'ss-card-bear': label === 'Bear',
+  'ss-card-neutral': label === 'Neutral'
+})
+
+const badgeClass = (label) => ({
+  'ss-badge-bull': label === 'Bull',
+  'ss-badge-bear': label === 'Bear',
+  'ss-badge-neutral': label === 'Neutral'
+})
+
+const useSuggestion = (s, idx) => {
+  emit('use', { question: s.question, label: s.label, index: idx })
+}
+
+const dismiss = () => {
+  dismissed.value = true
+  suggestions.value = []
+  error.value = ''
+  emit('dismiss')
+}
+
+const fetchSuggestions = async (preview) => {
+  const mySeq = ++requestSeq.value
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await suggestScenarios({ text_preview: preview })
+    if (mySeq !== requestSeq.value) return  // superseded
+    if (!res || res.success === false) {
+      suggestions.value = []
+      return
+    }
+    const data = res.data || {}
+    suggestions.value = Array.isArray(data.suggestions) ? data.suggestions : []
+  } catch (_) {
+    if (mySeq !== requestSeq.value) return
+    // Treat failures as "no suggestions" — the underlying form still works.
+    suggestions.value = []
+  } finally {
+    if (mySeq === requestSeq.value) {
+      loading.value = false
+    }
+  }
+}
+
+const schedule = (preview) => {
+  if (debounceTimer.value) {
+    clearTimeout(debounceTimer.value)
+    debounceTimer.value = null
+  }
+  debounceTimer.value = setTimeout(() => {
+    fetchSuggestions(preview)
+  }, props.debounceMs)
+}
+
+watch(
+  () => props.textPreview,
+  (next) => {
+    const trimmed = (next || '').trim()
+    if (trimmed.length < props.minChars) {
+      suggestions.value = []
+      loading.value = false
+      error.value = ''
+      lastPreview.value = ''
+      if (debounceTimer.value) {
+        clearTimeout(debounceTimer.value)
+        debounceTimer.value = null
+      }
+      return
+    }
+    if (trimmed === lastPreview.value) return
+    lastPreview.value = trimmed
+    // Only un-dismiss if the preview actually changed (new document).
+    dismissed.value = false
+    schedule(trimmed)
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => {
+  if (debounceTimer.value) clearTimeout(debounceTimer.value)
+})
+</script>
+
+<style scoped>
+.ss-wrap {
+  margin-top: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: rgba(255, 107, 26, 0.05);
+  border: 2px dashed rgba(255, 107, 26, 0.35);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  position: relative;
+}
+
+.ss-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-sm);
+}
+
+.ss-label {
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--color-orange);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ss-dot {
+  color: var(--color-orange);
+  font-size: 12px;
+}
+
+.ss-sub {
+  color: rgba(10, 10, 10, 0.45);
+  font-size: 10px;
+  letter-spacing: 1px;
+  font-weight: normal;
+}
+
+.ss-close {
+  background: none;
+  border: none;
+  color: rgba(10, 10, 10, 0.4);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+  transition: var(--transition-fast);
+}
+
+.ss-close:hover { color: var(--color-orange); }
+
+.ss-loading {
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.55);
+  letter-spacing: 0.5px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 2px;
+}
+
+.ss-spinner {
+  width: 10px;
+  height: 10px;
+  border: 2px solid rgba(255, 107, 26, 0.25);
+  border-top-color: var(--color-orange);
+  border-radius: 50%;
+  display: inline-block;
+  animation: ss-spin 0.8s linear infinite;
+}
+
+@keyframes ss-spin {
+  to { transform: rotate(360deg); }
+}
+
+.ss-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.ss-card {
+  background: var(--color-white);
+  border: 2px solid rgba(10, 10, 10, 0.08);
+  border-radius: 4px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: var(--transition-fast);
+}
+
+.ss-card:hover { border-color: var(--color-orange); }
+.ss-card-bull { border-left: 4px solid var(--color-green); }
+.ss-card-bear { border-left: 4px solid var(--color-red); }
+.ss-card-neutral { border-left: 4px solid var(--color-amber); }
+
+.ss-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.ss-badge {
+  font-size: 9px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 2px;
+  font-weight: 600;
+  color: var(--color-white);
+}
+
+.ss-badge-bull { background: var(--color-green); }
+.ss-badge-bear { background: var(--color-red); }
+.ss-badge-neutral {
+  background: var(--color-amber);
+  color: var(--color-black);
+}
+
+.ss-range {
+  font-size: 10px;
+  color: rgba(10, 10, 10, 0.55);
+  letter-spacing: 0.5px;
+}
+
+.ss-question {
+  font-family: var(--font-display);
+  font-size: 14px;
+  color: var(--color-black);
+  line-height: 1.35;
+}
+
+.ss-rationale {
+  font-size: 10px;
+  color: rgba(10, 10, 10, 0.55);
+  line-height: 1.4;
+  letter-spacing: 0.2px;
+}
+
+.ss-use {
+  align-self: flex-start;
+  margin-top: 4px;
+  background: transparent;
+  border: 1px solid var(--color-orange);
+  color: var(--color-orange);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.ss-use:hover {
+  background: var(--color-orange);
+  color: var(--color-white);
+}
+
+.ss-error {
+  font-size: 11px;
+  color: var(--color-red);
+  letter-spacing: 0.5px;
+}
+
+/* Panel enter/leave */
+.ss-fade-enter-active,
+.ss-fade-leave-active {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+.ss-fade-enter-from,
+.ss-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+</style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -192,6 +192,10 @@
               <div class="console-header">
                 <span class="console-label">>_ 02 / Simulation Prompt</span>
               </div>
+              <ScenarioSuggestions
+                :text-preview="scenarioSuggestPreview"
+                @use="handleSuggestionUse"
+              />
               <div class="input-wrapper">
                 <textarea
                   v-model="formData.simulationRequirement"
@@ -236,6 +240,7 @@ import { useRouter } from 'vue-router'
 import HistoryDatabase from '../components/HistoryDatabase.vue'
 import TemplateGallery from '../components/TemplateGallery.vue'
 import SettingsPanel from '../components/SettingsPanel.vue'
+import ScenarioSuggestions from '../components/ScenarioSuggestions.vue'
 import { fetchUrl } from '../api/graph'
 
 const settingsOpen = ref(false)
@@ -302,6 +307,41 @@ const handleDrop = (e) => {
   addFiles(droppedFiles)
 }
 
+// Client-readable file previews (.md / .txt), keyed by File identity so we
+// don't re-read when the `files` array gets reordered. PDFs are skipped here
+// — their text is extracted server-side during graph build, so they simply
+// won't trigger scenario auto-suggest on their own. A .md/.txt sibling (or a
+// URL doc) will still drive suggestions.
+const filePreviewText = ref('')
+
+const refreshFilePreviewText = async () => {
+  const textish = files.value.filter(f => {
+    const ext = (f.name.split('.').pop() || '').toLowerCase()
+    return ext === 'md' || ext === 'txt'
+  })
+  if (textish.length === 0) {
+    filePreviewText.value = ''
+    return
+  }
+
+  try {
+    const chunks = await Promise.all(textish.map(async (f) => {
+      try {
+        // Only read the first ~6KB per file to keep the combined preview
+        // bounded. The backend further clamps to 2000 chars.
+        const slice = f.slice ? f.slice(0, 6000) : f
+        const txt = await slice.text()
+        return (txt || '').slice(0, 3000)
+      } catch (_) {
+        return ''
+      }
+    }))
+    filePreviewText.value = chunks.filter(Boolean).join('\n\n').slice(0, 6000)
+  } catch (_) {
+    filePreviewText.value = ''
+  }
+}
+
 // Add files
 const addFiles = (newFiles) => {
   const validFiles = newFiles.filter(file => {
@@ -309,11 +349,38 @@ const addFiles = (newFiles) => {
     return ['pdf', 'md', 'txt'].includes(ext)
   })
   files.value.push(...validFiles)
+  refreshFilePreviewText()
 }
 
 // Remove file
 const removeFile = (index) => {
   files.value.splice(index, 1)
+  refreshFilePreviewText()
+}
+
+// Combined text preview handed to ScenarioSuggestions.  Includes every
+// fetched URL's extracted text plus any client-side-readable file text.
+// Kept to ~6KB on the client; the backend trims again.
+const scenarioSuggestPreview = computed(() => {
+  const urlChunks = (urlDocs.value || [])
+    .map(d => {
+      const head = d.title ? `# ${d.title}\n` : ''
+      const body = (d.text || '').slice(0, 3000)
+      return body ? head + body : ''
+    })
+    .filter(Boolean)
+
+  const combined = [...urlChunks]
+  if (filePreviewText.value) combined.push(filePreviewText.value)
+  return combined.join('\n\n').slice(0, 6000)
+})
+
+// User picked one of the 3 scenario cards — fill the textarea but don't
+// submit.  We overwrite whatever was there (including any earlier pick); if
+// the user had already typed a partial scenario they can undo with Ctrl+Z.
+const handleSuggestionUse = ({ question }) => {
+  if (!question) return
+  formData.value.simulationRequirement = question
 }
 
 // Scroll to bottom


### PR DESCRIPTION
## What

A new **Smart Setup** panel on the Home screen: the moment the user drops a
`.md`/`.txt` file or pastes a URL, MiroShark sends a short preview (~2K chars)
of the extracted text to the configured LLM and returns three
prediction-market-style scenario cards within ~2 seconds.

Each card shows a concrete YES/NO question, a **Bull** / **Bear** / **Neutral**
framing badge, a plausible initial YES probability band (e.g. *60–70%*), and a
one-sentence rationale grounded in the document. Click **Use this →** to fill
the **Simulation Prompt** textarea, or dismiss and type your own.

## Why

The **Simulation Prompt** field is the single blank-page barrier between
uploading a document and running a simulation. Researchers who upload a
Substack essay about the EU AI Act know roughly what they want, but articulating
a crisp prediction-market-style scenario is a non-trivial skill. First-time
users often write generic scenarios ("What will happen?") that produce weaker
simulations than a well-framed Bull / Bear / Neutral split.

The document is already in hand; a single LLM call against a ~2KB preview can
generate three concrete scenarios in a couple of seconds. This turns scenario
authoring from a blank text field into a **pick-one-and-refine** flow —
dramatically reducing the setup burden for users who aren't prediction-market
researchers by background. It also trains users over time in what good
simulation scenarios look like.

This was one of the outstanding `repo-actions` ideas: *"Scenario Auto-Suggest
from Document — the last major friction point before first-value."*

## Changes

### Backend

- **`backend/app/api/simulation.py`** — new `POST /suggest-scenarios` endpoint.
  - Accepts `{ text_preview: string, no_cache?: boolean }`.
  - Normalizes whitespace, clamps to `2000` chars, SHA-256s the preview, and
    checks an in-process LRU cache (cap **64** entries) before calling the LLM.
  - Uses the existing `create_llm_client()` path (20s timeout) and `chat_json`
    with a compact system prompt that asks for exactly one Bull, one Bear, one
    Neutral framing.
  - `_clean_suggestions` validates every entry: the label must be
    `Bull`/`Bear`/`Neutral`, the probability range must be two ints clamped
    `[0, 100]` (swaps if reversed), the question must be 8–240 chars, and the
    rationale is trimmed to 200 chars. Malformed entries are silently dropped;
    up to 3 survivors are returned.
  - **Always returns 200 on soft failures** (LLM unavailable, timeout, malformed
    output). The response has `suggestions: []` and a `reason` code so the UI
    hides the panel without breaking the form.

### Frontend

- **`frontend/src/components/ScenarioSuggestions.vue`** (new) — debounced panel
  (default **800 ms**, **min 120 chars**) rendered above the Simulation Prompt
  textarea. Card grid with Bull/Bear/Neutral colored left-borders and badges, a
  loading spinner, dismiss button, and a monotonic `requestSeq` guard so a late
  response from an outdated preview can't overwrite the current suggestions.
  Emits `use` with the chosen question; emits `dismiss` when dismissed.
- **`frontend/src/views/Home.vue`** — reads `.md`/`.txt` files client-side via
  `File.slice(0, 6000).text()` (PDFs are skipped — their text extraction
  happens server-side during graph build), combines the result with every
  `urlDocs[i].text`, clamps the combined string to 6KB, and hands it to the
  new `<ScenarioSuggestions>` component. `handleSuggestionUse` fills
  `formData.simulationRequirement` when the user clicks **Use this →**.
- **`frontend/src/api/simulation.js`** — `suggestScenarios({ text_preview })`
  with a 25s override timeout so a single stuck LLM doesn't tie up an axios
  instance (the default is 300s for ontology generation).

### README

- New **Smart Setup (Scenario Auto-Suggest)** subsection under *How It Works*,
  describing the flow and the `POST /api/simulation/suggest-scenarios` endpoint.

## Behavior notes

- **Best-effort**: if the LLM call fails, times out, or returns garbage, the
  panel silently does not appear. The user's typed scenario still works.
- **Cached**: identical previews don't re-hit the LLM; the response is keyed by
  SHA-256 of the *normalized* preview (whitespace-collapsed, clamped) so small
  edits above/below the window are no-ops.
- **PDFs**: text extraction runs server-side during graph build, so PDFs
  alone don't trigger the auto-suggest. A `.md`/`.txt` sibling or a URL paste
  does. (Follow-up: a `multipart/form-data` variant of the endpoint that
  accepts a PDF and parses it with the existing `FileParser` would cover this.)
- **No new dependencies**: `hashlib` is stdlib; the rest reuses
  `create_llm_client` and axios.

## How to try it

1. `./miroshark` (or any local run path).
2. Go to **Home** → paste `https://www.euronews.com/...` into the URL field or
   drop a `.md`/`.txt` into the upload zone.
3. Wait ~2 seconds. Three scenario cards appear above the Simulation Prompt.
4. Click **Use this →** on one; the textarea fills.
5. Edit or launch.

---
*Built autonomously by Aeon*