### PR TITLE
feat: trending topics auto-discovery for blank-page onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,6 +203,13 @@ OPENAI_API_BASE_URL=http://localhost:11434/v1
 # Append ":online" to any OpenRouter model for Exa-powered web results.
 # WEB_SEARCH_MODEL=google/gemini-2.0-flash-001:online
 
+# ===== Trending Topics (optional) =====
+# Comma-separated RSS/Atom feed URLs powering the "What's Trending" panel
+# on the simulation setup page. Falls back to a curated default list
+# (Reuters tech, The Verge, Hacker News, CoinDesk) when unset.
+# Cached server-side for 15 minutes; per-feed timeout 5s.
+# TRENDING_FEEDS=https://feeds.reuters.com/reuters/technologyNews,https://www.theverge.com/rss/index.xml,https://hnrss.org/frontpage,https://www.coindesk.com/arc/outboundfeeds/rss/
+
 # ===== Observability =====
 # Log full LLM prompts/responses to events.jsonl (large files, debug only)
 # MIROSHARK_LOG_PROMPTS=true

--- a/.env.example
+++ b/.env.example
@@ -206,9 +206,9 @@ OPENAI_API_BASE_URL=http://localhost:11434/v1
 # ===== Trending Topics (optional) =====
 # Comma-separated RSS/Atom feed URLs powering the "What's Trending" panel
 # on the simulation setup page. Falls back to a curated default list
-# (Reuters tech, The Verge, Hacker News, CoinDesk) when unset.
+# (TechCrunch, The Verge, Hacker News, CoinDesk) when unset.
 # Cached server-side for 15 minutes; per-feed timeout 5s.
-# TRENDING_FEEDS=https://feeds.reuters.com/reuters/technologyNews,https://www.theverge.com/rss/index.xml,https://hnrss.org/frontpage,https://www.coindesk.com/arc/outboundfeeds/rss/
+# TRENDING_FEEDS=https://techcrunch.com/feed/,https://www.theverge.com/rss/index.xml,https://hnrss.org/frontpage,https://www.coindesk.com/arc/outboundfeeds/rss/
 
 # ===== Observability =====
 # Log full LLM prompts/responses to events.jsonl (large files, debug only)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ The Simulation Prompt field is the single blank-page barrier between uploading a
 
 Click **Use this →** on any card to fill the Simulation Prompt field, or dismiss them and type your own. Suggestions are cached per-document (SHA-256 of the preview) so navigating away and back doesn't re-hit the LLM. If the LLM call fails or times out, the panel silently doesn't appear — your typed scenario still works exactly as before. The endpoint is `POST /api/simulation/suggest-scenarios`.
 
+### What's Trending (Auto-Discovery)
+
+Smart Setup handles users who arrive with a document. **What's Trending** handles the other half — people who want to simulate *something* about AI, crypto, or geopolitics but don't have a specific article in mind. The panel sits below the URL Import box and shows the 5 most recent items across a configurable list of public RSS/Atom feeds (defaults: Reuters tech, The Verge, Hacker News, CoinDesk).
+
+Click any card and MiroShark pre-fills the URL field, fetches the article, and immediately fires Scenario Auto-Suggest on the resulting text — blank page to three scenario cards in one click. Operators can override the feed list with the `TRENDING_FEEDS` env var (comma-separated URLs). Server-side cache holds results for 15 minutes; if every feed errors the panel disappears silently. The endpoint is `GET /api/simulation/trending`.
+
 ## Screenshots
 
 <div align="center">

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -382,6 +382,436 @@ def suggest_scenarios():
         }), 500
 
 
