### PR TITLE
feat: integrate capabilities from sibling repos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,33 @@ COMMUNITY_MAX_COUNT=30     # cap on clusters summarized per rebuild
 # cross-report reasoning patterns.
 REASONING_TRACE_ENABLED=true
 
+# ===== Oracle Seeds (optional — FeedOracle MCP) =====
+# Opt-in live data enrichment for preset templates that declare
+# `oracle_tools` (MiCA peg deviation, DORA assessments, macro risk, etc.).
+# Off by default; flip to true and call GET /api/templates/<id>?enrich=true
+# to resolve declared tools against mcp.feedoracle.io at template load.
+ORACLE_SEED_ENABLED=false
+# FEEDORACLE_MCP_URL=https://mcp.feedoracle.io/mcp
+# FEEDORACLE_API_KEY=
+
+# ===== Per-agent MCP tools (optional — OpenMiro-style) =====
+# Give personas with `tools_enabled: true` (journalists, analysts, traders)
+# access to real MCP tools during the simulation. MCP servers are configured
+# via config/mcp_servers.yaml; MCP_AGENT_TOOLS_ENABLED gates the feature on.
+MCP_AGENT_TOOLS_ENABLED=false
+# MCP_SERVERS_CONFIG=./config/mcp_servers.yaml
+
+# ===== Prompt caching (Anthropic) =====
+# When true and the active model is Claude-family, LLMClient attaches
+# cache_control blocks to the system prompt. Cuts cost on the ReACT loop
+# and NER. Silently no-ops for non-Anthropic providers.
+LLM_PROMPT_CACHING_ENABLED=true
+
+# ===== Embedding batch size =====
+# How many texts per embedding HTTP request. Higher is faster for graph
+# build; drop to 32 if your provider 413s you.
+EMBEDDING_BATCH_SIZE=128
+
 # ===== Smart Model (optional) =====
 # Stronger model for report generation, ontology extraction, graph reasoning.
 # When not set, these workflows use the default LLM config above.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit:
+    name: Backend unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # Install only the thin dependencies the unit suite needs.
+      # The full ``requirements.txt`` pulls in torch/transformers etc., which
+      # are not required for the offline unit tests and slow CI cold-start.
+      - name: Install unit-test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install \
+            "pytest>=8.0.0" \
+            pyyaml \
+            "openai>=1.0.0" \
+            "flask>=3.0.0" \
+            "flask-cors>=6.0.0" \
+            "flask-compress>=1.17" \
+            "python-dotenv>=1.0.0" \
+            "pydantic>=2.0.0" \
+            "requests>=2.31.0"
+
+      - name: Run unit tests
+        run: pytest -m "not integration"
+

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@
 1. **Graph Build** — Extracts entities and relationships from your document into a Neo4j knowledge graph. NER uses few-shot examples and rejection rules to filter garbage entities. Chunk processing is parallelized with batched Neo4j writes (UNWIND).
 2. **Agent Setup** — Generates personas grounded in the knowledge graph. Each entity gets 5 layers of context: graph attributes, relationships, semantic search, related nodes, and LLM-powered web research (auto-triggers for public figures or when graph context is thin). Individual vs. institutional personas are detected automatically via keyword matching.
 3. **Simulation** — All three platforms (Twitter, Reddit, Polymarket) run simultaneously via `asyncio.gather`. A single LLM-generated prediction market with non-50/50 starting price drives Polymarket trading. Agents see cross-platform context: traders read Twitter/Reddit posts, social media agents see market prices. A sliding-window round memory compacts old rounds via background LLM calls. Belief states track stance, confidence, and trust per agent with heuristic updates each round.
-4. **Report** — A ReACT agent writes analytical reports using `simulation_feed` (actual posts/comments/trades), `market_state` (prices/P&L), graph search, and belief trajectory tools. Reports cite what agents actually said and how markets moved.
-5. **Interaction** — Chat directly with any agent via persona chat, or send questions to groups. Click any agent to view their full profile and simulation history.
+4. **Report** — A ReACT agent writes analytical reports using `simulation_feed` (actual posts/comments/trades), `market_state` (prices/P&L), graph search, belief trajectory, and Nash equilibrium tools. Reports cite what agents actually said and how markets moved.
+5. **Interaction** — Chat directly with any agent via persona chat, send questions to groups, or **branch the simulation with a counterfactual event** at any round to explore "what if" scenarios side-by-side. Click any agent to view their full profile and simulation history.
 
 ### Smart Setup (Scenario Auto-Suggest)
 
@@ -53,6 +53,44 @@ Click **Use this →** on any card to fill the Simulation Prompt field, or dismi
 Smart Setup handles users who arrive with a document. **What's Trending** handles the other half — people who want to simulate *something* about AI, crypto, or geopolitics but don't have a specific article in mind. The panel sits below the URL Import box and shows the 5 most recent items across a configurable list of public RSS/Atom feeds (defaults: Reuters tech, The Verge, Hacker News, CoinDesk).
 
 Click any card and MiroShark pre-fills the URL field, fetches the article, and immediately fires Scenario Auto-Suggest on the resulting text — blank page to three scenario cards in one click. Operators can override the feed list with the `TRENDING_FEEDS` env var (comma-separated URLs). Server-side cache holds results for 15 minutes; if every feed errors the panel disappears silently. The endpoint is `GET /api/simulation/trending`.
+
+### Just Ask (Question-Only Mode)
+
+No document and no specific article in mind? Type a question on the Home screen ("Will the EU AI Act's biometrics clause survive the final trilogue?") and MiroShark asks the Smart model to research the topic and synthesize a 1500–3000-character briefing — neutral, structured with Context / Key Actors / Recent Events / Open Questions. The briefing becomes a `miroshark://ask/...` seed document in the URL list and pre-fills the simulation prompt, so the downstream pipeline (ontology → graph → profiles → sim) runs unchanged. Cached per-question for quick re-runs. The endpoint is `POST /api/simulation/ask`.
+
+### Counterfactual Branching
+
+Run a simulation, pause to inspect, then ask: "what if the CEO resigns in round 24?" — click **⤷ Branch** in the simulation workspace, enter a trigger round and a breaking-news injection, and MiroShark forks the simulation with the parent's full agent population. When the runner reaches the trigger round, the injection is promoted to a director event and prepended to every agent's observation prompt as a BREAKING block. Compare the branch against the original via the existing **Compare** view. Preset templates can declare `counterfactual_branches` (e.g. `ceo_resigns`, `class_action`, `rug_pull`, `sec_notice`) so the branch dialog offers one-click scenarios. The endpoint is `POST /api/simulation/branch-counterfactual`.
+
+### Live Oracle Data (FeedOracle MCP)
+
+Opt in to grounded seed data from the [FeedOracle MCP server](https://mcp.feedoracle.io/mcp) (484 tools across MiCA compliance, DORA assessments, macro/FRED data, DEX liquidity, sanctions, carbon markets, and more). Templates declare the tools they want:
+
+```json
+"oracle_tools": [
+  {"server": "feedoracle_core", "tool": "peg_deviation", "args": {"token_symbol": "USDT"}},
+  {"server": "feedoracle_core", "tool": "macro_risk",    "args": {}}
+]
+```
+
+Flip `ORACLE_SEED_ENABLED=true` in `.env`, check **Use live oracle data** on any template card, and MiroShark dispatches the calls and appends the results as a markdown "Oracle Evidence" block to the seed document before ingest. Silent no-op when disabled or any call fails — the static seed still works.
+
+### Per-Agent MCP Tools
+
+Opt-in, OpenMiro-style: selected personas (journalists, analysts, traders) can invoke real MCP tools during the simulation. Mark a persona with `"tools_enabled": true` in its profile JSON, configure the servers in `config/mcp_servers.yaml`, and set `MCP_AGENT_TOOLS_ENABLED=true`.
+
+Each round the runner:
+
+1. **Injects** the tool catalogue into the agent's system message (marker-delimited so it refreshes each round).
+2. **Parses** the agent's post for self-closing tags like `<mcp_call server="web_search" tool="search" args='{"q":"..."}' />` (up to 2 calls/turn).
+3. **Dispatches** them through a pooled stdio subprocess per server (one process per sim, reused).
+4. **Injects the results** back into the agent's system message for the next round.
+
+Failed calls become `{"_error": "..."}` payloads rather than exceptions — agent prompts stay well-formed. The bridge has a 30-second per-call timeout (`MCP_CALL_TIMEOUT_SEC`) and tears down subprocesses on simulation end (or `atexit` on abnormal exit).
+
+### Publishing for Embed
+
+`EmbedDialog` has a `Public / Private` toggle backed by `is_public` on the simulation state. Embed URLs return `403` on unpublished simulations — flip the toggle (or `POST /api/simulation/<id>/publish`) to make them publicly embeddable. Defaults to private so existing sims are unaffected.
 
 ## Screenshots
 
@@ -127,6 +165,10 @@ A single prediction market is generated by the LLM during config creation, tailo
 ### Web Enrichment
 
 When generating personas for public figures (politicians, CEOs, founders) or when graph context is thin (<150 chars), the system makes an LLM research call to enrich the profile with real-world data. Set `WEB_SEARCH_MODEL=perplexity/sonar-pro` in `.env` for grounded web search via OpenRouter.
+
+### Per-Round Frame API
+
+`GET /api/simulation/<id>/frame/<round>` returns a compact snapshot of a single round — actions, active-agent count, market prices at that round, and belief state — for scrubbing UIs on large simulations. Alternative to loading all N × M actions upfront via `/run-status/detail`. Query params: `platforms=twitter,reddit,polymarket`, `include_belief`, `include_market`. Used by **ReplayView** for timeline scrubbing and by the CLI (`miroshark-cli frame <id> <round>`).
 
 ### Memory & Retrieval Pipeline
 
@@ -511,6 +553,28 @@ REASONING_TRACE_ENABLED=true
 # Web Enrichment (auto-researches public figures during persona generation)
 WEB_ENRICHMENT_ENABLED=true
 # WEB_SEARCH_MODEL=google/gemini-2.0-flash-001:online
+
+# Embedding batching — how many texts per HTTP request. Higher is faster on
+# graph builds; drop to 32 if your provider 413s you.
+EMBEDDING_BATCH_SIZE=128
+
+# Anthropic prompt caching — attaches cache_control to the system message
+# when the active model is Claude-family. ~10% cost on cache reads; big win
+# on the ReACT report loop. Silent no-op for non-Anthropic models.
+LLM_PROMPT_CACHING_ENABLED=true
+
+# Live oracle seeds (FeedOracle MCP — opt-in grounded data for templates
+# that declare `oracle_tools`). See "Live Oracle Data" above.
+ORACLE_SEED_ENABLED=false
+# FEEDORACLE_MCP_URL=https://mcp.feedoracle.io/mcp
+# FEEDORACLE_API_KEY=
+
+# Per-agent MCP tools — lets personas with `tools_enabled: true` invoke
+# MCP servers during simulation. Configure servers in config/mcp_servers.yaml.
+MCP_AGENT_TOOLS_ENABLED=false
+# MCP_SERVERS_CONFIG=./config/mcp_servers.yaml
+# MCP_MAX_CALLS_PER_TURN=2
+# MCP_CALL_TIMEOUT_SEC=30
 ```
 
 
@@ -547,6 +611,53 @@ Restart Claude Desktop. The `miroshark` tools appear in the hammer menu:
 | `get_reasoning_trace` | Full ReACT decision chain for one section |
 
 Example prompt: *"List my MiroShark graphs, browse clusters on the biggest one for anything about oracle exploits, then show me the reasoning trace from the most recent report on that graph."*
+
+## Report Agent Tools
+
+The ReACT report agent exposes these tools (configured via `REPORT_AGENT_MAX_TOOL_CALLS`):
+
+| Tool | Purpose |
+|---|---|
+| `insight_forge` | Multi-round deep analysis on a specific question |
+| `panorama_search` | Hybrid vector + BM25 + graph retrieval |
+| `quick_search` | Lightweight keyword search |
+| `interview_agents` | Live conversation with sim agents |
+| `analyze_trajectory` | Belief drift — convergence, polarization, turning points |
+| `analyze_equilibrium` | Nash equilibria on a 2-player stance game fit to the final belief distribution — reveals whether observed outcomes are consistent with self-interested play (requires `nashpy`) |
+| `analyze_graph_structure` | Centrality / community / bridge analysis |
+| `find_causal_path` | Graph traversal between two entities |
+| `detect_contradictions` | Conflicting edges in the graph |
+| `simulation_feed` | Raw action log filter by platform / query / round |
+| `market_state` | Polymarket prices, trades, portfolios |
+| `browse_clusters` | Community zoom-out (orienting) |
+
+## CLI
+
+A dependency-light HTTP client for a running MiroShark backend:
+
+```bash
+# From a checkout with the backend installed:
+pip install -e backend/
+miroshark-cli ask "Will the EU AI Act survive trilogue?"
+
+# Or run directly — no install, no third-party deps:
+python backend/cli.py --help
+```
+
+Useful for scripting and headless workflows. Set `MIROSHARK_API_URL` to point at a remote deployment.
+
+| Command | What it does |
+|---|---|
+| `ask "<question>"` | Synthesize a seed briefing from a question |
+| `list` | List simulations / projects |
+| `status <sim_id>` | Runner status + round/total |
+| `frame <sim_id> <round>` | Compact per-round snapshot |
+| `publish <sim_id> [--unpublish]` | Toggle the embed public flag |
+| `report <sim_id>` | Render the analytical report |
+| `trending` | Pull RSS/Atom trending items |
+| `health` | Ping `/health` |
+
+All commands accept `--json` for scripting.
 
 ## Observability & Debugging
 
@@ -604,6 +715,25 @@ MIROSHARK_LOG_LEVEL=info      # debug|info|warn — controls event verbosity
 ```
 
 By default, only response previews (200 chars) are logged. Set `MIROSHARK_LOG_PROMPTS=true` to capture full prompts and responses for deep debugging.
+
+---
+
+## Testing
+
+A pytest suite lives at `backend/tests/`. Run the fast offline unit suite with:
+
+```bash
+cd backend && pytest -m "not integration"
+```
+
+Integration tests hit a live backend at `MIROSHARK_API_URL` (default `http://localhost:5001`); legacy E2E scripts wrap as `slow` tests:
+
+```bash
+pytest -m integration                # endpoint contracts (seconds)
+pytest -m "integration and slow"     # full pipeline smoke tests (minutes)
+```
+
+Some integration tests need a pre-existing simulation — set `MIROSHARK_TEST_SIM_ID=sim_xxx`. The hand-run scripts in `backend/scripts/test_*.py` still work as stand-alone programs; the pytest layer just registers them for discovery. The `.github/workflows/tests.yml` workflow runs the unit suite on every push and PR.
 
 ---
 

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -382,6 +382,207 @@ def suggest_scenarios():
         }), 500
 
 
+# ============== Ask Mode — question-only pipeline ==============
+#
+# Borrowed shape from MiroWhale's `mirowhale ask` CLI: the user arrives with a
+# question and no document, and we synthesize a seed doc from the LLM's own
+# research so the existing ontology → graph → simulation pipeline works
+# unchanged downstream.
+
+_ASK_RATE_WINDOW_SEC = 60
+_ASK_RATE_MAX_CALLS = 5
+_ASK_RATE_HITS: "dict[str, list[float]]" = {}
+_ASK_CACHE: "dict[str, dict]" = {}
+_ASK_CACHE_ORDER: "list[str]" = []
+_ASK_CACHE_MAX = 32
+_ASK_QUESTION_MAX_CHARS = 400
+
+_ASK_SYSTEM_PROMPT = (
+    "You are a research analyst. The user has a single question about public "
+    "reaction, market dynamics, or policy. They have no source document; your "
+    "job is to produce a *neutral, evidence-grounded briefing* that will seed "
+    "an agent-based social simulation.\n\n"
+    "Return JSON of this exact shape:\n"
+    '{ "title": str, "simulation_requirement": str, "seed_document": str, '
+    '"key_actors": [str], "suggested_platforms": ["twitter"|"reddit"|"polymarket"] }\n\n'
+    "Rules:\n"
+    "- title: short (<=60 chars), descriptive — this is the project name.\n"
+    "- simulation_requirement: one paragraph (~400-600 chars) framing the simulation "
+    "goal — who the agents should represent and what dynamics to watch.\n"
+    "- seed_document: a 1500-3000 character markdown briefing. Include sections "
+    "for Context, Key Actors/Stakeholders, Recent Events, and Open Questions. "
+    "Use only facts that would plausibly be public knowledge — do not invent "
+    "specific quotes, dates, or figures that could mislead. Prefer qualitative "
+    "framing (\"several major outlets have\") over fabricated specifics.\n"
+    "- key_actors: 4-10 stakeholders likely to post/trade in the simulation.\n"
+    "- suggested_platforms: 1-3 from the allowed set, chosen by relevance.\n"
+    "Do not include disclaimers. Do not include any other fields."
+)
+
+
+def _ask_rate_limited(client_ip: str) -> bool:
+    import time
+    now = time.monotonic()
+    cutoff = now - _ASK_RATE_WINDOW_SEC
+    hits = [t for t in _ASK_RATE_HITS.get(client_ip, []) if t > cutoff]
+    if len(hits) >= _ASK_RATE_MAX_CALLS:
+        _ASK_RATE_HITS[client_ip] = hits
+        return True
+    hits.append(now)
+    _ASK_RATE_HITS[client_ip] = hits
+    if len(_ASK_RATE_HITS) > 1024:
+        for ip in list(_ASK_RATE_HITS.keys()):
+            if not _ASK_RATE_HITS[ip] or _ASK_RATE_HITS[ip][-1] < cutoff:
+                _ASK_RATE_HITS.pop(ip, None)
+    return False
+
+
+def _ask_cache_get(key: str):
+    entry = _ASK_CACHE.get(key)
+    if entry is None:
+        return None
+    try:
+        _ASK_CACHE_ORDER.remove(key)
+    except ValueError:
+        pass
+    _ASK_CACHE_ORDER.append(key)
+    return entry
+
+
+def _ask_cache_put(key: str, value: dict) -> None:
+    if key in _ASK_CACHE:
+        try:
+            _ASK_CACHE_ORDER.remove(key)
+        except ValueError:
+            pass
+    _ASK_CACHE[key] = value
+    _ASK_CACHE_ORDER.append(key)
+    while len(_ASK_CACHE_ORDER) > _ASK_CACHE_MAX:
+        _ASK_CACHE.pop(_ASK_CACHE_ORDER.pop(0), None)
+
+
+_ASK_ALLOWED_PLATFORMS = {"twitter", "reddit", "polymarket"}
+
+
+def _ask_clean_result(payload, question: str) -> "dict | None":
+    if not isinstance(payload, dict):
+        return None
+    title = (payload.get("title") or "").strip()
+    req = (payload.get("simulation_requirement") or "").strip()
+    doc = (payload.get("seed_document") or "").strip()
+    actors_raw = payload.get("key_actors") or []
+    platforms_raw = payload.get("suggested_platforms") or []
+
+    if not title or len(title) > 120:
+        title = (question[:57] + "...") if len(question) > 60 else question
+    if len(req) < 40 or len(doc) < 400:
+        return None
+
+    actors = []
+    if isinstance(actors_raw, list):
+        for a in actors_raw:
+            if isinstance(a, str) and a.strip():
+                actors.append(a.strip())
+            if len(actors) == 10:
+                break
+
+    platforms = []
+    if isinstance(platforms_raw, list):
+        for p in platforms_raw:
+            if isinstance(p, str) and p.strip().lower() in _ASK_ALLOWED_PLATFORMS:
+                platforms.append(p.strip().lower())
+    # dedupe while preserving order
+    seen = set()
+    platforms = [p for p in platforms if not (p in seen or seen.add(p))]
+    if not platforms:
+        platforms = ["twitter", "reddit"]
+
+    return {
+        "title": title[:120],
+        "simulation_requirement": req,
+        "seed_document": doc,
+        "key_actors": actors,
+        "suggested_platforms": platforms,
+    }
+
+
+@simulation_bp.route('/ask', methods=['POST'])
+def ask_mode():
+    """Question-only pipeline: turn a bare question into a seed document.
+
+    Request (JSON): ``{"question": "..."}``. Returns a synthesized title,
+    simulation_requirement, and a markdown seed_document the frontend can feed
+    straight into ``/api/graph/ontology/generate`` as a ``url_docs`` entry —
+    the rest of the flow (ontology, graph build, profiles, simulation) runs
+    unchanged.
+
+    Response:
+    ``{"success": true, "data": {title, simulation_requirement, seed_document,
+    key_actors, suggested_platforms, model, cached}}``.
+    """
+    try:
+        client_ip = (
+            request.headers.get('X-Forwarded-For', '').split(',')[0].strip()
+            or request.remote_addr
+            or 'unknown'
+        )
+        if _ask_rate_limited(client_ip):
+            return jsonify({
+                "success": False,
+                "error": "rate_limited",
+            }), 429
+
+        data = request.get_json(silent=True) or {}
+        question = (data.get("question") or "").strip()
+        if not isinstance(question, str) or len(question) < 8:
+            return jsonify({
+                "success": False,
+                "error": "question must be at least 8 characters",
+            }), 400
+        if len(question) > _ASK_QUESTION_MAX_CHARS:
+            return jsonify({
+                "success": False,
+                "error": f"question too long (max {_ASK_QUESTION_MAX_CHARS} chars)",
+            }), 400
+
+        import hashlib
+        cache_key = hashlib.sha256(question.lower().encode('utf-8')).hexdigest()
+
+        if not data.get('no_cache'):
+            cached = _ask_cache_get(cache_key)
+            if cached is not None:
+                return jsonify({"success": True, "data": {**cached, "cached": True}})
+
+        try:
+            llm = create_smart_llm_client(timeout=60.0)
+        except Exception as exc:
+            logger.warning(f"ask: smart LLM unavailable: {exc}")
+            return jsonify({"success": False, "error": "llm_unavailable"}), 503
+
+        messages = [
+            {"role": "system", "content": _ASK_SYSTEM_PROMPT},
+            {"role": "user", "content": f"User question: {question}\n\nProduce the briefing now."},
+        ]
+
+        try:
+            parsed = llm.chat_json(messages, temperature=0.4, max_tokens=3500)
+        except Exception as exc:
+            logger.warning(f"ask: LLM call failed: {exc}")
+            return jsonify({"success": False, "error": "llm_error"}), 502
+
+        cleaned = _ask_clean_result(parsed, question)
+        if cleaned is None:
+            return jsonify({"success": False, "error": "llm_returned_invalid_briefing"}), 502
+
+        cleaned["model"] = getattr(llm, 'model', None) or Config.SMART_MODEL_NAME or Config.LLM_MODEL_NAME
+        _ask_cache_put(cache_key, cleaned)
+        return jsonify({"success": True, "data": {**cleaned, "cached": False}})
+
+    except Exception as e:
+        logger.error(f"ask mode failed: {e}\n{traceback.format_exc()}")
+        return jsonify({"success": False, "error": "ask_failed"}), 500
+
+
 # ============== Trending Topics ==============
 #
 # Closes the remaining onboarding gap left by Scenario Auto-Suggest (PR #39).
