### PR TITLE
feat: public simulation gallery (/explore)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
 | **Per-Agent MCP Tools** | Personas can invoke real MCP tools (web search, APIs) during simulation |
 | **Embed & Publish** | Public/private toggle + embed URLs for sharing finished runs |
 | **Social Share Card** | 1200×630 PNG that auto-unfurls scenario, status, quality, and belief split on Twitter/X, Discord, Slack, LinkedIn |
+| **Public Gallery** | `/explore` browses every published simulation as a card grid — preview the share card, consensus split, and quality health; click to open or one-click fork |
 | **Article Generation** | Substack-style write-up of what happened, grounded in actual posts and trades |
 | **Interaction Network** | Force-directed agent-to-agent graph with echo-chamber metrics |
 | **Demographics** | Archetype clustering (analyst / influencer / retail / observer…) |

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4610,6 +4610,221 @@ def get_share_card(simulation_id: str):
         }), 500
 
 
+# ============== Public Gallery ==============
+
+
+def _build_gallery_card_payload(state, sim_dir: str) -> dict:
+    """Assemble the minimal card-friendly payload for the public gallery.
+
+    Cheap reads only — no DB joins, no LLM calls. Walks the on-disk
+    artifacts (``state.json``, ``simulation_config.json``, ``quality.json``,
+    ``trajectory.json``, ``resolution.json``) that are already produced by
+    the normal run pipeline. Any missing artifact degrades gracefully into
+    ``None`` rather than raising.
+    """
+    scenario = ""
+    total_rounds = 0
+    config_path = os.path.join(sim_dir, "simulation_config.json")
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, 'r', encoding='utf-8') as f:
+                cfg = json.load(f)
+            scenario = (cfg.get("simulation_requirement") or "").strip()
+            time_config = cfg.get("time_config", {}) or {}
+            minutes_per_round = max(int(time_config.get("minutes_per_round", 60) or 60), 1)
+            hours = int(time_config.get("total_simulation_hours", 0) or 0)
+            total_rounds = int(hours * 60 / minutes_per_round)
+        except Exception:
+            pass
+
+    # Cap the scenario to a tweet-sized headline so the gallery stays
+    # visually even regardless of how verbose the operator was.
+    if scenario and len(scenario) > 180:
+        scenario = scenario[:177].rstrip() + "…"
+
+    current_round = 0
+    runner_status = "idle"
+    try:
+        run_state = SimulationRunner.get_run_state(state.simulation_id)
+        if run_state:
+            current_round = run_state.current_round
+            runner_status = (
+                run_state.runner_status.value
+                if hasattr(run_state.runner_status, 'value')
+                else str(run_state.runner_status)
+            )
+            if getattr(run_state, 'total_rounds', 0):
+                total_rounds = run_state.total_rounds
+    except Exception:
+        pass
+
+    quality_health = None
+    quality_path = os.path.join(sim_dir, "quality.json")
+    if os.path.exists(quality_path):
+        try:
+            with open(quality_path, 'r', encoding='utf-8') as f:
+                q = json.load(f)
+            quality_health = q.get("health")
+        except Exception:
+            pass
+
+    final_consensus = None
+    trajectory_path = os.path.join(sim_dir, "trajectory.json")
+    if os.path.exists(trajectory_path):
+        try:
+            with open(trajectory_path, 'r', encoding='utf-8') as f:
+                traj = json.load(f)
+            snapshots = traj.get("snapshots", []) or []
+            # Walk snapshots in reverse to pick the last one with
+            # computable belief positions.
+            for snap in reversed(snapshots):
+                positions = snap.get("belief_positions", {}) or {}
+                if not positions:
+                    continue
+                stances = []
+                for p in positions.values():
+                    if p:
+                        stances.append(sum(p.values()) / len(p))
+                if not stances:
+                    continue
+                total = len(stances)
+                nb = sum(1 for s in stances if s > 0.2)
+                nbe = sum(1 for s in stances if s < -0.2)
+                nn = total - nb - nbe
+                final_consensus = {
+                    "bullish": round(nb / total * 100, 1),
+                    "neutral": round(nn / total * 100, 1),
+                    "bearish": round(nbe / total * 100, 1),
+                }
+                break
+        except Exception:
+            pass
+
+    resolution_outcome = None
+    resolution_path = os.path.join(sim_dir, "resolution.json")
+    if os.path.exists(resolution_path):
+        try:
+            with open(resolution_path, 'r', encoding='utf-8') as f:
+                r = json.load(f)
+            resolution_outcome = r.get("actual_outcome")
+        except Exception:
+            pass
+
+    return {
+        "simulation_id": state.simulation_id,
+        "scenario": scenario,
+        "status": state.status.value if hasattr(state.status, 'value') else str(state.status),
+        "runner_status": runner_status,
+        "current_round": current_round,
+        "total_rounds": total_rounds,
+        "agent_count": state.profiles_count,
+        "quality_health": quality_health,
+        "final_consensus": final_consensus,
+        "resolution_outcome": resolution_outcome,
+        "created_at": state.created_at,
+        "parent_simulation_id": state.parent_simulation_id,
+        "share_card_url": f"/api/simulation/{state.simulation_id}/share-card.png",
+        "share_landing_url": f"/share/{state.simulation_id}",
+    }
+
+
+@simulation_bp.route('/public', methods=['GET'])
+def list_public_simulations():
+    """Gallery feed of simulations the operator has toggled public.
+
+    Every published simulation already has a share card, embed summary,
+    and public landing page — this endpoint is the discovery layer that
+    lists them all in one place so the ``/explore`` view can render a
+    gallery grid.
+
+    Query parameters:
+        limit: max items to return (default 50, clamped to [1, 100])
+        offset: pagination offset (default 0)
+
+    Response shape::
+
+        {
+          "success": true,
+          "data": [
+            {
+              "simulation_id": "sim_xxx",
+              "scenario": "Will the ECB cut rates in June?",
+              "status": "completed",
+              "runner_status": "completed",
+              "current_round": 20,
+              "total_rounds": 20,
+              "agent_count": 248,
+              "quality_health": "Excellent",
+              "final_consensus": {"bullish": 62.0, "neutral": 13.0, "bearish": 25.0},
+              "resolution_outcome": "YES",
+              "created_at": "2026-04-22T10:12:34",
+              "parent_simulation_id": null,
+              "share_card_url": "/api/simulation/sim_xxx/share-card.png",
+              "share_landing_url": "/share/sim_xxx"
+            },
+            ...
+          ],
+          "count": 17,
+          "total": 17,
+          "limit": 50,
+          "offset": 0,
+          "has_more": false
+        }
+
+    ``count`` is the size of the current page; ``total`` is the count of
+    all public simulations. An empty ``data`` array is normal — the
+    caller should render the "No public simulations yet" empty state.
+    """
+    try:
+        limit = request.args.get('limit', 50, type=int)
+        offset = request.args.get('offset', 0, type=int)
+        limit = max(1, min(100, int(limit or 50)))
+        offset = max(0, int(offset or 0))
+
+        manager = SimulationManager()
+        all_sims = manager.list_simulations()
+
+        public_sims = [s for s in all_sims if bool(getattr(s, "is_public", False))]
+        public_sims.sort(key=lambda s: s.created_at or "", reverse=True)
+
+        total = len(public_sims)
+        page = public_sims[offset:offset + limit]
+
+        items = []
+        for state in page:
+            sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, state.simulation_id)
+            try:
+                items.append(_build_gallery_card_payload(state, sim_dir))
+            except Exception as exc:
+                # One bad artifact shouldn't tank the whole gallery.
+                logger.warning(
+                    f"public-gallery: failed to build card for {state.simulation_id}: {exc}"
+                )
+                continue
+
+        response = jsonify({
+            "success": True,
+            "data": items,
+            "count": len(items),
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + len(items) < total,
+        })
+        # Short cache so newly-published simulations show up quickly while
+        # still absorbing repeat hits from bots/social unfurlers.
+        response.headers["Cache-Control"] = "public, max-age=30"
+        return response
+
+    except Exception as e:
+        logger.error(f"Failed to list public simulations: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc()
+        }), 500
+
+
 # ============== Database Query Endpoints ==============
 
 @simulation_bp.route('/<simulation_id>/posts', methods=['GET'])

