### PR TITLE
feat: social share card (Open Graph image + landing page)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,8 @@ jobs:
             "python-dotenv>=1.0.0" \
             "pydantic>=2.0.0" \
             "requests>=2.31.0" \
-            "neo4j>=5.15.0"
+            "neo4j>=5.15.0" \
+            "pillow>=12.0.0"
 
       - name: Run unit tests
         run: pytest -m "not integration"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
 | **Live Oracle Data** | Opt-in grounded seeds from the [FeedOracle](https://mcp.feedoracle.io/mcp) MCP (484 tools) |
 | **Per-Agent MCP Tools** | Personas can invoke real MCP tools (web search, APIs) during simulation |
 | **Embed & Publish** | Public/private toggle + embed URLs for sharing finished runs |
+| **Social Share Card** | 1200×630 PNG that auto-unfurls scenario, status, quality, and belief split on Twitter/X, Discord, Slack, LinkedIn |
 | **Article Generation** | Substack-style write-up of what happened, grounded in actual posts and trades |
 | **Interaction Network** | Force-directed agent-to-agent graph with echo-chamber metrics |
 | **Demographics** | Archetype clustering (analyst / influencer / retail / observer…) |

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -79,13 +79,16 @@ def create_app(config_class=Config):
         return response
     
     # Register blueprints
-    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp
+    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, share_bp
     app.register_blueprint(graph_bp, url_prefix='/api/graph')
     app.register_blueprint(simulation_bp, url_prefix='/api/simulation')
     app.register_blueprint(report_bp, url_prefix='/api/report')
     app.register_blueprint(templates_bp, url_prefix='/api/templates')
     app.register_blueprint(settings_bp, url_prefix='/api/settings')
     app.register_blueprint(observability_bp, url_prefix='/api/observability')
+    # share_bp serves the public OG-tag landing page at /share/<sim_id>
+    # (no prefix — keeps the social share URL short).
+    app.register_blueprint(share_bp)
     
     # Health check
     @app.route('/health')

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -18,3 +18,7 @@ from . import templates  # noqa: E402, F401
 from . import settings  # noqa: E402, F401
 from . import observability  # noqa: E402, F401
 
+# share_bp is mounted at the root (no /api prefix) so the public landing
+# URL stays clean — see api/share.py.
+from .share import share_bp  # noqa: E402, F401
+

--- a/backend/app/api/share.py
+++ b/backend/app/api/share.py
@@ -1,0 +1,181 @@
+"""Public share landing route.
+
+Serves an HTML page at ``/share/<simulation_id>`` with the right
+Open Graph / Twitter card meta tags so links to a MiroShark simulation
+unfurl as a rich preview on Twitter/X, Discord, Slack, LinkedIn, iMessage,
+etc.
+
+Bots that scrape the URL read the meta tags and render the share card.
+Real browsers immediately bounce to the SPA — JS first (instant), with a
+``<meta http-equiv="refresh">`` fallback for clients with JS disabled.
+
+Mounted on a separate blueprint with no URL prefix so the URL stays clean
+(``/share/sim_xxx`` rather than ``/api/share/sim_xxx``). Anyone with the
+URL can hit the endpoint, but the underlying share-card.png and
+embed-summary endpoints both enforce the ``is_public`` gate so a private
+simulation just renders a generic preview.
+"""
+
+from __future__ import annotations
+
+import html
+from flask import Blueprint, Response, request
+
+from ..services.simulation_manager import SimulationManager
+from ..utils.validation import validate_simulation_id
+
+
+share_bp = Blueprint('share', __name__)
+
+
+def _esc(value: str) -> str:
+    """HTML attribute escape — quotes are critical here since values land
+    inside ``content="..."``."""
+    return html.escape(value or "", quote=True)
+
+
+def _render_landing_html(
+    simulation_id: str,
+    scenario: str,
+    is_public: bool,
+    spa_url: str,
+    card_url: str,
+) -> str:
+    """Build the static HTML returned to scrapers + browsers.
+
+    Keep this small and dependency-free — the page exists purely to expose
+    Open Graph tags. The body is a minimal "redirecting" splash so users
+    who somehow see it briefly know what's happening.
+    """
+    if scenario:
+        scenario_clean = scenario.strip()
+        if len(scenario_clean) > 200:
+            scenario_clean = scenario_clean[:197].rstrip() + "…"
+        title = f"MiroShark · {scenario_clean}"
+    else:
+        title = "MiroShark Simulation"
+
+    description = (
+        scenario.strip() if scenario else
+        "An autonomous social-simulation result on MiroShark — view the full belief drift, agent network, and prediction outcome."
+    )
+    if len(description) > 280:
+        description = description[:277].rstrip() + "…"
+
+    import json as _json
+
+    title_e = _esc(title)
+    desc_e = _esc(description)
+    card_e = _esc(card_url)
+    spa_e = _esc(spa_url)
+    spa_js = _json.dumps(spa_url)  # safe for inline <script> string literal
+
+    # Note the dual redirect: <meta refresh> handles JS-off; the inline
+    # script handles JS-on (instant). Bots ignore both.
+    return (
+        "<!DOCTYPE html>\n"
+        "<html lang=\"en\">\n"
+        "<head>\n"
+        "<meta charset=\"utf-8\">\n"
+        f"<title>{title_e}</title>\n"
+        f"<meta name=\"description\" content=\"{desc_e}\">\n"
+        "\n"
+        "<meta property=\"og:type\" content=\"website\">\n"
+        f"<meta property=\"og:title\" content=\"{title_e}\">\n"
+        f"<meta property=\"og:description\" content=\"{desc_e}\">\n"
+        f"<meta property=\"og:image\" content=\"{card_e}\">\n"
+        "<meta property=\"og:image:width\" content=\"1200\">\n"
+        "<meta property=\"og:image:height\" content=\"630\">\n"
+        f"<meta property=\"og:url\" content=\"{spa_e}\">\n"
+        "<meta property=\"og:site_name\" content=\"MiroShark\">\n"
+        "\n"
+        "<meta name=\"twitter:card\" content=\"summary_large_image\">\n"
+        f"<meta name=\"twitter:title\" content=\"{title_e}\">\n"
+        f"<meta name=\"twitter:description\" content=\"{desc_e}\">\n"
+        f"<meta name=\"twitter:image\" content=\"{card_e}\">\n"
+        "\n"
+        f"<meta http-equiv=\"refresh\" content=\"0; url={spa_e}\">\n"
+        f"<link rel=\"canonical\" href=\"{spa_e}\">\n"
+        "<style>\n"
+        "  body { font-family: -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif;\n"
+        "         background: #0a0a0a; color: #fafafa; margin: 0;\n"
+        "         display: flex; align-items: center; justify-content: center;\n"
+        "         min-height: 100vh; text-align: center; padding: 24px; }\n"
+        "  a { color: #ea580c; }\n"
+        "  .wrap { max-width: 480px; }\n"
+        "  h1 { font-size: 16px; letter-spacing: 0.18em; margin: 0 0 8px; opacity: 0.5;\n"
+        "       text-transform: uppercase; font-weight: 700; }\n"
+        "  p { font-size: 18px; line-height: 1.5; margin: 0 0 24px; }\n"
+        "</style>\n"
+        "</head>\n"
+        "<body>\n"
+        "<div class=\"wrap\">\n"
+        "  <h1>MiroShark</h1>\n"
+        "  <p>Opening simulation…</p>\n"
+        f"  <p><a href=\"{spa_e}\">Continue →</a></p>\n"
+        "</div>\n"
+        "<script>\n"
+        f"  window.location.replace({spa_js});\n"
+        "</script>\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+@share_bp.route('/share/<simulation_id>', methods=['GET'])
+def share_landing(simulation_id: str):
+    """Server-rendered HTML with OG meta tags pointing to the share-card
+    PNG endpoint. Browsers JS-redirect to the SPA simulation view.
+
+    No auth — but the underlying ``/share-card.png`` honors ``is_public``,
+    so private sims fall back to a generic preview rather than leaking
+    scenario detail through the meta tags.
+    """
+    try:
+        validate_simulation_id(simulation_id)
+    except ValueError as exc:
+        return Response(f"Invalid simulation id: {exc}", status=400, mimetype="text/plain")
+
+    # Pull just enough to populate OG tags — never raise on missing data.
+    scenario = ""
+    is_public = False
+    try:
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if state:
+            is_public = bool(getattr(state, "is_public", False))
+            if is_public:
+                config = manager.get_simulation_config(simulation_id)
+                if config:
+                    scenario = (config.get("simulation_requirement") or "").strip()
+    except Exception:
+        # Don't 500 the page just because a peripheral lookup failed —
+        # the worst case is a generic preview.
+        pass
+
+    # Prefer the proxied ``Host`` header so links work behind a reverse
+    # proxy. Falls back to ``request.host_url`` (which uses the WSGI
+    # SERVER_NAME).
+    base = request.host_url.rstrip("/")
+    forwarded_proto = request.headers.get("X-Forwarded-Proto")
+    forwarded_host = request.headers.get("X-Forwarded-Host")
+    if forwarded_host:
+        proto = forwarded_proto or ("https" if request.is_secure else "http")
+        base = f"{proto}://{forwarded_host}"
+
+    spa_url = f"{base}/simulation/{simulation_id}/start"
+    card_url = f"{base}/api/simulation/{simulation_id}/share-card.png"
+
+    body = _render_landing_html(
+        simulation_id=simulation_id,
+        scenario=scenario if is_public else "",
+        is_public=is_public,
+        spa_url=spa_url,
+        card_url=card_url,
+    )
+
+    response = Response(body, mimetype="text/html; charset=utf-8")
+    # OG scrapers cache aggressively — keep the cache short so newly
+    # published sims show their card without long delays.
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return response

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4374,6 +4374,147 @@ def publish_simulation(simulation_id: str):
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+def _build_embed_summary_payload(simulation_id: str) -> dict:
+    """Assemble the same dict the embed-summary endpoint returns.
+
+    Extracted so the share-card renderer can reuse the data pipeline without
+    going back through HTTP. Caller is responsible for the ``is_public``
+    gate — this only does the disk reads and aggregation. Raises
+    ``LookupError`` if the simulation doesn't exist.
+    """
+    manager = SimulationManager()
+    state = manager.get_simulation(simulation_id)
+    if not state:
+        raise LookupError(f"Simulation not found: {simulation_id}")
+
+    sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+
+    config = manager.get_simulation_config(simulation_id)
+    scenario = ""
+    if config:
+        scenario = (config.get("simulation_requirement") or "").strip()
+
+    run_state = SimulationRunner.get_run_state(simulation_id)
+    if run_state:
+        current_round = run_state.current_round
+        total_rounds = run_state.total_rounds if getattr(run_state, 'total_rounds', 0) else 0
+        runner_status = run_state.runner_status.value if hasattr(run_state.runner_status, 'value') else str(run_state.runner_status)
+    else:
+        current_round = 0
+        total_rounds = 0
+        runner_status = "idle"
+
+    if total_rounds == 0 and config:
+        time_config = config.get("time_config", {})
+        minutes_per_round = max(int(time_config.get("minutes_per_round", 60) or 60), 1)
+        hours = int(time_config.get("total_simulation_hours", 0) or 0)
+        total_rounds = int(hours * 60 / minutes_per_round)
+
+    belief = None
+    trajectory_path = os.path.join(sim_dir, "trajectory.json") if os.path.exists(sim_dir) else None
+    if trajectory_path and os.path.exists(trajectory_path):
+        try:
+            with open(trajectory_path, 'r', encoding='utf-8') as f:
+                traj = json.load(f)
+
+            rounds = []
+            bullish = []
+            neutral = []
+            bearish = []
+            for snap in traj.get("snapshots", []):
+                positions = snap.get("belief_positions", {}) or {}
+                if not positions:
+                    continue
+                stances = []
+                for p in positions.values():
+                    if p:
+                        stances.append(sum(p.values()) / len(p))
+                if not stances:
+                    continue
+                total = len(stances)
+                nb = sum(1 for s in stances if s > 0.2)
+                nbe = sum(1 for s in stances if s < -0.2)
+                nn = total - nb - nbe
+                rounds.append(snap.get("round_num", len(rounds)))
+                bullish.append(round(nb / total * 100, 1))
+                neutral.append(round(nn / total * 100, 1))
+                bearish.append(round(nbe / total * 100, 1))
+
+            consensus_round = None
+            consensus_stance = None
+            for i, _ in enumerate(rounds):
+                if bullish[i] > 50:
+                    consensus_round = rounds[i]
+                    consensus_stance = "bullish"
+                    break
+                if bearish[i] > 50:
+                    consensus_round = rounds[i]
+                    consensus_stance = "bearish"
+                    break
+
+            if rounds:
+                belief = {
+                    "rounds": rounds,
+                    "bullish": bullish,
+                    "neutral": neutral,
+                    "bearish": bearish,
+                    "final": {
+                        "bullish": bullish[-1],
+                        "neutral": neutral[-1],
+                        "bearish": bearish[-1],
+                    },
+                    "consensus_round": consensus_round,
+                    "consensus_stance": consensus_stance,
+                }
+        except Exception as exc:
+            logger.warning(f"Embed summary: failed to parse trajectory for {simulation_id}: {exc}")
+
+    quality = None
+    quality_path = os.path.join(sim_dir, "quality.json") if os.path.exists(sim_dir) else None
+    if quality_path and os.path.exists(quality_path):
+        try:
+            with open(quality_path, 'r', encoding='utf-8') as f:
+                q = json.load(f)
+            quality = {
+                "health": q.get("health"),
+                "participation_rate": q.get("participation_rate"),
+            }
+        except Exception:
+            quality = None
+
+    resolution = None
+    resolution_path = os.path.join(sim_dir, "resolution.json") if os.path.exists(sim_dir) else None
+    if resolution_path and os.path.exists(resolution_path):
+        try:
+            with open(resolution_path, 'r', encoding='utf-8') as f:
+                r = json.load(f)
+            resolution = {
+                "actual_outcome": r.get("actual_outcome"),
+                "predicted_consensus": r.get("predicted_consensus"),
+                "accuracy_score": r.get("accuracy_score"),
+            }
+        except Exception:
+            resolution = None
+
+    created_date = (state.created_at or "")[:10]
+
+    return {
+        "simulation_id": simulation_id,
+        "scenario": scenario,
+        "status": state.status.value if hasattr(state.status, 'value') else str(state.status),
+        "runner_status": runner_status,
+        "current_round": current_round,
+        "total_rounds": total_rounds,
+        "profiles_count": state.profiles_count,
+        "created_date": created_date,
+        "parent_simulation_id": state.parent_simulation_id,
+        "is_public": getattr(state, "is_public", False),
+        "belief": belief,
+        "quality": quality,
+        "resolution": resolution,
+    }
+
+
 @simulation_bp.route('/<simulation_id>/embed-summary', methods=['GET'])
 def get_embed_summary(simulation_id: str):
     """
@@ -4388,150 +4529,16 @@ def get_embed_summary(simulation_id: str):
     ``/publish`` endpoint to toggle.
     """
     try:
-        manager = SimulationManager()
-        state = manager.get_simulation(simulation_id)
-        if not state:
-            return jsonify({
-                "success": False,
-                "error": f"Simulation not found: {simulation_id}"
-            }), 404
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
 
-        if not getattr(state, "is_public", False):
+        if not summary.get("is_public"):
             return jsonify({
                 "success": False,
                 "error": "Simulation is not published for embedding. POST /api/simulation/<id>/publish to enable.",
             }), 403
-
-        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
-
-        # Scenario & timing
-        config = manager.get_simulation_config(simulation_id)
-        scenario = ""
-        if config:
-            scenario = (config.get("simulation_requirement") or "").strip()
-
-        run_state = SimulationRunner.get_run_state(simulation_id)
-        if run_state:
-            current_round = run_state.current_round
-            total_rounds = run_state.total_rounds if getattr(run_state, 'total_rounds', 0) else 0
-            runner_status = run_state.runner_status.value if hasattr(run_state.runner_status, 'value') else str(run_state.runner_status)
-        else:
-            current_round = 0
-            total_rounds = 0
-            runner_status = "idle"
-
-        if total_rounds == 0 and config:
-            time_config = config.get("time_config", {})
-            minutes_per_round = max(int(time_config.get("minutes_per_round", 60) or 60), 1)
-            hours = int(time_config.get("total_simulation_hours", 0) or 0)
-            total_rounds = int(hours * 60 / minutes_per_round)
-
-        # Belief drift sparkline
-        belief = None
-        trajectory_path = os.path.join(sim_dir, "trajectory.json") if os.path.exists(sim_dir) else None
-        if trajectory_path and os.path.exists(trajectory_path):
-            try:
-                with open(trajectory_path, 'r', encoding='utf-8') as f:
-                    traj = json.load(f)
-
-                rounds = []
-                bullish = []
-                neutral = []
-                bearish = []
-                for snap in traj.get("snapshots", []):
-                    positions = snap.get("belief_positions", {}) or {}
-                    if not positions:
-                        continue
-                    stances = []
-                    for p in positions.values():
-                        if p:
-                            stances.append(sum(p.values()) / len(p))
-                    if not stances:
-                        continue
-                    total = len(stances)
-                    nb = sum(1 for s in stances if s > 0.2)
-                    nbe = sum(1 for s in stances if s < -0.2)
-                    nn = total - nb - nbe
-                    rounds.append(snap.get("round_num", len(rounds)))
-                    bullish.append(round(nb / total * 100, 1))
-                    neutral.append(round(nn / total * 100, 1))
-                    bearish.append(round(nbe / total * 100, 1))
-
-                consensus_round = None
-                consensus_stance = None
-                for i, _ in enumerate(rounds):
-                    if bullish[i] > 50:
-                        consensus_round = rounds[i]
-                        consensus_stance = "bullish"
-                        break
-                    if bearish[i] > 50:
-                        consensus_round = rounds[i]
-                        consensus_stance = "bearish"
-                        break
-
-                if rounds:
-                    belief = {
-                        "rounds": rounds,
-                        "bullish": bullish,
-                        "neutral": neutral,
-                        "bearish": bearish,
-                        "final": {
-                            "bullish": bullish[-1],
-                            "neutral": neutral[-1],
-                            "bearish": bearish[-1],
-                        },
-                        "consensus_round": consensus_round,
-                        "consensus_stance": consensus_stance,
-                    }
-            except Exception as exc:
-                logger.warning(f"Embed summary: failed to parse trajectory for {simulation_id}: {exc}")
-
-        # Quality (cached)
-        quality = None
-        quality_path = os.path.join(sim_dir, "quality.json") if os.path.exists(sim_dir) else None
-        if quality_path and os.path.exists(quality_path):
-            try:
-                with open(quality_path, 'r', encoding='utf-8') as f:
-                    q = json.load(f)
-                quality = {
-                    "health": q.get("health"),
-                    "participation_rate": q.get("participation_rate"),
-                }
-            except Exception:
-                quality = None
-
-        # Resolution (cached)
-        resolution = None
-        resolution_path = os.path.join(sim_dir, "resolution.json") if os.path.exists(sim_dir) else None
-        if resolution_path and os.path.exists(resolution_path):
-            try:
-                with open(resolution_path, 'r', encoding='utf-8') as f:
-                    r = json.load(f)
-                resolution = {
-                    "actual_outcome": r.get("actual_outcome"),
-                    "predicted_consensus": r.get("predicted_consensus"),
-                    "accuracy_score": r.get("accuracy_score"),
-                }
-            except Exception:
-                resolution = None
-
-        created_date = (state.created_at or "")[:10]
-
-        summary = {
-            "simulation_id": simulation_id,
-            "scenario": scenario,
-            "status": state.status.value if hasattr(state.status, 'value') else str(state.status),
-            "runner_status": runner_status,
-            "current_round": current_round,
-            "total_rounds": total_rounds,
-            "profiles_count": state.profiles_count,
-            "created_date": created_date,
-            "parent_simulation_id": state.parent_simulation_id,
-            "is_public": getattr(state, "is_public", False),
-            "belief": belief,
-            "quality": quality,
-            "resolution": resolution,
-        }
 
         response = jsonify({"success": True, "data": summary})
         # Widget is read-only and explicitly designed to be embedded anywhere.
@@ -4544,6 +4551,62 @@ def get_embed_summary(simulation_id: str):
             "success": False,
             "error": str(e),
             "traceback": traceback.format_exc()
+        }), 500
+
+
+@simulation_bp.route('/<simulation_id>/share-card.png', methods=['GET'])
+def get_share_card(simulation_id: str):
+    """Render a 1200x630 PNG suitable for Open Graph / Twitter image
+    unfurling.
+
+    Same publish gate as ``/embed-summary``: requires ``is_public=True`` on
+    the simulation state. Cached on disk by content hash so repeat
+    unfurler hits don't re-render.
+    """
+    from ..services import share_card as share_card_renderer
+    from flask import Response
+
+    try:
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+            }), 403
+
+        cache_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id, "share-cards")
+        os.makedirs(cache_dir, exist_ok=True)
+        key = share_card_renderer.summary_cache_key(summary)
+        cache_path = os.path.join(cache_dir, f"{key}.png")
+
+        if os.path.exists(cache_path):
+            with open(cache_path, "rb") as fh:
+                png_bytes = fh.read()
+        else:
+            png_bytes = share_card_renderer.render_share_card(summary)
+            try:
+                with open(cache_path, "wb") as fh:
+                    fh.write(png_bytes)
+            except OSError as exc:
+                logger.warning(f"share-card: failed to cache to {cache_path}: {exc}")
+
+        response = Response(png_bytes, mimetype="image/png")
+        response.headers["Cache-Control"] = "public, max-age=3600"
+        # Suggest a friendly filename when downloaded directly.
+        response.headers["Content-Disposition"] = (
+            f'inline; filename="miroshark-{simulation_id[:12]}.png"'
+        )
+        return response
+
+    except Exception as e:
+        logger.error(f"share-card: failed for {simulation_id}: {e}\n{traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
         }), 500
 
 