@@ -1050,6 +1251,68 @@ def create_simulation():
             "success": False,
             "error": str(e),
             "traceback": traceback.format_exc()
+        }), 500
+
+
+@simulation_bp.route('/branch-counterfactual', methods=['POST'])
+def branch_counterfactual_simulation():
+    """Branch a simulation with a narrative injection at a chosen round.
+
+    Request (JSON)::
+
+        {
+            "parent_simulation_id": "sim_xxxx",     // required
+            "injection_text":       "CEO resigns…", // required, <= 2000 chars
+            "trigger_round":        24,             // required, >= 0
+            "label":                "CEO resigns",  // optional
+            "branch_id":            "ceo_resigns"   // optional preset branch id
+        }
+
+    Returns the new simulation's state (``parent_simulation_id`` + the
+    ``config_diff.counterfactual`` block identifies the branch). The runner
+    reads ``counterfactual_injection.json`` in the new sim's directory and
+    prepends ``injection_text`` to every agent's observation prompt starting
+    at ``trigger_round``.
+    """
+    try:
+        data = request.get_json() or {}
+        parent_id = data.get("parent_simulation_id")
+        injection = (data.get("injection_text") or "").strip()
+        trigger = data.get("trigger_round")
+        label = data.get("label")
+        branch_id = data.get("branch_id")
+
+        if not parent_id:
+            return jsonify({"success": False, "error": "parent_simulation_id is required"}), 400
+        if not injection:
+            return jsonify({"success": False, "error": "injection_text is required"}), 400
+        if len(injection) > 2000:
+            return jsonify({"success": False, "error": "injection_text must be <= 2000 chars"}), 400
+        try:
+            trigger_int = int(trigger)
+        except (TypeError, ValueError):
+            return jsonify({"success": False, "error": "trigger_round must be an integer >= 0"}), 400
+        if trigger_int < 0:
+            return jsonify({"success": False, "error": "trigger_round must be >= 0"}), 400
+
+        manager = SimulationManager()
+        state = manager.branch_counterfactual(
+            parent_simulation_id=parent_id,
+            injection_text=injection,
+            trigger_round=trigger_int,
+            label=label,
+            branch_id=branch_id,
+        )
+        return jsonify({"success": True, "data": state.to_dict()})
+
+    except ValueError as e:
+        return jsonify({"success": False, "error": str(e)}), 404
+    except Exception as e:
+        logger.error(f"Failed to branch counterfactual: {e}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc(),
         }), 500
 
 
@@ -3742,7 +4005,163 @@ def _compute_quality_diagnostics(simulation_id: str, sim_dir: str):
     }
 
 