--- a/backend/tests/test_unit_public_gallery.py
+++ b/backend/tests/test_unit_public_gallery.py
@@ -1,0 +1,197 @@
+"""Unit tests for the public gallery helper.
+
+The ``_build_gallery_card_payload`` helper assembles the card payload
+returned by ``GET /api/simulation/public``. These tests verify its
+offline behavior — no Flask, no database, just tmp-path artifacts. We
+cover three paths that matter for gallery rendering:
+
+  1. A minimal state with no on-disk artifacts still produces a valid
+     card (graceful degradation — the gallery shouldn't blow up on
+     in-progress sims that haven't written trajectory yet).
+  2. A fully-populated simulation dir yields every optional field —
+     quality, final consensus, resolution — so the card has enough
+     signal to render nicely.
+  3. Scenario headlines longer than 180 chars are truncated with a
+     unicode ellipsis so the grid stays visually even.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+class _FakeStatus:
+    value = "completed"
+
+
+def _make_state(
+    simulation_id: str = "sim_abc123def456",
+    *,
+    is_public: bool = True,
+    profiles_count: int = 248,
+    created_at: str = "2026-04-22T10:12:34",
+    parent_simulation_id=None,
+):
+    """Lightweight stand-in for SimulationState — only the attributes the
+    gallery helper reads."""
+    class _State:
+        pass
+    s = _State()
+    s.simulation_id = simulation_id
+    s.is_public = is_public
+    s.profiles_count = profiles_count
+    s.created_at = created_at
+    s.parent_simulation_id = parent_simulation_id
+    s.status = _FakeStatus()
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _no_runner_state():
+    """Bypass SimulationRunner.get_run_state — it touches disk + process
+    state we don't care about here. A ``None`` run_state makes the helper
+    fall back to the values it derives from simulation_config.json alone.
+    """
+    from app.api import simulation as sim_mod
+    with patch.object(sim_mod.SimulationRunner, "get_run_state", return_value=None):
+        yield
+
+
+def test_minimal_card_for_missing_artifacts(tmp_path: Path):
+    """When the sim dir is empty (e.g. a freshly published but not-yet-run
+    simulation), the card still renders without raising."""
+    from app.api.simulation import _build_gallery_card_payload
+
+    state = _make_state()
+    card = _build_gallery_card_payload(state, str(tmp_path))
+
+    assert card["simulation_id"] == state.simulation_id
+    assert card["agent_count"] == 248
+    assert card["scenario"] == ""
+    assert card["status"] == "completed"
+    assert card["quality_health"] is None
+    assert card["final_consensus"] is None
+    assert card["resolution_outcome"] is None
+    assert card["share_card_url"].endswith("/share-card.png")
+    assert card["share_landing_url"].startswith("/share/")
+
+
+def test_full_card_from_complete_simulation_dir(tmp_path: Path):
+    """All optional fields populated when each artifact file exists."""
+    from app.api.simulation import _build_gallery_card_payload
+
+    (tmp_path / "simulation_config.json").write_text(json.dumps({
+        "simulation_requirement": "Will the SEC approve a spot Solana ETF?",
+        "time_config": {
+            "minutes_per_round": 60,
+            "total_simulation_hours": 20,
+        },
+    }))
+    (tmp_path / "quality.json").write_text(json.dumps({
+        "health": "Excellent",
+        "participation_rate": 0.92,
+    }))
+    # A minimal two-snapshot trajectory where round 1 has clear bullish
+    # dominance.
+    (tmp_path / "trajectory.json").write_text(json.dumps({
+        "snapshots": [
+            {
+                "round_num": 0,
+                "belief_positions": {
+                    "a": {"topic": 0.0},
+                    "b": {"topic": 0.0},
+                    "c": {"topic": 0.0},
+                },
+            },
+            {
+                "round_num": 1,
+                "belief_positions": {
+                    "a": {"topic": 0.6},
+                    "b": {"topic": 0.4},
+                    "c": {"topic": -0.5},
+                    "d": {"topic": 0.0},
+                },
+            },
+        ],
+    }))
+    (tmp_path / "resolution.json").write_text(json.dumps({
+        "actual_outcome": "YES",
+        "predicted_consensus": "YES",
+        "accuracy_score": 1.0,
+    }))
+
+    state = _make_state()
+    card = _build_gallery_card_payload(state, str(tmp_path))
+
+    assert card["scenario"] == "Will the SEC approve a spot Solana ETF?"
+    assert card["total_rounds"] == 20  # 20h * 60m / 60m per round
+    assert card["quality_health"] == "Excellent"
+    assert card["resolution_outcome"] == "YES"
+
+    consensus = card["final_consensus"]
+    assert consensus is not None
+    # 2/4 stances > 0.2 = bullish; 1/4 < -0.2 = bearish; 1/4 neutral.
+    assert consensus["bullish"] == 50.0
+    assert consensus["bearish"] == 25.0
+    assert consensus["neutral"] == 25.0
+
+
+def test_scenario_gets_truncated_when_too_long(tmp_path: Path):
+    """Scenarios over 180 chars get an ellipsis so card layout stays
+    uniform."""
+    from app.api.simulation import _build_gallery_card_payload
+
+    long_scenario = "A " * 200  # 400 chars
+    (tmp_path / "simulation_config.json").write_text(json.dumps({
+        "simulation_requirement": long_scenario,
+        "time_config": {"minutes_per_round": 60, "total_simulation_hours": 10},
+    }))
+
+    state = _make_state()
+    card = _build_gallery_card_payload(state, str(tmp_path))
+
+    assert len(card["scenario"]) <= 180
+    assert card["scenario"].endswith("…")
+
+
+def test_empty_trajectory_yields_no_consensus(tmp_path: Path):
+    """An empty or malformed trajectory shouldn't raise — it just means
+    no consensus pill is rendered."""
+    from app.api.simulation import _build_gallery_card_payload
+
+    (tmp_path / "trajectory.json").write_text(json.dumps({"snapshots": []}))
+
+    state = _make_state()
+    card = _build_gallery_card_payload(state, str(tmp_path))
+    assert card["final_consensus"] is None
+
+
+def test_malformed_artifact_json_is_swallowed(tmp_path: Path):
+    """Corrupt JSON on any optional artifact shouldn't take down the card.
+    The gallery helper must keep returning a card so one bad sim doesn't
+    blank out the whole /explore page."""
+    from app.api.simulation import _build_gallery_card_payload
+
+    (tmp_path / "simulation_config.json").write_text("{this is not json")
+    (tmp_path / "quality.json").write_text("also not json")
+    (tmp_path / "trajectory.json").write_text("definitely not json")
+    (tmp_path / "resolution.json").write_text("{")
+
+    state = _make_state()
+    card = _build_gallery_card_payload(state, str(tmp_path))
+
+    assert card["simulation_id"] == state.simulation_id
+    assert card["scenario"] == ""
+    assert card["quality_health"] is None
+    assert card["final_consensus"] is None
+    assert card["resolution_outcome"] is None

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -555,6 +555,37 @@ export const suggestScenarios = (data) => {
 }
 
 /**
+ * List simulations that have been toggled public via the /publish endpoint.
+ * Powers the /explore gallery — every entry already has a rendered share
+ * card, embed summary, and public landing page, so the frontend just
+ * needs to lay them out.
+ *
+ * Response shape:
+ *   {
+ *     data: [
+ *       { simulation_id, scenario, status, runner_status, current_round,
+ *         total_rounds, agent_count, quality_health, final_consensus,
+ *         resolution_outcome, created_at, parent_simulation_id,
+ *         share_card_url, share_landing_url }
+ *     ],
+ *     count: number,        // items on this page
+ *     total: number,        // total public simulations
+ *     limit: number,
+ *     offset: number,
+ *     has_more: boolean
+ *   }
+ *
+ * An empty `data` array is normal (render the empty state).
+ * @param {Object} options - { limit?: number, offset?: number }
+ */
+export const getPublicSimulations = (options = {}) => {
+  const params = {}
+  if (Number.isFinite(options.limit)) params.limit = options.limit
+  if (Number.isFinite(options.offset)) params.offset = options.offset
+  return service.get('/api/simulation/public', { params, timeout: 15000 })
+}
+
+/**
  * List all Polymarket prediction markets for a simulation.
  * @param {string} simulationId
  */

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -160,6 +160,42 @@
                 ↓ Download PNG
               </a>
             </div>
+
+            <!-- Gallery callout — appears once the simulation is public so the
+                 operator knows their run is visible on /explore, and offers a
+                 one-click jump to see it in situ alongside other public runs. -->
+            <div class="gallery-callout" :class="{ 'gallery-callout-live': isPublic }">
+              <div class="gallery-callout-icon">◎</div>
+              <div class="gallery-callout-body">
+                <div class="gallery-callout-title">
+                  {{ isPublic ? 'Live on the public gallery' : 'Submit to the public gallery' }}
+                </div>
+                <div class="gallery-callout-desc">
+                  <template v-if="isPublic">
+                    This simulation is now visible on
+                    <a href="/explore" target="_blank" rel="noopener">/explore</a> —
+                    the public gallery where anyone can browse published runs
+                    and fork them into their own simulations.
+                  </template>
+                  <template v-else>
+                    Toggle "Public" above and this run joins the community
+                    gallery at
+                    <a href="/explore" target="_blank" rel="noopener">/explore</a>.
+                    Others can browse it, view the full belief drift, and
+                    fork your agents into their own scenarios.
+                  </template>
+                </div>
+              </div>
+              <a
+                v-if="isPublic"
+                href="/explore"
+                target="_blank"
+                rel="noopener"
+                class="gallery-callout-link"
+              >
+                Open gallery ↗
+              </a>
+            </div>
           </div>
 
           <!-- Hint -->
@@ -707,6 +743,79 @@ watch(isPublic, () => {
 
 .share-download-btn:hover {
   background: #2a2a2a;
+}
+
+.gallery-callout {
+  margin-top: 18px;
+  padding: 14px 16px;
+  background: #fafafa;
+  border: 1px dashed rgba(10, 10, 10, 0.18);
+  border-radius: 10px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.gallery-callout-live {
+  background: rgba(255, 107, 26, 0.06);
+  border-color: rgba(255, 107, 26, 0.45);
+  border-style: solid;
+}
+
+.gallery-callout-icon {
+  font-size: 22px;
+  line-height: 1;
+  color: var(--color-orange, #ff6b1a);
+  padding-top: 2px;
+}
+
+.gallery-callout-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.gallery-callout-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0a0a0a;
+  margin-bottom: 4px;
+}
+
+.gallery-callout-desc {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: #4a4a4a;
+}
+
+.gallery-callout-desc a {
+  color: var(--color-orange, #ff6b1a);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.gallery-callout-desc a:hover { text-decoration: underline; }
+
+.gallery-callout-link {
+  flex-shrink: 0;
+  align-self: center;
+  padding: 6px 12px;
+  background: var(--color-orange, #ff6b1a);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  border-radius: 6px;
+  white-space: nowrap;
+  transition: background 0.15s ease;
+}
+
+.gallery-callout-link:hover {
+  background: #0a0a0a;
 }
 
 .snippet-copy-btn:disabled {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -54,6 +54,11 @@ const routes = [
     name: 'Embed',
     component: () => import('../views/EmbedView.vue'),
     props: true
+  },
+  {
+    path: '/explore',
+    name: 'Explore',
+    component: () => import('../views/ExploreView.vue')
   }
 ]
 

--- a/frontend/src/views/ExploreView.vue
+++ b/frontend/src/views/ExploreView.vue
@@ -1,0 +1,957 @@
+<template>
+  <div class="explore-container">
+    <!-- Top Navigation Bar (mirrors Home.vue nav for visual consistency) -->
+    <nav class="navbar">
+      <router-link to="/" class="nav-brand" title="Back to home">MIROSHARK</router-link>
+      <div class="nav-links">
+        <router-link to="/" class="nav-link" title="Back to home">
+          <span class="arrow">←</span> Home
+        </router-link>
+        <a
+          href="https://github.com/aaronjmars/MiroShark"
+          target="_blank"
+          rel="noopener"
+          class="github-link"
+        >
+          GitHub <span class="arrow">↗</span>
+        </a>
+      </div>
+    </nav>
+
+    <div class="main-content">
+      <!-- Header -->
+      <header class="explore-header">
+        <div class="tag-row">
+          <span class="orange-tag">◎ Explore</span>
+          <span class="meta-sep">·</span>
+          <span class="meta-text">Public simulation gallery</span>
+        </div>
+        <h1 class="page-title">Simulations the community ran.</h1>
+        <p class="page-subtitle">
+          Every card is a real MiroShark run someone published. Open one to see
+          the full belief drift, agent network, and prediction outcome — or fork
+          it in one click and run your own variant with the same agent population.
+        </p>
+        <div class="stats-row">
+          <span class="stat-chip">
+            <span class="stat-num">{{ loading ? '…' : total }}</span>
+            <span class="stat-label">published</span>
+          </span>
+          <span v-if="!loading && items.length > 0" class="stat-chip">
+            <span class="stat-num">{{ resolvedCount }}</span>
+            <span class="stat-label">resolved</span>
+          </span>
+          <button
+            class="refresh-btn"
+            @click="refresh"
+            :disabled="loading"
+            title="Re-fetch the gallery"
+          >
+            <span v-if="loading">…</span>
+            <span v-else>↻ Refresh</span>
+          </button>
+        </div>
+      </header>
+
+      <!-- Loading -->
+      <div v-if="loading && items.length === 0" class="gallery-loading">
+        <div class="loading-grid">
+          <div v-for="n in 6" :key="n" class="loading-card"></div>
+        </div>
+      </div>
+
+      <!-- Error -->
+      <div v-else-if="error" class="gallery-error">
+        <div class="error-icon">⚠</div>
+        <div class="error-title">Couldn't load the gallery</div>
+        <div class="error-msg">{{ error }}</div>
+        <button class="error-retry" @click="refresh">Try again</button>
+      </div>
+
+      <!-- Empty -->
+      <div v-else-if="items.length === 0" class="gallery-empty">
+        <div class="empty-icon">◇</div>
+        <div class="empty-title">No public simulations yet.</div>
+        <div class="empty-msg">
+          Yours could be first. Run a simulation, click the share icon on the
+          result page, toggle "Public" — it'll appear here within 30 seconds.
+        </div>
+        <router-link to="/" class="empty-cta">Run a simulation →</router-link>
+      </div>
+
+      <!-- Grid -->
+      <div v-else class="gallery-grid">
+        <article
+          v-for="item in items"
+          :key="item.simulation_id"
+          class="gallery-card"
+          :class="{ 'card-resolved': item.resolution_outcome }"
+        >
+          <!-- Thumbnail: the server-rendered share card PNG -->
+          <router-link
+            :to="{ name: 'SimulationRun', params: { simulationId: item.simulation_id } }"
+            class="card-thumb-link"
+            :title="item.scenario || 'Open simulation'"
+          >
+            <img
+              :src="shareCardSrc(item)"
+              class="card-thumb"
+              alt=""
+              loading="lazy"
+              @error="onThumbError($event, item)"
+            />
+            <div class="card-thumb-overlay"></div>
+          </router-link>
+
+          <!-- Body -->
+          <div class="card-body">
+            <h2 class="card-scenario" :title="item.scenario">
+              {{ item.scenario || '(untitled scenario)' }}
+            </h2>
+
+            <div class="card-pills">
+              <span
+                v-if="item.quality_health"
+                class="pill"
+                :class="qualityPillClass(item.quality_health)"
+                :title="'Quality health: ' + item.quality_health"
+              >
+                ◉ {{ item.quality_health }}
+              </span>
+              <span
+                v-if="dominantStance(item)"
+                class="pill"
+                :class="stancePillClass(dominantStance(item).label)"
+                :title="'Final consensus: ' + stanceTooltip(item)"
+              >
+                {{ stanceGlyph(dominantStance(item).label) }}
+                {{ dominantStance(item).label }} {{ dominantStance(item).pct }}%
+              </span>
+              <span
+                v-if="item.resolution_outcome"
+                class="pill pill-resolved"
+                :title="'Real-world outcome recorded: ' + item.resolution_outcome"
+              >
+                ✓ Resolved · {{ item.resolution_outcome }}
+              </span>
+              <span
+                v-else
+                class="pill pill-status"
+                :title="'Runner status: ' + item.runner_status"
+              >
+                {{ formatStatus(item) }}
+              </span>
+            </div>
+
+            <!-- Belief split bar -->
+            <div v-if="item.final_consensus" class="consensus-bar" :title="stanceTooltip(item)">
+              <div
+                v-if="item.final_consensus.bullish > 0"
+                class="bar-seg bar-bullish"
+                :style="{ width: item.final_consensus.bullish + '%' }"
+              ></div>
+              <div
+                v-if="item.final_consensus.neutral > 0"
+                class="bar-seg bar-neutral"
+                :style="{ width: item.final_consensus.neutral + '%' }"
+              ></div>
+              <div
+                v-if="item.final_consensus.bearish > 0"
+                class="bar-seg bar-bearish"
+                :style="{ width: item.final_consensus.bearish + '%' }"
+              ></div>
+            </div>
+
+            <div class="card-meta">
+              <span class="meta-item">
+                <span class="meta-label">Agents</span>
+                <span class="meta-val">{{ item.agent_count || 0 }}</span>
+              </span>
+              <span class="meta-sep">·</span>
+              <span class="meta-item">
+                <span class="meta-label">Rounds</span>
+                <span class="meta-val">
+                  {{ item.current_round || 0 }}<span v-if="item.total_rounds">/{{ item.total_rounds }}</span>
+                </span>
+              </span>
+              <span class="meta-sep">·</span>
+              <span class="meta-item" :title="item.created_at">
+                <span class="meta-val">{{ formatDate(item.created_at) }}</span>
+              </span>
+            </div>
+
+            <!-- Actions -->
+            <div class="card-actions">
+              <router-link
+                :to="{ name: 'SimulationRun', params: { simulationId: item.simulation_id } }"
+                class="action-btn action-view"
+              >
+                Open →
+              </router-link>
+              <button
+                class="action-btn action-fork"
+                @click="forkAndOpen(item)"
+                :disabled="forkingId === item.simulation_id"
+                :title="'Copy this simulation\'s agents + config into a new run'"
+              >
+                <span v-if="forkingId === item.simulation_id">Forking…</span>
+                <span v-else>Fork this →</span>
+              </button>
+            </div>
+            <div
+              v-if="forkErrors[item.simulation_id]"
+              class="fork-error"
+            >
+              {{ forkErrors[item.simulation_id] }}
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <!-- Load more -->
+      <div v-if="items.length > 0 && hasMore" class="load-more-row">
+        <button
+          class="load-more-btn"
+          @click="loadMore"
+          :disabled="loadingMore"
+        >
+          <span v-if="loadingMore">Loading…</span>
+          <span v-else>Load more ({{ total - items.length }} remaining)</span>
+        </button>
+      </div>
+    </div>
+
+    <footer class="explore-footer">
+      <span class="footer-line"></span>
+      <span class="footer-text">
+        Want yours here? Run a sim, open the Embed dialog, toggle "Public."
+      </span>
+      <span class="footer-line"></span>
+    </footer>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  getPublicSimulations,
+  forkSimulation,
+  getShareCardUrl,
+} from '../api/simulation'
+
+const router = useRouter()
+
+const items = ref([])
+const total = ref(0)
+const hasMore = ref(false)
+const limit = 30
+const loading = ref(false)
+const loadingMore = ref(false)
+const error = ref('')
+const forkingId = ref('')
+const forkErrors = ref({})
+
+const resolvedCount = computed(
+  () => items.value.filter((item) => item.resolution_outcome).length,
+)
+
+const shareCardSrc = (item) => {
+  // The backend includes a relative ``share_card_url``. Resolve against
+  // the SPA origin so the <img> works whether the frontend is served by
+  // Flask in production or by Vite in dev (the dev server proxies /api).
+  if (item.share_card_url) {
+    if (item.share_card_url.startsWith('http')) return item.share_card_url
+    return item.share_card_url
+  }
+  return getShareCardUrl(item.simulation_id)
+}
+
+const onThumbError = (event, item) => {
+  // Hide broken images (e.g. if the simulation was unpublished between
+  // fetch and image load) — fall back to a monochrome tile so the card
+  // still lays out evenly.
+  const img = event?.target
+  if (!img || img.dataset.fellBack === '1') return
+  img.dataset.fellBack = '1'
+  img.style.display = 'none'
+}
+
+const dominantStance = (item) => {
+  const c = item.final_consensus
+  if (!c) return null
+  const entries = [
+    { label: 'Bullish', pct: c.bullish ?? 0 },
+    { label: 'Neutral', pct: c.neutral ?? 0 },
+    { label: 'Bearish', pct: c.bearish ?? 0 },
+  ]
+  entries.sort((a, b) => b.pct - a.pct)
+  const top = entries[0]
+  if (!top || top.pct <= 0) return null
+  return { label: top.label, pct: Math.round(top.pct) }
+}
+
+const stanceGlyph = (label) => {
+  if (label === 'Bullish') return '▲'
+  if (label === 'Bearish') return '▼'
+  return '●'
+}
+
+const stancePillClass = (label) => {
+  if (label === 'Bullish') return 'pill-bullish'
+  if (label === 'Bearish') return 'pill-bearish'
+  return 'pill-neutral'
+}
+
+const stanceTooltip = (item) => {
+  const c = item.final_consensus
+  if (!c) return ''
+  const b = (c.bullish ?? 0).toFixed(1)
+  const n = (c.neutral ?? 0).toFixed(1)
+  const be = (c.bearish ?? 0).toFixed(1)
+  return `Bullish ${b}% · Neutral ${n}% · Bearish ${be}%`
+}
+
+const qualityPillClass = (health) => {
+  const h = String(health || '').toLowerCase()
+  if (h.startsWith('excel')) return 'pill-quality-excellent'
+  if (h.startsWith('good')) return 'pill-quality-good'
+  if (h.startsWith('fair')) return 'pill-quality-fair'
+  if (h.startsWith('poor')) return 'pill-quality-poor'
+  return 'pill-quality-unknown'
+}
+
+const formatStatus = (item) => {
+  const status = item.runner_status || item.status || 'idle'
+  return String(status).replace(/_/g, ' ')
+}
+
+const formatDate = (iso) => {
+  if (!iso) return '—'
+  // Keep it cheap — just the YYYY-MM-DD prefix from the ISO string.
+  return String(iso).slice(0, 10)
+}
+
+const loadPage = async (offset = 0) => {
+  const res = await getPublicSimulations({ limit, offset })
+  if (!res?.success) {
+    throw new Error(res?.error || 'Request failed')
+  }
+  return {
+    data: res.data || [],
+    total: Number.isFinite(res.total) ? res.total : (res.data?.length ?? 0),
+    hasMore: !!res.has_more,
+  }
+}
+
+const refresh = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    const page = await loadPage(0)
+    items.value = page.data
+    total.value = page.total
+    hasMore.value = page.hasMore
+    forkErrors.value = {}
+  } catch (err) {
+    error.value =
+      err?.response?.data?.error || err?.message || 'Failed to load gallery'
+  } finally {
+    loading.value = false
+  }
+}
+
+const loadMore = async () => {
+  if (loadingMore.value || !hasMore.value) return
+  loadingMore.value = true
+  try {
+    const page = await loadPage(items.value.length)
+    const seen = new Set(items.value.map((item) => item.simulation_id))
+    for (const incoming of page.data) {
+      if (!seen.has(incoming.simulation_id)) items.value.push(incoming)
+    }
+    total.value = page.total
+    hasMore.value = page.hasMore
+  } catch (err) {
+    error.value =
+      err?.response?.data?.error || err?.message || 'Failed to load more'
+  } finally {
+    loadingMore.value = false
+  }
+}
+
+const forkAndOpen = async (item) => {
+  if (forkingId.value) return
+  forkingId.value = item.simulation_id
+  forkErrors.value = { ...forkErrors.value, [item.simulation_id]: '' }
+  try {
+    const res = await forkSimulation({
+      parent_simulation_id: item.simulation_id,
+    })
+    if (!res?.success) {
+      throw new Error(res?.error || 'Fork failed')
+    }
+    const newId = res.data?.simulation_id
+    if (!newId) throw new Error('Fork did not return a simulation_id')
+    router.push({ name: 'SimulationRun', params: { simulationId: newId } })
+  } catch (err) {
+    forkErrors.value = {
+      ...forkErrors.value,
+      [item.simulation_id]:
+        err?.response?.data?.error || err?.message || 'Fork failed',
+    }
+  } finally {
+    forkingId.value = ''
+  }
+}
+
+onMounted(refresh)
+</script>
+
+<style scoped>
+.explore-container {
+  min-height: 100vh;
+  background: var(--background);
+  font-family: var(--font-display);
+  color: var(--foreground);
+}
+
+/* ── Nav (matches Home.vue) ── */
+.navbar {
+  height: var(--space-xl);
+  background: var(--color-black);
+  color: var(--color-white);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 var(--space-lg);
+}
+
+.nav-brand {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  letter-spacing: 3px;
+  font-size: 14px;
+  text-transform: uppercase;
+  color: var(--color-white);
+  text-decoration: none;
+  transition: var(--transition-fast);
+}
+
+.nav-brand:hover { color: var(--color-orange); }
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.nav-link,
+.github-link {
+  color: var(--color-white);
+  text-decoration: none;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 1px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  transition: var(--transition-fast);
+  opacity: 0.6;
+}
+
+.nav-link:hover,
+.github-link:hover { opacity: 1; }
+
+.arrow { font-family: sans-serif; }
+
+/* ── Main Content ── */
+.main-content {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-lg) var(--space-xl);
+}
+
+/* ── Header ── */
+.explore-header {
+  margin-bottom: var(--space-xl);
+  max-width: 780px;
+}
+
+.tag-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.orange-tag {
+  background: var(--color-orange);
+  color: var(--color-white);
+  padding: 4px var(--space-sm);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.meta-sep { color: rgba(10, 10, 10, 0.35); }
+.meta-text { color: rgba(10, 10, 10, 0.7); }
+
+.page-title {
+  font-family: var(--font-display);
+  font-size: 52px;
+  line-height: 1.1;
+  margin-bottom: var(--space-md);
+  letter-spacing: -0.5px;
+}
+
+.page-subtitle {
+  font-size: 17px;
+  line-height: 1.55;
+  color: rgba(10, 10, 10, 0.7);
+  margin-bottom: var(--space-lg);
+}
+
+.stats-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.stat-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--color-gray);
+  border: var(--border-light);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.5px;
+}
+
+.stat-num {
+  font-weight: 700;
+  font-size: 16px;
+  color: var(--color-orange);
+}
+
+.stat-label {
+  color: rgba(10, 10, 10, 0.5);
+  text-transform: uppercase;
+}
+
+.refresh-btn {
+  padding: 6px 12px;
+  background: transparent;
+  border: var(--border-medium);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.5px;
+  color: rgba(10, 10, 10, 0.7);
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.refresh-btn:hover:not(:disabled) {
+  color: var(--color-orange);
+  border-color: var(--color-orange);
+}
+
+.refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Loading skeleton ── */
+.gallery-loading { margin-top: var(--space-lg); }
+
+.loading-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--space-md);
+}
+
+.loading-card {
+  height: 360px;
+  background: linear-gradient(
+    90deg,
+    rgba(10, 10, 10, 0.04) 0%,
+    rgba(10, 10, 10, 0.08) 50%,
+    rgba(10, 10, 10, 0.04) 100%
+  );
+  background-size: 200% 100%;
+  border: var(--border-light);
+  animation: shimmer-bg 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer-bg {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ── Error ── */
+.gallery-error,
+.gallery-empty {
+  padding: var(--space-2xl) var(--space-lg);
+  border: var(--border-medium);
+  text-align: center;
+  max-width: 540px;
+  margin: var(--space-xl) auto;
+}
+
+.error-icon,
+.empty-icon {
+  font-size: 32px;
+  color: var(--color-orange);
+  margin-bottom: var(--space-sm);
+}
+
+.error-title,
+.empty-title {
+  font-family: var(--font-display);
+  font-size: 22px;
+  margin-bottom: var(--space-sm);
+}
+
+.error-msg,
+.empty-msg {
+  color: rgba(10, 10, 10, 0.65);
+  font-size: 15px;
+  line-height: 1.5;
+  margin-bottom: var(--space-md);
+}
+
+.error-retry,
+.empty-cta {
+  display: inline-block;
+  padding: 10px 20px;
+  background: var(--color-orange);
+  color: var(--color-white);
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  text-decoration: none;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.error-retry:hover,
+.empty-cta:hover {
+  background: var(--color-black);
+}
+
+/* ── Grid ── */
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--space-md);
+  margin-top: var(--space-md);
+}
+
+.gallery-card {
+  background: var(--color-white);
+  border: var(--border-light);
+  display: flex;
+  flex-direction: column;
+  transition: var(--transition-medium);
+  animation: fade-in 0.4s ease-out;
+}
+
+.gallery-card:hover {
+  border-color: var(--color-orange);
+  transform: translateY(-2px);
+}
+
+.card-resolved {
+  border-left: 3px solid var(--color-green);
+}
+
+/* ── Thumbnail ── */
+.card-thumb-link {
+  display: block;
+  position: relative;
+  aspect-ratio: 1200 / 630;
+  background: var(--color-black);
+  overflow: hidden;
+}
+
+.card-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: var(--transition-medium);
+}
+
+.gallery-card:hover .card-thumb {
+  transform: scale(1.015);
+}
+
+.card-thumb-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    transparent 60%,
+    rgba(10, 10, 10, 0.15) 100%
+  );
+  pointer-events: none;
+}
+
+/* ── Card body ── */
+.card-body {
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  flex: 1;
+}
+
+.card-scenario {
+  font-family: var(--font-display);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: -0.2px;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: calc(18px * 1.3 * 2);
+}
+
+.card-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  font-weight: 600;
+  border-radius: 2px;
+}
+
+.pill-bullish {
+  background: rgba(67, 193, 101, 0.15);
+  color: #2a8545;
+}
+
+.pill-bearish {
+  background: rgba(255, 68, 68, 0.14);
+  color: #c52d2d;
+}
+
+.pill-neutral {
+  background: rgba(10, 10, 10, 0.08);
+  color: rgba(10, 10, 10, 0.7);
+}
+
+.pill-quality-excellent {
+  background: rgba(67, 193, 101, 0.15);
+  color: #2a8545;
+}
+
+.pill-quality-good {
+  background: rgba(67, 193, 101, 0.1);
+  color: #2a8545;
+}
+
+.pill-quality-fair {
+  background: rgba(255, 179, 71, 0.18);
+  color: #a66414;
+}
+
+.pill-quality-poor {
+  background: rgba(255, 68, 68, 0.14);
+  color: #c52d2d;
+}
+
+.pill-quality-unknown {
+  background: rgba(10, 10, 10, 0.06);
+  color: rgba(10, 10, 10, 0.5);
+}
+
+.pill-resolved {
+  background: var(--color-green);
+  color: var(--color-white);
+}
+
+.pill-status {
+  background: rgba(10, 10, 10, 0.06);
+  color: rgba(10, 10, 10, 0.55);
+}
+
+/* ── Consensus bar ── */
+.consensus-bar {
+  display: flex;
+  height: 6px;
+  background: rgba(10, 10, 10, 0.06);
+  overflow: hidden;
+  border-radius: 3px;
+}
+
+.bar-seg { height: 100%; transition: width 0.2s ease; }
+.bar-bullish { background: var(--color-green); }
+.bar-neutral { background: rgba(10, 10, 10, 0.3); }
+.bar-bearish { background: var(--color-red); }
+
+/* ── Metadata ── */
+.card-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(10, 10, 10, 0.55);
+  letter-spacing: 0.3px;
+  flex-wrap: wrap;
+}
+
+.meta-item {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.meta-label {
+  text-transform: uppercase;
+  color: rgba(10, 10, 10, 0.4);
+}
+
+.meta-val {
+  color: rgba(10, 10, 10, 0.75);
+  font-weight: 600;
+}
+
+/* ── Actions ── */
+.card-actions {
+  display: flex;
+  gap: var(--space-xs);
+  margin-top: auto;
+  padding-top: var(--space-sm);
+  border-top: 1px solid rgba(10, 10, 10, 0.06);
+}
+
+.action-btn {
+  flex: 1;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  text-decoration: none;
+  text-align: center;
+  border: var(--border-light);
+  background: transparent;
+  color: rgba(10, 10, 10, 0.75);
+  cursor: pointer;
+  transition: var(--transition-fast);
+  font-weight: 600;
+}
+
+.action-view:hover {
+  background: var(--color-black);
+  color: var(--color-white);
+  border-color: var(--color-black);
+}
+
+.action-fork {
+  background: var(--color-orange);
+  color: var(--color-white);
+  border-color: var(--color-orange);
+}
+
+.action-fork:hover:not(:disabled) {
+  background: var(--color-black);
+  border-color: var(--color-black);
+}
+
+.action-fork:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.fork-error {
+  margin-top: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: #c52d2d;
+  line-height: 1.4;
+}
+
+/* ── Load more ── */
+.load-more-row {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--space-xl);
+}
+
+.load-more-btn {
+  padding: 12px 32px;
+  background: transparent;
+  border: var(--border-medium);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: rgba(10, 10, 10, 0.75);
+  cursor: pointer;
+  transition: var(--transition-fast);
+  font-weight: 600;
+}
+
+.load-more-btn:hover:not(:disabled) {
+  background: var(--color-black);
+  color: var(--color-white);
+  border-color: var(--color-black);
+}
+
+.load-more-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Footer ── */
+.explore-footer {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: var(--space-lg);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  color: rgba(10, 10, 10, 0.4);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.5px;
+}
+
+.footer-line {
+  flex: 1;
+  height: 1px;
+  background: rgba(10, 10, 10, 0.08);
+}
+
+.footer-text { white-space: nowrap; }
+
+/* ── Responsive ── */
+@media (max-width: 720px) {
+  .page-title { font-size: 36px; }
+  .page-subtitle { font-size: 15px; }
+  .main-content { padding: var(--space-xl) var(--space-md); }
+  .gallery-grid { grid-template-columns: 1fr; }
+}
+</style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -4,6 +4,9 @@
     <nav class="navbar">
       <div class="nav-brand">MIROSHARK</div>
       <div class="nav-links">
+        <router-link to="/explore" class="explore-link" title="Browse public simulations">
+          <span class="compass">◎</span> Explore
+        </router-link>
         <a href="https://github.com/aaronjmars/MiroShark" target="_blank" class="github-link">
           GitHub <span class="arrow">↗</span>
         </a>
@@ -635,7 +638,25 @@ const startSimulation = () => {
 .nav-links {
   display: flex;
   align-items: center;
+  gap: var(--space-md);
 }
+
+.explore-link {
+  color: var(--color-white);
+  text-decoration: none;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 1px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  transition: var(--transition-fast);
+  opacity: 0.6;
+}
+
+.explore-link:hover { opacity: 1; color: var(--color-orange); }
+
+.compass { font-size: 15px; line-height: 1; }
 
 .github-link {
   color: var(--color-white);


### PR DESCRIPTION
## What

Adds **`/explore`** — the public gallery for simulations the operator has
toggled public via `POST /api/simulation/:id/publish`. Every published
simulation already has a rendered share card (PR #42), an embed summary
(PR #34), and a public landing page — this PR adds the discovery layer
that ties them together.

## Why

The `is_public` flag, `POST /publish` endpoint, share-card renderer, and
`/share/:id` OG landing page are all in place, but there was no page
listing the published simulations as a set. Each public run was
invisible to anyone who didn't already have the URL. The article
[repo-actions — 2026-04-22](https://github.com/aaronjmars/MiroShark/blob/main/articles/repo-actions-2026-04-22.md)
called this out as the single highest-leverage distribution lever for
the 1K-stars-by-Apr-30 target — a visitor who lands on `/explore` sees
real research rather than a blank setup form.

## Changes

### Backend

- **`GET /api/simulation/public`** — paginated list of `is_public=true`
  simulations sorted by `created_at desc`. `limit` / `offset` query params
  (clamped to 1–100 / ≥0). Reads existing on-disk artifacts
  (`state.json`, `simulation_config.json`, `quality.json`,
  `trajectory.json`, `resolution.json`) to build a card-friendly payload
  per item — scenario headline (truncated to 180 chars), status,
  `agent_count`, `quality_health`, `final_consensus` (bullish / neutral /
  bearish %), `resolution_outcome`, `share_card_url`, `share_landing_url`,
  `parent_simulation_id`. Graceful degradation: any missing or malformed
  artifact falls through to `None` so one bad simulation can't blank the
  whole gallery. Short cache header (`public, max-age=30`) so new
  publishes surface quickly while still absorbing repeat hits from bots.

### Frontend

- **`/explore` route** + **`views/ExploreView.vue`** — responsive card
  grid using the server-rendered 1200×630 share-card PNG as thumbnail.
  Each card renders: scenario (3-line clamp), quality + dominant-stance
  pills, resolution or runner-status pill, a belief-split mini-bar,
  agent/round/date metadata, and paired **Open →** + **Fork this →**
  actions. Fork hits the existing `POST /api/simulation/fork` and routes
  to `SimulationRun` on the new sim. Includes a loading skeleton, error
  state with retry, empty state copy ("No public simulations yet —
  yours could be first"), and `Load more` pagination.

- **Explore link in `Home.vue` nav** (compass icon `◎ Explore`).

- **"Submit to the public gallery" callout** added to the Social Card
  section of `EmbedDialog.vue`. Flips to **"Live on the public gallery"**
  with an **Open gallery ↗** link the moment the operator toggles
  Public on.

- **`getPublicSimulations()`** helper in
  `frontend/src/api/simulation.js`.

### Tests

- **`backend/tests/test_unit_public_gallery.py`** — 5 offline unit tests
  over `_build_gallery_card_payload`:
    1. Minimal card when the sim dir is empty (graceful degradation).
    2. Full payload from a complete dir — scenario, quality, consensus
       split, resolution all populated (including arithmetic check:
       2/4/1/1 stances → bullish 50% / neutral 25% / bearish 25%).
    3. Scenario over 180 chars gets a unicode ellipsis.
    4. Empty trajectory yields `final_consensus: null`.
    5. Corrupt JSON on any artifact is swallowed — the card still renders.

### Docs

- Public Gallery row added to the README features table.

## How it integrates

- No DB schema change — piggybacks on `SimulationState.is_public` and the
  existing disk layout. New simulations need nothing beyond the existing
  publish toggle to show up in the gallery.
- No new dependencies — Flask-only on the backend; no new npm packages
  on the frontend.
- The gallery → fork pathway is end-to-end with zero new backend
  plumbing: the "Fork this →" button reuses `POST /api/simulation/fork`
  and the existing `SimulationRun` route.

---

*Built autonomously by Aeon.*