--- a/backend/app/services/share_card.py
+++ b/backend/app/services/share_card.py
@@ -1,0 +1,501 @@
+"""Social share card renderer.
+
+Builds a 1200x630 PNG (the canonical Open Graph / Twitter large-image size)
+from a simulation's embed-summary payload, suitable for unfurling on
+Twitter/X, Discord, Slack, LinkedIn, and any platform that reads
+``og:image`` / ``twitter:image`` meta tags.
+
+Pure Pillow — no external font files required. Falls back to the platform
+DejaVu fonts (present on every standard Linux container we ship) and
+finally to PIL's bitmap default if those are missing.
+
+The renderer is intentionally small and deterministic: same input dict
+produces a byte-identical PNG, so ``Cache-Control`` + content-hash filenames
+on disk are sufficient. No threading, no I/O beyond the cache write.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+from datetime import datetime
+from typing import Optional
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+# Card geometry — fixed 1.91:1 (1200x630) to match Twitter/X / LinkedIn /
+# Slack large-image previews. Anything else gets cropped or letterboxed by
+# the unfurler so don't change without a reason.
+CARD_W = 1200
+CARD_H = 630
+
+# Color palette mirrors the MiroShark frontend tokens
+# (frontend/src/views/EmbedView.vue --bg/--fg/--bullish/...).
+INK = (10, 10, 10)              # #0a0a0a — header/footer band, primary text
+INK_SOFT = (75, 75, 75)         # #4b4b4b — secondary text
+INK_MUTED = (107, 107, 107)     # #6b6b6b — labels
+PAPER = (250, 250, 250)         # #fafafa — body background
+PAPER_LINE = (228, 228, 228)    # subtle dividers
+BULLISH = (14, 165, 160)        # teal — high-bull consensus / "correct" badge
+NEUTRAL = (154, 160, 166)       # slate — split / mixed
+BEARISH = (240, 120, 103)       # coral — high-bear / "wrong"
+ACCENT = (234, 88, 12)          # MiroShark orange — brand accent only
+
+# Anchor positions
+HEADER_H = 78
+FOOTER_H = 70
+BODY_Y0 = HEADER_H
+BODY_Y1 = CARD_H - FOOTER_H
+PAD_X = 56
+
+
+# ── Font discovery ──────────────────────────────────────────────────────────
+# Prefer the bundled-on-most-Linux DejaVu family. macOS dev boxes have
+# Helvetica; we fall through to the PIL default (a 10px bitmap) if neither
+# is available. That fallback still produces a readable card — it just looks
+# uglier — so the endpoint never 500s on missing fonts.
+_FONT_CANDIDATES = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/Library/Fonts/Helvetica.ttc",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "C:\\Windows\\Fonts\\arialbd.ttf",
+    "C:\\Windows\\Fonts\\arial.ttf",
+]
+
+_FONT_BOLD_CANDIDATES = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/Library/Fonts/Helvetica.ttc",
+    "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+    "C:\\Windows\\Fonts\\arialbd.ttf",
+]
+
+
+def _find_font(candidates: list[str]) -> Optional[str]:
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def _load_font(size: int, bold: bool = False) -> ImageFont.ImageFont:
+    path = _find_font(_FONT_BOLD_CANDIDATES if bold else _FONT_CANDIDATES)
+    if path:
+        try:
+            return ImageFont.truetype(path, size=size)
+        except OSError:
+            pass
+    return ImageFont.load_default()
+
+
+# ── Text helpers ────────────────────────────────────────────────────────────
+
+
+def _text_width(draw: ImageDraw.ImageDraw, text: str, font) -> int:
+    """Measure pixel width — uses textbbox (Pillow 10+) which is accurate
+    for both TTF and the bitmap fallback."""
+    if not text:
+        return 0
+    bbox = draw.textbbox((0, 0), text, font=font)
+    return bbox[2] - bbox[0]
+
+
+def _wrap_text(
+    draw: ImageDraw.ImageDraw, text: str, font, max_width: int, max_lines: int
+) -> list[str]:
+    """Word-wrap ``text`` to fit ``max_width`` pixels, capping at
+    ``max_lines``. Long final lines get an ellipsis. Long single words
+    that overflow on their own are truncated character-wise."""
+    if not text:
+        return []
+    words = text.split()
+    lines: list[str] = []
+    cur = ""
+    for w in words:
+        candidate = f"{cur} {w}".strip()
+        if _text_width(draw, candidate, font) <= max_width:
+            cur = candidate
+            continue
+        # Single word longer than the line — chop with ellipsis
+        if not cur:
+            truncated = w
+            while truncated and _text_width(draw, truncated + "…", font) > max_width:
+                truncated = truncated[:-1]
+            lines.append((truncated + "…") if truncated else "…")
+            cur = ""
+            if len(lines) >= max_lines:
+                break
+            continue
+        lines.append(cur)
+        cur = w
+        if len(lines) >= max_lines:
+            break
+    if cur and len(lines) < max_lines:
+        lines.append(cur)
+
+    # If we ran out of room, mark the last line with an ellipsis.
+    if len(lines) >= max_lines and len(words) > sum(len(l.split()) for l in lines):
+        last = lines[-1]
+        while last and _text_width(draw, last + "…", font) > max_width:
+            last = last[:-1].rstrip()
+        lines[-1] = (last + "…") if last else "…"
+    return lines
+
+
+def _format_date(iso_date: str) -> str:
+    """Convert ``2026-04-22`` (or full ISO timestamp) to ``Apr 22, 2026``.
+    Returns the input untouched if parsing fails."""
+    if not iso_date:
+        return ""
+    try:
+        s = iso_date[:10]
+        dt = datetime.strptime(s, "%Y-%m-%d")
+        return dt.strftime("%b %-d, %Y")
+    except (ValueError, TypeError):
+        # %-d isn't supported on Windows — fall back to zero-padded.
+        try:
+            dt = datetime.strptime(iso_date[:10], "%Y-%m-%d")
+            return dt.strftime("%b %d, %Y")
+        except (ValueError, TypeError):
+            return iso_date[:10] or ""
+
+
+def _short_sim_id(sim_id: str) -> str:
+    """``sim_abc123def456`` → ``SIM_ABC123``."""
+    if not sim_id:
+        return ""
+    body = sim_id.replace("sim_", "", 1).split("_", 1)[0]
+    return f"SIM_{body[:6].upper()}"
+
+
+# ── Drawing primitives ─────────────────────────────────────────────────────
+
+
+def _draw_pill(
+    draw: ImageDraw.ImageDraw,
+    x: int,
+    y: int,
+    text: str,
+    font,
+    bg: tuple,
+    fg: tuple,
+    pad_x: int = 14,
+    pad_y: int = 6,
+) -> tuple[int, int]:
+    """Draw a rounded-rect pill, return (right_x, bottom_y) for chaining."""
+    tw = _text_width(draw, text, font)
+    th_bbox = draw.textbbox((0, 0), text, font=font)
+    th = th_bbox[3] - th_bbox[1]
+    w = tw + pad_x * 2
+    h = th + pad_y * 2
+    radius = h // 2
+    draw.rounded_rectangle((x, y, x + w, y + h), radius=radius, fill=bg)
+    # textbbox y0 isn't always 0 — offset so glyphs sit centered.
+    draw.text((x + pad_x - th_bbox[0], y + pad_y - th_bbox[1]), text, fill=fg, font=font)
+    return x + w, y + h
+
+
+def _draw_belief_bar(
+    draw: ImageDraw.ImageDraw,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    bullish_pct: float,
+    neutral_pct: float,
+    bearish_pct: float,
+) -> None:
+    """Three-segment horizontal stacked bar — bullish | neutral | bearish.
+    Percentages are normalized so they always fill the bar exactly, even when
+    the source data sums to 99.9 due to rounding."""
+    total = max(bullish_pct + neutral_pct + bearish_pct, 0.01)
+    bu_w = int(round(width * (bullish_pct / total)))
+    ne_w = int(round(width * (neutral_pct / total)))
+    be_w = width - bu_w - ne_w  # absorb any rounding drift here
+
+    cur_x = x
+    if bu_w > 0:
+        draw.rectangle((cur_x, y, cur_x + bu_w, y + height), fill=BULLISH)
+        cur_x += bu_w
+    if ne_w > 0:
+        draw.rectangle((cur_x, y, cur_x + ne_w, y + height), fill=NEUTRAL)
+        cur_x += ne_w
+    if be_w > 0:
+        draw.rectangle((cur_x, y, cur_x + be_w, y + height), fill=BEARISH)
+
+
+# ── Public entry points ────────────────────────────────────────────────────
+
+
+def render_share_card(summary: dict) -> bytes:
+    """Render a summary dict into a 1200x630 PNG. Always returns valid PNG
+    bytes — missing fields render as a stripped-down "Setup" card instead
+    of erroring. ``summary`` is the same shape as the embed-summary
+    endpoint response.
+
+    The dict keys consumed (all optional except ``simulation_id``):
+        simulation_id, scenario, status, runner_status,
+        current_round, total_rounds, profiles_count, created_date,
+        belief: { final: {bullish, neutral, bearish}, consensus_round, consensus_stance },
+        quality: { health },
+        resolution: { actual_outcome, accuracy_score }
+    """
+    img = Image.new("RGB", (CARD_W, CARD_H), PAPER)
+    draw = ImageDraw.Draw(img)
+
+    # Fonts — sized for 1200px width.
+    f_brand = _load_font(28, bold=True)
+    f_section = _load_font(18, bold=True)
+    f_scenario = _load_font(48, bold=True)
+    f_scenario_sm = _load_font(40, bold=True)  # used when text wraps to 3+ lines
+    f_metric_label = _load_font(16, bold=True)
+    f_metric_value = _load_font(36, bold=True)
+    f_pct = _load_font(20, bold=True)
+    f_pct_label = _load_font(16, bold=True)
+    f_footer = _load_font(18, bold=False)
+    f_pill = _load_font(15, bold=True)
+
+    # ── Header band ────────────────────────────────────────────────────────
+    draw.rectangle((0, 0, CARD_W, HEADER_H), fill=INK)
+    draw.text((PAD_X, 22), "MIROSHARK", fill=PAPER, font=f_brand)
+    # Brand subtitle to the right of the wordmark.
+    brand_w = _text_width(draw, "MIROSHARK", f_brand)
+    sub_x = PAD_X + brand_w + 18
+    draw.text((sub_x, 30), "▸  Simulation share", fill=(180, 180, 180), font=f_pill)
+
+    # Right-aligned simulation id badge in header.
+    sim_id_text = _short_sim_id(summary.get("simulation_id", ""))
+    if sim_id_text:
+        sid_w = _text_width(draw, sim_id_text, f_pill)
+        sid_x = CARD_W - PAD_X - sid_w - 28
+        sid_y = HEADER_H // 2 - 14
+        draw.rounded_rectangle(
+            (sid_x, sid_y, sid_x + sid_w + 28, sid_y + 28),
+            radius=14,
+            fill=(40, 40, 40),
+        )
+        draw.text((sid_x + 14, sid_y + 6), sim_id_text, fill=(220, 220, 220), font=f_pill)
+
+    # ── Body ───────────────────────────────────────────────────────────────
+    body_x = PAD_X
+    body_w = CARD_W - PAD_X * 2
+    cur_y = BODY_Y0 + 28
+
+    # Scenario headline. Try the larger size first, drop down if it can't fit
+    # in 3 lines.
+    scenario = (summary.get("scenario") or "Untitled simulation").strip()
+    scenario_lines = _wrap_text(draw, scenario, f_scenario, body_w, max_lines=3)
+    scenario_font = f_scenario
+    if not scenario_lines or _text_width(draw, scenario_lines[0], f_scenario) > body_w:
+        scenario_font = f_scenario_sm
+        scenario_lines = _wrap_text(draw, scenario, scenario_font, body_w, max_lines=3)
+    line_h = scenario_font.size + 8 if hasattr(scenario_font, "size") else 56
+    for line in scenario_lines:
+        draw.text((body_x, cur_y), line, fill=INK, font=scenario_font)
+        cur_y += line_h
+    cur_y += 12
+
+    # ── Status / quality / resolution pills row ──
+    pills_y = cur_y
+    pill_x = body_x
+
+    status_label, status_bg, status_fg = _status_pill(summary)
+    if status_label:
+        pill_x, _ = _draw_pill(draw, pill_x, pills_y, status_label, f_pill, status_bg, status_fg)
+        pill_x += 8
+
+    quality_health = (summary.get("quality") or {}).get("health")
+    if quality_health:
+        q_bg, q_fg = _quality_colors(quality_health)
+        pill_x, _ = _draw_pill(
+            draw, pill_x, pills_y, f"Quality · {quality_health}", f_pill, q_bg, q_fg
+        )
+        pill_x += 8
+
+    resolution = summary.get("resolution") or {}
+    res_label = _resolution_label(resolution)
+    if res_label:
+        r_bg, r_fg = _resolution_colors(resolution)
+        pill_x, _ = _draw_pill(draw, pill_x, pills_y, res_label, f_pill, r_bg, r_fg)
+        pill_x += 8
+
+    consensus = (summary.get("belief") or {}).get("consensus_round")
+    if consensus:
+        stance = (summary.get("belief") or {}).get("consensus_stance") or ""
+        cons_text = f"Consensus R{consensus}"
+        if stance:
+            cons_text += f" · {stance.capitalize()}"
+        pill_x, _ = _draw_pill(
+            draw, pill_x, pills_y, cons_text, f_pill, (240, 240, 240), INK
+        )
+
+    cur_y = pills_y + 40
+
+    # ── Metrics row (3 columns) ──
+    metrics = _build_metrics(summary)
+    if metrics:
+        col_w = body_w // len(metrics)
+        for i, (label, value) in enumerate(metrics):
+            col_x = body_x + i * col_w
+            draw.text((col_x, cur_y), label.upper(), fill=INK_MUTED, font=f_metric_label)
+            draw.text((col_x, cur_y + 22), value, fill=INK, font=f_metric_value)
+        cur_y += 90
+
+    # ── Belief bar ──
+    belief = (summary.get("belief") or {}).get("final") or {}
+    has_belief = any(belief.get(k) for k in ("bullish", "neutral", "bearish"))
+    if has_belief:
+        bar_y = cur_y
+        bar_h = 28
+        bu = float(belief.get("bullish") or 0)
+        ne = float(belief.get("neutral") or 0)
+        be = float(belief.get("bearish") or 0)
+        _draw_belief_bar(draw, body_x, bar_y, body_w, bar_h, bu, ne, be)
+
+        # Legend row beneath the bar.
+        legend_y = bar_y + bar_h + 14
+        items = [
+            (f"Bullish {int(round(bu))}%", BULLISH),
+            (f"Neutral {int(round(ne))}%", NEUTRAL),
+            (f"Bearish {int(round(be))}%", BEARISH),
+        ]
+        legend_x = body_x
+        for text, color in items:
+            # Color square + label
+            draw.rectangle((legend_x, legend_y + 4, legend_x + 14, legend_y + 18), fill=color)
+            draw.text((legend_x + 22, legend_y), text, fill=INK_SOFT, font=f_pct)
+            legend_x += _text_width(draw, text, f_pct) + 60
+
+    # ── Footer band ────────────────────────────────────────────────────────
+    draw.rectangle((0, BODY_Y1, CARD_W, CARD_H), fill=INK)
+    repo_text = "github.com/aaronjmars/MiroShark"
+    draw.text((PAD_X, BODY_Y1 + 24), repo_text, fill=(220, 220, 220), font=f_footer)
+
+    date_text = _format_date(summary.get("created_date") or "")
+    if date_text:
+        dw = _text_width(draw, date_text, f_footer)
+        draw.text((CARD_W - PAD_X - dw, BODY_Y1 + 24), date_text, fill=(160, 160, 160), font=f_footer)
+
+    # Output PNG bytes (optimize=False keeps generation fast and
+    # deterministic; 1200x630 cards are ~30-60 KB without it).
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=False)
+    return buf.getvalue()
+
+
+# ── Pill / metric helpers ──────────────────────────────────────────────────
+
+
+def _status_pill(summary: dict) -> tuple[str, tuple, tuple]:
+    s = (summary.get("runner_status") or summary.get("status") or "").lower()
+    if s in ("completed", "finished", "stopped"):
+        return "Completed", (217, 245, 240), BULLISH
+    if s in ("running", "in_progress"):
+        return "Running", (255, 232, 209), ACCENT
+    if s in ("failed", "error"):
+        return "Failed", (255, 224, 219), BEARISH
+    if s == "ready":
+        return "Ready", (236, 236, 236), INK_SOFT
+    return ("Setup", (236, 236, 236), INK_SOFT)
+
+
+def _quality_colors(health: str) -> tuple[tuple, tuple]:
+    h = (health or "").lower()
+    if h == "excellent":
+        return (217, 245, 240), BULLISH
+    if h == "good":
+        return (255, 240, 204), (180, 83, 9)
+    if h == "low":
+        return (255, 224, 219), BEARISH
+    return (236, 236, 236), INK_SOFT
+
+
+def _resolution_label(resolution: dict) -> str:
+    if not resolution:
+        return ""
+    actual = resolution.get("actual_outcome")
+    if actual is None:
+        return ""
+    score = resolution.get("accuracy_score")
+    if score is None:
+        return f"Actual {actual}"
+    if score >= 1.0:
+        return f"✓ Correct · Actual {actual}"
+    if score <= 0.0:
+        return f"✗ Missed · Actual {actual}"
+    return f"~ Split · Actual {actual}"
+
+
+def _resolution_colors(resolution: dict) -> tuple[tuple, tuple]:
+    if not resolution:
+        return (236, 236, 236), INK_SOFT
+    score = resolution.get("accuracy_score")
+    if score is None:
+        return (236, 236, 236), INK_SOFT
+    if score >= 1.0:
+        return (217, 245, 240), BULLISH
+    if score <= 0.0:
+        return (255, 224, 219), BEARISH
+    return (236, 236, 236), INK_SOFT
+
+
+def _build_metrics(summary: dict) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+
+    agents = summary.get("profiles_count")
+    if agents:
+        out.append(("Agents", str(int(agents))))
+
+    cur = int(summary.get("current_round") or 0)
+    total = int(summary.get("total_rounds") or 0)
+    if total:
+        out.append(("Rounds", f"{cur}/{total}"))
+    elif cur:
+        out.append(("Rounds", str(cur)))
+
+    belief = (summary.get("belief") or {}).get("final") or {}
+    if belief:
+        bu = belief.get("bullish")
+        be = belief.get("bearish")
+        if bu is not None and be is not None:
+            net = round(bu - be)
+            sign = "+" if net > 0 else ""
+            out.append(("Net Bull-Bear", f"{sign}{net}%"))
+
+    return out[:4]
+
+
+# ── Cache helpers ──────────────────────────────────────────────────────────
+
+
+def summary_cache_key(summary: dict) -> str:
+    """Stable hash of the inputs that affect the rendered card. Two cards
+    with the same hash are guaranteed byte-identical (as long as the
+    renderer code itself doesn't change)."""
+    parts = {
+        "scenario": summary.get("scenario") or "",
+        "runner_status": summary.get("runner_status") or summary.get("status") or "",
+        "current_round": summary.get("current_round") or 0,
+        "total_rounds": summary.get("total_rounds") or 0,
+        "profiles_count": summary.get("profiles_count") or 0,
+        "created_date": summary.get("created_date") or "",
+    }
+    belief_final = (summary.get("belief") or {}).get("final") or {}
+    parts["belief_final"] = (
+        round(float(belief_final.get("bullish") or 0), 1),
+        round(float(belief_final.get("neutral") or 0), 1),
+        round(float(belief_final.get("bearish") or 0), 1),
+    )
+    parts["consensus_round"] = (summary.get("belief") or {}).get("consensus_round") or 0
+    parts["consensus_stance"] = (summary.get("belief") or {}).get("consensus_stance") or ""
+    parts["quality"] = (summary.get("quality") or {}).get("health") or ""
+    res = summary.get("resolution") or {}
+    parts["resolution"] = (
+        res.get("actual_outcome") or "",
+        res.get("accuracy_score"),
+    )
+    blob = repr(sorted(parts.items())).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]