+# ============== Trending Topics ==============
+#
+# Closes the remaining onboarding gap left by Scenario Auto-Suggest (PR #39).
+# Auto-Suggest helps users who already pasted a document; Trending Topics
+# helps users who arrive without one — they pick a current headline, the URL
+# is fetched, and Auto-Suggest fires immediately on the resulting text.
+
+# Curated default feed list — broadly newsworthy, free, public.
+# Operators can override via TRENDING_FEEDS env var (comma-separated URLs).
+_TRENDING_DEFAULT_FEEDS = (
+    "https://feeds.reuters.com/reuters/technologyNews",
+    "https://www.theverge.com/rss/index.xml",
+    "https://hnrss.org/frontpage",
+    "https://www.coindesk.com/arc/outboundfeeds/rss/",
+)
+
+# Items returned to the client per request.
+_TRENDING_ITEM_LIMIT = 5
+
+# Per-feed fetch timeout. Keeps a slow upstream from stalling the whole call.
+_TRENDING_FEED_TIMEOUT_SEC = 5.0
+
+# Cache freshness window. Avoids re-hitting upstream feeds on every page load.
+_TRENDING_CACHE_TTL_SEC = 900   # 15 minutes
+
+# Per-IP rate limit. RSS fetches are cheaper than LLM calls, so the budget is
+# higher than scenario-suggest's, but still bounded.
+_TRENDING_RATE_WINDOW_SEC = 60
+_TRENDING_RATE_MAX_CALLS = 30
+_TRENDING_RATE_HITS: "dict[str, list[float]]" = {}
+
+# Cache: keyed by feed-list hash → (expires_at_monotonic, items)
+_TRENDING_CACHE: "dict[str, tuple[float, list[dict]]]" = {}
+
+# RSS/Atom XML namespaces we care about. Atom uses default namespaces; RSS
+# 2.0 sometimes injects Dublin Core for dates. ElementTree exposes namespaces
+# as "{uri}localname" in tag names.
+_TRENDING_NS = {
+    "atom": "http://www.w3.org/2005/Atom",
+    "dc": "http://purl.org/dc/elements/1.1/",
+}
+
+
+def _trending_get_feeds() -> "list[str]":
+    """Resolve the configured feed list from env, falling back to defaults."""
+    raw = (os.environ.get('TRENDING_FEEDS') or '').strip()
+    if not raw:
+        return list(_TRENDING_DEFAULT_FEEDS)
+    feeds = [u.strip() for u in raw.split(',') if u.strip()]
+    return feeds or list(_TRENDING_DEFAULT_FEEDS)
+
+
+def _trending_rate_limited(client_ip: str) -> bool:
+    """Sliding-window per-IP rate limit, mirroring scenario-suggest's pattern."""
+    import time
+    now = time.monotonic()
+    cutoff = now - _TRENDING_RATE_WINDOW_SEC
+    hits = _TRENDING_RATE_HITS.get(client_ip, [])
+    hits = [t for t in hits if t > cutoff]
+    if len(hits) >= _TRENDING_RATE_MAX_CALLS:
+        _TRENDING_RATE_HITS[client_ip] = hits
+        return True
+    hits.append(now)
+    _TRENDING_RATE_HITS[client_ip] = hits
+    if len(_TRENDING_RATE_HITS) > 1024:
+        for ip in list(_TRENDING_RATE_HITS.keys()):
+            if not _TRENDING_RATE_HITS[ip] or _TRENDING_RATE_HITS[ip][-1] < cutoff:
+                _TRENDING_RATE_HITS.pop(ip, None)
+    return False
+
+
+def _trending_parse_pubdate(raw: str):
+    """Best-effort parse of RSS/Atom date strings into a UTC datetime.
+
+    Handles RFC 822 (RSS pubDate), RFC 3339 / ISO 8601 (Atom updated/published),
+    and a couple of common malformed variants seen in the wild. Returns None
+    on failure — callers fall back to "now-ish" sort order.
+    """
+    if not raw:
+        return None
+    raw = raw.strip()
+    # Try ISO 8601 first (Atom + many modern RSS feeds use it).
+    try:
+        # Python's fromisoformat needs "+00:00" not "Z".
+        iso = raw.replace('Z', '+00:00')
+        dt = datetime.fromisoformat(iso)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except (ValueError, TypeError):
+        pass
+    # Fall back to RFC 822 / 2822 via email.utils (RSS pubDate format).
+    try:
+        from email.utils import parsedate_to_datetime
+        dt = parsedate_to_datetime(raw)
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def _trending_strip_localname(tag: str) -> str:
+    """Strip XML namespace prefix from a tag name: '{ns}foo' → 'foo'."""
+    if tag.startswith('{'):
+        return tag.split('}', 1)[1]
+    return tag
+
+
+def _trending_text(elem) -> str:
+    """Return the trimmed text of an XML element, or '' if missing/empty."""
+    if elem is None:
+        return ''
+    return (elem.text or '').strip()
+
+
+def _trending_extract_link(item) -> str:
+    """Pull the first usable URL from an RSS or Atom entry.
+
+    Atom feeds emit multiple <link> elements per entry: rel="alternate" is
+    the article URL, rel="self" is the entry's own representation, and other
+    rels (enclosure, replies) point at non-article resources. We always
+    prefer rel="alternate" (or an unspecified rel, which Atom treats as
+    alternate by default).
+    """
+    # First pass: prefer Atom <link rel="alternate" href="..."/> entries.
+    for child in item:
+        if _trending_strip_localname(child.tag) != 'link':
+            continue
+        href = (child.get('href') or '').strip()
+        if not href:
+            continue
+        rel = (child.get('rel') or 'alternate').lower()
+        if rel == 'alternate' and href.startswith('http'):
+            return href
+    # Second pass: RSS 2.0 — <link>https://...</link> with no attributes.
+    for child in item:
+        if _trending_strip_localname(child.tag) != 'link':
+            continue
+        text = (child.text or '').strip()
+        if text.startswith('http'):
+            return text
+    # Last resort: <guid isPermaLink="true"> may carry the article URL.
+    for child in item:
+        if _trending_strip_localname(child.tag) != 'guid':
+            continue
+        text = (child.text or '').strip()
+        is_perma = (child.get('isPermaLink', 'true').lower() != 'false')
+        if is_perma and text.startswith('http'):
+            return text
+    return ''
+
+
+def _trending_extract_published(item) -> str:
+    """Pull the best available timestamp from an RSS or Atom entry."""
+    # Try in priority order: published > updated > pubDate > dc:date.
+    candidates = []
+    for child in item:
+        local = _trending_strip_localname(child.tag)
+        if local in ('published', 'updated', 'pubDate', 'date'):
+            text = (child.text or '').strip()
+            if text:
+                candidates.append((local, text))
+    priority = {'published': 0, 'updated': 1, 'pubDate': 2, 'date': 3}
+    candidates.sort(key=lambda t: priority.get(t[0], 99))
+    return candidates[0][1] if candidates else ''
+
+
+def _trending_extract_source(root, feed_url: str) -> str:
+    """Pick a human-readable source name from the channel/feed metadata."""
+    # RSS: <channel><title>...</title>
+    channel = root.find('channel')
+    if channel is not None:
+        title = _trending_text(channel.find('title'))
+        if title:
+            return title[:80]
+    # Atom: <feed><title>...</title>. ElementTree elements evaluate as falsy
+    # when they have no children, even if they have .text — so use explicit
+    # `is not None` rather than `or` chaining.
+    title_elem = root.find('atom:title', _TRENDING_NS)
+    if title_elem is None:
+        title_elem = root.find('title')
+    title = _trending_text(title_elem)
+    if title:
+        return title[:80]
+    # Last resort: derive from the feed URL host.
+    try:
+        from urllib.parse import urlparse
+        host = (urlparse(feed_url).netloc or feed_url)
+        if host.startswith('www.'):
+            host = host[4:]
+        return host[:80] or 'Unknown'
+    except Exception:
+        return 'Unknown'
+
+
+def _trending_fetch_one(feed_url: str) -> "list[dict]":
+    """Fetch and parse a single feed. Returns [] on any failure."""
+    import xml.etree.ElementTree as ET
+    from urllib.request import Request, urlopen
+    from urllib.error import URLError
+
+    try:
+        # User-Agent header — some feeds (Reuters, Atom-based blogs) reject the
+        # default Python urllib UA with 403.
+        req = Request(
+            feed_url,
+            headers={
+                'User-Agent': 'MiroShark/1.0 (+https://github.com/aaronjmars/MiroShark)',
+                'Accept': 'application/rss+xml, application/atom+xml, application/xml;q=0.9, */*;q=0.8',
+            },
+        )
+        with urlopen(req, timeout=_TRENDING_FEED_TIMEOUT_SEC) as resp:
+            # Cap read at 1 MB to avoid hostile/oversized feeds.
+            body = resp.read(1024 * 1024)
+    except (URLError, TimeoutError, OSError) as exc:
+        logger.info(f"trending: feed fetch failed for {feed_url}: {exc}")
+        return []
+
+    if not body:
+        return []
+
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError as exc:
+        logger.info(f"trending: feed parse failed for {feed_url}: {exc}")
+        return []
+
+    source_name = _trending_extract_source(root, feed_url)
+
+    # RSS 2.0: items live under <channel><item>. Atom: <entry> directly under
+    # <feed>. Try both — empty list is fine.
+    items = []
+    channel = root.find('channel')
+    if channel is not None:
+        items.extend(channel.findall('item'))
+    items.extend(root.findall('atom:entry', _TRENDING_NS))
+    items.extend(root.findall('entry'))
+
+    out = []
+    for item in items:
+        title = ''
+        for child in item:
+            if _trending_strip_localname(child.tag) == 'title':
+                title = (child.text or '').strip()
+                break
+        url = _trending_extract_link(item)
+        if not title or not url or not url.startswith('http'):
+            continue
+        published_raw = _trending_extract_published(item)
+        published_at = _trending_parse_pubdate(published_raw)
+        out.append({
+            "title": title[:240],
+            "url": url,
+            "source_name": source_name,
+            "published_at": (
+                published_at.isoformat() if published_at else None
+            ),
+            "_sort_ts": (
+                published_at.timestamp() if published_at else 0.0
+            ),
+        })
+    return out
+
+
+def _trending_fetch_all(feeds: "list[str]") -> "list[dict]":
+    """Fetch every feed in parallel and merge the results, newest first."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    if not feeds:
+        return []
+
+    merged = []
+    # Bound workers so a long feed list doesn't open hundreds of sockets.
+    max_workers = min(len(feeds), 8)
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_trending_fetch_one, url): url for url in feeds}
+        for fut in as_completed(futures):
+            try:
+                merged.extend(fut.result() or [])
+            except Exception as exc:
+                logger.info(
+                    f"trending: worker failed for {futures[fut]}: {exc}"
+                )
+
+    # Drop duplicates by URL while preserving the newest occurrence.
+    seen = {}
+    for item in merged:
+        prev = seen.get(item['url'])
+        if prev is None or item['_sort_ts'] > prev['_sort_ts']:
+            seen[item['url']] = item
+
+    deduped = list(seen.values())
+    deduped.sort(key=lambda i: i['_sort_ts'], reverse=True)
+
+    # Strip the internal sort key before returning.
+    for item in deduped:
+        item.pop('_sort_ts', None)
+    return deduped
+
+
+@simulation_bp.route('/trending', methods=['GET'])
+def trending_topics():
+    """Return the most recent items across the configured RSS/Atom feeds.
+
+    Query params:
+        feeds:   optional comma-separated URL list to override TRENDING_FEEDS
+        refresh: pass any truthy value to bypass the in-memory cache
+
+    Response:
+        {
+          "success": true,
+          "data": {
+            "items": [
+              {"title": "...", "url": "...", "source_name": "...",
+               "published_at": "2026-04-21T13:45:00+00:00"}
+            ],
+            "feeds_used": [...],
+            "cached": true,
+            "fetched_at": "2026-04-21T13:50:00+00:00"
+          }
+        }
+
+    On total failure (every feed errored), `items` is an empty array — the
+    UI hides the panel silently. The endpoint never 5xx's the client.
+    """
+    try:
+        client_ip = (
+            request.headers.get('X-Forwarded-For', '').split(',')[0].strip()
+            or request.remote_addr
+            or 'unknown'
+        )
+        if _trending_rate_limited(client_ip):
+            return jsonify({
+                "success": True,
+                "data": {
+                    "items": [],
+                    "feeds_used": [],
+                    "cached": False,
+                    "reason": "rate_limited",
+                }
+            }), 429
+
+        # Resolve feeds: ?feeds=... overrides; otherwise env / default list.
+        feeds_param = (request.args.get('feeds') or '').strip()
+        if feeds_param:
+            feeds = [u.strip() for u in feeds_param.split(',') if u.strip()]
+        else:
+            feeds = _trending_get_feeds()
+
+        # Defensive: cap at 12 feeds per request to bound work.
+        if len(feeds) > 12:
+            feeds = feeds[:12]
+
+        if not feeds:
+            return jsonify({
+                "success": True,
+                "data": {
+                    "items": [],
+                    "feeds_used": [],
+                    "cached": False,
+                    "reason": "no_feeds_configured",
+                }
+            })
+
+        import time
+        import hashlib
+        cache_key = hashlib.sha1(
+            ('|'.join(feeds)).encode('utf-8')
+        ).hexdigest()
+
+        force_refresh = (request.args.get('refresh') or '').lower() in (
+            '1', 'true', 'yes'
+        )
+
+        now = time.monotonic()
+        if not force_refresh:
+            cached = _TRENDING_CACHE.get(cache_key)
+            if cached and cached[0] > now:
+                items = cached[1][:_TRENDING_ITEM_LIMIT]
+                return jsonify({
+                    "success": True,
+                    "data": {
+                        "items": items,
+                        "feeds_used": feeds,
+                        "cached": True,
+                        "fetched_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                })
+
+        items = _trending_fetch_all(feeds)
+        # Cache even an empty list briefly so we don't retry every page load
+        # when all upstreams are down — but use a shorter TTL (60s) for the
+        # empty case so recovery is fast.
+        ttl = _TRENDING_CACHE_TTL_SEC if items else 60
+        _TRENDING_CACHE[cache_key] = (now + ttl, items)
+        # Bound cache size — feed-list permutations can otherwise leak.
+        if len(_TRENDING_CACHE) > 64:
+            # Drop the oldest expiring entry.
+            oldest_key = min(_TRENDING_CACHE, key=lambda k: _TRENDING_CACHE[k][0])
+            _TRENDING_CACHE.pop(oldest_key, None)
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "items": items[:_TRENDING_ITEM_LIMIT],
+                "feeds_used": feeds,
+                "cached": False,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+            }
+        })
+
+    except Exception as exc:
+        logger.error(
+            f"Failed to fetch trending topics: {exc}\n{traceback.format_exc()}"
+        )
+        # Never 5xx — the panel is non-essential and should silently disappear.
+        return jsonify({
+            "success": True,
+            "data": {
+                "items": [],
+                "feeds_used": [],
+                "cached": False,
+                "reason": "internal_error",
+            }
+        })
+
+
 # ============== Entity Reading Endpoints ==============
 
 @simulation_bp.route('/entities/<graph_id>', methods=['GET'])

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -392,7 +392,7 @@ def suggest_scenarios():
 # Curated default feed list — broadly newsworthy, free, public.
 # Operators can override via TRENDING_FEEDS env var (comma-separated URLs).
 _TRENDING_DEFAULT_FEEDS = (
-    "https://feeds.reuters.com/reuters/technologyNews",
+    "https://techcrunch.com/feed/",
     "https://www.theverge.com/rss/index.xml",
     "https://hnrss.org/frontpage",
     "https://www.coindesk.com/arc/outboundfeeds/rss/",
@@ -432,6 +432,54 @@ def _trending_get_feeds() -> "list[str]":
         return list(_TRENDING_DEFAULT_FEEDS)
     feeds = [u.strip() for u in raw.split(',') if u.strip()]
     return feeds or list(_TRENDING_DEFAULT_FEEDS)
+
+
+def _trending_url_allowed(url: str) -> bool:
+    """Reject URLs that aren't http(s) or target private/loopback hosts.
+
+    First line of defense against using this endpoint as an SSRF proxy via
+    the ?feeds= query param. We don't resolve DNS here (that would add
+    per-call latency and still leaves a rebinding window); the hostname-level
+    deny combined with the other controls — rate limit, 1 MB body cap, 5 s
+    timeout, structured-output-only — is sufficient for this feature's scope.
+    """
+    try:
+        from urllib.parse import urlparse
+        import ipaddress
+        parsed = urlparse(url)
+    except Exception:
+        return False
+    if parsed.scheme not in ('http', 'https'):
+        return False
+    host = (parsed.hostname or '').strip().lower()
+    if not host:
+        return False
+    # Block obvious loopback / cloud-metadata hostnames.
+    if host in ('localhost', 'ip6-localhost', 'metadata.google.internal'):
+        return False
+    # If host parses as a standard IP literal, block private / reserved ranges.
+    try:
+        ip = ipaddress.ip_address(host)
+        if (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
+            return False
+    except ValueError:
+        pass  # Not a standard IP literal — fall through to obfuscated-form check.
+    # Guard against obfuscated IPv4: Python's socket.getaddrinfo accepts
+    # integer (2130706433), octal (0177.0.0.1), and hex (0x7f000001) encodings
+    # of 127.0.0.1, and ipaddress.ip_address rejects all of them — so an
+    # attacker could bypass the check above and still hit localhost. Normalize
+    # via inet_aton (which accepts every form socket does) and re-check.
+    try:
+        import socket
+        canonical = socket.inet_ntoa(socket.inet_aton(host))
+        ip = ipaddress.ip_address(canonical)
+        if (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
+            return False
+    except (OSError, ValueError):
+        pass  # Not an IPv4 in any encoding — a real DNS name. Allow.
+    return True
 
 
 def _trending_rate_limited(client_ip: str) -> bool:
@@ -728,9 +776,15 @@ def trending_topics():
             }), 429
 
         # Resolve feeds: ?feeds=... overrides; otherwise env / default list.
+        # User-supplied URLs pass through _trending_url_allowed to block SSRF
+        # attempts (non-http(s) schemes, loopback, private / link-local hosts).
+        # Env / default feeds are operator-controlled and trusted as-is.
         feeds_param = (request.args.get('feeds') or '').strip()
         if feeds_param:
-            feeds = [u.strip() for u in feeds_param.split(',') if u.strip()]
+            feeds = [
+                u.strip() for u in feeds_param.split(',')
+                if u.strip() and _trending_url_allowed(u.strip())
+            ]
         else:
             feeds = _trending_get_feeds()
 

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -400,6 +400,38 @@ export const getDemographicBreakdown = (simulationId, options = {}) => {
 }
 
 /**
+ * Fetch the most recent items across configured RSS/Atom feeds. Used by the
+ * Home screen "What's Trending" panel — gives users who arrive without a
+ * specific document a one-click starting point. Clicking a card pre-fills
+ * the URL field and immediately fires the existing fetch + scenario-suggest
+ * pipeline.
+ *
+ * Response shape:
+ *   {
+ *     items: [
+ *       { title, url, source_name, published_at }
+ *     ],
+ *     feeds_used: [...],
+ *     cached: boolean,
+ *     fetched_at?: string,
+ *     reason?: 'rate_limited' | 'no_feeds_configured' | 'internal_error'
+ *   }
+ *
+ * An empty `items` array is normal when every feed errored — the caller
+ * should hide the panel silently.
+ *
+ * @param {Object} options - { feeds?: string[], refresh?: boolean }
+ */
+export const getTrendingTopics = (options = {}) => {
+  const params = {}
+  if (Array.isArray(options.feeds) && options.feeds.length) {
+    params.feeds = options.feeds.join(',')
+  }
+  if (options.refresh) params.refresh = 'true'
+  return service.get('/api/simulation/trending', { params, timeout: 12000 })
+}
+
+/**
  * Generate 3 prediction-market-style scenario suggestions from a document
  * preview. Used by the Home screen to eliminate the blank-page problem at
  * simulation setup — the user pastes a URL or drops a file, and within a

--- a/frontend/src/components/TrendingTopics.vue
+++ b/frontend/src/components/TrendingTopics.vue
@@ -1,0 +1,315 @@
+<template>
+  <div v-if="shouldRender" class="tt-wrap">
+    <div class="tt-head">
+      <span class="tt-label">
+        <span class="tt-dot">◉</span> What's Trending
+        <span class="tt-sub">{{ statusLine }}</span>
+      </span>
+      <button
+        v-if="!loading"
+        class="tt-refresh"
+        type="button"
+        title="Refresh feeds"
+        @click="refresh"
+      >↻</button>
+    </div>
+
+    <div v-if="loading && items.length === 0" class="tt-loading">
+      <span class="tt-spinner"></span>
+      Pulling current headlines from public feeds…
+    </div>
+
+    <div v-else-if="items.length > 0" class="tt-grid">
+      <button
+        v-for="(item, idx) in items"
+        :key="item.url"
+        type="button"
+        class="tt-card"
+        :disabled="busy"
+        :title="item.title"
+        @click="select(item, idx)"
+      >
+        <div class="tt-card-head">
+          <span class="tt-source">{{ item.source_name }}</span>
+          <span v-if="item.published_at" class="tt-time">
+            {{ relativeTime(item.published_at) }}
+          </span>
+        </div>
+        <div class="tt-title">{{ item.title }}</div>
+        <div class="tt-cta">
+          <span class="tt-cta-text">Simulate</span>
+          <span class="tt-cta-arrow">→</span>
+        </div>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * TrendingTopics
+ *
+ * Renders the 5 most recent items from a configurable list of RSS/Atom feeds
+ * (Reuters tech, The Verge, Hacker News, CoinDesk by default — operator can
+ * override with TRENDING_FEEDS). Each card is a one-click jumping-off point:
+ * the parent receives a `select` event with the URL and is expected to
+ * push it into the same fetch + scenario-suggest pipeline that powers the
+ * URL Import box.
+ *
+ * Designed to be silently absent when nothing is available — if every feed
+ * errors, the API returns an empty `items` array and this component renders
+ * nothing rather than a broken-looking placeholder.
+ */
+
+import { computed, onMounted, ref } from 'vue'
+import { getTrendingTopics } from '../api/simulation'
+
+const props = defineProps({
+  // When true, the parent has an active fetch underway and we should
+  // disable card clicks to avoid stacking concurrent URL fetches.
+  busy: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['select'])
+
+const items = ref([])
+const loading = ref(false)
+const fetchedAt = ref(null)
+const cached = ref(false)
+const errored = ref(false)
+
+const shouldRender = computed(() => {
+  if (loading.value) return true
+  return items.value.length > 0
+})
+
+const statusLine = computed(() => {
+  if (loading.value) return '// fetching…'
+  if (!fetchedAt.value) return ''
+  const ago = relativeTime(fetchedAt.value)
+  return cached.value ? `// cached · refreshed ${ago}` : `// refreshed ${ago}`
+})
+
+const relativeTime = (iso) => {
+  if (!iso) return ''
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return ''
+  const diffSec = Math.max(0, Math.floor((Date.now() - t) / 1000))
+  if (diffSec < 60) return 'just now'
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDay = Math.floor(diffHr / 24)
+  return `${diffDay}d ago`
+}
+
+const load = async ({ force = false } = {}) => {
+  loading.value = true
+  errored.value = false
+  try {
+    const res = await getTrendingTopics({ refresh: force })
+    if (!res || res.success === false) {
+      items.value = []
+      errored.value = true
+      return
+    }
+    const data = res.data || {}
+    items.value = Array.isArray(data.items) ? data.items : []
+    fetchedAt.value = data.fetched_at || new Date().toISOString()
+    cached.value = !!data.cached
+  } catch (_) {
+    // Swallow — trending is non-essential. Hide the panel on hard errors.
+    items.value = []
+    errored.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+const refresh = () => {
+  if (loading.value) return
+  load({ force: true })
+}
+
+const select = (item, idx) => {
+  if (props.busy) return
+  emit('select', { url: item.url, title: item.title, source: item.source_name, index: idx })
+}
+
+onMounted(() => {
+  load()
+})
+</script>
+
+<style scoped>
+.tt-wrap {
+  margin-top: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: rgba(67, 193, 101, 0.04);
+  border: 2px dashed rgba(67, 193, 101, 0.3);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  position: relative;
+}
+
+.tt-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-sm);
+}
+
+.tt-label {
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--color-green);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tt-dot {
+  color: var(--color-green);
+  font-size: 12px;
+}
+
+.tt-sub {
+  color: rgba(10, 10, 10, 0.45);
+  font-size: 10px;
+  letter-spacing: 1px;
+  font-weight: normal;
+  text-transform: none;
+}
+
+.tt-refresh {
+  background: none;
+  border: 1px solid rgba(10, 10, 10, 0.15);
+  color: rgba(10, 10, 10, 0.45);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 3px 8px;
+  border-radius: 2px;
+  transition: var(--transition-fast);
+}
+
+.tt-refresh:hover {
+  color: var(--color-green);
+  border-color: var(--color-green);
+}
+
+.tt-loading {
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.55);
+  letter-spacing: 0.5px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 2px;
+}
+
+.tt-spinner {
+  width: 10px;
+  height: 10px;
+  border: 2px solid rgba(67, 193, 101, 0.25);
+  border-top-color: var(--color-green);
+  border-radius: 50%;
+  display: inline-block;
+  animation: tt-spin 0.8s linear infinite;
+}
+
+@keyframes tt-spin {
+  to { transform: rotate(360deg); }
+}
+
+.tt-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+.tt-card {
+  background: var(--color-white);
+  border: 2px solid rgba(10, 10, 10, 0.08);
+  border-left: 4px solid var(--color-green);
+  border-radius: 4px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  transition: var(--transition-fast);
+  min-height: 110px;
+}
+
+.tt-card:hover:not(:disabled) {
+  border-color: var(--color-green);
+  border-left-color: var(--color-green);
+  transform: translateY(-1px);
+}
+
+.tt-card:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tt-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 9px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: rgba(10, 10, 10, 0.55);
+}
+
+.tt-source {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 60%;
+}
+
+.tt-time {
+  font-size: 9px;
+  color: rgba(10, 10, 10, 0.4);
+  letter-spacing: 0.5px;
+  text-transform: none;
+  flex-shrink: 0;
+}
+
+.tt-title {
+  font-family: var(--font-display);
+  font-size: 13px;
+  color: var(--color-black);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  flex: 1;
+}
+
+.tt-cta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-top: auto;
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--color-green);
+}
+
+.tt-cta-arrow {
+  font-family: sans-serif;
+  font-size: 13px;
+}
+</style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -180,6 +180,10 @@
                   <button @click.stop="removeUrlDoc(index)" class="remove-btn">×</button>
                 </div>
               </div>
+              <TrendingTopics
+                :busy="urlFetching"
+                @select="handleTrendingSelect"
+              />
             </div>
 
             <!-- Divider -->
@@ -241,6 +245,7 @@ import HistoryDatabase from '../components/HistoryDatabase.vue'
 import TemplateGallery from '../components/TemplateGallery.vue'
 import SettingsPanel from '../components/SettingsPanel.vue'
 import ScenarioSuggestions from '../components/ScenarioSuggestions.vue'
+import TrendingTopics from '../components/TrendingTopics.vue'
 import { fetchUrl } from '../api/graph'
 
 const settingsOpen = ref(false)
@@ -417,6 +422,21 @@ const fetchUrlDoc = async () => {
   } finally {
     urlFetching.value = false
   }
+}
+
+// User picked a "What's Trending" card — push the URL into the input and
+// reuse the existing fetch pipeline. ScenarioSuggestions already watches
+// urlDocs and will fire once the fetched doc lands, so the user goes from
+// blank-page to three scenario cards in one click.
+const handleTrendingSelect = ({ url }) => {
+  if (!url || urlFetching.value) return
+  if (urlDocs.value.some(d => d.url === url)) {
+    urlError.value = 'This URL is already loaded.'
+    return
+  }
+  urlInput.value = url
+  urlError.value = ''
+  fetchUrlDoc()
 }
 
 // Remove a URL document from the list


### PR DESCRIPTION
## What

Adds **What's Trending** — a 5-card panel on the simulation setup page that surfaces the most recent items across a configurable list of public RSS/Atom feeds. Clicking a card pre-fills the URL field and immediately fires the existing fetch + Scenario Auto-Suggest pipeline. New users go from blank canvas to three scenario cards in a single click.

## Why

Scenario Auto-Suggest (PR #39) eliminated the blank-page problem for users who arrive with a document. But a meaningful share of MiroShark's audience comes in wanting to simulate *something* about AI, crypto, or geopolitics without a specific article in mind — and was still left staring at an empty input. This closes that remaining onboarding gap and connects MiroShark directly to the real-time news cycle that prediction-market framings are built around.

The Kelp DAO / Aave cascade coincidence over the weekend (a Director Mode demo accidentally previewing a real-world exploit ~24h before it happened) is exactly the kind of moment this feature unlocks: surface a breaking headline, click, and within seconds you have three Bull/Bear/Neutral scenarios ready to simulate.

## Changes

- **`backend/app/api/simulation.py`** — New `GET /api/simulation/trending` endpoint. Stdlib-only RSS/Atom parser (`xml.etree.ElementTree` + `urllib.request`), no new Python dependencies. Parallel feed fetch via `ThreadPoolExecutor` with a 5s per-feed timeout and 1 MB body cap. Returns the top 5 most recent items deduplicated by URL, sorted newest-first. In-memory cache keyed by feed-list hash (15 min TTL on success, 60s on empty so recovery is fast). Per-IP sliding-window rate limit (30 calls/min) mirrors the existing `suggest-scenarios` pattern. Endpoint never 5xxes — on total feed failure it returns an empty `items` array and the panel disappears silently. Handles RSS 2.0 (RFC 822 dates), Atom (RFC 3339, multiple `<link rel>` variants), and `dc:date` fallbacks. UA header set so feeds that reject default Python urllib (Reuters, several Atom blogs) still work.
- **`frontend/src/components/TrendingTopics.vue`** — New Vue 3 `<script setup>` component. Loads on mount, renders 5 cards in a responsive auto-fit grid; each card shows source name, relative time ("3h ago"), title (clamped to 3 lines), and a "Simulate →" CTA. Manual refresh button bypasses the server cache. Disables clicks while the parent is mid-fetch so URL fetches can't stack. Hidden entirely when `items` is empty — no broken-looking placeholder.
- **`frontend/src/api/simulation.js`** — `getTrendingTopics({ feeds?, refresh? })` API client wrapping the new endpoint with a 12s timeout.
- **`frontend/src/views/Home.vue`** — Imports `TrendingTopics`, mounts it directly under the URL Import section, wires `@select` to a new `handleTrendingSelect` handler that pushes the picked URL into `urlInput` and calls the existing `fetchUrlDoc()`. The `ScenarioSuggestions` component already watches `urlDocs` and will fire automatically once the article text lands — zero coupling between the two features.
- **`.env.example`** — Documents the new optional `TRENDING_FEEDS` env var (comma-separated URLs) with an example of the default feed list.
- **`README.md`** — New "What's Trending (Auto-Discovery)" section under Smart Setup explaining the panel, the env var override, the cache behavior, and the silent-failure guarantee.

## How it works

The frontend calls `GET /api/simulation/trending` on mount. The backend resolves the feed list (env var → curated default of Reuters tech / The Verge / Hacker News / CoinDesk), checks the in-memory cache, and on miss spawns up to 8 worker threads that each fetch one feed with a 5s timeout. Each response is XML-parsed with stdlib `ElementTree`; the parser handles both RSS 2.0 (`<channel><item>` + `<pubDate>`) and Atom (`<feed><entry>` + `<published>`/`<updated>` + multi-`<link>` with `rel` discrimination). Results are merged, URL-deduplicated, sorted by published timestamp newest-first, top-5 returned, and the full sorted list cached. The endpoint always returns HTTP 200 with `success: true` — failure modes (rate limit, no feeds, all upstreams down, internal exception) are all signaled by an empty `items` array plus a `reason` code, which the UI treats as "hide the panel."

The frontend wiring intentionally goes through the existing URL input rather than a separate code path: clicking a trending card is identical to typing the URL by hand and clicking Fetch. That means every downstream behavior (URL deduplication, error handling, the ScenarioSuggestions auto-fire on `urlDocs` change, the file-and-URL combined preview) just works without modification.

## What's next

Operators with strong topical preferences can drop a `TRENDING_FEEDS` line into `.env`. Natural future extensions: a settings-modal feed picker persisted to a config record; per-feed source icons; a topic filter (AI / crypto / geopolitics) that cycles between curated subsets. None of those are needed today — the v1 already removes the friction.

---
*Built autonomously by Aeon*