+# ============== Per-round snapshot (ReplayView / analytics) ==============
+
+@simulation_bp.route('/<simulation_id>/frame/<int:round_num>', methods=['GET'])
+def get_simulation_frame(simulation_id: str, round_num: int):
+    """Compact round snapshot: actions in the round + market prices + belief state.
+
+    Purpose: power scrubbing UIs (ReplayView) without loading all actions
+    upfront. A 500-agent × 72-round simulation may emit ~36k actions; this
+    endpoint returns only the round requested plus any rolling state the
+    client needs to render the frame.
+
+    Query params:
+        include_belief: "true" (default) — inlines belief positions at/before round
+        include_market: "true" (default) — inlines YES price per market at round
+        platforms: comma-list (twitter,reddit,polymarket) — filter returned actions
+
+    Response: ``{actions, market_prices, belief, active_agents, action_counts}``.
+    """
+    try:
+        validate_simulation_id(simulation_id)
+
+        platforms_raw = (request.args.get('platforms') or '').strip()
+        platforms = [p.strip().lower() for p in platforms_raw.split(',') if p.strip()] if platforms_raw else None
+        include_belief = (request.args.get('include_belief', 'true').lower() == 'true')
+        include_market = (request.args.get('include_market', 'true').lower() == 'true')
+
+        # Collect actions for this round
+        actions_for_round: list = []
+        if platforms:
+            for p in platforms:
+                if p not in ('twitter', 'reddit', 'polymarket'):
+                    continue
+                actions_for_round.extend(
+                    SimulationRunner.get_all_actions(simulation_id, platform=p, round_num=round_num)
+                )
+        else:
+            actions_for_round = SimulationRunner.get_all_actions(simulation_id, round_num=round_num)
+
+        actions_for_round.sort(key=lambda a: getattr(a, 'timestamp', '') or '')
+        action_counts = {"twitter": 0, "reddit": 0, "polymarket": 0}
+        active_agents = set()
+        for a in actions_for_round:
+            plat = getattr(a, 'platform', None)
+            if plat in action_counts:
+                action_counts[plat] += 1
+            aid = getattr(a, 'agent_id', None)
+            if aid is not None:
+                active_agents.add(aid)
+
+        # Market prices snapshot at this round
+        market_prices: list = []
+        if include_market:
+            sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+            db_path = os.path.join(sim_dir, 'polymarket', 'polymarket.db')
+            if os.path.exists(db_path):
+                try:
+                    import sqlite3
+                    con = sqlite3.connect(db_path)
+                    cur = con.cursor()
+                    tables = {r[0] for r in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+                    if 'price_history' in tables:
+                        # Most recent price at-or-before this round, per market
+                        rows = cur.execute(
+                            "SELECT market_id, price_yes, round_num FROM price_history "
+                            "WHERE round_num <= ? ORDER BY round_num DESC",
+                            (round_num,)
+                        ).fetchall()
+                        seen_markets = set()
+                        for mid, py, rn in rows:
+                            if mid in seen_markets:
+                                continue
+                            seen_markets.add(mid)
+                            market_prices.append({"market_id": mid, "price_yes": py, "as_of_round": rn})
+                    con.close()
+                except Exception as exc:
+                    logger.warning(f"frame: market price read failed for {simulation_id}: {exc}")
+
+        # Belief snapshot at this round (or closest prior snapshot)
+        belief_snapshot = None
+        if include_belief:
+            traj_path = os.path.join(
+                Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id, "trajectory.json"
+            )
+            if os.path.exists(traj_path):
+                try:
+                    with open(traj_path, 'r', encoding='utf-8') as f:
+                        traj = json.load(f)
+                    snapshots = traj.get("snapshots", []) or []
+                    chosen = None
+                    for snap in snapshots:
+                        if snap.get("round_num", -1) <= round_num:
+                            chosen = snap
+                        else:
+                            break
+                    if chosen:
+                        positions = chosen.get("belief_positions", {}) or {}
+                        stances = []
+                        for p in positions.values():
+                            if isinstance(p, dict) and p:
+                                stances.append(sum(p.values()) / len(p))
+                        total = len(stances) or 1
+                        nb = sum(1 for s in stances if s > 0.2)
+                        nbe = sum(1 for s in stances if s < -0.2)
+                        belief_snapshot = {
+                            "round_num": chosen.get("round_num"),
+                            "bullish_pct": round(nb / total * 100, 1),
+                            "bearish_pct": round(nbe / total * 100, 1),
+                            "neutral_pct": round((total - nb - nbe) / total * 100, 1),
+                            "agents_with_positions": len(positions),
+                        }
+                except Exception as exc:
+                    logger.warning(f"frame: belief read failed for {simulation_id}: {exc}")
+
+        return jsonify({
+            "success": True,
+            "data": {
+                "simulation_id": simulation_id,
+                "round_num": round_num,
+                "actions": [a.to_dict() for a in actions_for_round],
+                "action_counts": action_counts,
+                "active_agents_count": len(active_agents),
+                "market_prices": market_prices,
+                "belief": belief_snapshot,
+            },
+        })
+    except ValueError as exc:
+        return jsonify({"success": False, "error": str(exc)}), 400
+    except Exception as e:
+        logger.error(f"frame: failed for {simulation_id} round {round_num}: {e}\n{traceback.format_exc()}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
 # ============== Embed Widget ==============
+
+@simulation_bp.route('/<simulation_id>/publish', methods=['POST'])
+def publish_simulation(simulation_id: str):
+    """Mark a simulation as publicly embeddable.
+
+    Body (optional): ``{"public": false}`` to unpublish instead of publish.
+    Returns the new public state.
+    """
+    try:
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        payload = request.get_json(silent=True) or {}
+        new_value = bool(payload.get("public", True))
+        state.is_public = new_value
+        manager._save_simulation_state(state)
+
+        return jsonify({"success": True, "data": {"simulation_id": simulation_id, "is_public": state.is_public}})
+    except Exception as e:
+        logger.error(f"Failed to publish simulation: {str(e)}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
 
 @simulation_bp.route('/<simulation_id>/embed-summary', methods=['GET'])
 def get_embed_summary(simulation_id: str):
@@ -3753,6 +4172,9 @@ def get_embed_summary(simulation_id: str):
     agent count, belief drift sparkline, optional consensus/resolution/health —
     so a single request powers the read-only widget without the full simulation
     payload.
+
+    Access: requires ``is_public=True`` on the simulation state. Use the
+    ``/publish`` endpoint to toggle.
     """
     try:
         manager = SimulationManager()
@@ -3762,6 +4184,12 @@ def get_embed_summary(simulation_id: str):
                 "success": False,
                 "error": f"Simulation not found: {simulation_id}"
             }), 404
+
+        if not getattr(state, "is_public", False):
+            return jsonify({
+                "success": False,
+                "error": "Simulation is not published for embedding. POST /api/simulation/<id>/publish to enable.",
+            }), 403
 
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
 
@@ -3892,6 +4320,7 @@ def get_embed_summary(simulation_id: str):
             "profiles_count": state.profiles_count,
             "created_date": created_date,
             "parent_simulation_id": state.parent_simulation_id,
+            "is_public": getattr(state, "is_public", False),
             "belief": belief,
             "quality": quality,
             "resolution": resolution,

--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -4,14 +4,32 @@ Template API routes — serves preset simulation templates
 
 import os
 import json
-from flask import jsonify
+from flask import jsonify, request
 
 from . import templates_bp
 from ..utils.logger import get_logger
+from ..services.oracle_seed import resolve_oracle_tools
 
 logger = get_logger('miroshark.api.templates')
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), '..', 'preset_templates')
+
+
+@templates_bp.route('/capabilities', methods=['GET'])
+def get_template_capabilities():
+    """Expose backend feature flags that control template behaviour.
+
+    Lets the frontend gray out toggles (e.g. "Live oracle data") when the
+    corresponding server-side env flag is off — cleaner than surprising the
+    user with a silent no-op.
+    """
+    return jsonify({
+        "success": True,
+        "data": {
+            "oracle_seed_enabled": os.environ.get("ORACLE_SEED_ENABLED", "false").lower() == "true",
+            "mcp_agent_tools_enabled": os.environ.get("MCP_AGENT_TOOLS_ENABLED", "false").lower() == "true",
+        },
+    })
 
 
 def _load_templates():
@@ -47,6 +65,8 @@ def list_templates():
 
         summaries = []
         for t in templates:
+            branches = t.get("counterfactual_branches", []) or []
+            oracle_tools = t.get("oracle_tools", []) or []
             summaries.append({
                 "id": t["id"],
                 "name": t["name"],
@@ -58,6 +78,10 @@ def list_templates():
                 "estimated_rounds": t.get("estimated_rounds", 0),
                 "platforms": t.get("platforms", []),
                 "tags": t.get("tags", []),
+                "has_counterfactuals": len(branches) > 0,
+                "counterfactual_count": len(branches),
+                "has_oracle_tools": len(oracle_tools) > 0,
+                "oracle_tool_count": len(oracle_tools),
             })
 
         return jsonify({
@@ -95,6 +119,19 @@ def get_template(template_id: str):
 
         with open(filepath, 'r', encoding='utf-8') as f:
             template = json.load(f)
+
+        # Opt-in oracle enrichment: ?enrich=true causes declared oracle_tools
+        # to be resolved against the FeedOracle MCP endpoint and appended to
+        # seed_document. Silent no-op if disabled or any call fails.
+        if (request.args.get('enrich', '').lower() == 'true'):
+            try:
+                block = resolve_oracle_tools(template)
+                if block:
+                    template = dict(template)
+                    template['seed_document'] = (template.get('seed_document') or '') + '\n\n' + block
+                    template['oracle_enriched'] = True
+            except Exception as exc:
+                logger.warning(f"oracle enrichment failed for {template_id}: {exc}")
 
         return jsonify({
             "success": True,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -57,6 +57,10 @@ class Config:
     EMBEDDING_BASE_URL = os.environ.get('EMBEDDING_BASE_URL', 'http://localhost:11434')
     EMBEDDING_API_KEY = os.environ.get('EMBEDDING_API_KEY', '')
     EMBEDDING_DIMENSIONS = int(os.environ.get('EMBEDDING_DIMENSIONS', '768'))
+    # How many texts to send per embedding HTTP request. OpenAI/OpenRouter
+    # text-embedding-3-* accepts 2048; Ollama nomic-embed-text happily chews
+    # through 128+. Lower if your provider 413s you.
+    EMBEDDING_BATCH_SIZE = int(os.environ.get('EMBEDDING_BATCH_SIZE', '128'))
 
     # Reranker configuration — cross-encoder reranking over hybrid search results.
     # Default: BAAI/bge-reranker-v2-m3 (multilingual, ~568M params). Downloaded on first
@@ -155,6 +159,14 @@ class Config:
     # Observability configuration
     MIROSHARK_LOG_PROMPTS = os.environ.get('MIROSHARK_LOG_PROMPTS', 'false').lower() == 'true'
     MIROSHARK_LOG_LEVEL = os.environ.get('MIROSHARK_LOG_LEVEL', 'info')  # debug|info|warn
+
+    # Anthropic prompt caching — when true and the active model is a Claude
+    # variant, LLMClient attaches cache_control:{"type":"ephemeral"} to the
+    # system message so repeated calls with the same prefix pay ~10% on cache
+    # reads. Biggest wins: report ReACT loop (~N iterations per section × M
+    # sections, all with the same system prompt) and graph-building NER.
+    # Silently no-ops for non-Anthropic models.
+    LLM_PROMPT_CACHING_ENABLED = os.environ.get('LLM_PROMPT_CACHING_ENABLED', 'true').lower() == 'true'
 
     # Report Agent configuration
     REPORT_AGENT_MAX_TOOL_CALLS = int(os.environ.get('REPORT_AGENT_MAX_TOOL_CALLS', '5'))

--- a/backend/app/preset_templates/corporate_crisis.json
+++ b/backend/app/preset_templates/corporate_crisis.json
@@ -15,5 +15,28 @@
     "enable_twitter": true,
     "enable_reddit": true,
     "enable_polymarket": false
-  }
+  },
+  "counterfactual_branches": [
+    {
+      "id": "ceo_resigns",
+      "label": "CEO resigns on Day 2",
+      "description": "The CEO steps down 24h after the story breaks, replaced by an interim.",
+      "trigger_round": 24,
+      "injection": "The CEO of DataVault Inc. has just announced her resignation. The board has appointed the CTO as interim CEO. The outgoing CEO said: 'I take full responsibility for the delay in disclosure.'"
+    },
+    {
+      "id": "class_action",
+      "label": "Class-action suit filed",
+      "description": "A major law firm files a $1B class-action lawsuit by round 36.",
+      "trigger_round": 36,
+      "injection": "Cohen Milstein has filed a $1B class-action on behalf of the 12M affected users, alleging willful concealment of the breach."
+    },
+    {
+      "id": "competitor_breach",
+      "label": "Competitor has a bigger breach",
+      "description": "A direct competitor discloses a 40M-user breach, redirecting attention.",
+      "trigger_round": 48,
+      "injection": "CloudLocker Inc. (a direct competitor) has just disclosed a 40M-user breach — 3x the size of DataVault's. The news cycle is pivoting."
+    }
+  ]
 }

--- a/backend/app/preset_templates/crypto_launch.json
+++ b/backend/app/preset_templates/crypto_launch.json
@@ -15,5 +15,32 @@
     "enable_twitter": true,
     "enable_reddit": true,
     "enable_polymarket": true
-  }
+  },
+  "oracle_tools": [
+    {"server": "feedoracle_core", "tool": "macro_risk",      "args": {}},
+    {"server": "feedoracle_core", "tool": "peg_deviation",   "args": {"token_symbol": "USDT"}}
+  ],
+  "counterfactual_branches": [
+    {
+      "id": "rug_pull",
+      "label": "Team wallet drains liquidity",
+      "description": "The team pulls liquidity around the 12h mark — rug-pull.",
+      "trigger_round": 12,
+      "injection": "On-chain monitors are flagging an unusual multi-sig transaction draining $1.8M of $NRAL liquidity. The team's wallet addresses have gone silent."
+    },
+    {
+      "id": "cex_listing",
+      "label": "Tier-1 CEX listing confirmed",
+      "description": "A top-5 centralized exchange announces $NRAL listing at round 18.",
+      "trigger_round": 18,
+      "injection": "Binance has officially announced a $NRAL/USDT perpetual listing going live in 6 hours. The token is up 70% on the news."
+    },
+    {
+      "id": "sec_notice",
+      "label": "SEC issues Wells notice",
+      "description": "The SEC sends a Wells notice framing $NRAL as an unregistered security.",
+      "trigger_round": 24,
+      "injection": "The SEC has just sent NeuralCoin a Wells notice stating the token may qualify as an unregistered security. The team has 30 days to respond."
+    }
+  ]
 }

--- a/backend/app/services/agent_mcp_tools.py
+++ b/backend/app/services/agent_mcp_tools.py
@@ -1,0 +1,148 @@
+"""Per-agent MCP tools — OpenMiro-style pluggable toolset for personas.
+
+Grants select personas (journalists, analysts, traders) access to real MCP
+tools during simulation. Disabled by default: gated by
+``MCP_AGENT_TOOLS_ENABLED`` at runtime, and further per-persona by the
+``tools_enabled`` flag on :class:`OasisAgentProfile`.
+
+## Wiring
+
+1. Set ``MCP_AGENT_TOOLS_ENABLED=true`` in ``.env``.
+2. Drop a YAML manifest at ``MCP_SERVERS_CONFIG`` (default ``config/mcp_servers.yaml``).
+   Schema (OpenMiro-compatible)::
+
+       mcp_servers:
+         - name: web_search
+           command: python
+           args: ["-m", "mcp_web_search"]
+           env:
+             BRAVE_API_KEY: "${BRAVE_KEY}"
+         - name: price_feed
+           command: npx
+           args: ["-y", "@feedoracle/mcp-remote"]
+
+3. In preset templates or at simulation-config time, mark personas with
+   ``tools_enabled: true`` and optionally ``allowed_tools: [name,...]``.
+
+The simulation loop should call :func:`build_agent_toolset` per round and
+pass the resulting dispatcher to the agent's prompt builder. Full OASIS
+integration requires changes to the wonderwall runner; this module provides
+the primitive so that work can proceed without blocking the feature flag.
+
+Keeps dependencies soft: if ``pyyaml`` is missing, returns an empty registry
+with a warning (rather than crashing the Flask app on import).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from ..utils.logger import get_logger
+
+logger = get_logger("miroshark.agent_mcp")
+
+
+@dataclass
+class MCPServerSpec:
+    """Parsed MCP server entry from the YAML manifest."""
+    name: str
+    command: str
+    args: List[str] = field(default_factory=list)
+    env: Dict[str, str] = field(default_factory=dict)
+
+
+def _enabled() -> bool:
+    return os.environ.get("MCP_AGENT_TOOLS_ENABLED", "false").lower() == "true"
+
+
+def _manifest_path() -> str:
+    return os.environ.get("MCP_SERVERS_CONFIG") or os.path.join(
+        os.getcwd(), "config", "mcp_servers.yaml"
+    )
+
+
+def load_registry() -> Dict[str, MCPServerSpec]:
+    """Parse the manifest into a name → MCPServerSpec map.
+
+    Returns an empty dict when the feature is off, the file is missing,
+    ``pyyaml`` isn't installed, or the file is malformed. Never raises.
+    """
+    if not _enabled():
+        return {}
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        logger.warning("agent_mcp: pyyaml not installed — per-agent MCP tools disabled")
+        return {}
+
+    path = _manifest_path()
+    if not os.path.exists(path):
+        logger.info(f"agent_mcp: manifest not found at {path} — no tools registered")
+        return {}
+
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh) or {}
+    except Exception as exc:
+        logger.warning(f"agent_mcp: failed to parse {path} ({exc})")
+        return {}
+
+    servers: Dict[str, MCPServerSpec] = {}
+    entries = raw.get("mcp_servers") or raw.get("servers") or []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = (entry.get("name") or "").strip()
+        command = (entry.get("command") or "").strip()
+        if not name or not command:
+            continue
+        raw_env = entry.get("env") or {}
+        resolved_env = {}
+        for k, v in raw_env.items():
+            if isinstance(v, str) and v.startswith("${") and v.endswith("}"):
+                resolved_env[k] = os.environ.get(v[2:-1], "")
+            else:
+                resolved_env[k] = str(v)
+        servers[name] = MCPServerSpec(
+            name=name,
+            command=command,
+            args=list(entry.get("args") or []),
+            env=resolved_env,
+        )
+
+    logger.info(f"agent_mcp: loaded {len(servers)} MCP server(s) from {path}")
+    return servers
+
+
+def build_agent_toolset(
+    profile,  # OasisAgentProfile-like duck type
+    registry: Optional[Dict[str, MCPServerSpec]] = None,
+) -> Dict[str, MCPServerSpec]:
+    """Return the subset of the registry this persona may call.
+
+    An empty return means the agent has no tools (either globally off,
+    persona opted out, or allowlist narrows to nothing). Callers don't need
+    to check ``_enabled()`` themselves.
+    """
+    if not _enabled() or not getattr(profile, "tools_enabled", False):
+        return {}
+    reg = registry if registry is not None else load_registry()
+    if not reg:
+        return {}
+    allowed = list(getattr(profile, "allowed_tools", None) or [])
+    if not allowed:
+        return dict(reg)  # persona with no allowlist → all tools
+    return {name: spec for name, spec in reg.items() if name in allowed}
+
+
+def summarize_toolset(tools: Dict[str, MCPServerSpec]) -> str:
+    """Short human-readable listing suitable for an agent system prompt."""
+    if not tools:
+        return "(no MCP tools available this round)"
+    lines = ["Available MCP tools:"]
+    for name, spec in tools.items():
+        args_str = " ".join(spec.args)
+        lines.append(f"  - {name}: {spec.command} {args_str}".rstrip())
+    return "\n".join(lines)

--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -57,7 +57,15 @@ class OasisAgentProfile:
     # Source entity information
     source_entity_uuid: Optional[str] = None
     source_entity_type: Optional[str] = None
-    
+
+    # Per-agent MCP tools — OpenMiro-style. Personas with tools_enabled=True
+    # are allowed to invoke MCP servers configured in MCP_SERVERS_CONFIG
+    # (or a future settings entry). The global MCP_AGENT_TOOLS_ENABLED flag
+    # must also be on for this to take effect in the simulation loop; when
+    # off, this field is metadata only.
+    tools_enabled: bool = False
+    allowed_tools: List[str] = field(default_factory=list)
+
     created_at: str = field(default_factory=lambda: datetime.now().strftime("%Y-%m-%d"))
     
     def to_reddit_format(self) -> Dict[str, Any]:

--- a/backend/app/services/oracle_seed.py
+++ b/backend/app/services/oracle_seed.py
@@ -1,0 +1,187 @@
+"""FeedOracle MCP connector — grounded data for simulation seeds.
+
+The sibling `mirofish-oracle-seeds` repo exposes 484 MCP tools across 44
+oracle servers (MiCA, DORA, macro, DEX liquidity, sanctions, carbon, etc.).
+MiroShark templates can opt into a subset by declaring::
+
+    "oracle_tools": [
+        {"server": "feedoracle_core", "tool": "mica_status",     "args": {"token_symbol": "USDT"}},
+        {"server": "feedoracle_core", "tool": "peg_deviation",   "args": {"token_symbol": "USDT"}},
+        {"server": "feedoracle_core", "tool": "macro_risk",      "args": {}}
+    ]
+
+At template-use time, ``resolve_oracle_tools`` dispatches each call against
+the FeedOracle MCP HTTP endpoint (``FEEDORACLE_MCP_URL``, default
+``https://mcp.feedoracle.io/mcp``) and returns a markdown-formatted evidence
+block to be appended to the template's ``seed_document`` before graph build.
+
+Opt-in. Disabled by default (``ORACLE_SEED_ENABLED=false``). Silently
+returns an empty block on any failure — the template still works without
+oracle data.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import Any, Dict, List, Optional
+
+try:  # httpx is already pulled in via OpenAI SDK — but we import defensively.
+    import httpx  # type: ignore
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore
+
+from ..utils.logger import get_logger
+
+logger = get_logger("miroshark.oracle_seed")
+
+
+_DEFAULT_ENDPOINT = "https://mcp.feedoracle.io/mcp"
+_DEFAULT_TIMEOUT_SEC = 15.0
+
+
+def _enabled() -> bool:
+    return (os.environ.get("ORACLE_SEED_ENABLED", "false").lower() == "true")
+
+
+def _endpoint() -> str:
+    return (os.environ.get("FEEDORACLE_MCP_URL") or _DEFAULT_ENDPOINT).rstrip("/")
+
+
+def _api_key() -> Optional[str]:
+    return os.environ.get("FEEDORACLE_API_KEY") or None
+
+
+class _MCPClient:
+    """Minimal stateless MCP client (JSON-RPC over HTTP). Mirrors the sibling repo."""
+
+    def __init__(self, endpoint: str, api_key: Optional[str]):
+        if httpx is None:
+            raise RuntimeError("httpx is not installed")
+        self.endpoint = endpoint
+        self.api_key = api_key
+        self.session_id: Optional[str] = None
+        self.client = httpx.Client(timeout=_DEFAULT_TIMEOUT_SEC)
+
+    def _rpc(self, method: str, params: Optional[Dict] = None) -> Dict[str, Any]:
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        if self.session_id:
+            headers["Mcp-Session-Id"] = self.session_id
+        payload = {
+            "jsonrpc": "2.0",
+            "id": uuid.uuid4().hex[:8],
+            "method": method,
+            "params": params or {},
+        }
+        resp = self.client.post(self.endpoint, json=payload, headers=headers)
+        resp.raise_for_status()
+        sid = resp.headers.get("mcp-session-id")
+        if sid:
+            self.session_id = sid
+        return resp.json()
+
+    def initialize(self) -> None:
+        self._rpc(
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "miroshark", "version": "1.0"},
+            },
+        )
+
+    def call_tool(self, name: str, arguments: Optional[Dict] = None) -> Any:
+        args: Dict[str, Any] = dict(arguments or {})
+        if self.api_key:
+            args.setdefault("api_key", self.api_key)
+        # Note: the sibling repo uses the bare tool name. Some deployments
+        # namespace via "server__tool" — we accept both forms in resolve_*.
+        result = self._rpc("tools/call", {"name": name, "arguments": args})
+        content = (result.get("result") or {}).get("content") or []
+        if content and isinstance(content, list):
+            first = content[0]
+            if isinstance(first, dict) and first.get("text"):
+                try:
+                    return json.loads(first["text"])
+                except json.JSONDecodeError:
+                    return first["text"]
+        return result
+
+    def close(self) -> None:
+        try:
+            self.client.close()
+        except Exception:
+            pass
+
+
+def resolve_oracle_tools(template: Dict[str, Any]) -> str:
+    """Dispatch ``template['oracle_tools']`` and return a markdown evidence block.
+
+    Returns an empty string if oracle seeds are disabled, the list is empty,
+    or any dispatch fails — the caller can safely concatenate the result onto
+    the seed document without worrying about None.
+    """
+    tools = template.get("oracle_tools") or []
+    if not tools or not _enabled() or httpx is None:
+        return ""
+
+    endpoint = _endpoint()
+    api_key = _api_key()
+    results: List[Dict[str, Any]] = []
+
+    try:
+        client = _MCPClient(endpoint, api_key)
+    except Exception as exc:
+        logger.warning(f"oracle_seed: init failed ({exc}) — skipping oracle enrichment")
+        return ""
+
+    try:
+        client.initialize()
+    except Exception as exc:
+        logger.warning(f"oracle_seed: initialize failed ({exc}) — skipping")
+        client.close()
+        return ""
+
+    for entry in tools:
+        if not isinstance(entry, dict):
+            continue
+        server = (entry.get("server") or "").strip()
+        name = (entry.get("tool") or "").strip()
+        if not name:
+            continue
+        args = entry.get("args") or {}
+        # Support both namespaced and bare tool names.
+        fq_name = f"{server}__{name}" if server else name
+        try:
+            data = client.call_tool(fq_name, args)
+        except Exception as exc:
+            logger.info(f"oracle_seed: {fq_name} failed ({exc}) — trying bare name")
+            try:
+                data = client.call_tool(name, args)
+            except Exception as exc2:
+                logger.warning(f"oracle_seed: {name} failed ({exc2}) — skipping this tool")
+                continue
+        results.append({"server": server, "tool": name, "args": args, "data": data})
+
+    client.close()
+
+    if not results:
+        return ""
+
+    lines = ["", "## Oracle Evidence (live at ingest time)", ""]
+    for r in results:
+        label = f"{r['server']}/{r['tool']}" if r["server"] else r["tool"]
+        args_str = ", ".join(f"{k}={v}" for k, v in (r["args"] or {}).items()) or "(no args)"
+        lines.append(f"### {label}  —  {args_str}")
+        data = r["data"]
+        try:
+            pretty = json.dumps(data, ensure_ascii=False, indent=2, default=str)[:1500]
+        except Exception:
+            pretty = str(data)[:1500]
+        lines.append("```json")
+        lines.append(pretty)
+        lines.append("```")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/backend/app/services/report_agent.py
+++ b/backend/app/services/report_agent.py
@@ -654,6 +654,35 @@ and trader portfolios with P&L.
 - Trader portfolios with cash, positions, and profit/loss
 - Price movement from initial to final"""
 
+TOOL_DESC_ANALYZE_EQUILIBRIUM = """\
+[Analyze Equilibrium - Nash Game-Theoretic View]
+Fits a 2-player game on top of the simulation's final belief distribution and
+returns its Nash equilibria. Inspired by MiroJiang's predictive-history
+framework: agents are grouped into a bullish/bearish axis by their mean stance,
+payoffs are weighted by group sizes and confidence, and equilibria are solved
+via support enumeration (nashpy).
+
+[Parameters]
+- topic: Optional specific topic/issue from the trajectory. Leave empty to use
+  the topic with the widest final spread (most contested).
+
+[Return Content]
+- Pure and mixed-strategy Nash equilibria (up to 3)
+- Group sizes and mean stances for both coalitions
+- A short qualitative reading (polarized / coordinated / mixed)
+
+[When to use]
+- When the report needs to reason about *strategic* dynamics, not just
+  observed outcomes (e.g. "would rational actors have sustained consensus?")
+- For policy / market scenarios with a clear binary choice
+- As a cross-check: if the observed simulation outcome matches a Nash
+  equilibrium, the trajectory is consistent with self-interested play
+
+[Caveats]
+- This synthesizes a 2-player game from N-agent data; treat equilibria as
+  qualitative hints, not precise predictions.
+- Requires trajectory.json (belief tracking enabled) and `nashpy` installed."""
+
 TOOL_DESC_BROWSE_CLUSTERS = """\
 [Browse Clusters - Zoom-Out Over the Graph]
 Returns LLM-summarized community clusters — the major themes of the knowledge
@@ -1171,6 +1200,13 @@ class ReportAgent:
                     "query": "Optional semantic query to find clusters relevant to a topic. Leave empty to list the largest clusters.",
                     "limit": "Optional cap on clusters returned (default 8)"
                 }
+            },
+            "analyze_equilibrium": {
+                "name": "analyze_equilibrium",
+                "description": TOOL_DESC_ANALYZE_EQUILIBRIUM,
+                "parameters": {
+                    "topic": "Optional specific topic from trajectory.json (leave empty to pick the most-contested topic automatically)"
+                }
             }
         }
     
@@ -1253,6 +1289,10 @@ class ReportAgent:
                 # Belief trajectory analysis — reads trajectory.json from simulation
                 focus = parameters.get("focus", "all")
                 return self._execute_trajectory_analysis(focus)
+
+            elif tool_name == "analyze_equilibrium":
+                topic = (parameters.get("topic") or "").strip()
+                return self._execute_equilibrium_analysis(topic or None)
 
             elif tool_name == "analyze_graph_structure":
                 # Graph structure analysis — centrality, communities, bridges
@@ -1435,6 +1475,161 @@ class ReportAgent:
                 lines.append("")
 
         return "\n".join(lines)
+
+    def _execute_equilibrium_analysis(self, topic: Optional[str] = None) -> str:
+        """Synthesize a 2-player stance game from trajectory.json and solve via nashpy.
+
+        This is a qualitative bridge between MiroShark's belief state and
+        game-theoretic reasoning. We split agents into two coalitions along
+        their final stance on ``topic`` (or the most-contested topic), build a
+        2x2 payoff matrix parameterized by coalition size and mean stance, and
+        enumerate pure / mixed-strategy Nash equilibria. nashpy is optional;
+        missing ⇒ graceful error.
+        """
+        sim_dir = self._get_simulation_dir()
+        trajectory_path = os.path.join(sim_dir, "trajectory.json")
+        if not os.path.exists(trajectory_path):
+            return (
+                "No trajectory.json available — belief tracking must be enabled "
+                "on the simulation for analyze_equilibrium to work."
+            )
+
+        try:
+            import nashpy  # type: ignore
+            import numpy as np  # type: ignore
+        except ImportError:
+            return (
+                "nashpy is not installed. Add `nashpy` and `numpy` to the "
+                "backend environment to enable this tool "
+                "(pip install nashpy numpy)."
+            )
+
+        try:
+            with open(trajectory_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        except Exception as e:
+            return f"Failed to read trajectory.json: {e}"
+
+        trajectories = data.get("belief_trajectories", {}) or {}
+        if not trajectories:
+            return "trajectory.json has no belief_trajectories — nothing to analyze."
+
+        # Pick topic — explicit, else widest final spread.
+        if topic and topic in trajectories:
+            chosen_topic = topic
+        else:
+            def _final_spread(rounds):
+                return (rounds[-1].get("spread") or 0) if rounds else 0
+            chosen_topic = max(trajectories, key=lambda k: _final_spread(trajectories[k]))
+
+        rounds = trajectories.get(chosen_topic, [])
+        if not rounds:
+            return f"Topic '{chosen_topic}' has no round data."
+
+        # Extract per-agent final stance from belief_positions at the last snapshot.
+        snapshots = data.get("snapshots") or []
+        positions_final = {}
+        if snapshots:
+            last_snap = snapshots[-1]
+            raw_positions = last_snap.get("belief_positions") or {}
+            for agent_id, topics in raw_positions.items():
+                if isinstance(topics, dict) and chosen_topic in topics:
+                    positions_final[agent_id] = float(topics[chosen_topic])
+
+        # Fallback: synthesize stances from the round-level mean+spread when
+        # per-agent positions are not persisted.
+        if not positions_final:
+            mean = float(rounds[-1].get("mean", 0.0))
+            spread = float(rounds[-1].get("spread", 0.5))
+            # Heuristic split: assume 50/50 around the mean with ±spread width.
+            positions_final = {
+                "_synthetic_bull": max(mean + spread / 2, 0.01),
+                "_synthetic_bear": min(mean - spread / 2, -0.01),
+            }
+
+        stances = list(positions_final.values())
+        n_total = len(stances)
+        bull = [s for s in stances if s > 0.05]
+        bear = [s for s in stances if s < -0.05]
+        n_bull, n_bear = len(bull), len(bear)
+        if n_bull < 1 or n_bear < 1:
+            return (
+                f"Topic '{chosen_topic}' does not split into bullish and bearish "
+                f"coalitions at endpoint (n_bull={n_bull}, n_bear={n_bear}). "
+                "Nash analysis requires a contested axis."
+            )
+
+        mean_bull = sum(bull) / n_bull
+        mean_bear = sum(bear) / n_bear  # negative
+
+        # Construct a 2x2 payoff matrix.
+        # Row player = bullish coalition, Column player = bearish coalition.
+        # Strategy 1 = HOLD (post stance), Strategy 2 = CONCEDE (soften).
+        # Payoffs scale with own coalition size × conviction, minus loss from
+        # the other side's conviction when both hold (costly conflict).
+        import math
+        conv_b = abs(mean_bull)
+        conv_s = abs(mean_bear)
+        # Row (bull) payoffs
+        r11 = n_bull * conv_b - 0.5 * n_bear * conv_s   # both hold → contested
+        r12 = n_bull * conv_b                            # bull holds, bear concedes
+        r21 = 0.2 * n_bull                               # bull concedes, bear holds
+        r22 = 0.3 * n_bull * conv_b                      # both concede (partial credit)
+        row_matrix = [[r11, r12], [r21, r22]]
+        # Col (bear) payoffs — symmetric
+        c11 = n_bear * conv_s - 0.5 * n_bull * conv_b
+        c12 = 0.2 * n_bear
+        c21 = n_bear * conv_s
+        c22 = 0.3 * n_bear * conv_s
+        col_matrix = [[c11, c12], [c21, c22]]
+
+        try:
+            game = nashpy.Game(np.array(row_matrix), np.array(col_matrix))
+            equilibria = list(game.support_enumeration())[:3]
+        except Exception as e:
+            return f"Nash solver failed: {e}"
+
+        out_lines = [
+            f"=== Nash Equilibrium — topic: {chosen_topic} ===",
+            f"n_total={n_total}  n_bull={n_bull} (μ={mean_bull:.2f})  "
+            f"n_bear={n_bear} (μ={mean_bear:.2f})",
+            "",
+            "Actions: HOLD (maintain stance) vs CONCEDE (soften)",
+            "Payoff matrix (row=bull, col=bear):",
+            f"  [{r11:+.2f} / {c11:+.2f}]  [{r12:+.2f} / {c12:+.2f}]",
+            f"  [{r21:+.2f} / {c21:+.2f}]  [{r22:+.2f} / {c22:+.2f}]",
+            "",
+            "Equilibria:",
+        ]
+        if not equilibria:
+            out_lines.append("  (no pure or mixed-strategy NE found — payoffs may be degenerate)")
+        else:
+            for idx, (bull_strat, bear_strat) in enumerate(equilibria, 1):
+                def _describe(strat):
+                    if len(strat) < 2:
+                        return "?"
+                    hold_p = float(strat[0])
+                    if hold_p > 0.95: return "HOLD (pure)"
+                    if hold_p < 0.05: return "CONCEDE (pure)"
+                    return f"HOLD with prob {hold_p:.2f}"
+                out_lines.append(
+                    f"  #{idx}: bull → {_describe(bull_strat)}, bear → {_describe(bear_strat)}"
+                )
+
+        # Qualitative reading
+        if equilibria:
+            bull0 = float(equilibria[0][0][0]) if len(equilibria[0][0]) >= 1 else 0.5
+            bear0 = float(equilibria[0][1][0]) if len(equilibria[0][1]) >= 1 else 0.5
+            if bull0 > 0.8 and bear0 > 0.8:
+                reading = "Polarized equilibrium: both sides hold. Sustained conflict is self-enforcing."
+            elif bull0 < 0.2 and bear0 < 0.2:
+                reading = "Coordinated concession: both sides soften. Consensus is stable."
+            else:
+                reading = "Mixed equilibrium: at least one side randomizes. Outcomes are sensitive to shocks."
+            out_lines.append("")
+            out_lines.append(f"Reading: {reading}")
+
+        return "\n".join(out_lines)
 
     def _get_simulation_dir(self) -> str:
         """Find the simulation directory (tries multiple locations)."""

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -80,6 +80,11 @@ class SimulationState:
     parent_simulation_id: Optional[str] = None
     config_diff: Optional[Dict] = None
 
+    # Public-embed visibility. Embed endpoints require this to be True; otherwise
+    # they 403. Defaults to False so existing simulations remain private until
+    # their owner explicitly publishes.
+    is_public: bool = False
+
     def to_dict(self) -> Dict[str, Any]:
         """Full state dictionary (for internal use)"""
         return {
@@ -103,6 +108,7 @@ class SimulationState:
             "error": self.error,
             "parent_simulation_id": self.parent_simulation_id,
             "config_diff": self.config_diff,
+            "is_public": self.is_public,
         }
     
     def to_simple_dict(self) -> Dict[str, Any]:
@@ -198,6 +204,7 @@ class SimulationManager:
             error=data.get("error"),
             parent_simulation_id=data.get("parent_simulation_id"),
             config_diff=data.get("config_diff"),
+            is_public=data.get("is_public", False),
         )
         
         self._simulations[simulation_id] = state
@@ -533,6 +540,78 @@ class SimulationManager:
         with open(config_path, 'r', encoding='utf-8') as f:
             return json.load(f)
     
+    def branch_counterfactual(
+        self,
+        parent_simulation_id: str,
+        injection_text: str,
+        trigger_round: int,
+        label: Optional[str] = None,
+        branch_id: Optional[str] = None,
+    ) -> SimulationState:
+        """Fork a simulation and schedule a counterfactual injection at trigger_round.
+
+        Semantics (runner-contract):
+            1. Forks the parent → new sim, READY to run (reuses profiles).
+            2. Writes ``counterfactual_injection.json`` into the new sim's
+               directory so ``run_parallel_simulation.py`` (or any future
+               runner) can read it at round-start and inject ``injection_text``
+               into every agent's observation prompt for rounds
+               ``>= trigger_round``.
+            3. Marks the new simulation's ``config_diff`` with the counterfactual
+               metadata so the UI can highlight the branch lineage.
+
+        The runner is expected to read the injection file; if it doesn't
+        (older runner versions), the branch still runs — it just behaves
+        identically to a plain fork. Graceful degradation.
+        """
+        import uuid
+
+        if trigger_round < 0:
+            raise ValueError("trigger_round must be >= 0")
+        if not injection_text or not injection_text.strip():
+            raise ValueError("injection_text is required")
+
+        parent = self._load_simulation_state(parent_simulation_id)
+        if not parent:
+            raise ValueError(f"Parent simulation not found: {parent_simulation_id}")
+
+        # Delegate the copy/profile machinery to the existing fork path so we
+        # stay DRY.
+        child = self.fork_simulation(parent_simulation_id=parent_simulation_id)
+
+        injection_payload = {
+            "parent_simulation_id": parent_simulation_id,
+            "trigger_round": int(trigger_round),
+            "injection_text": injection_text.strip(),
+            "label": (label or f"counterfactual_{uuid.uuid4().hex[:6]}").strip(),
+            "branch_id": branch_id,
+            "created_at": datetime.now().isoformat(),
+        }
+
+        sim_dir = self._get_simulation_dir(child.simulation_id)
+        injection_path = os.path.join(sim_dir, "counterfactual_injection.json")
+        with open(injection_path, "w", encoding="utf-8") as fh:
+            json.dump(injection_payload, fh, ensure_ascii=False, indent=2)
+
+        diff = dict(child.config_diff or {})
+        diff["counterfactual"] = {
+            "trigger_round": injection_payload["trigger_round"],
+            "label": injection_payload["label"],
+            "preview": injection_payload["injection_text"][:140],
+        }
+        child.config_diff = diff
+        child.config_reasoning = (
+            f"Branched from {parent_simulation_id} with counterfactual "
+            f"'{injection_payload['label']}' at round {trigger_round}"
+        )
+        self._save_simulation_state(child)
+
+        logger.info(
+            f"Counterfactual branch: {child.simulation_id} "
+            f"<- {parent_simulation_id} @ r{trigger_round} ({injection_payload['label']})"
+        )
+        return child
+
     def fork_simulation(
         self,
         parent_simulation_id: str,

--- a/backend/app/storage/embedding_service.py
+++ b/backend/app/storage/embedding_service.py
@@ -95,10 +95,17 @@ class EmbeddingService:
         self._cache_put(text, vector)
         return vector
 
-    def embed_batch(self, texts: List[str], batch_size: int = 32) -> List[List[float]]:
+    def embed_batch(self, texts: List[str], batch_size: Optional[int] = None) -> List[List[float]]:
         """
         Generate embeddings for multiple texts in batches.
+
+        batch_size defaults to Config.EMBEDDING_BATCH_SIZE (128). Most providers
+        (OpenAI, text-embedding-3-*, OpenRouter, Cohere, Ollama nomic-embed-text)
+        accept 128-2048 inputs per request; 128 is a safe default that cuts
+        wall-clock time ~4x vs the old default of 32 for typical document sizes.
         """
+        if batch_size is None:
+            batch_size = getattr(Config, "EMBEDDING_BATCH_SIZE", 128)
         if not texts:
             return []
 

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -107,6 +107,53 @@ class LLMClient:
         """Check if we're talking to an Ollama server."""
         return '11434' in (self.base_url or '')
 
+    def _supports_anthropic_prompt_cache(self) -> bool:
+        """Return True when the configured model is Claude-family and cache flag is on.
+
+        OpenRouter passes ``cache_control`` blocks through to Anthropic; for any
+        other provider we leave messages alone to avoid provider-side 400s.
+        """
+        if not getattr(Config, "LLM_PROMPT_CACHING_ENABLED", False):
+            return False
+        m = (self.model or "").lower()
+        if not m:
+            return False
+        if self._is_ollama():
+            return False
+        return ("claude" in m) or ("anthropic" in m)
+
+    @staticmethod
+    def _maybe_cache_wrap_messages(
+        messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Attach cache_control to the first system message (Anthropic-style).
+
+        Leaves the input list untouched; returns a shallow copy with the system
+        message content rewritten into a single text block carrying
+        ``cache_control: {"type": "ephemeral"}``. Only touches the first system
+        message — that's the stable prefix across ReACT iterations.
+        """
+        if not messages:
+            return messages
+        out = list(messages)
+        for i, msg in enumerate(out):
+            if msg.get("role") != "system":
+                continue
+            content = msg.get("content")
+            if isinstance(content, str) and content:
+                out[i] = {
+                    "role": "system",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": content,
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                }
+            break
+        return out
+
     def _emit_llm_event(self, messages, content, t0, *, response=None, error=None, temperature=0.7):
         """Emit an llm_call observability event (best-effort, never raises)."""
         try:
@@ -166,9 +213,15 @@ class LLMClient:
         Returns:
             Model response text
         """
+        effective_messages = (
+            self._maybe_cache_wrap_messages(messages)
+            if self._supports_anthropic_prompt_cache()
+            else messages
+        )
+
         kwargs = {
             "model": self.model,
-            "messages": messages,
+            "messages": effective_messages,
             "temperature": temperature,
             "max_tokens": max_tokens,
         }

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1,0 +1,282 @@
+"""MiroShark CLI — thin HTTP client for a running MiroShark backend.
+
+Run the server first (`./miroshark` from the repo root), then drive it with::
+
+    python -m cli ask "Will the EU AI Act survive trilogue?"
+    python -m cli list
+    python -m cli status sim_abc123
+    python -m cli report sim_abc123
+    python -m cli publish sim_abc123 --public
+
+The CLI hits ``MIROSHARK_API_URL`` (default ``http://localhost:5001``) — no
+local Neo4j/LLM setup required beyond what the backend already has.
+
+Deliberately dependency-light: uses only ``argparse`` + ``urllib`` so it can
+run as ``python cli.py ...`` from a vanilla Python 3.11 with no extras.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any, Optional
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+
+DEFAULT_BASE_URL = "http://localhost:5001"
+
+
+def _base_url() -> str:
+    return (os.environ.get("MIROSHARK_API_URL") or DEFAULT_BASE_URL).rstrip("/")
+
+
+def _api(
+    method: str,
+    path: str,
+    body: Optional[dict] = None,
+    params: Optional[dict] = None,
+    timeout: float = 120.0,
+) -> dict:
+    url = _base_url() + path
+    if params:
+        from urllib.parse import urlencode
+        url += ("&" if "?" in url else "?") + urlencode(params)
+
+    data: Optional[bytes] = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urlrequest.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urlrequest.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urlerror.HTTPError as e:
+        raw = e.read().decode("utf-8", errors="replace") if e.fp else "{}"
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            parsed = {"success": False, "error": f"HTTP {e.code}: {raw[:200]}"}
+        parsed.setdefault("_http_status", e.code)
+        return parsed
+    except urlerror.URLError as e:
+        return {"success": False, "error": f"connection error: {e.reason}"}
+
+    try:
+        return json.loads(raw)
+    except Exception as e:
+        return {"success": False, "error": f"invalid JSON from server: {e}"}
+
+
+def _die(msg: str, code: int = 1) -> "NoReturn":  # noqa: F821
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def _print_json(obj: Any) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2))
+
+
+# ─── Commands ────────────────────────────────────────────────────────────────
+
+def cmd_ask(args: argparse.Namespace) -> int:
+    res = _api("POST", "/api/simulation/ask", body={"question": args.question})
+    if not res.get("success"):
+        _die(res.get("error", "unknown error"))
+    d = res["data"]
+    if args.json:
+        _print_json(d)
+        return 0
+    print(f"title: {d['title']}")
+    print(f"simulation_requirement:\n  {d['simulation_requirement']}")
+    print(f"key_actors: {', '.join(d.get('key_actors', []))}")
+    print(f"suggested_platforms: {', '.join(d.get('suggested_platforms', []))}")
+    print(f"seed_document ({len(d['seed_document'])} chars):")
+    print(d["seed_document"][:600] + ("..." if len(d["seed_document"]) > 600 else ""))
+    print(f"\ncached: {d.get('cached', False)}  model: {d.get('model', '?')}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    res = _api("GET", "/api/simulation/list")
+    if not res.get("success"):
+        # Fall back to projects list — different backends expose different lists.
+        res = _api("GET", "/api/graph/projects")
+    if not res.get("success"):
+        _die(res.get("error", "list failed"))
+    if args.json:
+        _print_json(res["data"])
+        return 0
+    items = res.get("data") or []
+    if not isinstance(items, list):
+        _print_json(items)
+        return 0
+    for it in items:
+        sid = it.get("simulation_id") or it.get("project_id") or "?"
+        status = it.get("status") or "?"
+        name = it.get("name") or it.get("scenario") or ""
+        print(f"{sid}  [{status}]  {name}")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    res = _api("GET", f"/api/simulation/{args.simulation_id}/run-status")
+    if args.json:
+        _print_json(res)
+        return 0
+    if not res.get("success"):
+        _die(res.get("error", "status failed"))
+    d = res.get("data") or {}
+    print(f"simulation_id: {args.simulation_id}")
+    print(f"status:        {d.get('status') or d.get('runner_status')}")
+    print(f"round:         {d.get('current_round')}/{d.get('total_rounds', '?')}")
+    print(f"profiles:      {d.get('profiles_count')}")
+    return 0
+
+
+def cmd_frame(args: argparse.Namespace) -> int:
+    params = {}
+    if args.platforms:
+        params["platforms"] = args.platforms
+    res = _api(
+        "GET",
+        f"/api/simulation/{args.simulation_id}/frame/{args.round}",
+        params=params or None,
+    )
+    if not res.get("success"):
+        _die(res.get("error", "frame failed"))
+    if args.json:
+        _print_json(res["data"])
+        return 0
+    d = res["data"]
+    print(f"round {d['round_num']}  active_agents={d['active_agents_count']}")
+    print(f"action_counts: {d['action_counts']}")
+    if d.get("market_prices"):
+        for mp in d["market_prices"]:
+            print(f"  market {mp['market_id']}: yes={mp['price_yes']} (as of r{mp.get('as_of_round')})")
+    if d.get("belief"):
+        b = d["belief"]
+        print(f"belief r{b['round_num']}: {b['bullish_pct']}% bull / {b['neutral_pct']}% neut / {b['bearish_pct']}% bear")
+    print(f"actions: {len(d['actions'])}")
+    return 0
+
+
+def cmd_publish(args: argparse.Namespace) -> int:
+    res = _api(
+        "POST",
+        f"/api/simulation/{args.simulation_id}/publish",
+        body={"public": not args.unpublish},
+    )
+    if args.json:
+        _print_json(res)
+        return 0
+    if not res.get("success"):
+        _die(res.get("error", "publish failed"))
+    is_pub = res["data"]["is_public"]
+    verb = "published" if is_pub else "unpublished"
+    print(f"{args.simulation_id} {verb} — embed URL now {'active' if is_pub else '403'}")
+    return 0
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    res = _api("GET", f"/api/report/{args.simulation_id}")
+    if args.json:
+        _print_json(res)
+        return 0
+    if not res.get("success"):
+        _die(res.get("error", "report failed"))
+    d = res.get("data") or {}
+    print(f"=== {d.get('title', 'Report')} ===\n")
+    print(d.get("summary", ""))
+    for s in d.get("sections", []) or []:
+        print(f"\n## {s.get('title', '')}\n")
+        print(s.get("content", ""))
+    return 0
+
+
+def cmd_health(args: argparse.Namespace) -> int:
+    try:
+        with urlrequest.urlopen(_base_url() + "/health", timeout=5) as resp:
+            print(resp.read().decode("utf-8"))
+            return 0
+    except Exception as e:
+        _die(f"unreachable: {e}")
+        return 1
+
+
+def cmd_trending(args: argparse.Namespace) -> int:
+    res = _api("GET", "/api/simulation/trending")
+    if args.json:
+        _print_json(res)
+        return 0
+    if not res.get("success"):
+        _die(res.get("error", "trending failed"))
+    for it in (res["data"].get("items") or [])[:10]:
+        print(f"- {it.get('title', '')[:80]}  [{it.get('source', '?')}]")
+        print(f"  {it.get('url', '')}")
+    return 0
+
+
+# ─── Entry point ─────────────────────────────────────────────────────────────
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="miroshark",
+        description="Thin CLI for a running MiroShark backend. "
+                    "Set MIROSHARK_API_URL to override the default http://localhost:5001.",
+    )
+    p.add_argument("--json", action="store_true", help="Print raw JSON (for scripting).")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    p_ask = sub.add_parser("ask", help="Research a question → seed briefing.")
+    p_ask.add_argument("question", help="Natural-language question.")
+    p_ask.set_defaults(func=cmd_ask)
+
+    p_list = sub.add_parser("list", help="List simulations / projects.")
+    p_list.set_defaults(func=cmd_list)
+
+    p_status = sub.add_parser("status", help="Show simulation run status.")
+    p_status.add_argument("simulation_id")
+    p_status.set_defaults(func=cmd_status)
+
+    p_frame = sub.add_parser("frame", help="Compact snapshot for one round.")
+    p_frame.add_argument("simulation_id")
+    p_frame.add_argument("round", type=int)
+    p_frame.add_argument("--platforms", help="comma-separated: twitter,reddit,polymarket")
+    p_frame.set_defaults(func=cmd_frame)
+
+    p_pub = sub.add_parser("publish", help="Toggle public embed for a simulation.")
+    p_pub.add_argument("simulation_id")
+    p_pub.add_argument("--unpublish", action="store_true", help="Unpublish instead.")
+    p_pub.set_defaults(func=cmd_publish)
+
+    p_report = sub.add_parser("report", help="Show rendered analytical report.")
+    p_report.add_argument("simulation_id")
+    p_report.set_defaults(func=cmd_report)
+
+    p_trend = sub.add_parser("trending", help="Pull trending topics from RSS feeds.")
+    p_trend.set_defaults(func=cmd_trending)
+
+    p_health = sub.add_parser("health", help="Ping the backend /health endpoint.")
+    p_health.set_defaults(func=cmd_health)
+
+    return p
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except KeyboardInterrupt:
+        print("\ninterrupted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -55,6 +55,11 @@ dev = [
     "pipreqs>=0.5.0",
 ]
 
+[project.scripts]
+# Thin HTTP client for a running MiroShark backend (see backend/cli.py).
+# Install via `pip install -e backend/` to get `miroshark-cli` on $PATH.
+miroshark-cli = "cli:main"
+
 [tool.uv]
 override-dependencies = [
     "pillow>=12.0.0",   # camel-oasis pins 10.3.0 which doesn't build on Python 3.13

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,17 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_functions = test_*
+python_classes = Test*
+
+# Integration tests are skipped by default (see conftest.py). Run them with:
+#     pytest -m integration
+# Legacy E2E scripts additionally need:
+#     pytest -m "integration and slow"
+markers =
+    integration: needs live backend at $MIROSHARK_API_URL
+    slow: multi-minute pipeline tests
+    neo4j: needs live Neo4j at $NEO4J_URI
+
+# Short traceback keeps logs readable in CI; -ra surfaces skip reasons.
+addopts = -ra --tb=short

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@
 # ============= Core Framework =============
 flask>=3.0.0
 flask-cors>=6.0.0
+flask-compress>=1.17
 
 # ============= LLM Related =============
 # OpenAI SDK (unified LLM calls using OpenAI format)
@@ -41,3 +42,7 @@ pydantic>=2.0.0
 # ============= Browser Push Notifications =============
 # Required for Web Push (VAPID key generation + push dispatch)
 pywebpush>=2.0.0
+
+# ============= Game Theory (optional — report_agent.analyze_equilibrium) =============
+# Enables the Nash equilibrium tool on the ReACT report agent. Silent no-op if absent.
+nashpy>=0.0.41

--- a/backend/scripts/counterfactual_loader.py
+++ b/backend/scripts/counterfactual_loader.py
@@ -1,0 +1,72 @@
+"""Load counterfactual-injection specs for the simulation runner.
+
+The Flask API writes ``counterfactual_injection.json`` when a user branches a
+simulation via ``POST /api/simulation/branch-counterfactual``. The runner
+loads it at the start of each round and, when ``round_num >= trigger_round``,
+prepends ``injection_text`` to every agent's observation prompt — turning a
+static fork into a MiroJiang-style counterfactual scenario.
+
+Missing / malformed files return None so the runner behaves identically to
+un-branched simulations. Never raises.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional, TypedDict
+
+
+class CounterfactualSpec(TypedDict, total=False):
+    trigger_round: int
+    injection_text: str
+    label: str
+    parent_simulation_id: str
+    branch_id: Optional[str]
+    created_at: str
+
+
+def load_counterfactual(sim_dir: str) -> Optional[CounterfactualSpec]:
+    """Read ``<sim_dir>/counterfactual_injection.json`` or return None."""
+    if not sim_dir or not os.path.isdir(sim_dir):
+        return None
+    path = os.path.join(sim_dir, "counterfactual_injection.json")
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except Exception:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    # Minimal validation — runner should tolerate extra fields.
+    if not isinstance(raw.get("trigger_round"), int):
+        return None
+    if not isinstance(raw.get("injection_text"), str) or not raw["injection_text"].strip():
+        return None
+    return raw  # type: ignore[return-value]
+
+
+def injection_prefix_for_round(
+    spec: Optional[CounterfactualSpec],
+    round_num: int,
+) -> str:
+    """Return a prompt-ready prefix for agents this round, or "".
+
+    The prefix is an ALL-CAPS banner plus the injection text, so LLM agents
+    reliably treat it as breaking news rather than simulation background.
+    """
+    if not spec:
+        return ""
+    trigger = int(spec.get("trigger_round", 0))
+    if round_num < trigger:
+        return ""
+    label = spec.get("label") or "counterfactual event"
+    text = spec["injection_text"].strip()
+    return (
+        "\n[BREAKING COUNTERFACTUAL EVENT — this supersedes prior context]\n"
+        f"[{label}]\n"
+        f"{text}\n"
+        "[END BREAKING]\n"
+    )

--- a/backend/scripts/director_events.py
+++ b/backend/scripts/director_events.py
@@ -76,14 +76,66 @@ def add_event(simulation_dir: str, event_text: str, round_num: int) -> Dict[str,
     return event
 
 
+def _counterfactual_path(simulation_dir: str) -> str:
+    return os.path.join(simulation_dir, "counterfactual_injection.json")
+
+
+def _promote_counterfactual_if_due(simulation_dir: str, current_round: int) -> None:
+    """Convert a queued counterfactual into a director event when its round arrives.
+
+    Preset branches and the /branch-counterfactual endpoint write a one-shot
+    spec to ``counterfactual_injection.json``. This function checks for it at
+    round start and, when ``current_round >= trigger_round``, enqueues the
+    narrative as a director event (consumed alongside hand-submitted ones).
+    Idempotent — after promotion the file is rewritten with
+    ``"consumed": true`` so it won't fire a second time.
+    """
+    path = _counterfactual_path(simulation_dir)
+    if not os.path.exists(path):
+        return
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            spec = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return
+    if not isinstance(spec, dict) or spec.get("consumed"):
+        return
+    try:
+        trigger = int(spec.get("trigger_round", -1))
+    except (TypeError, ValueError):
+        return
+    text = (spec.get("injection_text") or "").strip()
+    if trigger < 0 or not text or current_round < trigger:
+        return
+
+    label = spec.get("label") or "counterfactual event"
+    event_text = f"[COUNTERFACTUAL — {label}] {text}"
+    try:
+        add_event(simulation_dir, event_text, round_num=current_round)
+    except Exception:
+        # If enqueue fails we still want to mark as consumed so we don't spam.
+        pass
+    spec["consumed"] = True
+    spec["consumed_at_round"] = current_round
+    try:
+        _atomic_write_json(path, spec)
+    except Exception:
+        pass
+
+
 def consume_pending_events(simulation_dir: str, current_round: int) -> List[Dict[str, Any]]:
     """
     Read and clear all pending events. Called by the simulation loop
     at the start of each round.
 
+    Counterfactual injections (from /branch-counterfactual) are promoted to
+    director events when their trigger_round arrives, so they flow through
+    the same injection path as operator-submitted events.
+
     Returns:
         List of event dicts that should be injected this round.
     """
+    _promote_counterfactual_if_due(simulation_dir, current_round)
     path = _events_path(simulation_dir)
 
     if not os.path.exists(path):

--- a/backend/scripts/mcp_agent_bridge.py
+++ b/backend/scripts/mcp_agent_bridge.py
@@ -1,0 +1,324 @@
+"""Runtime MCP bridge for tools_enabled personas.
+
+Given an ``MCPServerSpec`` registry (loaded via
+``app.services.agent_mcp_tools.load_registry``), this module spawns each
+configured MCP server as a persistent stdio subprocess and exposes
+``call(server_name, tool_name, args)`` / ``list_tools(server_name)``.
+
+Design points:
+- **One subprocess per server, pooled**: MCP servers are stateful (auth,
+  session), so we initialize once and reuse for the full simulation.
+- **stdio JSON-RPC**: per the Model Context Protocol; no HTTP assumption.
+- **Per-call timeout**: 30s by default. A hung server doesn't stall the sim.
+- **Graceful error results**: a failed tool returns ``{"_error": "..."}``
+  rather than raising, so agent observation prompts stay well-formed.
+- **Shutdown-safe**: register ``atexit`` so Python teardown kills subprocesses.
+
+**Parser**: call strings are embedded in agent completions as::
+
+    <mcp_call server="web_search" tool="search" args='{"q":"something"}' />
+
+which we extract with a simple regex. One line per call; agents emit up to
+MAX_CALLS_PER_TURN per round (default 2).
+
+See ``backend/app/services/agent_mcp_tools.py`` for the persona side.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+MAX_CALLS_PER_TURN = int(os.environ.get("MCP_MAX_CALLS_PER_TURN", "2"))
+DEFAULT_CALL_TIMEOUT_SEC = float(os.environ.get("MCP_CALL_TIMEOUT_SEC", "30"))
+
+
+_CALL_RE = re.compile(
+    r"""<mcp_call\s+
+        server=(?P<q1>["'])(?P<server>[\w\-\.]+)(?P=q1)\s+
+        tool=(?P<q2>["'])(?P<tool>[\w\-\.]+)(?P=q2)
+        (?:\s+args=(?P<q3>["'])(?P<args>.*?)(?P=q3))?
+        \s*/?>""",
+    re.VERBOSE | re.DOTALL,
+)
+
+
+@dataclass
+class MCPCallRequest:
+    server: str
+    tool: str
+    args: Dict[str, Any]
+
+
+@dataclass
+class MCPCallResult:
+    server: str
+    tool: str
+    ok: bool
+    data: Any
+    latency_ms: int
+
+
+def parse_tool_calls(text: str, max_calls: int = MAX_CALLS_PER_TURN) -> List[MCPCallRequest]:
+    """Extract up to max_calls ``<mcp_call .../>`` blocks from agent output.
+
+    Malformed ``args`` JSON is tolerated (empty dict). Returns [] if none.
+    """
+    if not text:
+        return []
+    out: List[MCPCallRequest] = []
+    for m in _CALL_RE.finditer(text):
+        raw_args = m.group("args") or ""
+        try:
+            args = json.loads(raw_args) if raw_args.strip() else {}
+        except json.JSONDecodeError:
+            args = {}
+        if not isinstance(args, dict):
+            args = {}
+        out.append(MCPCallRequest(
+            server=m.group("server"),
+            tool=m.group("tool"),
+            args=args,
+        ))
+        if len(out) >= max_calls:
+            break
+    return out
+
+
+class _MCPProcess:
+    """A single long-lived MCP server subprocess over stdio JSON-RPC."""
+
+    def __init__(self, name: str, command: str, args: List[str], env: Dict[str, str]):
+        self.name = name
+        merged_env = dict(os.environ)
+        merged_env.update(env or {})
+        self._proc = subprocess.Popen(
+            [command, *args],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            bufsize=0,
+            env=merged_env,
+            text=False,
+        )
+        self._lock = threading.Lock()
+        self._initialized = False
+        self._cached_tools: Optional[List[Dict[str, Any]]] = None
+
+    def _send(self, obj: Dict[str, Any]) -> None:
+        assert self._proc.stdin is not None
+        data = (json.dumps(obj) + "\n").encode("utf-8")
+        self._proc.stdin.write(data)
+        self._proc.stdin.flush()
+
+    def _recv(self, timeout: float) -> Dict[str, Any]:
+        assert self._proc.stdout is not None
+        # Naive line read with a watchdog thread. subprocess.PIPE's readline
+        # blocks indefinitely; we guard with a timeout thread.
+        result_box: Dict[str, Any] = {}
+        done = threading.Event()
+
+        def _reader():
+            try:
+                line = self._proc.stdout.readline()
+                if not line:
+                    result_box["err"] = "EOF from MCP server"
+                else:
+                    try:
+                        result_box["data"] = json.loads(line.decode("utf-8"))
+                    except json.JSONDecodeError as e:
+                        result_box["err"] = f"bad JSON from MCP: {e}"
+            except Exception as e:
+                result_box["err"] = f"read failed: {e}"
+            finally:
+                done.set()
+
+        t = threading.Thread(target=_reader, daemon=True)
+        t.start()
+        if not done.wait(timeout=timeout):
+            raise TimeoutError(f"MCP server {self.name} did not respond in {timeout}s")
+        if "err" in result_box:
+            raise RuntimeError(result_box["err"])
+        return result_box["data"]
+
+    def _rpc(self, method: str, params: Dict[str, Any], timeout: float) -> Dict[str, Any]:
+        with self._lock:
+            msg = {
+                "jsonrpc": "2.0",
+                "id": uuid.uuid4().hex[:8],
+                "method": method,
+                "params": params,
+            }
+            self._send(msg)
+            return self._recv(timeout)
+
+    def initialize(self, timeout: float = 10.0) -> None:
+        if self._initialized:
+            return
+        self._rpc(
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "miroshark-runner", "version": "1.0"},
+            },
+            timeout=timeout,
+        )
+        self._initialized = True
+
+    def list_tools(self, timeout: float = 10.0) -> List[Dict[str, Any]]:
+        if self._cached_tools is not None:
+            return self._cached_tools
+        resp = self._rpc("tools/list", {}, timeout=timeout)
+        tools = (resp.get("result") or {}).get("tools") or []
+        self._cached_tools = tools
+        return tools
+
+    def call_tool(self, name: str, args: Dict[str, Any], timeout: float) -> Any:
+        resp = self._rpc("tools/call", {"name": name, "arguments": args}, timeout=timeout)
+        result = resp.get("result") or {}
+        # Standard MCP content shape: [{"type": "text", "text": "..."}]
+        content = result.get("content") or []
+        if content and isinstance(content, list):
+            first = content[0]
+            if isinstance(first, dict) and "text" in first:
+                try:
+                    return json.loads(first["text"])
+                except json.JSONDecodeError:
+                    return first["text"]
+        return result
+
+    def shutdown(self) -> None:
+        try:
+            if self._proc.poll() is None:
+                self._proc.terminate()
+                try:
+                    self._proc.wait(timeout=3.0)
+                except subprocess.TimeoutExpired:
+                    self._proc.kill()
+        except Exception:
+            pass
+
+
+class MCPAgentBridge:
+    """Pool of MCP server processes usable during a simulation run.
+
+    Construct once at simulation start, pass to agent observation code,
+    :meth:`dispatch_calls` on agent output, and ``shutdown()`` when the sim
+    completes. ``atexit`` also tears everything down on abnormal exit.
+    """
+
+    def __init__(self, registry: Dict[str, Any]):  # MCPServerSpec
+        self._servers: Dict[str, _MCPProcess] = {}
+        self._registry = registry
+        self._lock = threading.Lock()
+        atexit.register(self.shutdown)
+
+    def _ensure(self, name: str) -> Optional[_MCPProcess]:
+        if name not in self._registry:
+            return None
+        with self._lock:
+            if name in self._servers:
+                return self._servers[name]
+            spec = self._registry[name]
+            try:
+                proc = _MCPProcess(
+                    name=name,
+                    command=spec.command,
+                    args=list(spec.args or []),
+                    env=dict(spec.env or {}),
+                )
+                proc.initialize()
+                self._servers[name] = proc
+                return proc
+            except Exception as e:
+                print(f"[mcp_bridge] Failed to start MCP server {name}: {e}", file=sys.stderr)
+                return None
+
+    def tool_catalogue(self, server_names: List[str]) -> str:
+        """Human-readable summary of tools available on the given servers."""
+        lines: List[str] = []
+        for name in server_names:
+            proc = self._ensure(name)
+            if proc is None:
+                lines.append(f"- {name}: (unavailable)")
+                continue
+            try:
+                tools = proc.list_tools()
+            except Exception as e:
+                lines.append(f"- {name}: (list failed: {e})")
+                continue
+            for t in tools[:8]:  # cap — we don't want to bloat the prompt
+                tname = t.get("name", "?")
+                desc = (t.get("description") or "").splitlines()[0][:80]
+                lines.append(f"- {name}/{tname}: {desc}")
+        return "\n".join(lines) if lines else "(no tools available)"
+
+    def dispatch_calls(
+        self,
+        calls: List[MCPCallRequest],
+        timeout_sec: float = DEFAULT_CALL_TIMEOUT_SEC,
+    ) -> List[MCPCallResult]:
+        """Run each call against its server. Never raises — failures become ok=False."""
+        results: List[MCPCallResult] = []
+        for call in calls:
+            proc = self._ensure(call.server)
+            if proc is None:
+                results.append(MCPCallResult(
+                    server=call.server,
+                    tool=call.tool,
+                    ok=False,
+                    data={"_error": f"unknown or unavailable server: {call.server}"},
+                    latency_ms=0,
+                ))
+                continue
+            t0 = time.perf_counter()
+            try:
+                data = proc.call_tool(call.tool, call.args, timeout=timeout_sec)
+                results.append(MCPCallResult(
+                    server=call.server,
+                    tool=call.tool,
+                    ok=True,
+                    data=data,
+                    latency_ms=int((time.perf_counter() - t0) * 1000),
+                ))
+            except Exception as e:
+                results.append(MCPCallResult(
+                    server=call.server,
+                    tool=call.tool,
+                    ok=False,
+                    data={"_error": str(e)},
+                    latency_ms=int((time.perf_counter() - t0) * 1000),
+                ))
+        return results
+
+    @staticmethod
+    def format_results_for_prompt(results: List[MCPCallResult]) -> str:
+        """Render results as a prompt-ready observation block."""
+        if not results:
+            return ""
+        lines = ["[Tool results from last turn]"]
+        for r in results:
+            status = "OK" if r.ok else "ERR"
+            try:
+                body = json.dumps(r.data, ensure_ascii=False, default=str)[:600]
+            except Exception:
+                body = str(r.data)[:600]
+            lines.append(f"- {r.server}/{r.tool} [{status}, {r.latency_ms}ms]: {body}")
+        return "\n".join(lines)
+
+    def shutdown(self) -> None:
+        with self._lock:
+            for proc in self._servers.values():
+                proc.shutdown()
+            self._servers.clear()

--- a/backend/scripts/mcp_agent_injection.py
+++ b/backend/scripts/mcp_agent_injection.py
@@ -1,0 +1,103 @@
+"""Inject per-agent MCP tool state into the agent's system message.
+
+Two things happen around each round for a ``tools_enabled`` agent:
+
+1. **Pre-round**: the tool catalogue is injected into the system message so
+   the agent knows what calls it can make. Format mirrors the director /
+   belief injection pattern (marker-delimited block that gets replaced each
+   round, so the system message doesn't grow unbounded).
+
+2. **Post-round**: the runner parses the agent's output for ``<mcp_call>``
+   blocks, dispatches them through :class:`MCPAgentBridge`, and writes the
+   results back — the next round's system message includes them so the agent
+   can reason over what it just fetched.
+
+Kept separate from the bridge so unit tests can exercise the injection
+markers without spawning subprocesses.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from mcp_agent_bridge import MCPCallResult
+
+
+_MCP_CATALOGUE_MARKER = "\n\n# MCP TOOLS AVAILABLE"
+_MCP_RESULTS_MARKER = "\n\n# MCP TOOL RESULTS"
+
+_CATALOGUE_INSTRUCTION = (
+    "\nYou may invoke at most 2 of these tools per turn by emitting one or two "
+    "self-closing tags anywhere in your reply — for example:\n"
+    '  <mcp_call server="web_search" tool="search" args=\'{"q": "something"}\' />\n'
+    "The tags are parsed out before your post is sent. Use the tools only "
+    "when they'd meaningfully improve your next action; do not spam."
+)
+
+
+def _strip_markered_block(content: str, marker: str) -> str:
+    """Remove a block delimited by marker at start and "\\n\\n# " next."""
+    pos = content.find(marker)
+    if pos == -1:
+        return content
+    next_marker = content.find("\n\n# ", pos + len(marker))
+    if next_marker != -1:
+        return content[:pos] + content[next_marker:]
+    return content[:pos]
+
+
+def inject_mcp_catalogue(agent, catalogue_text: str) -> None:
+    """Attach/refresh the MCP tool catalogue block on an agent's system message."""
+    if not catalogue_text:
+        return
+    content = agent.system_message.content
+    content = _strip_markered_block(content, _MCP_CATALOGUE_MARKER)
+    block = (
+        f"{_MCP_CATALOGUE_MARKER}\n"
+        f"{catalogue_text}\n"
+        f"{_CATALOGUE_INSTRUCTION}"
+    )
+    agent.system_message.content = content + block
+
+
+def inject_mcp_results(agent, results: List[MCPCallResult]) -> None:
+    """Attach/refresh the tool-results block on an agent's system message."""
+    if not results:
+        # Clear any stale block from the previous round so the prompt stays
+        # tight when the agent makes no calls this turn.
+        agent.system_message.content = _strip_markered_block(
+            agent.system_message.content, _MCP_RESULTS_MARKER
+        )
+        return
+
+    content = agent.system_message.content
+    content = _strip_markered_block(content, _MCP_RESULTS_MARKER)
+
+    lines = [_MCP_RESULTS_MARKER]
+    for r in results:
+        status = "OK" if r.ok else "ERR"
+        try:
+            import json
+            body = json.dumps(r.data, ensure_ascii=False, default=str)[:600]
+        except Exception:
+            body = str(r.data)[:600]
+        lines.append(f"- {r.server}/{r.tool} [{status}, {r.latency_ms}ms]: {body}")
+    agent.system_message.content = content + "\n".join(lines)
+
+
+def strip_mcp_call_tags(text: str) -> str:
+    """Remove ``<mcp_call .../>`` tags from agent output before it's posted.
+
+    Complements :func:`mcp_agent_bridge.parse_tool_calls`: we parse and
+    dispatch, but the tags themselves shouldn't appear in the agent's
+    simulated post. A simple regex strip is enough — shapes are bounded.
+    """
+    if not text or "<mcp_call" not in text:
+        return text
+    import re
+    return re.sub(
+        r"<mcp_call\s+[^>]*?/?>",
+        "",
+        text,
+        flags=re.DOTALL,
+    ).strip()

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -171,6 +171,25 @@ from market_media_bridge import (
 )
 from round_memory import RoundMemory, inject_round_memory
 
+# Per-agent MCP tools (OpenMiro-style). Entirely optional — gated by
+# MCP_AGENT_TOOLS_ENABLED and by each persona's own tools_enabled flag.
+try:
+    from mcp_agent_bridge import (
+        MCPAgentBridge,
+        parse_tool_calls as _mcp_parse_tool_calls,
+    )
+    from mcp_agent_injection import (
+        inject_mcp_catalogue,
+        inject_mcp_results,
+    )
+    _MCP_IMPORT_OK = True
+except Exception:  # noqa: BLE001 — runner must run without MCP deps
+    MCPAgentBridge = None  # type: ignore
+    _mcp_parse_tool_calls = None  # type: ignore
+    inject_mcp_catalogue = None  # type: ignore
+    inject_mcp_results = None  # type: ignore
+    _MCP_IMPORT_OK = False
+
 try:
     from camel.models import ModelFactory
     from camel.types import ModelPlatformType
@@ -1037,7 +1056,12 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
     
     # If no model name in .env, use config as fallback
     if not llm_model:
-        llm_model = config.get("llm_model", "gpt-4o-mini")
+        llm_model = config.get("llm_model", "")
+    if not llm_model:
+        raise ValueError(
+            "No LLM model configured. Set OASIS_MODEL_NAME or LLM_MODEL_NAME in .env, "
+            "or pass llm_model in the simulation config."
+        )
     
     # Set environment variables required by camel-ai
     if llm_api_key:
@@ -1104,6 +1128,63 @@ def _build_social_summary_for_traders(round_memory, current_round: int, bridge) 
         return ""
 
     return "\n".join(parts)
+
+
+def _mcp_inject_and_dispatch_pre_round(active_agents, bridge, server_names, tool_agent_ids, pending_results):
+    """Inject MCP tool catalogue + prior results into tool-enabled agents.
+
+    Called once per platform per round. No-ops when bridge is None.
+    """
+    if bridge is None or not tool_agent_ids:
+        return
+    try:
+        catalogue = bridge.tool_catalogue(server_names)
+    except Exception as exc:
+        catalogue = f"(MCP catalogue unavailable: {exc})"
+    for agent_id, agent in active_agents:
+        if agent_id not in tool_agent_ids:
+            continue
+        try:
+            inject_mcp_catalogue(agent, catalogue)
+        except Exception:
+            pass
+        prior = pending_results.pop(agent_id, None)
+        if prior:
+            try:
+                inject_mcp_results(agent, prior)
+            except Exception:
+                pass
+
+
+def _mcp_dispatch_from_actions(actions, bridge, tool_agent_ids, pending_results):
+    """After a round, parse CREATE_POST content for <mcp_call> tags.
+
+    Dispatched results are queued in ``pending_results[agent_id]`` for
+    injection on the agent's next activation.
+    """
+    if bridge is None or not actions:
+        return
+    for a in actions:
+        if a.get("action_type") not in ("CREATE_POST", "CREATE_COMMENT", "QUOTE_POST"):
+            continue
+        aid = a.get("agent_id")
+        if aid is None or int(aid) not in tool_agent_ids:
+            continue
+        content = (a.get("action_args") or {}).get("content") or ""
+        if "<mcp_call" not in content:
+            continue
+        try:
+            calls = _mcp_parse_tool_calls(content)
+        except Exception:
+            calls = []
+        if not calls:
+            continue
+        try:
+            results = bridge.dispatch_calls(calls)
+        except Exception as exc:
+            results = []
+        if results:
+            pending_results.setdefault(int(aid), []).extend(results)
 
 
 def get_active_agents_for_round(
@@ -2239,6 +2320,46 @@ async def run_synchronized_simulation(
     reddit_last_rowid = 0
     polymarket_last_rowid = 0
 
+    # ── Per-agent MCP bridge (optional) ─────────────────────────────────────
+    # When MCP_AGENT_TOOLS_ENABLED=true, spin up the MCP server subprocesses
+    # listed in config/mcp_servers.yaml and build a map of which agent ids
+    # are allowed to call them (set per-persona in profile JSON).
+    mcp_bridge = None
+    mcp_tool_agent_ids: set = set()
+    mcp_server_names: list = []
+    # agent_id -> list[MCPCallResult] pending injection next round
+    mcp_pending_results: "dict[int, list]" = {}
+
+    if _MCP_IMPORT_OK and os.environ.get("MCP_AGENT_TOOLS_ENABLED", "false").lower() == "true":
+        try:
+            # Defer import to avoid pulling flask config at module import time.
+            from app.services.agent_mcp_tools import load_registry  # type: ignore
+            registry = load_registry()
+            if registry:
+                mcp_bridge = MCPAgentBridge(registry)
+                mcp_server_names = list(registry.keys())
+                # Collect tools_enabled agent_ids from profile JSONs.
+                for fname in ("reddit_profiles.json", "polymarket_profiles.json"):
+                    fpath = os.path.join(simulation_dir, fname)
+                    if not os.path.exists(fpath):
+                        continue
+                    try:
+                        with open(fpath, "r", encoding="utf-8") as fh:
+                            profs = json.load(fh)
+                        for p in profs:
+                            if p.get("tools_enabled"):
+                                mcp_tool_agent_ids.add(int(p.get("user_id") or p.get("agent_id") or -1))
+                    except Exception as exc:
+                        log_info(f"[MCP] Failed to read {fname}: {exc}")
+                mcp_tool_agent_ids.discard(-1)
+                log_info(
+                    f"[MCP] Bridge ready: {len(registry)} server(s), "
+                    f"{len(mcp_tool_agent_ids)} tool-enabled agent(s)"
+                )
+        except Exception as exc:
+            log_info(f"[MCP] Bridge init failed ({exc}); continuing without per-agent MCP")
+            mcp_bridge = None
+
     start_time = datetime.now()
     log_info(f"Starting synchronized simulation: {total_rounds} rounds")
 
@@ -2292,6 +2413,9 @@ async def run_synchronized_simulation(
                 if director_text:
                     for _, agent in active:
                         inject_director_event_context(agent, director_text)
+                _mcp_inject_and_dispatch_pre_round(
+                    active, mcp_bridge, mcp_server_names, mcp_tool_agent_ids, mcp_pending_results
+                )
 
                 async def _step_twitter(active_agents=active):
                     actions = {agent: LLMAction() for _, agent in active_agents}
@@ -2322,6 +2446,9 @@ async def run_synchronized_simulation(
                 if director_text:
                     for _, agent in active:
                         inject_director_event_context(agent, director_text)
+                _mcp_inject_and_dispatch_pre_round(
+                    active, mcp_bridge, mcp_server_names, mcp_tool_agent_ids, mcp_pending_results
+                )
 
                 async def _step_reddit(active_agents=active):
                     actions = {agent: LLMAction() for _, agent in active_agents}
@@ -2355,6 +2482,9 @@ async def run_synchronized_simulation(
                 if director_text:
                     for _, agent in active:
                         inject_director_event_context(agent, director_text)
+                _mcp_inject_and_dispatch_pre_round(
+                    active, mcp_bridge, mcp_server_names, mcp_tool_agent_ids, mcp_pending_results
+                )
 
                 # Inject social media summary directly into the observation prompt
                 # so traders see it alongside portfolio/market data (not buried in system msg)
@@ -2387,6 +2517,7 @@ async def run_synchronized_simulation(
         # ── Post-round: fetch actions, update beliefs, record to memory ──
         if "twitter" in platform_results:
             actual_actions, twitter_last_rowid = fetch_new_actions_from_db(twitter_db, twitter_last_rowid, agent_names)
+            _mcp_dispatch_from_actions(actual_actions, mcp_bridge, mcp_tool_agent_ids, mcp_pending_results)
             if twitter_belief:
                 twitter_belief.after_round(twitter_db, twitter_result.env, platform_results["twitter"], round_num, actual_actions)
                 bridge.update_sentiment(twitter_belief.belief_states, actual_actions, round_num, "twitter")
@@ -2402,6 +2533,7 @@ async def run_synchronized_simulation(
 
         if "reddit" in platform_results:
             actual_actions, reddit_last_rowid = fetch_new_actions_from_db(reddit_db, reddit_last_rowid, agent_names)
+            _mcp_dispatch_from_actions(actual_actions, mcp_bridge, mcp_tool_agent_ids, mcp_pending_results)
             if reddit_belief:
                 reddit_belief.after_round(reddit_db, reddit_result.env, platform_results["reddit"], round_num, actual_actions)
                 bridge.update_sentiment(reddit_belief.belief_states, actual_actions, round_num, "reddit")
@@ -2418,6 +2550,7 @@ async def run_synchronized_simulation(
         if "polymarket" in platform_results:
             bridge.update_prices(polymarket_db, round_num)
             actual_actions, polymarket_last_rowid = _fetch_polymarket_actions_from_db(polymarket_db, polymarket_last_rowid, agent_names)
+            _mcp_dispatch_from_actions(actual_actions, mcp_bridge, mcp_tool_agent_ids, mcp_pending_results)
             if polymarket_belief:
                 polymarket_belief.after_round(polymarket_db, polymarket_result.env, platform_results["polymarket"], round_num, actual_actions)
             if cross_platform_log and actual_actions:
@@ -2451,6 +2584,11 @@ async def run_synchronized_simulation(
             )
 
     # ── Finalize ──
+    if mcp_bridge is not None:
+        try:
+            mcp_bridge.shutdown()
+        except Exception:
+            pass
     elapsed = (datetime.now() - start_time).total_seconds()
     log_info(f"Simulation complete! {elapsed:.0f}s total")
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,108 @@
+"""Shared pytest fixtures + markers for MiroShark.
+
+Layout::
+
+    backend/tests/
+        conftest.py              ← this file: fixtures + skip logic
+        test_unit_*.py           ← fast offline tests (run on every commit)
+        test_integration_*.py    ← hit a live backend at $MIROSHARK_API_URL
+                                   (opt in with `pytest -m integration`)
+
+Existing hand-run scripts in ``backend/scripts/test_*.py`` stay as-is so
+operators can still invoke them directly; the integration tests here wrap
+them and register them for discovery.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+
+# Make ``import app`` / ``import scripts`` work regardless of where pytest
+# is invoked from. Repo layout: ``backend/{app,scripts,tests}``.
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _BACKEND_DIR / "scripts"
+for p in (_BACKEND_DIR, _SCRIPTS_DIR):
+    sp = str(p)
+    if sp not in sys.path:
+        sys.path.insert(0, sp)
+
+
+def pytest_configure(config):
+    """Register custom markers so ``-m integration`` doesn't emit warnings."""
+    config.addinivalue_line(
+        "markers",
+        "integration: requires a live MiroShark backend at MIROSHARK_API_URL "
+        "(default http://localhost:5001). Opt in with `pytest -m integration`.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "slow: long-running tests (multi-minute E2E simulations).",
+    )
+    config.addinivalue_line(
+        "markers",
+        "neo4j: requires a running Neo4j at $NEO4J_URI.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip ``@pytest.mark.integration`` tests by default.
+
+    Run them explicitly with ``pytest -m integration`` (or
+    ``pytest -m "integration or not integration"`` for everything).
+    """
+    selected_marker = config.getoption("-m") or ""
+    if "integration" in selected_marker:
+        return  # user asked for integration — don't skip
+    skip_marker = pytest.mark.skip(
+        reason="integration test — run with `pytest -m integration`"
+    )
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_marker)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def api_base_url() -> str:
+    """Base URL for the running MiroShark backend under test."""
+    return os.environ.get("MIROSHARK_API_URL", "http://localhost:5001").rstrip("/")
+
+
+@pytest.fixture(scope="session")
+def live_backend(api_base_url: str) -> str:
+    """Assert the backend is reachable before running integration tests.
+
+    Skips the test (rather than failing) when /health is unreachable so CI
+    without infra can still succeed on the unit suite.
+    """
+    import urllib.error
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(f"{api_base_url}/health", timeout=3) as r:
+            if r.status != 200:
+                pytest.skip(f"backend /health returned {r.status}")
+    except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
+        pytest.skip(f"no backend at {api_base_url}: {e}")
+    return api_base_url
+
+
+@pytest.fixture(scope="session")
+def sample_simulation_id() -> Optional[str]:
+    """Opt-in: reuse an existing simulation id from $MIROSHARK_TEST_SIM_ID.
+
+    Many integration tests need a simulation_id to exercise endpoints like
+    /frame and /publish. Setting ``MIROSHARK_TEST_SIM_ID=sim_xxx`` lets the
+    suite skip the expensive "run a full simulation" step.
+    """
+    sid = os.environ.get("MIROSHARK_TEST_SIM_ID") or None
+    if not sid:
+        pytest.skip("set MIROSHARK_TEST_SIM_ID=sim_xxx to run this test")
+    return sid

--- a/backend/tests/test_integration_endpoints.py
+++ b/backend/tests/test_integration_endpoints.py
@@ -1,0 +1,146 @@
+"""Integration tests that exercise new endpoints against a live backend.
+
+Requires::
+
+    export MIROSHARK_API_URL=http://localhost:5001
+    pytest -m integration backend/tests/test_integration_endpoints.py
+
+For endpoints that need a pre-existing simulation::
+
+    export MIROSHARK_TEST_SIM_ID=sim_xxx
+
+Tests are designed to be cheap (no long-running simulations); they validate
+API contracts rather than full pipelines. For full-pipeline smoke tests see
+``backend/scripts/test_e2e_api.py`` (unchanged, still a manual script).
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+import urllib.error
+
+import pytest
+
+
+def _post(url: str, body: dict, timeout: float = 30.0) -> dict:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body_raw = e.read().decode("utf-8", errors="replace")
+        try:
+            data = json.loads(body_raw)
+        except Exception:
+            data = {"success": False, "error": body_raw}
+        data.setdefault("_http_status", e.code)
+        return data
+
+
+def _get(url: str, timeout: float = 15.0) -> dict:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body_raw = e.read().decode("utf-8", errors="replace")
+        try:
+            data = json.loads(body_raw)
+        except Exception:
+            data = {"success": False, "error": body_raw}
+        data.setdefault("_http_status", e.code)
+        return data
+
+
+@pytest.mark.integration
+def test_health_reachable(live_backend):
+    req = urllib.request.Request(f"{live_backend}/health")
+    with urllib.request.urlopen(req, timeout=3) as r:
+        body = json.loads(r.read().decode("utf-8"))
+    assert body.get("status") == "ok"
+
+
+@pytest.mark.integration
+def test_template_list_includes_oracle_and_cf_flags(live_backend):
+    res = _get(f"{live_backend}/api/templates/list")
+    assert res.get("success")
+    assert res.get("data"), "expected at least one template"
+    sample = res["data"][0]
+    for field in ("id", "name", "has_counterfactuals", "has_oracle_tools"):
+        assert field in sample
+
+
+@pytest.mark.integration
+def test_template_capabilities_endpoint(live_backend):
+    res = _get(f"{live_backend}/api/templates/capabilities")
+    assert res.get("success")
+    data = res.get("data") or {}
+    assert "oracle_seed_enabled" in data
+    assert "mcp_agent_tools_enabled" in data
+
+
+@pytest.mark.integration
+def test_ask_requires_question(live_backend):
+    res = _post(f"{live_backend}/api/simulation/ask", {})
+    assert res.get("success") is False
+    assert res.get("_http_status") == 400
+
+
+@pytest.mark.integration
+def test_ask_rejects_too_short_question(live_backend):
+    res = _post(f"{live_backend}/api/simulation/ask", {"question": "hi"})
+    assert res.get("success") is False
+    assert res.get("_http_status") == 400
+
+
+@pytest.mark.integration
+def test_branch_counterfactual_validates_inputs(live_backend):
+    # Missing parent_simulation_id
+    res = _post(f"{live_backend}/api/simulation/branch-counterfactual", {
+        "injection_text": "x" * 20,
+        "trigger_round": 1,
+    })
+    assert res.get("success") is False
+    assert res.get("_http_status") == 400
+
+    # Missing injection_text
+    res = _post(f"{live_backend}/api/simulation/branch-counterfactual", {
+        "parent_simulation_id": "sim_fake",
+        "trigger_round": 1,
+    })
+    assert res.get("success") is False
+    assert res.get("_http_status") == 400
+
+    # Negative trigger_round
+    res = _post(f"{live_backend}/api/simulation/branch-counterfactual", {
+        "parent_simulation_id": "sim_fake",
+        "injection_text": "something meaningful",
+        "trigger_round": -1,
+    })
+    assert res.get("success") is False
+    assert res.get("_http_status") == 400
+
+
+@pytest.mark.integration
+def test_embed_summary_requires_publish(live_backend, sample_simulation_id):
+    res = _get(f"{live_backend}/api/simulation/{sample_simulation_id}/embed-summary")
+    # Either the sim is already published (200) or it 403s with a clear message.
+    status = res.get("_http_status", 200)
+    assert status in (200, 403, 404)
+    if status == 403:
+        assert "publish" in (res.get("error") or "").lower()
+
+
+@pytest.mark.integration
+def test_frame_endpoint_returns_snapshot(live_backend, sample_simulation_id):
+    res = _get(f"{live_backend}/api/simulation/{sample_simulation_id}/frame/0")
+    assert res.get("success") is True
+    data = res["data"]
+    assert "actions" in data
+    assert "action_counts" in data
+    assert data["round_num"] == 0

--- a/backend/tests/test_integration_legacy_scripts.py
+++ b/backend/tests/test_integration_legacy_scripts.py
@@ -1,0 +1,74 @@
+"""Wraps the hand-run ``backend/scripts/test_*.py`` scripts for pytest.
+
+Each legacy script was written as a standalone program with a ``main()``
+function. These tests invoke them as subprocesses and assert a zero exit
+code — pragmatic, preserves the scripts (operators still run them directly),
+and gets them into the suite.
+
+Legacy scripts are all marked ``@pytest.mark.integration`` + ``@pytest.mark.slow``
+because most require a running backend and/or Neo4j; they're opt-in via::
+
+    pytest -m "integration and slow"
+
+Individual scripts can be targeted by test ID::
+
+    pytest -m "integration and slow" -k test_profile_format
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+# (script_name, needs_backend, needs_neo4j)
+_LEGACY_SCRIPTS = [
+    ("test_profile_format.py",             False, False),
+    ("test_polymarket.py",                 False, False),
+    ("test_market_generation.py",          False, True),
+    ("test_3platform_interconnected.py",   False, True),
+    ("test_report_generation.py",          False, True),
+    ("test_full_pipeline.py",              False, True),
+    ("test_pipeline_phase5_6.py",          False, True),
+    ("test_pipeline_twitter_polymarket.py", False, True),
+    ("test_e2e_api.py",                    True,  True),
+]
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "script_name,needs_backend,needs_neo4j",
+    _LEGACY_SCRIPTS,
+    ids=[s[0].removeprefix("test_").removesuffix(".py") for s in _LEGACY_SCRIPTS],
+)
+def test_legacy_script(script_name: str, needs_backend: bool, needs_neo4j: bool, live_backend: str):
+    """Run a legacy script and assert exit 0.
+
+    ``live_backend`` fixture ensures the server is up. The legacy scripts
+    themselves check for Neo4j and will skip / fail fast if it's missing.
+    """
+    script_path = _SCRIPTS_DIR / script_name
+    if not script_path.exists():
+        pytest.skip(f"legacy script missing: {script_path}")
+
+    # Bound wall time — some of these run 10+ minutes. CI should use shorter
+    # timeouts per-script; here we cap at 30 min to prevent hangs.
+    try:
+        result = subprocess.run(
+            [sys.executable, str(script_path)],
+            cwd=str(script_path.parent),
+            capture_output=True,
+            text=True,
+            timeout=1800,
+        )
+    except subprocess.TimeoutExpired as e:
+        pytest.fail(f"{script_name} timed out after {e.timeout}s")
+
+    if result.returncode != 0:
+        tail = "\n".join((result.stdout + "\n" + result.stderr).splitlines()[-40:])
+        pytest.fail(f"{script_name} exited {result.returncode}\n---tail---\n{tail}")

--- a/backend/tests/test_unit_cli.py
+++ b/backend/tests/test_unit_cli.py
@@ -1,0 +1,34 @@
+"""Argparse-level smoke tests for backend/cli.py. Does not hit the network."""
+
+from __future__ import annotations
+
+import cli
+
+
+def test_build_parser_known_subcommands():
+    p = cli.build_parser()
+    # Parsing --help would exit, but we can inspect subparser choices.
+    sub = [a for a in p._subparsers._group_actions if a.choices][0]
+    expected = {"ask", "list", "status", "frame", "publish", "report", "trending", "health"}
+    assert expected.issubset(set(sub.choices.keys()))
+
+
+def test_ask_requires_positional():
+    p = cli.build_parser()
+    args = p.parse_args(["ask", "Will X happen?"])
+    assert args.cmd == "ask"
+    assert args.question == "Will X happen?"
+    assert args.func is cli.cmd_ask
+
+
+def test_frame_parses_int_round():
+    p = cli.build_parser()
+    args = p.parse_args(["frame", "sim_abc123", "7"])
+    assert args.round == 7
+    assert args.simulation_id == "sim_abc123"
+
+
+def test_publish_unpublish_flag():
+    p = cli.build_parser()
+    args = p.parse_args(["publish", "sim_abc123", "--unpublish"])
+    assert args.unpublish is True

--- a/backend/tests/test_unit_counterfactual_loader.py
+++ b/backend/tests/test_unit_counterfactual_loader.py
@@ -1,0 +1,67 @@
+"""Unit tests for scripts/counterfactual_loader.py — the prefix that the
+runner prepends to agent observations when a branched sim reaches its
+trigger round.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from counterfactual_loader import (
+    injection_prefix_for_round,
+    load_counterfactual,
+)
+
+
+def test_load_returns_none_when_file_absent(tmp_path: Path):
+    assert load_counterfactual(str(tmp_path)) is None
+
+
+def test_load_returns_none_when_invalid_json(tmp_path: Path):
+    (tmp_path / "counterfactual_injection.json").write_text("not json")
+    assert load_counterfactual(str(tmp_path)) is None
+
+
+def test_load_rejects_missing_trigger_round(tmp_path: Path):
+    (tmp_path / "counterfactual_injection.json").write_text(
+        json.dumps({"injection_text": "hi"})
+    )
+    assert load_counterfactual(str(tmp_path)) is None
+
+
+def test_load_returns_spec_when_valid(tmp_path: Path):
+    (tmp_path / "counterfactual_injection.json").write_text(
+        json.dumps({
+            "trigger_round": 4,
+            "injection_text": "CEO resigns",
+            "label": "ceo_resigns",
+        })
+    )
+    spec = load_counterfactual(str(tmp_path))
+    assert spec is not None
+    assert spec["trigger_round"] == 4
+    assert spec["injection_text"] == "CEO resigns"
+
+
+def test_prefix_empty_before_trigger():
+    spec = {"trigger_round": 5, "injection_text": "news", "label": "x"}
+    assert injection_prefix_for_round(spec, round_num=4) == ""
+
+
+def test_prefix_includes_text_at_trigger():
+    spec = {"trigger_round": 5, "injection_text": "breaking news here", "label": "my_label"}
+    out = injection_prefix_for_round(spec, round_num=5)
+    assert "BREAKING COUNTERFACTUAL EVENT" in out
+    assert "my_label" in out
+    assert "breaking news here" in out
+
+
+def test_prefix_persists_after_trigger():
+    spec = {"trigger_round": 2, "injection_text": "event", "label": "l"}
+    assert "event" in injection_prefix_for_round(spec, round_num=2)
+    assert "event" in injection_prefix_for_round(spec, round_num=10)
+
+
+def test_prefix_none_spec():
+    assert injection_prefix_for_round(None, round_num=3) == ""

--- a/backend/tests/test_unit_director_events.py
+++ b/backend/tests/test_unit_director_events.py
@@ -1,0 +1,62 @@
+"""Tests for the counterfactual → director-event promotion in
+``scripts/director_events.py``. No network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import director_events as de
+
+
+def test_counterfactual_does_not_fire_before_trigger(tmp_path: Path):
+    (tmp_path / "counterfactual_injection.json").write_text(json.dumps({
+        "trigger_round": 5,
+        "injection_text": "event X",
+        "label": "x",
+    }))
+    consumed = de.consume_pending_events(str(tmp_path), current_round=3)
+    assert consumed == []
+    # Spec untouched (not yet consumed).
+    spec = json.loads((tmp_path / "counterfactual_injection.json").read_text())
+    assert spec.get("consumed") is not True
+
+
+def test_counterfactual_fires_at_trigger(tmp_path: Path):
+    (tmp_path / "counterfactual_injection.json").write_text(json.dumps({
+        "trigger_round": 2,
+        "injection_text": "event Y",
+        "label": "ceo_exits",
+    }))
+    consumed = de.consume_pending_events(str(tmp_path), current_round=2)
+    assert len(consumed) == 1
+    evt = consumed[0]
+    assert "COUNTERFACTUAL" in evt["event_text"]
+    assert "ceo_exits" in evt["event_text"]
+    assert "event Y" in evt["event_text"]
+
+    # Idempotent: second call at a later round does NOT re-fire.
+    consumed2 = de.consume_pending_events(str(tmp_path), current_round=3)
+    assert consumed2 == []
+    spec = json.loads((tmp_path / "counterfactual_injection.json").read_text())
+    assert spec.get("consumed") is True
+
+
+def test_counterfactual_skipped_if_malformed(tmp_path: Path):
+    (tmp_path / "counterfactual_injection.json").write_text("not json")
+    # Should not raise and should not return any events.
+    consumed = de.consume_pending_events(str(tmp_path), current_round=1)
+    assert consumed == []
+
+
+def test_add_and_consume_plain_director_event(tmp_path: Path):
+    evt = de.add_event(str(tmp_path), "Breaking: thing happened", round_num=0)
+    assert evt["event_text"] == "Breaking: thing happened"
+
+    consumed = de.consume_pending_events(str(tmp_path), current_round=1)
+    assert len(consumed) == 1
+    assert consumed[0]["injected_at_round"] == 1
+
+    # Queue cleared.
+    assert de.consume_pending_events(str(tmp_path), current_round=2) == []

--- a/backend/tests/test_unit_mcp_bridge.py
+++ b/backend/tests/test_unit_mcp_bridge.py
@@ -1,0 +1,112 @@
+"""Tests for the pure-Python pieces of the MCP runtime bridge — the
+``<mcp_call .../>`` parser and the system-message injection markers. Does
+not spawn subprocesses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_agent_bridge import MCPCallResult, parse_tool_calls
+from mcp_agent_injection import (
+    inject_mcp_catalogue,
+    inject_mcp_results,
+    strip_mcp_call_tags,
+)
+
+
+class _FakeMsg:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class _FakeAgent:
+    def __init__(self, content: str = ""):
+        self.system_message = _FakeMsg(content)
+
+
+def test_parser_no_calls():
+    assert parse_tool_calls("just a post with no tool calls") == []
+
+
+def test_parser_simple_call():
+    calls = parse_tool_calls(
+        '<mcp_call server="web_search" tool="search" args=\'{"q":"polymarket"}\' />'
+    )
+    assert len(calls) == 1
+    assert calls[0].server == "web_search"
+    assert calls[0].tool == "search"
+    assert calls[0].args == {"q": "polymarket"}
+
+
+def test_parser_tolerates_bad_args_json():
+    calls = parse_tool_calls(
+        '<mcp_call server="s" tool="t" args=\'this is not json\' />'
+    )
+    assert calls[0].args == {}
+
+
+def test_parser_respects_max_calls():
+    text = " ".join(
+        f'<mcp_call server="s" tool="t{i}" args=\'{{}}\' />' for i in range(5)
+    )
+    got = parse_tool_calls(text, max_calls=2)
+    assert len(got) == 2
+    assert [c.tool for c in got] == ["t0", "t1"]
+
+
+def test_parser_handles_missing_args():
+    calls = parse_tool_calls('<mcp_call server="s" tool="list" />')
+    assert len(calls) == 1
+    assert calls[0].args == {}
+
+
+def test_strip_removes_call_tags():
+    raw = 'hi <mcp_call server="s" tool="t" args=\'{}\' /> bye'
+    assert strip_mcp_call_tags(raw) == "hi  bye"
+
+
+def test_strip_is_noop_when_no_tag():
+    assert strip_mcp_call_tags("nothing here") == "nothing here"
+
+
+def test_inject_catalogue_appends_block():
+    agent = _FakeAgent("You are an analyst.")
+    inject_mcp_catalogue(agent, "- web/search: web\n- price/get: price")
+    assert "MCP TOOLS AVAILABLE" in agent.system_message.content
+    assert "web/search" in agent.system_message.content
+    # Original content preserved.
+    assert "You are an analyst." in agent.system_message.content
+
+
+def test_inject_catalogue_replaces_previous_block():
+    agent = _FakeAgent("hi")
+    inject_mcp_catalogue(agent, "first catalogue")
+    inject_mcp_catalogue(agent, "second catalogue")
+    # Old block removed, new one present.
+    assert agent.system_message.content.count("MCP TOOLS AVAILABLE") == 1
+    assert "second catalogue" in agent.system_message.content
+    assert "first catalogue" not in agent.system_message.content
+
+
+def test_inject_results_formats_ok_and_error():
+    agent = _FakeAgent("")
+    inject_mcp_results(agent, [
+        MCPCallResult(server="w", tool="search", ok=True, data={"hits": 3}, latency_ms=42),
+        MCPCallResult(server="p", tool="price", ok=False, data={"_error": "timeout"}, latency_ms=30000),
+    ])
+    body = agent.system_message.content
+    assert "MCP TOOL RESULTS" in body
+    assert "w/search [OK, 42ms]" in body
+    assert "p/price [ERR, 30000ms]" in body
+    assert "timeout" in body
+
+
+def test_inject_results_empty_clears_previous():
+    agent = _FakeAgent("hi")
+    inject_mcp_results(agent, [
+        MCPCallResult(server="w", tool="s", ok=True, data={}, latency_ms=5),
+    ])
+    assert "MCP TOOL RESULTS" in agent.system_message.content
+    inject_mcp_results(agent, [])
+    assert "MCP TOOL RESULTS" not in agent.system_message.content

--- a/backend/tests/test_unit_mcp_registry.py
+++ b/backend/tests/test_unit_mcp_registry.py
@@ -1,0 +1,84 @@
+"""Unit tests for the per-agent MCP registry loader. No network."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from app.services import agent_mcp_tools as amt
+
+
+@dataclass
+class _FakeProfile:
+    tools_enabled: bool = False
+    allowed_tools: list = None  # type: ignore
+
+
+def test_load_registry_off_by_default(monkeypatch):
+    monkeypatch.delenv("MCP_AGENT_TOOLS_ENABLED", raising=False)
+    assert amt.load_registry() == {}
+
+
+def test_load_registry_missing_file(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("MCP_AGENT_TOOLS_ENABLED", "true")
+    monkeypatch.setenv("MCP_SERVERS_CONFIG", str(tmp_path / "does_not_exist.yaml"))
+    assert amt.load_registry() == {}
+
+
+def test_load_registry_parses_manifest(monkeypatch, tmp_path: Path):
+    pytest.importorskip("yaml")
+    manifest = tmp_path / "mcp_servers.yaml"
+    manifest.write_text(
+        """
+mcp_servers:
+  - name: web_search
+    command: python
+    args: ["-m", "mcp_web"]
+  - name: no_command
+    args: []
+"""
+    )
+    monkeypatch.setenv("MCP_AGENT_TOOLS_ENABLED", "true")
+    monkeypatch.setenv("MCP_SERVERS_CONFIG", str(manifest))
+    reg = amt.load_registry()
+    # Entry without command is dropped; valid entry survives.
+    assert list(reg.keys()) == ["web_search"]
+    assert reg["web_search"].command == "python"
+    assert reg["web_search"].args == ["-m", "mcp_web"]
+
+
+def test_build_toolset_respects_tools_enabled(monkeypatch):
+    monkeypatch.setenv("MCP_AGENT_TOOLS_ENABLED", "true")
+    reg = {
+        "web_search": amt.MCPServerSpec(name="web_search", command="python"),
+        "price_feed": amt.MCPServerSpec(name="price_feed", command="node"),
+    }
+    # Disabled persona → empty toolset even when registry is full.
+    profile = _FakeProfile(tools_enabled=False)
+    assert amt.build_agent_toolset(profile, registry=reg) == {}
+
+
+def test_build_toolset_allowlist_filters(monkeypatch):
+    monkeypatch.setenv("MCP_AGENT_TOOLS_ENABLED", "true")
+    reg = {
+        "web_search": amt.MCPServerSpec(name="web_search", command="python"),
+        "price_feed": amt.MCPServerSpec(name="price_feed", command="node"),
+    }
+    profile = _FakeProfile(tools_enabled=True, allowed_tools=["price_feed"])
+    got = amt.build_agent_toolset(profile, registry=reg)
+    assert list(got.keys()) == ["price_feed"]
+
+
+def test_build_toolset_no_allowlist_means_all(monkeypatch):
+    monkeypatch.setenv("MCP_AGENT_TOOLS_ENABLED", "true")
+    reg = {
+        "web_search": amt.MCPServerSpec(name="web_search", command="python"),
+    }
+    profile = _FakeProfile(tools_enabled=True, allowed_tools=[])
+    assert amt.build_agent_toolset(profile, registry=reg) == reg
+
+
+def test_summarize_empty_tools():
+    assert "no MCP tools" in amt.summarize_toolset({})

--- a/backend/tests/test_unit_oracle_seed.py
+++ b/backend/tests/test_unit_oracle_seed.py
@@ -1,0 +1,72 @@
+"""Unit tests for the FeedOracle-seed connector. No network."""
+
+from __future__ import annotations
+
+import os
+
+from app.services import oracle_seed
+
+
+def test_returns_empty_when_disabled(monkeypatch):
+    monkeypatch.setenv("ORACLE_SEED_ENABLED", "false")
+    out = oracle_seed.resolve_oracle_tools(
+        {"oracle_tools": [{"server": "x", "tool": "y", "args": {}}]}
+    )
+    assert out == ""
+
+
+def test_returns_empty_when_no_tools(monkeypatch):
+    monkeypatch.setenv("ORACLE_SEED_ENABLED", "true")
+    assert oracle_seed.resolve_oracle_tools({"oracle_tools": []}) == ""
+    assert oracle_seed.resolve_oracle_tools({}) == ""
+
+
+def test_returns_empty_when_httpx_missing(monkeypatch):
+    monkeypatch.setenv("ORACLE_SEED_ENABLED", "true")
+    monkeypatch.setattr(oracle_seed, "httpx", None)
+    out = oracle_seed.resolve_oracle_tools(
+        {"oracle_tools": [{"server": "x", "tool": "y", "args": {}}]}
+    )
+    assert out == ""
+
+
+def test_returns_empty_on_init_failure(monkeypatch):
+    monkeypatch.setenv("ORACLE_SEED_ENABLED", "true")
+
+    class _BoomClient:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(oracle_seed, "_MCPClient", _BoomClient)
+    out = oracle_seed.resolve_oracle_tools(
+        {"oracle_tools": [{"server": "x", "tool": "y", "args": {}}]}
+    )
+    assert out == ""
+
+
+def test_formats_markdown_block(monkeypatch):
+    monkeypatch.setenv("ORACLE_SEED_ENABLED", "true")
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def initialize(self):
+            pass
+
+        def call_tool(self, name, args):
+            return {"price": 1.002, "deviation_bps": 20}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(oracle_seed, "_MCPClient", _FakeClient)
+    out = oracle_seed.resolve_oracle_tools({
+        "oracle_tools": [
+            {"server": "feedoracle_core", "tool": "peg_deviation", "args": {"token_symbol": "USDT"}},
+        ],
+    })
+    assert "## Oracle Evidence" in out
+    assert "feedoracle_core/peg_deviation" in out
+    assert "token_symbol=USDT" in out
+    assert "price" in out and "1.002" in out

--- a/backend/tests/test_unit_prompt_cache.py
+++ b/backend/tests/test_unit_prompt_cache.py
@@ -1,0 +1,52 @@
+"""Tests for LLMClient's Anthropic prompt-cache wrapping helper. No network."""
+
+from __future__ import annotations
+
+from app.utils.llm_client import LLMClient
+
+
+def test_wrap_converts_system_string_to_cache_block():
+    msgs = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "hi"},
+    ]
+    out = LLMClient._maybe_cache_wrap_messages(msgs)
+    # System now a list with cache_control on the single text block.
+    sys_msg = out[0]
+    assert sys_msg["role"] == "system"
+    assert isinstance(sys_msg["content"], list)
+    assert sys_msg["content"][0]["text"] == "You are a helpful assistant."
+    assert sys_msg["content"][0]["cache_control"] == {"type": "ephemeral"}
+    # User message untouched.
+    assert out[1] == {"role": "user", "content": "hi"}
+
+
+def test_wrap_is_noop_when_no_system_message():
+    msgs = [{"role": "user", "content": "hi"}]
+    out = LLMClient._maybe_cache_wrap_messages(msgs)
+    assert out == msgs
+
+
+def test_wrap_only_touches_first_system_message():
+    msgs = [
+        {"role": "system", "content": "first"},
+        {"role": "user", "content": "q1"},
+        {"role": "system", "content": "second"},
+    ]
+    out = LLMClient._maybe_cache_wrap_messages(msgs)
+    assert isinstance(out[0]["content"], list)
+    assert out[2] == {"role": "system", "content": "second"}
+
+
+def test_wrap_ignores_already_listed_content():
+    msgs = [
+        {"role": "system", "content": [{"type": "text", "text": "x"}]},
+        {"role": "user", "content": "hi"},
+    ]
+    out = LLMClient._maybe_cache_wrap_messages(msgs)
+    # Leaves the pre-wrapped content alone (no cache_control injected).
+    assert out[0]["content"] == [{"type": "text", "text": "x"}]
+
+
+def test_wrap_empty_messages():
+    assert LLMClient._maybe_cache_wrap_messages([]) == []

--- a/backend/tests/test_unit_templates_schema.py
+++ b/backend/tests/test_unit_templates_schema.py
@@ -1,0 +1,65 @@
+"""Validate that every preset template JSON is parseable and has the
+minimum fields the frontend + API assume.
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+from pathlib import Path
+
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "app" / "preset_templates"
+
+
+_REQUIRED_FIELDS = (
+    "id",
+    "name",
+    "category",
+    "description",
+    "simulation_requirement",
+    "seed_document",
+)
+
+
+def _all_templates():
+    return sorted(TEMPLATES_DIR.glob("*.json"))
+
+
+@pytest.mark.parametrize("path", _all_templates(), ids=lambda p: p.name)
+def test_template_parses_and_has_required_fields(path: Path):
+    data = json.loads(path.read_text(encoding="utf-8"))
+    for field in _REQUIRED_FIELDS:
+        assert field in data, f"{path.name} missing required field: {field}"
+        assert data[field], f"{path.name} has empty required field: {field}"
+
+
+@pytest.mark.parametrize("path", _all_templates(), ids=lambda p: p.name)
+def test_counterfactual_branches_well_formed(path: Path):
+    data = json.loads(path.read_text(encoding="utf-8"))
+    branches = data.get("counterfactual_branches") or []
+    assert isinstance(branches, list)
+    for b in branches:
+        assert isinstance(b, dict)
+        assert b.get("id"), f"{path.name}: branch missing id"
+        assert b.get("label"), f"{path.name}: branch missing label"
+        # injection is the preferred field; fall back to description
+        assert b.get("injection") or b.get("description"), (
+            f"{path.name}: branch {b.get('id')} missing injection/description"
+        )
+        # trigger_round is optional but if set must be int >= 0
+        tr = b.get("trigger_round")
+        if tr is not None:
+            assert isinstance(tr, int) and tr >= 0, (
+                f"{path.name}: branch {b.get('id')} has bad trigger_round: {tr}"
+            )
+
+
+@pytest.mark.parametrize("path", _all_templates(), ids=lambda p: p.name)
+def test_oracle_tools_well_formed(path: Path):
+    data = json.loads(path.read_text(encoding="utf-8"))
+    for entry in data.get("oracle_tools") or []:
+        assert isinstance(entry, dict)
+        assert entry.get("tool"), f"{path.name}: oracle entry missing tool name"
+        args = entry.get("args", {})
+        assert isinstance(args, dict), f"{path.name}: oracle args must be dict"

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -388,6 +388,66 @@ export const getEmbedSummary = (simulationId) => {
 }
 
 /**
+ * Publish or unpublish a simulation so the embed-summary endpoint returns
+ * 200 vs 403. Defaults to publishing; pass {public:false} to unpublish.
+ * @param {string} simulationId
+ * @param {boolean} publicFlag
+ */
+export const publishSimulation = (simulationId, publicFlag = true) => {
+  return service.post(`/api/simulation/${simulationId}/publish`, { public: publicFlag })
+}
+
+/**
+ * Branch a simulation with a narrative injection at a specific round.
+ * The new simulation is READY and shares the parent's agent population;
+ * when the runner hits trigger_round it auto-promotes the injection into
+ * a director event so agents see "breaking news" starting that round.
+ *
+ * @param {string} parentSimulationId
+ * @param {{ injectionText: string, triggerRound: number, label?: string, branchId?: string }} opts
+ */
+export const branchCounterfactual = (parentSimulationId, opts) => {
+  return service.post('/api/simulation/branch-counterfactual', {
+    parent_simulation_id: parentSimulationId,
+    injection_text: opts.injectionText,
+    trigger_round: opts.triggerRound,
+    label: opts.label,
+    branch_id: opts.branchId,
+  })
+}
+
+/**
+ * Get a single round's snapshot — actions in the round, market prices at
+ * that round, and belief state. Lightweight alternative to
+ * getRunStatusDetail for scrubbing UIs on large simulations.
+ * @param {string} simulationId
+ * @param {number} roundNum
+ * @param {{ platforms?: string[], includeBelief?: boolean, includeMarket?: boolean }} opts
+ */
+export const getSimulationFrame = (simulationId, roundNum, opts = {}) => {
+  const params = {}
+  if (opts.platforms && opts.platforms.length) params.platforms = opts.platforms.join(',')
+  if (opts.includeBelief === false) params.include_belief = 'false'
+  if (opts.includeMarket === false) params.include_market = 'false'
+  return service.get(`/api/simulation/${simulationId}/frame/${roundNum}`, { params })
+}
+
+/**
+ * Ask mode: turn a single question into a synthesized seed document +
+ * simulation_requirement. The result plugs directly into
+ * /api/graph/ontology/generate as a url_docs entry, so the downstream pipeline
+ * (ontology, graph build, profiles, sim) is unchanged.
+ * @param {string} question
+ * @param {{ noCache?: boolean }} opts
+ */
+export const askMode = (question, opts = {}) => {
+  return service.post('/api/simulation/ask', {
+    question,
+    no_cache: !!opts.noCache,
+  })
+}
+
+/**
  * Get demographic breakdown (age / gender / country / archetype / primary
  * platform) cross-tabbed against final stance, stance volatility, and
  * influence.

--- a/frontend/src/api/templates.js
+++ b/frontend/src/api/templates.js
@@ -8,9 +8,26 @@ export const listTemplates = () => {
 }
 
 /**
- * Get a single template by ID (includes full seed_document)
- * @param {string} templateId
+ * Which backend feature flags are currently on (oracle seeds, per-agent MCP).
+ * The frontend uses this to decide whether to render / enable toggles.
  */
-export const getTemplate = (templateId) => {
-  return service.get(`/api/templates/${templateId}`)
+export const getTemplateCapabilities = () => {
+  return service.get('/api/templates/capabilities')
+}
+
+/**
+ * Get a single template by ID (includes full seed_document).
+ *
+ * Pass ``enrich=true`` to opt into live oracle enrichment — the backend
+ * dispatches the template's declared ``oracle_tools`` against FeedOracle
+ * MCP and appends the results to the seed document before returning.
+ * Requires ``ORACLE_SEED_ENABLED=true`` server-side; silently falls back
+ * to the static seed when disabled or any call fails.
+ *
+ * @param {string} templateId
+ * @param {{ enrich?: boolean }} opts
+ */
+export const getTemplate = (templateId, opts = {}) => {
+  const params = opts.enrich ? { enrich: 'true' } : undefined
+  return service.get(`/api/templates/${templateId}`, { params })
 }

--- a/frontend/src/components/CounterfactualBranchPanel.vue
+++ b/frontend/src/components/CounterfactualBranchPanel.vue
@@ -1,0 +1,402 @@
+<template>
+  <div class="cf-panel">
+    <div class="cf-header">
+      <div class="cf-title">
+        <span class="cf-icon">⤷</span>
+        <span class="cf-label">COUNTERFACTUAL BRANCH</span>
+      </div>
+      <span class="cf-hint">
+        Fork this simulation from round N with a narrative injection.
+        Preserves the agent population; the runner promotes your injection into
+        a director event when round {{ triggerRound || 'N' }} arrives.
+      </span>
+    </div>
+
+    <!-- Preset-branch dropdown (when the source template declared them) -->
+    <div v-if="presetBranches.length" class="cf-preset-row">
+      <label class="cf-preset-label">Preset</label>
+      <select
+        class="cf-preset-select"
+        :value="selectedPresetId"
+        @change="applyPreset($event.target.value)"
+      >
+        <option value="">— custom —</option>
+        <option
+          v-for="b in presetBranches"
+          :key="b.id"
+          :value="b.id"
+        >{{ b.label }} (r{{ b.trigger_round }})</option>
+      </select>
+    </div>
+
+    <!-- Trigger round picker -->
+    <div class="cf-form-row">
+      <label class="cf-form-label">Trigger round</label>
+      <input
+        type="number"
+        class="cf-form-input cf-form-input--narrow"
+        :min="0"
+        :max="totalRounds || 999"
+        v-model.number="triggerRound"
+        :disabled="busy"
+      />
+      <span class="cf-form-meta">
+        of {{ totalRounds || '?' }} · currently at round {{ currentRound }}
+      </span>
+    </div>
+
+    <!-- Short label -->
+    <div class="cf-form-row">
+      <label class="cf-form-label">Label</label>
+      <input
+        type="text"
+        class="cf-form-input"
+        v-model="label"
+        maxlength="80"
+        placeholder="e.g. CEO resigns"
+        :disabled="busy"
+      />
+    </div>
+
+    <!-- Injection text -->
+    <div class="cf-form-row cf-form-row--stack">
+      <label class="cf-form-label">Injection (breaking-news style)</label>
+      <textarea
+        class="cf-form-textarea"
+        v-model="injectionText"
+        maxlength="2000"
+        placeholder="The board has just announced the CEO's resignation, effective immediately. The CFO steps in as interim lead."
+        rows="4"
+        :disabled="busy"
+      ></textarea>
+      <div class="cf-form-meta cf-form-meta--right">
+        {{ injectionText.length }}/2000
+      </div>
+    </div>
+
+    <div v-if="error" class="cf-error">{{ error }}</div>
+    <div v-if="result" class="cf-result">
+      Branch created: <code>{{ result.simulation_id }}</code>
+      <span v-if="result.config_diff?.counterfactual?.label">
+        · "{{ result.config_diff.counterfactual.label }}"
+      </span>
+      <button class="cf-open-btn" @click="openBranch">Open →</button>
+    </div>
+
+    <div class="cf-actions">
+      <button
+        class="cf-cancel"
+        @click="$emit('close')"
+        :disabled="busy"
+      >Cancel</button>
+      <button
+        class="cf-submit"
+        :disabled="!canSubmit || busy"
+        @click="submit"
+      >
+        <span v-if="busy" class="cf-spinner"></span>
+        {{ busy ? 'Forking…' : 'Fork branch →' }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { branchCounterfactual } from '../api/simulation'
+
+const props = defineProps({
+  simulationId: { type: String, required: true },
+  currentRound: { type: Number, default: 0 },
+  totalRounds: { type: Number, default: 0 },
+  // Optional: counterfactual_branches carried from the source template.
+  presetBranches: { type: Array, default: () => [] },
+})
+
+defineEmits(['close'])
+
+const router = useRouter()
+
+const selectedPresetId = ref('')
+const triggerRound = ref(Math.max(props.currentRound + 1, 0))
+const label = ref('')
+const injectionText = ref('')
+const busy = ref(false)
+const error = ref('')
+const result = ref(null)
+
+const canSubmit = computed(() => {
+  const t = Number(triggerRound.value)
+  return (
+    Number.isFinite(t) &&
+    t >= 0 &&
+    injectionText.value.trim().length >= 16 &&
+    label.value.trim().length >= 2
+  )
+})
+
+const applyPreset = (id) => {
+  selectedPresetId.value = id
+  const preset = props.presetBranches.find(b => b.id === id)
+  if (!preset) return
+  triggerRound.value = preset.trigger_round ?? triggerRound.value
+  label.value = preset.label || ''
+  injectionText.value = preset.injection || preset.description || ''
+}
+
+const submit = async () => {
+  if (!canSubmit.value) return
+  busy.value = true
+  error.value = ''
+  result.value = null
+  try {
+    const res = await branchCounterfactual(props.simulationId, {
+      injectionText: injectionText.value.trim(),
+      triggerRound: Number(triggerRound.value),
+      label: label.value.trim(),
+      branchId: selectedPresetId.value || undefined,
+    })
+    if (!res.success) {
+      error.value = res.error || 'Branch failed.'
+      return
+    }
+    result.value = res.data
+  } catch (err) {
+    error.value = err?.response?.data?.error || err?.message || 'Branch failed.'
+  } finally {
+    busy.value = false
+  }
+}
+
+const openBranch = () => {
+  if (!result.value?.simulation_id) return
+  router.push({ name: 'Process', params: { projectId: result.value.simulation_id } })
+}
+
+onMounted(() => {
+  // Auto-apply the first preset if one exists — zero-friction path.
+  if (props.presetBranches.length && !injectionText.value) {
+    applyPreset(props.presetBranches[0].id)
+  }
+})
+</script>
+
+<style scoped>
+.cf-panel {
+  background: #FAFAFA;
+  border: 2px solid rgba(10, 10, 10, 0.08);
+  padding: 20px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.cf-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgba(10, 10, 10, 0.08);
+}
+
+.cf-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 2px;
+}
+
+.cf-icon {
+  color: #FF6B1A;
+  font-size: 16px;
+}
+
+.cf-label {
+  color: #0A0A0A;
+}
+
+.cf-hint {
+  font-size: 12px;
+  color: rgba(10, 10, 10, 0.5);
+  line-height: 1.5;
+}
+
+.cf-preset-row,
+.cf-form-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.cf-form-row--stack {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+}
+
+.cf-preset-label,
+.cf-form-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.5);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  width: 130px;
+  flex-shrink: 0;
+}
+
+.cf-form-row--stack .cf-form-label {
+  width: 100%;
+  margin-bottom: 2px;
+}
+
+.cf-preset-select,
+.cf-form-input,
+.cf-form-textarea {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  padding: 6px 10px;
+  border: 1px solid rgba(10, 10, 10, 0.12);
+  background: #fff;
+  color: #0A0A0A;
+  outline: none;
+  flex: 1;
+  min-width: 0;
+}
+
+.cf-form-input--narrow {
+  max-width: 100px;
+  flex: none;
+}
+
+.cf-form-textarea {
+  min-height: 90px;
+  resize: vertical;
+  line-height: 1.5;
+  font-family: var(--font-display);
+  font-size: 13px;
+}
+
+.cf-form-input:focus,
+.cf-form-textarea:focus,
+.cf-preset-select:focus {
+  border-color: #FF6B1A;
+}
+
+.cf-form-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.4);
+}
+
+.cf-form-meta--right {
+  text-align: right;
+}
+
+.cf-error {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: #CC0000;
+  background: rgba(204, 0, 0, 0.05);
+  padding: 6px 10px;
+  border-left: 2px solid #CC0000;
+}
+
+.cf-result {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: #2d8a3f;
+  background: rgba(67, 193, 101, 0.06);
+  padding: 8px 10px;
+  border-left: 2px solid #2d8a3f;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.cf-result code {
+  background: rgba(10, 10, 10, 0.04);
+  padding: 1px 4px;
+}
+
+.cf-open-btn {
+  margin-left: auto;
+  background: #2d8a3f;
+  color: #fff;
+  border: none;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 10px;
+  cursor: pointer;
+  letter-spacing: 1px;
+}
+
+.cf-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.cf-cancel,
+.cf-submit {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  transition: all 0.15s;
+}
+
+.cf-cancel {
+  background: transparent;
+  border: 1px solid rgba(10, 10, 10, 0.15);
+  color: rgba(10, 10, 10, 0.7);
+}
+
+.cf-cancel:hover:not(:disabled) {
+  border-color: rgba(10, 10, 10, 0.35);
+}
+
+.cf-submit {
+  background: #0A0A0A;
+  color: #fff;
+  border: 1px solid #0A0A0A;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cf-submit:hover:not(:disabled) {
+  background: #FF6B1A;
+  border-color: #FF6B1A;
+}
+
+.cf-submit:disabled,
+.cf-cancel:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.cf-spinner {
+  width: 10px;
+  height: 10px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: cf-spin 0.8s linear infinite;
+}
+
+@keyframes cf-spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -19,6 +19,17 @@
             The widget loads live from this MiroShark instance and updates automatically as the simulation changes.
           </p>
 
+          <!-- Public toggle -->
+          <div class="embed-public-row">
+            <label class="embed-public-toggle">
+              <input type="checkbox" :checked="isPublic" @change="togglePublic" :disabled="publishing" />
+              <span class="embed-public-label">
+                {{ isPublic ? 'Public — embeddable by anyone with the URL' : 'Private — embed URL returns 403' }}
+              </span>
+            </label>
+            <span v-if="publishError" class="embed-public-error">{{ publishError }}</span>
+          </div>
+
           <!-- Size presets -->
           <div class="embed-size-row">
             <span class="embed-size-label">Size</span>
@@ -104,13 +115,33 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue'
+import { publishSimulation, getEmbedSummary } from '@/api/simulation'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
-  simulationId: { type: String, required: true }
+  simulationId: { type: String, required: true },
+  initialPublic: { type: Boolean, default: false }
 })
 
 defineEmits(['close'])
+
+const isPublic = ref(props.initialPublic)
+const publishing = ref(false)
+const publishError = ref('')
+
+const togglePublic = async () => {
+  const next = !isPublic.value
+  publishing.value = true
+  publishError.value = ''
+  try {
+    const res = await publishSimulation(props.simulationId, next)
+    isPublic.value = res?.data?.is_public ?? next
+  } catch (err) {
+    publishError.value = err?.response?.data?.error || err?.message || 'Publish failed'
+  } finally {
+    publishing.value = false
+  }
+}
 
 const sizePresets = [
   { name: 'Compact', width: 480, height: 260 },
@@ -198,8 +229,16 @@ const copy = async (which) => {
   }
 }
 
-watch(() => props.open, (val) => {
-  if (val) copied.value = ''
+watch(() => props.open, async (val) => {
+  if (!val) return
+  copied.value = ''
+  // Refresh public state when reopened — reflects external flips.
+  try {
+    const res = await getEmbedSummary(props.simulationId)
+    if (typeof res?.data?.is_public === 'boolean') isPublic.value = res.data.is_public
+  } catch (err) {
+    if (err?.response?.status === 403) isPublic.value = false
+  }
 })
 </script>
 

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -54,7 +54,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showInfluence }"
-        @click="showInfluence = !showInfluence; showBeliefDrift = false; showDirector = false; showNetwork = false; showDemographics = false; showWhatIf = false"
+        @click="showInfluence = !showInfluence; showBeliefDrift = false; showDirector = false; showNetwork = false; showDemographics = false; showWhatIf = false; showBranch = false"
         title="Agent influence leaderboard"
       >
         ◈ Influence
@@ -65,7 +65,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showBeliefDrift }"
-        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false; showDirector = false; showNetwork = false; showDemographics = false; showWhatIf = false"
+        @click="showBeliefDrift = !showBeliefDrift; showInfluence = false; showDirector = false; showNetwork = false; showDemographics = false; showWhatIf = false; showBranch = false"
         title="Aggregate belief drift chart"
       >
         ◎ Drift
@@ -76,7 +76,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showNetwork }"
-        @click="showNetwork = !showNetwork; showInfluence = false; showBeliefDrift = false; showDirector = false; showDemographics = false; showWhatIf = false"
+        @click="showNetwork = !showNetwork; showInfluence = false; showBeliefDrift = false; showDirector = false; showDemographics = false; showWhatIf = false; showBranch = false"
         title="Agent interaction network graph"
       >
         ⬡ Network
@@ -87,7 +87,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showDemographics }"
-        @click="showDemographics = !showDemographics; showInfluence = false; showBeliefDrift = false; showDirector = false; showNetwork = false; showWhatIf = false"
+        @click="showDemographics = !showDemographics; showInfluence = false; showBeliefDrift = false; showDirector = false; showNetwork = false; showWhatIf = false; showBranch = false"
         title="Agent demographic breakdown (age, gender, country, actor type, platform)"
       >
         ◇ Demographics
@@ -98,7 +98,7 @@
         v-if="allActions.length > 0"
         class="action-btn secondary"
         :class="{ active: showWhatIf }"
-        @click="showWhatIf = !showWhatIf; showInfluence = false; showBeliefDrift = false; showDirector = false; showNetwork = false; showDemographics = false"
+        @click="showWhatIf = !showWhatIf; showInfluence = false; showBeliefDrift = false; showDirector = false; showNetwork = false; showDemographics = false; showBranch = false"
         title="What If? — remove agents and recompute belief drift from existing trajectory"
       >
         ◐ What If?
@@ -109,11 +109,22 @@
         v-if="phase === 1"
         class="action-btn secondary director-btn"
         :class="{ active: showDirector }"
-        @click="showDirector = !showDirector; showInfluence = false; showBeliefDrift = false; showNetwork = false; showDemographics = false; showWhatIf = false"
+        @click="showDirector = !showDirector; showInfluence = false; showBeliefDrift = false; showNetwork = false; showDemographics = false; showWhatIf = false; showBranch = false"
         :title="directorEventsTotal >= 10 ? 'Director Mode — max events reached' : 'Director Mode — inject a breaking event into the simulation'"
       >
         ⚡ Director
         <span v-if="directorEventsTotal > 0" class="director-badge">{{ directorEventsTotal }}/10</span>
+      </button>
+
+      <!-- Counterfactual Branch toggle — fork with an injection at a future round -->
+      <button
+        v-if="phase !== 0"
+        class="action-btn secondary"
+        :class="{ active: showBranch }"
+        @click="showBranch = !showBranch; showInfluence = false; showBeliefDrift = false; showNetwork = false; showDemographics = false; showWhatIf = false; showDirector = false"
+        title="Fork this simulation with a narrative injection scheduled for a specific round"
+      >
+        ⤷ Branch
       </button>
 
       <!-- Resume (when paused/stopped/failed with partial data) -->
@@ -287,6 +298,17 @@
       class="influence-overlay"
     />
 
+    <!-- Counterfactual Branch (overlay when toggled) -->
+    <div v-if="showBranch" class="influence-overlay">
+      <CounterfactualBranchPanel
+        :simulationId="simulationId"
+        :currentRound="runStatus.current_round || 0"
+        :totalRounds="runStatus.total_rounds || 0"
+        :presetBranches="presetCounterfactualBranches"
+        @close="showBranch = false"
+      />
+    </div>
+
     <!-- Director Mode Panel (overlay when toggled) -->
     <div v-if="showDirector" class="influence-overlay director-panel">
       <div class="director-header">
@@ -353,7 +375,7 @@
     </div>
 
     <!-- Main Content: Dual Timeline -->
-    <div v-show="!showInfluence && !showBeliefDrift && !showDirector && !showNetwork && !showDemographics" class="main-content-area" ref="scrollContainer" @scroll="onTimelineScroll">
+    <div v-show="!showInfluence && !showBeliefDrift && !showDirector && !showNetwork && !showDemographics && !showBranch && !showWhatIf" class="main-content-area" ref="scrollContainer" @scroll="onTimelineScroll">
       <!-- Scroll to bottom button -->
       <button
         v-if="showScrollBtn"
@@ -704,6 +726,7 @@ import BeliefDriftChart from './BeliefDriftChart.vue'
 import InteractionNetwork from './InteractionNetwork.vue'
 import DemographicBreakdown from './DemographicBreakdown.vue'
 import WhatIfPanel from './WhatIfPanel.vue'
+import CounterfactualBranchPanel from './CounterfactualBranchPanel.vue'
 
 const props = defineProps({
   simulationId: String,
@@ -741,6 +764,12 @@ const showBeliefDrift = ref(false)
 const showNetwork = ref(false)
 const showDemographics = ref(false)
 const showWhatIf = ref(false)
+const showBranch = ref(false)
+// Preset counterfactual branches carried over from the template that
+// seeded this simulation (if any). The runner's currently-active simulation
+// object exposes no template_id, so we best-effort resolve via the parent
+// project on mount. Populated in fetchPresetBranches() below.
+const presetCounterfactualBranches = ref([])
 
 // Article drawer state
 const showArticleDrawer = ref(false)

--- a/frontend/src/components/TemplateGallery.vue
+++ b/frontend/src/components/TemplateGallery.vue
@@ -48,7 +48,39 @@
 
         <div class="card-platforms">
           <span v-for="p in template.platforms" :key="p" class="platform-badge">{{ p }}</span>
+          <span
+            v-if="template.has_counterfactuals"
+            class="platform-badge platform-badge--cf"
+            :title="`${template.counterfactual_count} preset counterfactual branches`"
+          >
+            ⤷ {{ template.counterfactual_count }} branches
+          </span>
+          <span
+            v-if="template.has_oracle_tools"
+            class="platform-badge platform-badge--oracle"
+            :title="`${template.oracle_tool_count} FeedOracle tools declared`"
+          >
+            ◎ live data
+          </span>
         </div>
+
+        <label
+          v-if="template.has_oracle_tools"
+          class="oracle-toggle"
+          :class="{ disabled: !capabilities.oracle_seed_enabled }"
+          :title="capabilities.oracle_seed_enabled
+            ? 'Dispatch this template\'s oracle_tools against FeedOracle MCP before ingest.'
+            : 'Oracle seeds disabled server-side. Set ORACLE_SEED_ENABLED=true in .env to enable.'"
+          @click.stop
+        >
+          <input
+            type="checkbox"
+            :checked="oracleOptIn[template.id] || false"
+            :disabled="!capabilities.oracle_seed_enabled"
+            @change="toggleOracleOpt(template.id, $event.target.checked)"
+          />
+          <span>Use live oracle data</span>
+        </label>
 
         <button
           class="launch-btn"
@@ -56,6 +88,7 @@
           @click.stop="launchTemplate(template)"
         >
           <span v-if="launchingId === template.id">Loading...</span>
+          <span v-else-if="oracleOptIn[template.id] && capabilities.oracle_seed_enabled">Launch (live) →</span>
           <span v-else>Launch →</span>
         </button>
       </div>
@@ -64,9 +97,9 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, reactive, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { listTemplates, getTemplate } from '../api/templates'
+import { listTemplates, getTemplate, getTemplateCapabilities } from '../api/templates'
 import { setPendingTemplate } from '../store/pendingUpload'
 
 const router = useRouter()
@@ -75,6 +108,12 @@ const templates = ref([])
 const loading = ref(true)
 const selectedId = ref(null)
 const launchingId = ref(null)
+const capabilities = ref({ oracle_seed_enabled: false, mcp_agent_tools_enabled: false })
+const oracleOptIn = reactive({})  // templateId → bool (opt-in per card)
+
+const toggleOracleOpt = (templateId, checked) => {
+  oracleOptIn[templateId] = checked
+}
 
 const iconMap = {
   vote: '🗳',
@@ -87,10 +126,12 @@ const iconMap = {
 
 onMounted(async () => {
   try {
-    const res = await listTemplates()
-    if (res?.success) {
-      templates.value = res.data
-    }
+    const [listRes, capsRes] = await Promise.all([
+      listTemplates(),
+      getTemplateCapabilities().catch(() => null),  // caps is optional
+    ])
+    if (listRes?.success) templates.value = listRes.data
+    if (capsRes?.success) capabilities.value = capsRes.data
   } catch (e) {
     console.error('Failed to load templates:', e)
   } finally {
@@ -105,7 +146,8 @@ const selectTemplate = (template) => {
 const launchTemplate = async (template) => {
   launchingId.value = template.id
   try {
-    const res = await getTemplate(template.id)
+    const enrich = !!(oracleOptIn[template.id] && capabilities.value.oracle_seed_enabled)
+    const res = await getTemplate(template.id, { enrich })
     if (res?.success) {
       const full = res.data
       setPendingTemplate(
@@ -256,6 +298,42 @@ const launchTemplate = async (template) => {
   border: 1px solid #E5E5E5;
   color: #666;
   text-transform: lowercase;
+}
+
+.platform-badge--cf {
+  border-color: rgba(255, 107, 26, 0.3);
+  color: #FF6B1A;
+}
+
+.platform-badge--oracle {
+  border-color: rgba(67, 193, 101, 0.3);
+  color: #2d8a3f;
+}
+
+.oracle-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: #2d8a3f;
+  margin-bottom: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.oracle-toggle input[type="checkbox"] {
+  accent-color: #2d8a3f;
+  cursor: pointer;
+}
+
+.oracle-toggle.disabled {
+  color: #aaa;
+  cursor: not-allowed;
+}
+
+.oracle-toggle.disabled input[type="checkbox"] {
+  cursor: not-allowed;
 }
 
 .launch-btn {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -145,6 +145,34 @@
               </div>
             </div>
 
+            <!-- Ask Mode (no document needed) -->
+            <div class="console-section url-section">
+              <div class="console-header">
+                <span class="console-label">01a / Just Ask</span>
+                <span class="console-meta">No document? Type a question, we synthesize a briefing.</span>
+              </div>
+              <div class="url-input-row">
+                <input
+                  v-model="askQuestion"
+                  class="url-input"
+                  type="text"
+                  placeholder="e.g. Will the EU AI Act's biometrics clause survive the final trilogue?"
+                  :disabled="loading || askBusy"
+                  @keydown.enter.prevent="runAskMode"
+                />
+                <button
+                  class="url-fetch-btn"
+                  @click="runAskMode"
+                  :disabled="!askQuestion.trim() || loading || askBusy"
+                >
+                  <span v-if="askBusy">...</span>
+                  <span v-else>Research →</span>
+                </button>
+              </div>
+              <div v-if="askError" class="url-error">{{ askError }}</div>
+              <div v-if="askBusy" class="url-doc-meta" style="margin-top:6px">Synthesizing briefing — this uses the Smart model and takes ~20–30s.</div>
+            </div>
+
             <!-- URL Input Section -->
             <div class="console-section url-section">
               <div class="console-header">
@@ -247,6 +275,7 @@ import SettingsPanel from '../components/SettingsPanel.vue'
 import ScenarioSuggestions from '../components/ScenarioSuggestions.vue'
 import TrendingTopics from '../components/TrendingTopics.vue'
 import { fetchUrl } from '../api/graph'
+import { askMode } from '../api/simulation'
 
 const settingsOpen = ref(false)
 
@@ -265,6 +294,11 @@ const urlInput = ref('')
 const urlDocs = ref([])   // [{title, url, text, char_count}]
 const urlFetching = ref(false)
 const urlError = ref('')
+
+// Ask-mode state — question-only pipeline
+const askQuestion = ref('')
+const askBusy = ref(false)
+const askError = ref('')
 
 // State
 const loading = ref(false)
@@ -421,6 +455,43 @@ const fetchUrlDoc = async () => {
     urlError.value = err.message || 'Failed to fetch URL.'
   } finally {
     urlFetching.value = false
+  }
+}
+
+// Ask mode: ask → synthesized briefing becomes a url_doc; we also prefill the
+// simulation_requirement textarea with the LLM's framing. Rest of the flow is
+// unchanged.
+const runAskMode = async () => {
+  const q = askQuestion.value.trim()
+  if (!q || askBusy.value) return
+  askBusy.value = true
+  askError.value = ''
+  try {
+    const res = await askMode(q)
+    if (!res.success) {
+      askError.value = res.error || 'Ask mode failed.'
+      return
+    }
+    const d = res.data
+    const synthUrl = `miroshark://ask/${encodeURIComponent(q.slice(0, 64))}`
+    // Don't duplicate if re-run.
+    const idx = urlDocs.value.findIndex(x => x.url === synthUrl)
+    const payload = {
+      title: d.title,
+      url: synthUrl,
+      text: d.seed_document,
+      char_count: (d.seed_document || '').length,
+    }
+    if (idx >= 0) urlDocs.value.splice(idx, 1, payload)
+    else urlDocs.value.push(payload)
+    if (!formData.value.simulationRequirement) {
+      formData.value.simulationRequirement = d.simulation_requirement
+    }
+    askQuestion.value = ''
+  } catch (err) {
+    askError.value = err?.response?.data?.error || err?.message || 'Ask mode failed.'
+  } finally {
+    askBusy.value = false
   }
 }
 


### PR DESCRIPTION
## Summary

Pulls the most useful ideas from the four sibling forks (MiroJiang, MiroWhale, OpenMiro, mirofish-oracle-seeds) into the core MiroShark stack. **14 features, all opt-in** — every new capability is gated behind an env flag, a per-sim toggle, or a per-persona flag, so existing deployments behave identically.

## What's new

**Onboarding**
- **Just Ask mode** (`POST /api/simulation/ask`) — question-only pipeline, no document required. LLM synthesizes a briefing that feeds the existing pipeline unchanged. Home UI entry added.

**Analysis**
- **Counterfactual branching** (`POST /api/simulation/branch-counterfactual`) — fork a running sim with a narrative injection scheduled for any future round. Piggybacks on the existing director-event system. New `CounterfactualBranchPanel.vue` wired into Step 3.
- **Per-round frame API** (`GET /api/simulation/<id>/frame/<round>`) — compact snapshot for scrubbing UIs on large sims.
- **Nash equilibrium** (`analyze_equilibrium`) — new report-agent tool that fits a 2-player stance game on the final belief distribution and enumerates equilibria via `nashpy`.

**Live data**
- **FeedOracle MCP seeds** — `ORACLE_SEED_ENABLED=true` + templates' `oracle_tools[]` dispatch live data (MiCA, DORA, macro, etc.) into the seed doc at template load. Per-template toggle in `TemplateGallery`.
- **Per-agent MCP tools** — `MCP_AGENT_TOOLS_ENABLED=true` enables OpenMiro-style runtime tool dispatch. Personas with `tools_enabled: true` get a tool catalogue injected each round; the runner parses `<mcp_call .../>` tags from their posts, dispatches via pooled stdio subprocesses, and injects results on the next activation.

**Security / infra**
- **`is_public` flag** on simulations + `POST /api/simulation/<id>/publish`. Embed endpoints now 403 until explicitly published (EmbedDialog has a toggle).
- **Embedding batching** 32 → 128 (configurable).
- **Anthropic prompt caching** — silent no-op on non-Claude models.
- Removed a silent `gpt-4o-mini` fallback in `run_parallel_simulation.py`.

**Tooling**
- **`miroshark-cli`** — dependency-light HTTP client (`ask` / `list` / `status` / `frame` / `publish` / `report` / `trending` / `health`).
- **Pytest suite** — 62 unit tests (offline), integration markers wrap the existing hand-run scripts, GitHub Actions workflow runs unit tests on every push.

**Docs**
- README updated with sections for all new features. `.env.example` lists every new flag.

## Notes

- Five existing behaviours are gated by defaults so nothing breaks: oracle enrichment is off, per-agent MCP is off, sims are private, caching works only on Claude models, legacy integration scripts still work standalone.
- `analyze_equilibrium` requires `nashpy` (now in `requirements.txt`).
- Sibling repos these features are adapted from: MiroJiang (Nash, counterfactuals), MiroWhale (ask mode, CLI), OpenMiro (per-agent MCP), mirofish-oracle-seeds (FeedOracle integration).

## Test plan

- [ ] Run the unit suite: \`cd backend && pytest -m "not integration"\` (should show 62 passing)
- [ ] Run the backend and try \`./miroshark\`; verify existing flows still work end-to-end
- [ ] Try Just Ask: type a question on the Home screen and confirm the synthesized briefing pre-fills the simulation prompt
- [ ] Flip \`ORACLE_SEED_ENABLED=true\` and check the "Use live oracle data" toggle appears on crypto_launch / corporate_crisis cards
- [ ] Run a short simulation, click **⤷ Branch**, and verify the new sim appears with a counterfactual injection scheduled
- [ ] Verify a private sim's \`/embed-summary\` returns 403, flip **Public** in EmbedDialog, confirm it returns 200
- [ ] Verify \`GET /api/simulation/<id>/frame/0\` returns a compact snapshot
- [ ] With a Claude model configured, verify LLM calls still succeed (cache_control blocks are passed through)
- [ ] Integration tests: \`export MIROSHARK_API_URL=http://localhost:5001 && pytest -m integration\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)