--- a/backend/tests/test_unit_share_card.py
+++ b/backend/tests/test_unit_share_card.py
@@ -1,0 +1,252 @@
+"""Unit tests for the share-card renderer.
+
+Pure offline tests — no backend, no network. Verifies that:
+
+  - the renderer returns valid PNG bytes for both fully-populated and
+    minimal summary dicts,
+  - the cache key is deterministic and changes only when render-affecting
+    fields change,
+  - text wrapping doesn't crash on empty / oversize / single-word input,
+  - the published landing HTML carries the right Open Graph + Twitter card
+    meta tags.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+import sys
+
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ── Renderer tests ─────────────────────────────────────────────────────────
+
+
+def _is_png(data: bytes) -> bool:
+    """The PNG signature is fixed at 8 bytes: 89 50 4e 47 0d 0a 1a 0a."""
+    return len(data) >= 8 and data[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def _png_size(data: bytes) -> tuple[int, int]:
+    """Read width/height from the PNG IHDR chunk (bytes 16-24)."""
+    assert _is_png(data)
+    width = struct.unpack(">I", data[16:20])[0]
+    height = struct.unpack(">I", data[20:24])[0]
+    return width, height
+
+
+@pytest.fixture
+def full_summary() -> dict:
+    return {
+        "simulation_id": "sim_abc123def456",
+        "scenario": "Will the SEC approve a spot Solana ETF before the end of Q3 2026?",
+        "status": "completed",
+        "runner_status": "completed",
+        "current_round": 20,
+        "total_rounds": 20,
+        "profiles_count": 248,
+        "created_date": "2026-04-22",
+        "is_public": True,
+        "belief": {
+            "rounds": list(range(20)),
+            "bullish": [10] * 19 + [62.0],
+            "neutral": [10] * 19 + [13.0],
+            "bearish": [80] * 19 + [25.0],
+            "final": {"bullish": 62.0, "neutral": 13.0, "bearish": 25.0},
+            "consensus_round": 14,
+            "consensus_stance": "bullish",
+        },
+        "quality": {"health": "Excellent", "participation_rate": 0.92},
+        "resolution": {
+            "actual_outcome": "YES",
+            "predicted_consensus": "YES",
+            "accuracy_score": 1.0,
+        },
+    }
+
+
+def test_renders_png_for_full_summary(full_summary):
+    from app.services.share_card import render_share_card
+
+    png = render_share_card(full_summary)
+    assert _is_png(png)
+    w, h = _png_size(png)
+    assert (w, h) == (1200, 630)
+    # Sanity floor — a blank-rendered PNG would be tiny.
+    assert len(png) > 5000
+
+
+def test_renders_png_for_minimal_summary():
+    """Even with almost no data, the renderer must produce a valid PNG —
+    this guards against the unfurler getting a 500 on a brand-new
+    simulation that hasn't run yet."""
+    from app.services.share_card import render_share_card
+
+    png = render_share_card({"simulation_id": "sim_x"})
+    assert _is_png(png)
+    assert _png_size(png) == (1200, 630)
+
+
+def test_renders_with_only_scenario():
+    from app.services.share_card import render_share_card
+
+    png = render_share_card(
+        {
+            "simulation_id": "sim_x",
+            "scenario": "A" * 600,  # extreme-length scenario forces wrap+truncate
+        }
+    )
+    assert _is_png(png)
+
+
+def test_renders_with_long_single_word():
+    """Single-word scenarios that exceed the line width must character-chop
+    instead of looping forever."""
+    from app.services.share_card import render_share_card
+
+    png = render_share_card(
+        {
+            "simulation_id": "sim_x",
+            "scenario": "Supercalifragilisticexpialidocious" * 20,
+        }
+    )
+    assert _is_png(png)
+
+
+def test_handles_failed_status():
+    from app.services.share_card import render_share_card
+
+    png = render_share_card(
+        {
+            "simulation_id": "sim_x",
+            "scenario": "Failed run",
+            "runner_status": "failed",
+        }
+    )
+    assert _is_png(png)
+
+
+# ── Cache-key tests ────────────────────────────────────────────────────────
+
+
+def test_cache_key_stable_across_calls(full_summary):
+    from app.services.share_card import summary_cache_key
+
+    a = summary_cache_key(full_summary)
+    b = summary_cache_key(dict(full_summary))
+    assert a == b
+    assert len(a) == 16
+
+
+def test_cache_key_changes_when_render_inputs_change(full_summary):
+    from app.services.share_card import summary_cache_key
+
+    base = summary_cache_key(full_summary)
+
+    # Mutating a render-affecting field should change the key.
+    s2 = {**full_summary, "scenario": full_summary["scenario"] + "?"}
+    assert summary_cache_key(s2) != base
+
+    s3 = {**full_summary, "current_round": 19}
+    assert summary_cache_key(s3) != base
+
+    s4 = {
+        **full_summary,
+        "belief": {
+            **full_summary["belief"],
+            "final": {"bullish": 50.0, "neutral": 25.0, "bearish": 25.0},
+        },
+    }
+    assert summary_cache_key(s4) != base
+
+
+def test_cache_key_ignores_non_render_fields(full_summary):
+    from app.services.share_card import summary_cache_key
+
+    base = summary_cache_key(full_summary)
+
+    # Adding fields the renderer doesn't read shouldn't bust the cache.
+    extra = {**full_summary, "parent_simulation_id": "sim_zzz", "extra_unused": [1, 2, 3]}
+    assert summary_cache_key(extra) == base
+
+
+# ── Helper tests ───────────────────────────────────────────────────────────
+
+
+def test_short_sim_id():
+    from app.services.share_card import _short_sim_id
+
+    assert _short_sim_id("sim_abc123def456") == "SIM_ABC123"
+    assert _short_sim_id("") == ""
+    assert _short_sim_id("sim_x") == "SIM_X"
+
+
+def test_format_date_round_trip():
+    from app.services.share_card import _format_date
+
+    out = _format_date("2026-04-22")
+    assert "2026" in out
+    assert "Apr" in out
+    # Garbage in → graceful fallback (no crash, no traceback).
+    assert _format_date("") == ""
+    assert _format_date("not-a-date").startswith("not-a-da")
+
+
+# ── Landing-page meta-tag test ─────────────────────────────────────────────
+
+
+def test_landing_html_includes_og_and_twitter_tags():
+    from app.api.share import _render_landing_html
+
+    html = _render_landing_html(
+        simulation_id="sim_xyz789",
+        scenario='Will "X" happen?',  # quotes → must be escaped
+        is_public=True,
+        spa_url="https://example.com/simulation/sim_xyz789/start",
+        card_url="https://example.com/api/simulation/sim_xyz789/share-card.png",
+    )
+
+    # Required OG tags
+    assert 'property="og:title"' in html
+    assert 'property="og:image"' in html
+    assert 'content="https://example.com/api/simulation/sim_xyz789/share-card.png"' in html
+    assert 'property="og:image:width"' in html and 'content="1200"' in html
+    assert 'property="og:image:height"' in html and 'content="630"' in html
+
+    # Twitter card
+    assert 'name="twitter:card"' in html
+    assert 'content="summary_large_image"' in html
+    assert 'name="twitter:image"' in html
+
+    # Quote-escape must turn the inner " into &quot; — otherwise the
+    # content="..." attribute would terminate early and the scraper would
+    # see a broken tag.
+    assert "&quot;X&quot;" in html
+
+    # Both redirect mechanisms present
+    assert 'http-equiv="refresh"' in html
+    assert "window.location.replace" in html
+
+
+def test_landing_html_for_private_sim_omits_scenario():
+    """Private simulations should still render the landing page (the URL
+    is public), but must not leak the scenario through OG tags."""
+    from app.api.share import _render_landing_html
+
+    html = _render_landing_html(
+        simulation_id="sim_private",
+        scenario="",  # caller passes empty when is_public is False
+        is_public=False,
+        spa_url="https://example.com/simulation/sim_private/start",
+        card_url="https://example.com/api/simulation/sim_private/share-card.png",
+    )
+
+    assert "MiroShark Simulation" in html  # generic title
+    assert 'property="og:image"' in html  # card URL still present

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -85,6 +85,15 @@ Failed calls become `{"_error": "..."}` payloads rather than exceptions — agen
 
 `EmbedDialog` has a `Public / Private` toggle backed by `is_public` on the simulation state. Embed URLs return `403` on unpublished simulations — flip the toggle (or `POST /api/simulation/<id>/publish`) to make them publicly embeddable. Defaults to private so existing sims are unaffected.
 
+## Social Share Card
+
+When a simulation is published, the Embed dialog also exposes a **social card** that can be auto-unfurled by Twitter/X, Discord, Slack, LinkedIn, and any other Open-Graph-aware client. Two endpoints back it:
+
+- `GET /api/simulation/<id>/share-card.png` — a 1200×630 PNG rendered server-side (Pillow). Shows the scenario headline, status pill, optional quality badge + resolution, agent / round metrics, and the final bullish/neutral/bearish split as a stacked bar. Same `is_public` gate as the embed widget. Cached on disk by content hash so repeat unfurler hits don't re-render.
+- `GET /share/<id>` — a public landing page carrying the right `og:image` / `twitter:image` meta tags. Bots scrape the tags and render the card; real browsers redirect to the SPA simulation view (JS-first, with `<meta http-equiv="refresh">` fallback).
+
+Paste the `/share/<id>` URL anywhere — the post unfurls with a polished card instead of a generic preview.
+
 ## Article Generation
 
 After a simulation finishes, click **Write Article** and MiroShark asks the Smart model to produce a 400–600-word Substack-style write-up grounded in what actually happened — key findings, market dynamics, belief shifts, and implications. The article is cached at `generated_article.json` so it doesn't re-spend tokens on reopen; pass `force_regenerate=true` to refresh.

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -398,6 +398,43 @@ export const publishSimulation = (simulationId, publicFlag = true) => {
 }
 
 /**
+ * Build the absolute URL of the 1200x630 PNG share card for a simulation.
+ *
+ * The card is server-rendered from the same data that powers the embed
+ * widget — scenario, status, agent count, belief drift split, quality
+ * health, resolution. Requires the simulation to be published (same gate
+ * as the embed widget).
+ *
+ * Returns an absolute URL (rather than fetching) so it can be dropped
+ * straight into an `<img src>` for previews or copied to the clipboard
+ * for manual pasting into Twitter/X / Discord / Slack.
+ *
+ * @param {string} simulationId
+ * @param {string} [origin] - override base URL (defaults to window.location.origin)
+ * @returns {string}
+ */
+export const getShareCardUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/api/simulation/${simulationId}/share-card.png`
+}
+
+/**
+ * Build the absolute URL of the public share landing page for a
+ * simulation. The page exposes Open Graph + Twitter Card meta tags so
+ * pasting the URL into Twitter/X / Discord / Slack / LinkedIn unfurls
+ * with the share card image, scenario as title, etc. Real browsers are
+ * redirected to the SPA simulation view instantly.
+ *
+ * @param {string} simulationId
+ * @param {string} [origin]
+ * @returns {string}
+ */
+export const getShareLandingUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/share/${simulationId}`
+}
+
+/**
  * Branch a simulation with a narrative injection at a specific round.
  * The new simulation is READY and shares the parent's agent population;
  * when the runner hits trigger_round it auto-promotes the injection into

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -101,6 +101,67 @@
             </div>
           </div>
 
+          <!-- Social share card -->
+          <div class="share-card-section">
+            <div class="share-card-divider">
+              <span class="divider-line"></span>
+              <span class="divider-text">Social card</span>
+              <span class="divider-line"></span>
+            </div>
+
+            <p class="share-card-desc">
+              A 1200×630 PNG with the scenario headline, status, quality, and
+              belief split — the same image Twitter/X, Discord, Slack, and
+              LinkedIn unfurl automatically when someone pastes the share
+              link.
+            </p>
+
+            <div class="share-card-preview-wrap">
+              <img
+                v-if="isPublic && shareCardUrl"
+                :src="shareCardUrl"
+                :key="shareCardCacheBust"
+                class="share-card-preview"
+                alt="MiroShark share card preview"
+                @error="onShareCardError"
+              />
+              <div v-else class="share-card-empty">
+                {{ isPublic ? 'Loading preview…' : 'Publish the simulation to enable the share card.' }}
+              </div>
+            </div>
+
+            <div class="share-card-actions">
+              <div class="snippet-block share-snippet">
+                <div class="snippet-head">
+                  <span class="snippet-label">Share link (auto-unfurls with card)</span>
+                  <button class="snippet-copy-btn" @click="copy('share')" :disabled="!isPublic">
+                    {{ copied === 'share' ? '✓ Copied' : 'Copy link' }}
+                  </button>
+                </div>
+                <pre class="snippet-code"><code>{{ shareLandingUrl || '—' }}</code></pre>
+              </div>
+
+              <div class="snippet-block share-snippet">
+                <div class="snippet-head">
+                  <span class="snippet-label">Card image URL (for manual paste)</span>
+                  <button class="snippet-copy-btn" @click="copy('card')" :disabled="!isPublic">
+                    {{ copied === 'card' ? '✓ Copied' : 'Copy URL' }}
+                  </button>
+                </div>
+                <pre class="snippet-code"><code>{{ shareCardUrl || '—' }}</code></pre>
+              </div>
+
+              <a
+                v-if="isPublic && shareCardUrl"
+                class="share-download-btn"
+                :href="shareCardUrl"
+                :download="`miroshark-${simulationId.slice(0, 12)}.png`"
+              >
+                ↓ Download PNG
+              </a>
+            </div>
+          </div>
+
           <!-- Hint -->
           <div class="embed-dialog-hint">
             <span class="hint-icon">ⓘ</span>
@@ -115,7 +176,7 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue'
-import { publishSimulation, getEmbedSummary } from '../api/simulation'
+import { publishSimulation, getEmbedSummary, getShareCardUrl, getShareLandingUrl } from '../api/simulation'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -181,6 +242,28 @@ const markdownSnippet = computed(() => {
   return `[MiroShark simulation ↗](${embedUrl.value})`
 })
 
+const shareCardCacheBust = ref(0)
+
+const shareCardUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  // Append a cache-bust token so re-opening the dialog after a state change
+  // (e.g. resolution recorded) shows the freshly rendered card.
+  const base = getShareCardUrl(props.simulationId, origin.value)
+  return shareCardCacheBust.value
+    ? `${base}?v=${shareCardCacheBust.value}`
+    : base
+})
+
+const shareLandingUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  return getShareLandingUrl(props.simulationId, origin.value)
+})
+
+const onShareCardError = () => {
+  // The image fails until the simulation is published; once the operator
+  // toggles public on, watch(isPublic) below busts the cache.
+}
+
 const previewStyle = computed(() => {
   const { width, height } = currentSize.value
   return {
@@ -207,6 +290,8 @@ const copy = async (which) => {
   if (which === 'iframe') text = iframeSnippet.value
   else if (which === 'markdown') text = markdownSnippet.value
   else if (which === 'url') text = embedUrl.value
+  else if (which === 'share') text = shareLandingUrl.value
+  else if (which === 'card') text = shareCardUrl.value
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)
@@ -239,6 +324,16 @@ watch(() => props.open, async (val) => {
   } catch (err) {
     if (err?.response?.status === 403) isPublic.value = false
   }
+  // Bust the share-card image cache so the preview reloads with whatever
+  // state the simulation is in right now (resolution may have landed
+  // since the dialog was last opened).
+  shareCardCacheBust.value = Date.now()
+})
+
+// When the operator toggles public on, the share-card endpoint flips from
+// 403 → 200. Bust the cache so the <img> retries instead of staying broken.
+watch(isPublic, () => {
+  shareCardCacheBust.value = Date.now()
 })
 </script>
 
@@ -511,6 +606,112 @@ watch(() => props.open, async (val) => {
   background: rgba(10, 10, 10, 0.06);
   border-radius: 4px;
   font-size: 11px;
+}
+
+.share-card-section {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.share-card-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #6b6b6b;
+}
+
+.share-card-divider .divider-line {
+  flex: 1;
+  height: 1px;
+  background: rgba(10, 10, 10, 0.08);
+}
+
+.share-card-divider .divider-text {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.share-card-desc {
+  font-size: 12.5px;
+  color: #4b4b4b;
+  margin: 0;
+  line-height: 1.55;
+}
+
+.share-card-preview-wrap {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(10, 10, 10, 0.03),
+    rgba(10, 10, 10, 0.03) 10px,
+    rgba(10, 10, 10, 0.06) 10px,
+    rgba(10, 10, 10, 0.06) 20px
+  );
+  border: 1px solid rgba(10, 10, 10, 0.08);
+  border-radius: 10px;
+  padding: 14px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 140px;
+}
+
+.share-card-preview {
+  width: 100%;
+  max-width: 560px;
+  aspect-ratio: 1200 / 630;
+  border-radius: 8px;
+  background: #fafafa;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+  object-fit: contain;
+  display: block;
+}
+
+.share-card-empty {
+  color: #6b6b6b;
+  font-size: 13px;
+  text-align: center;
+  padding: 24px 18px;
+  line-height: 1.55;
+}
+
+.share-card-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.share-snippet {
+  margin: 0;
+}
+
+.share-download-btn {
+  display: inline-flex;
+  align-self: flex-start;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: #0a0a0a;
+  color: #ffffff;
+  text-decoration: none;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.share-download-btn:hover {
+  background: #2a2a2a;
+}
+
+.snippet-copy-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 /* Transition */


### PR DESCRIPTION
## What

Adds a 1200×630 PNG that auto-unfurls a simulation's scenario, status, quality, and bullish/neutral/bearish split when the share link is pasted into Twitter/X, Discord, Slack, LinkedIn, or any other Open-Graph-aware client.

Two endpoints:

- `GET /api/simulation/<id>/share-card.png` — server-rendered 1200×630 PNG. Same `is_public` gate as `/embed-summary`. Cached on disk by content hash.
- `GET /share/<id>` — public landing page with `og:image` / `twitter:image` meta tags. Bots scrape the tags and render the card; real browsers JS-redirect (with `<meta refresh>` fallback) to the SPA simulation view.

The Embed dialog now has a "Social card" section with a live preview, a copyable share link, a copyable card image URL, and a download button.

## Why

MiroShark's existing share permalinks unfurl as a generic page preview — text-only, no visual hook. Today's Kelp/Aave coincidence is driving organic mentions of Director Mode runs, but every share is a flat URL. Closing this gap is a direct lever on the 1K-stars-by-Apr-30 target (currently 767, ~14/day needed): every researcher who shares a result becomes a richer distribution channel.

This was idea #2 in `repo-actions 2026-04-20`. The original spec assumed Pillow as a new dep, but the project already pins Pillow≥12.0 via `tool.uv.override-dependencies`, so this PR adds **zero new dependencies**.

## Changes

**Backend**
- `backend/app/services/share_card.py` (new) — Pillow renderer. Builds the card from the same data the embed-summary endpoint exposes — scenario, status, agent count, round count, belief final split, quality health, resolution accuracy. Deterministic output + content-hash cache key. Handles missing fields, oversize scenarios, single-word overflow, and Windows date formatting without crashing.
- `backend/app/api/simulation.py` — extracted `_build_embed_summary_payload()` so embed-summary and share-card share one source of truth. Added `GET /<id>/share-card.png` endpoint with on-disk cache at `<sim_dir>/share-cards/<hash>.png` and `Cache-Control: public, max-age=3600`.
- `backend/app/api/share.py` (new) + `share_bp` — `GET /share/<id>` HTML route with full OG / Twitter Card meta tags, instant JS redirect, and `<meta http-equiv="refresh">` fallback. Honors `X-Forwarded-Proto` / `X-Forwarded-Host` so URLs work behind a reverse proxy. Private sims still render the page (the URL is public) but omit the scenario from meta tags so they don't leak.

**Frontend**
- `frontend/src/api/simulation.js` — `getShareCardUrl()` and `getShareLandingUrl()` helpers.
- `frontend/src/components/EmbedDialog.vue` — new "Social card" section with preview `<img>`, copyable share link + card URL, download PNG button. Cache-busts the preview when the public toggle flips so the image re-fetches instead of staying broken.

**Tests / docs**
- `backend/tests/test_unit_share_card.py` (new, 11 tests) — PNG signature + size validation, cache-key stability + sensitivity, edge-case scenarios (empty / 600-char / single-word / failed status), OG meta tag rendering with quote escaping, private-sim leak check.
- `README.md` features table + new "Social Share Card" section in `docs/FEATURES.md`.

Net: +1390 / -138 across 10 files (3 new). No new dependencies.

## How to verify

1. Publish a completed simulation via the Embed dialog toggle.
2. Hit `GET /api/simulation/<sim_id>/share-card.png` — should return a 1200×630 PNG.
3. Hit `GET /share/<sim_id>` and `view-source:` it — should show populated `og:title`, `og:image`, `twitter:card` tags.
4. Paste the `/share/<sim_id>` URL into Twitter/X, Discord, or any unfurler — should render the card.
5. Run `pytest backend/tests/test_unit_share_card.py` — 11 tests.

---
*Built autonomously by Aeon*