### PR TITLE
feat: AI Integration · MCP onboarding panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 | [Features](docs/FEATURES.md) | Deep dive on every feature in the table above |
 | [HTTP API](docs/API.md) | Every endpoint, grouped by concern |
 | [CLI](docs/CLI.md) | `miroshark-cli` reference |
-| [MCP](docs/MCP.md) | Claude Desktop integration + report agent tools |
+| [MCP](docs/MCP.md) | Claude Desktop / Cursor / Windsurf / Continue integration + report agent tools (auto-generated snippets in Settings → AI Integration) |
 | [Observability](docs/OBSERVABILITY.md) | Debug panel, event stream, logging |
 | [Contributing](CONTRIBUTING.md) | Tests and development |
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -79,13 +79,14 @@ def create_app(config_class=Config):
         return response
     
     # Register blueprints
-    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, share_bp
+    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, mcp_bp, share_bp
     app.register_blueprint(graph_bp, url_prefix='/api/graph')
     app.register_blueprint(simulation_bp, url_prefix='/api/simulation')
     app.register_blueprint(report_bp, url_prefix='/api/report')
     app.register_blueprint(templates_bp, url_prefix='/api/templates')
     app.register_blueprint(settings_bp, url_prefix='/api/settings')
     app.register_blueprint(observability_bp, url_prefix='/api/observability')
+    app.register_blueprint(mcp_bp, url_prefix='/api/mcp')
     # share_bp serves the public OG-tag landing page at /share/<sim_id>
     # (no prefix — keeps the social share URL short).
     app.register_blueprint(share_bp)

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -10,6 +10,7 @@ report_bp = Blueprint('report', __name__)
 templates_bp = Blueprint('templates', __name__)
 settings_bp = Blueprint('settings', __name__)
 observability_bp = Blueprint('observability', __name__)
+mcp_bp = Blueprint('mcp', __name__)
 
 from . import graph  # noqa: E402, F401
 from . import simulation  # noqa: E402, F401
@@ -17,6 +18,7 @@ from . import report  # noqa: E402, F401
 from . import templates  # noqa: E402, F401
 from . import settings  # noqa: E402, F401
 from . import observability  # noqa: E402, F401
+from . import mcp  # noqa: E402, F401
 
 # share_bp is mounted at the root (no /api prefix) so the public landing
 # URL stays clean — see api/share.py.

--- a/backend/app/api/mcp.py
+++ b/backend/app/api/mcp.py
@@ -1,0 +1,291 @@
+"""
+MCP API — surface the bundled `mcp_server.py` so the frontend can show users
+exactly how to wire MiroShark into Claude Desktop, Cursor, Windsurf, Continue,
+or any other MCP-aware client.
+
+GET /api/mcp/status — returns:
+  - the MiroShark MCP tool catalog (parsed from `mcp_server.py`)
+  - resolved absolute paths for the python interpreter and `mcp_server.py`
+    on this host (so the JSON snippets the UI shows are copy-paste ready
+    for the user's own machine)
+  - pre-rendered config blocks for each supported client
+  - a graph database health probe (connection + graph count) so the UI can
+    tell the user whether Neo4j is up and whether anything is in it yet
+
+The MCP server itself runs over stdio — this endpoint never spawns or talks
+to it. We only describe how to launch it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from flask import current_app, jsonify
+
+from . import mcp_bp
+from ..config import Config
+from ..utils.logger import get_logger
+
+
+logger = get_logger('miroshark.api.mcp')
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tool catalog — kept in sync with `backend/mcp_server.py`. The backend ships
+# both files, so a stale catalog here becomes a CI failure surfaced by the
+# unit tests below (test_unit_mcp_api.py).
+# ──────────────────────────────────────────────────────────────────────────
+
+_TOOLS: List[Dict[str, str]] = [
+    {
+        'name': 'list_graphs',
+        'description': (
+            'Survey every knowledge graph in this MiroShark instance with '
+            'entity and edge counts. Use this first to discover graph_ids.'
+        ),
+    },
+    {
+        'name': 'search_graph',
+        'description': (
+            'Hybrid retrieval over a graph: vector + BM25 + graph-traversal '
+            'fused and reranked with a cross-encoder. Supports time-travel '
+            '(as_of) and epistemic filtering (kinds=fact|belief|observation).'
+        ),
+    },
+    {
+        'name': 'browse_clusters',
+        'description': (
+            'Zoom-out over a graph: return LLM-summarized community clusters. '
+            'Auto-builds clusters on first call if none exist.'
+        ),
+    },
+    {
+        'name': 'search_communities',
+        'description': 'Semantic search over cluster summaries only (faster than search_graph).',
+    },
+    {
+        'name': 'get_community',
+        'description': 'Expand one cluster — returns title, summary, and member entities.',
+    },
+    {
+        'name': 'list_reports',
+        'description': 'List prior reports generated for a graph (most recent first).',
+    },
+    {
+        'name': 'list_report_sections',
+        'description': 'List the sections of a report in order.',
+    },
+    {
+        'name': 'get_reasoning_trace',
+        'description': (
+            "Return the report-agent's full decision chain for one report "
+            'section: thoughts, tool calls, observations, conclusion.'
+        ),
+    },
+]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Path resolution — these are the values that get stamped into the config
+# snippets shown to the user.
+# ──────────────────────────────────────────────────────────────────────────
+
+def _resolve_paths() -> Dict[str, str]:
+    """Locate the bundled mcp_server.py and the interpreter that should run it.
+
+    The user copies these values into their MCP client config, so they must
+    point at the *server's* on-disk install — that's the same machine where
+    they'll be running both the backend and (eventually) the MCP server.
+    """
+    backend_dir = Path(__file__).resolve().parent.parent.parent
+    mcp_script = backend_dir / 'mcp_server.py'
+    return {
+        'backend_dir': str(backend_dir),
+        'mcp_script': str(mcp_script),
+        'mcp_script_exists': mcp_script.is_file(),
+        'python_executable': sys.executable,
+    }
+
+
+def _build_config_snippets(paths: Dict[str, str]) -> Dict[str, Dict[str, Any]]:
+    """Pre-render copy-pasteable config blocks for each supported MCP client.
+
+    Each entry has:
+      - label:    human-readable client name
+      - file:     where the config typically lives on disk
+      - config:   the JSON snippet (returned as a dict so the frontend can
+                  pretty-print it however it wants)
+      - notes:    optional one-liner shown beneath the snippet
+    """
+    py = paths['python_executable']
+    script = paths['mcp_script']
+    backend = paths['backend_dir']
+
+    # The server ships as a uv-managed project; if the operator launched the
+    # backend with uv we surface the cleaner `uv run` command which doesn't
+    # depend on the .venv path being stable across hosts.
+    uv_command = {
+        'command': 'uv',
+        'args': ['run', '--directory', backend, 'python', 'mcp_server.py'],
+    }
+
+    direct_command = {
+        'command': py,
+        'args': [script],
+    }
+
+    # Claude Desktop / Continue / generic-MCP all use the `mcpServers` shape.
+    claude_desktop = {
+        'mcpServers': {
+            'miroshark': uv_command,
+        }
+    }
+
+    # Cursor's `.cursor/mcp.json` is the same shape as Claude Desktop.
+    cursor = {
+        'mcpServers': {
+            'miroshark': uv_command,
+        }
+    }
+
+    # Windsurf's `~/.codeium/windsurf/mcp_config.json` also uses `mcpServers`.
+    windsurf = {
+        'mcpServers': {
+            'miroshark': uv_command,
+        }
+    }
+
+    # Continue prefers a flat list inside `experimental.modelContextProtocolServers`.
+    continue_dev = {
+        'experimental': {
+            'modelContextProtocolServers': [
+                {
+                    'transport': {
+                        'type': 'stdio',
+                        **uv_command,
+                    }
+                }
+            ]
+        }
+    }
+
+    return {
+        'claude_desktop': {
+            'label': 'Claude Desktop',
+            'file': '~/Library/Application Support/Claude/claude_desktop_config.json (macOS) · %APPDATA%\\Claude\\claude_desktop_config.json (Windows)',
+            'config': claude_desktop,
+            'notes': 'Open Claude Desktop → Settings → Developer → Edit Config. Restart Claude Desktop after saving.',
+        },
+        'cursor': {
+            'label': 'Cursor',
+            'file': '.cursor/mcp.json (in your workspace) or ~/.cursor/mcp.json (global)',
+            'config': cursor,
+            'notes': 'Reload the Cursor window after editing. The miroshark tools appear in the @ menu.',
+        },
+        'windsurf': {
+            'label': 'Windsurf',
+            'file': '~/.codeium/windsurf/mcp_config.json',
+            'config': windsurf,
+            'notes': 'Open Windsurf → Cascade → MCP Servers → Refresh after saving.',
+        },
+        'continue': {
+            'label': 'Continue (VS Code / JetBrains)',
+            'file': '~/.continue/config.json',
+            'config': continue_dev,
+            'notes': 'Continue ≥ 0.9.x. Reload your editor after saving.',
+        },
+        'fallback_direct': {
+            'label': 'No uv? Use the interpreter path directly',
+            'file': 'Replace the uv block above with this if `uv` is not on PATH.',
+            'config': {'mcpServers': {'miroshark': direct_command}},
+            'notes': f'Uses the same Python interpreter currently serving the backend ({py}).',
+        },
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Neo4j health probe — non-fatal. The endpoint must always return 200 so the
+# frontend can render guidance even when Neo4j is down.
+# ──────────────────────────────────────────────────────────────────────────
+
+def _probe_neo4j() -> Dict[str, Any]:
+    """Best-effort liveness + graph count. Never raises."""
+    storage = current_app.extensions.get('neo4j_storage') if current_app else None
+    result: Dict[str, Any] = {
+        'connected': False,
+        'uri': Config.NEO4J_URI,
+        'user': Config.NEO4J_USER,
+        'graph_count': None,
+        'entity_count': None,
+        'error': None,
+    }
+
+    if storage is None:
+        result['error'] = 'Neo4jStorage failed to initialize at app startup. Check NEO4J_URI / NEO4J_USER / NEO4J_PASSWORD.'
+        return result
+
+    try:
+        with storage._driver.session() as sess:
+            sess.run('RETURN 1').single()
+            result['connected'] = True
+
+            # Graph count — distinct graph_ids that own at least one Entity.
+            row = sess.run(
+                """
+                MATCH (n:Entity)
+                WITH count(DISTINCT n.graph_id) AS graphs, count(n) AS entities
+                RETURN graphs, entities
+                """
+            ).single()
+            if row is not None:
+                result['graph_count'] = int(row['graphs'])
+                result['entity_count'] = int(row['entities'])
+            else:
+                result['graph_count'] = 0
+                result['entity_count'] = 0
+    except Exception as e:  # noqa: BLE001 — surface every Neo4j failure mode
+        logger.warning('MCP status: Neo4j probe failed: %s', e)
+        result['error'] = str(e)
+
+    return result
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pure helpers — exported for unit testing without a Flask app context.
+# ──────────────────────────────────────────────────────────────────────────
+
+def build_status_payload(
+    neo4j_probe: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Assemble the GET /api/mcp/status response body.
+
+    Splitting this from the request handler keeps the unit tests Flask-free.
+    """
+    paths = _resolve_paths()
+    snippets = _build_config_snippets(paths)
+    return {
+        'enabled': True,
+        'transport': 'stdio',
+        'paths': paths,
+        'tools': _TOOLS,
+        'tool_count': len(_TOOLS),
+        'clients': snippets,
+        'neo4j': neo4j_probe if neo4j_probe is not None else {
+            'connected': False,
+            'uri': Config.NEO4J_URI,
+            'user': Config.NEO4J_USER,
+            'graph_count': None,
+            'entity_count': None,
+            'error': 'Neo4j probe skipped.',
+        },
+        'docs_url': 'https://github.com/aaronjmars/MiroShark/blob/main/docs/MCP.md',
+    }
+
+
+@mcp_bp.route('/status', methods=['GET'])
+def mcp_status():
+    """Return the MiroShark MCP server catalog + per-client config snippets."""
+    payload = build_status_payload(neo4j_probe=_probe_neo4j())
+    return jsonify({'success': True, 'data': payload})

--- a/backend/tests/test_unit_mcp_api.py
+++ b/backend/tests/test_unit_mcp_api.py
@@ -1,0 +1,203 @@
+"""Unit tests for the MCP onboarding API.
+
+These tests are pure offline checks against the helpers in
+``app/api/mcp.py``. The ``GET /api/mcp/status`` route is a thin Flask
+wrapper around ``build_status_payload`` — verifying the helper covers the
+shape contract that the SettingsPanel.vue frontend relies on. Live Flask /
+Neo4j integration is exercised by the integration suite.
+
+We cover:
+
+  1. The tool catalog matches what ``backend/mcp_server.py`` actually
+     registers (drift here means the Settings panel would advertise tools
+     that don't exist or hide ones that do).
+  2. Every supported MCP client gets a valid, non-empty config snippet
+     whose paths can be JSON-serialized (the frontend pretty-prints them).
+  3. The Neo4j probe defaults are conservative when no probe is supplied
+     — the endpoint must always return a payload, never raise.
+  4. The resolved Python interpreter and mcp_server.py paths point at
+     real, on-disk locations under the backend dir.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ── Tool catalog drift ──────────────────────────────────────────────────
+
+
+def _tool_names_from_mcp_server() -> set:
+    """Extract every ``Tool(name="...")`` from mcp_server.py without
+    importing it (importing would pull in the MCP SDK and Neo4j driver).
+    """
+    src = (_BACKEND / "mcp_server.py").read_text(encoding="utf-8")
+    return set(re.findall(r'Tool\(\s*name=\"([a-z_]+)\"', src))
+
+
+def test_tool_catalog_matches_mcp_server():
+    """The Settings panel's advertised tool list must equal mcp_server.py's
+    actual registrations — no phantom tools, no missing tools."""
+    from app.api.mcp import _TOOLS
+
+    api_names = {t["name"] for t in _TOOLS}
+    server_names = _tool_names_from_mcp_server()
+
+    assert api_names == server_names, (
+        f"Tool catalog drift!\n"
+        f"  in api/mcp.py only: {api_names - server_names}\n"
+        f"  in mcp_server.py only: {server_names - api_names}"
+    )
+
+
+def test_every_tool_has_nonempty_description():
+    """Empty descriptions render as a blank cell in the AI Integration
+    panel — not useful and visually broken."""
+    from app.api.mcp import _TOOLS
+
+    for tool in _TOOLS:
+        assert tool["description"].strip(), f"Tool {tool['name']!r} has empty description"
+
+
+# ── Status payload shape ────────────────────────────────────────────────
+
+
+def test_status_payload_has_required_top_level_keys():
+    from app.api.mcp import build_status_payload
+
+    payload = build_status_payload()
+
+    for key in ("enabled", "transport", "paths", "tools", "tool_count", "clients", "neo4j", "docs_url"):
+        assert key in payload, f"missing key {key!r} in payload"
+
+    assert payload["enabled"] is True
+    assert payload["transport"] == "stdio"
+    assert payload["tool_count"] == len(payload["tools"])
+    assert payload["docs_url"].startswith("https://")
+
+
+def test_paths_block_resolves_to_real_files():
+    """The snippet stamps these absolute paths into the user's MCP client
+    config. They must point at on-disk locations under the backend dir,
+    otherwise the snippet is broken on first paste."""
+    from app.api.mcp import build_status_payload
+
+    paths = build_status_payload()["paths"]
+
+    backend_dir = Path(paths["backend_dir"])
+    mcp_script = Path(paths["mcp_script"])
+    py_executable = Path(paths["python_executable"])
+
+    assert backend_dir.is_dir(), f"backend_dir {backend_dir} is not a directory"
+    assert mcp_script == backend_dir / "mcp_server.py"
+    assert mcp_script.is_file(), "mcp_server.py was not packaged with backend"
+    assert paths["mcp_script_exists"] is True
+    # Don't require .is_file() on the interpreter — pytest may run under a
+    # frozen / shimmed binary on some platforms — but it must be absolute.
+    assert py_executable.is_absolute(), f"python_executable {py_executable} is not absolute"
+
+
+# ── Client snippets ─────────────────────────────────────────────────────
+
+
+_REQUIRED_CLIENTS = ("claude_desktop", "cursor", "windsurf", "continue", "fallback_direct")
+
+
+@pytest.mark.parametrize("client_key", _REQUIRED_CLIENTS)
+def test_each_client_snippet_is_present_and_serializable(client_key):
+    """Every client supported by the Settings panel must have a snippet
+    that round-trips through json.dumps without raising — that's what the
+    frontend ``formatJson(config)`` call relies on."""
+    from app.api.mcp import build_status_payload
+
+    clients = build_status_payload()["clients"]
+    assert client_key in clients, f"missing client {client_key!r}"
+
+    entry = clients[client_key]
+    assert entry["label"], f"{client_key} missing label"
+    assert entry["config"], f"{client_key} has empty config"
+    # Round-trips cleanly — frontend uses JSON.stringify with the same data.
+    serialized = json.dumps(entry["config"], indent=2)
+    assert serialized
+    # Parsable back into the same dict.
+    assert json.loads(serialized) == entry["config"]
+
+
+def test_mcpServers_snippets_reference_miroshark_entry():
+    """All four mcpServers-shaped snippets must register under the key
+    'miroshark' so the docs/UI guidance stays consistent."""
+    from app.api.mcp import build_status_payload
+
+    clients = build_status_payload()["clients"]
+    for key in ("claude_desktop", "cursor", "windsurf", "fallback_direct"):
+        cfg = clients[key]["config"]
+        assert "mcpServers" in cfg, f"{key} snippet missing mcpServers wrapper"
+        assert "miroshark" in cfg["mcpServers"], f"{key} snippet missing 'miroshark' entry"
+
+
+def test_continue_snippet_uses_modelContextProtocolServers():
+    """Continue uses a different config shape than Claude Desktop / Cursor —
+    if this regresses, Continue users get an empty MCP server list."""
+    from app.api.mcp import build_status_payload
+
+    cfg = build_status_payload()["clients"]["continue"]["config"]
+    servers = cfg.get("experimental", {}).get("modelContextProtocolServers")
+    assert isinstance(servers, list) and servers, "continue: missing or empty server list"
+    assert servers[0]["transport"]["type"] == "stdio"
+    assert "command" in servers[0]["transport"]
+    assert "args" in servers[0]["transport"]
+
+
+def test_fallback_direct_snippet_uses_python_interpreter_directly():
+    """The fallback path is for users without uv on PATH — it must wire the
+    snippet to the actual Python interpreter, not the uv wrapper."""
+    from app.api.mcp import build_status_payload
+
+    payload = build_status_payload()
+    fallback = payload["clients"]["fallback_direct"]["config"]["mcpServers"]["miroshark"]
+    assert fallback["command"] == payload["paths"]["python_executable"]
+    assert fallback["args"] == [payload["paths"]["mcp_script"]]
+
+
+# ── Defensive defaults ──────────────────────────────────────────────────
+
+
+def test_payload_includes_neo4j_block_even_without_probe():
+    """The endpoint must always return 200 with a complete payload —
+    the Settings panel renders error guidance from the neo4j block when
+    things are down."""
+    from app.api.mcp import build_status_payload
+
+    neo4j = build_status_payload()["neo4j"]
+    for key in ("connected", "uri", "user", "graph_count", "entity_count", "error"):
+        assert key in neo4j, f"missing neo4j key {key!r}"
+    # No probe was supplied → connected must be False, error explained.
+    assert neo4j["connected"] is False
+    assert neo4j["error"]
+
+
+def test_supplied_probe_is_passed_through_unchanged():
+    """When the route's _probe_neo4j() succeeds, its dict must reach the
+    UI verbatim so we don't double-mask connection state."""
+    from app.api.mcp import build_status_payload
+
+    probe = {
+        "connected": True,
+        "uri": "bolt://localhost:7687",
+        "user": "neo4j",
+        "graph_count": 7,
+        "entity_count": 1234,
+        "error": None,
+    }
+    payload = build_status_payload(neo4j_probe=probe)
+    assert payload["neo4j"] == probe

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,25 +1,12 @@
 # MCP
 
-MiroShark ships two MCP surfaces: a **standalone MCP server** so you can query your knowledge graphs from Claude Desktop, and a set of **report agent tools** used internally by the ReACT report agent.
+MiroShark ships two MCP surfaces: a **standalone MCP server** so you can query your knowledge graphs from Claude Desktop, Cursor, Windsurf, or Continue, and a set of **report agent tools** used internally by the ReACT report agent.
 
-## Claude Desktop
+> **Tip:** open MiroShark → **Settings → AI Integration · MCP** for an auto-generated, copy-paste-ready config snippet for each client. The Settings panel reads `GET /api/mcp/status` and stamps the snippet with the absolute paths on your machine.
 
-`backend/mcp_server.py` exposes MiroShark's graph over MCP so you can query it from Claude Desktop without opening the web UI.
+## What's exposed
 
-Add to your `claude_desktop_config.json` (Claude Desktop → Settings → Developer → Edit Config):
-
-```json
-{
-  "mcpServers": {
-    "miroshark": {
-      "command": "/absolute/path/to/MiroShark/backend/.venv/bin/python",
-      "args": ["/absolute/path/to/MiroShark/backend/mcp_server.py"]
-    }
-  }
-}
-```
-
-Restart Claude Desktop. The `miroshark` tools appear in the hammer menu:
+`backend/mcp_server.py` runs over **stdio** (no port to open, no daemon to keep alive — your MCP client launches it on demand) and uses your existing `.env` for Neo4j + LLM credentials.
 
 | Tool | What it does |
 |---|---|
@@ -33,6 +20,146 @@ Restart Claude Desktop. The `miroshark` tools appear in the hammer menu:
 | `get_reasoning_trace` | Full ReACT decision chain for one section |
 
 **Example prompt:** *"List my MiroShark graphs, browse clusters on the biggest one for anything about oracle exploits, then show me the reasoning trace from the most recent report on that graph."*
+
+---
+
+## Claude Desktop
+
+Open **Claude Desktop → Settings → Developer → Edit Config**. The file lives at:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux:** `~/.config/Claude/claude_desktop_config.json`
+
+Add (or merge into) the `mcpServers` block — replace `/absolute/path/to/MiroShark/backend` with the path on your machine:
+
+```json
+{
+  "mcpServers": {
+    "miroshark": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/MiroShark/backend",
+        "python",
+        "mcp_server.py"
+      ]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The `miroshark` tools appear in the hammer / 🛠️ menu.
+
+> **No `uv`?** Use the Python interpreter directly:
+> ```json
+> "command": "/absolute/path/to/MiroShark/backend/.venv/bin/python",
+> "args": ["/absolute/path/to/MiroShark/backend/mcp_server.py"]
+> ```
+
+---
+
+## Cursor
+
+Cursor reads `mcpServers` from either:
+
+- a workspace config: `.cursor/mcp.json` in the repo you're working in, **or**
+- a global config: `~/.cursor/mcp.json`
+
+Add:
+
+```json
+{
+  "mcpServers": {
+    "miroshark": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/MiroShark/backend",
+        "python",
+        "mcp_server.py"
+      ]
+    }
+  }
+}
+```
+
+Reload the Cursor window (`Cmd/Ctrl+Shift+P → Reload Window`). The miroshark tools appear when you `@mention` MCP in chat.
+
+---
+
+## Windsurf
+
+Windsurf reads MCP servers from `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "miroshark": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/MiroShark/backend",
+        "python",
+        "mcp_server.py"
+      ]
+    }
+  }
+}
+```
+
+Then open **Cascade → MCP Servers → Refresh**. The miroshark tools become callable from Cascade conversations.
+
+---
+
+## Continue (VS Code / JetBrains)
+
+Continue ≥ 0.9.x supports MCP via `~/.continue/config.json`:
+
+```json
+{
+  "experimental": {
+    "modelContextProtocolServers": [
+      {
+        "transport": {
+          "type": "stdio",
+          "command": "uv",
+          "args": [
+            "run",
+            "--directory",
+            "/absolute/path/to/MiroShark/backend",
+            "python",
+            "mcp_server.py"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Reload your editor after saving.
+
+---
+
+## Verifying it works
+
+1. Start your MCP client. Within a few seconds it should spawn `mcp_server.py` as a child process.
+2. Ask: *"Use the `list_graphs` tool to show my MiroShark graphs."* — the assistant should respond with one row per graph and entity/edge counts. If the response is empty (`No graphs found.`), build at least one graph in the MiroShark UI first (Step 1: Graph Build).
+3. The MiroShark UI's **Settings → AI Integration · MCP** panel surfaces the same Neo4j health probe — if the panel says *Neo4j down*, the MCP tools will fail the same way.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `uv: command not found` in your client's MCP logs | `uv` is not on the PATH the client inherited | Switch to the **No uv?** snippet (direct interpreter path), or install `uv` system-wide. |
+| `No graphs found.` from `list_graphs` | Empty Neo4j | Run a simulation in the MiroShark UI to populate at least one graph. |
+| `Neo.ClientError.Security.Unauthorized` | Stale `NEO4J_PASSWORD` in `.env` | Update `.env` and restart any client that already spawned the server. |
+| Server starts then dies immediately | `mcp` Python package missing | The MCP SDK is in `pyproject.toml` — make sure `uv sync` (or `pip install -e backend/`) ran cleanly. |
+| Snippet shows `mcp_script: missing` in the Settings panel | You're running the backend from a different checkout than the one with `mcp_server.py` | Re-clone or `git pull` so `backend/mcp_server.py` exists. |
 
 ## Report Agent Tools
 

--- a/frontend/src/api/mcp.js
+++ b/frontend/src/api/mcp.js
@@ -1,0 +1,24 @@
+import service from './index'
+
+/**
+ * Get the MiroShark MCP server status, tool catalog, and per-client config
+ * snippets. Used by the Settings → AI Integration panel to give users a
+ * copy-paste path into Claude Desktop, Cursor, Windsurf, and Continue.
+ *
+ * @returns {Promise<{
+ *   success: boolean,
+ *   data: {
+ *     enabled: boolean,
+ *     transport: string,
+ *     paths: { backend_dir: string, mcp_script: string, mcp_script_exists: boolean, python_executable: string },
+ *     tools: Array<{ name: string, description: string }>,
+ *     tool_count: number,
+ *     clients: Object<string, { label: string, file: string, config: object, notes: string }>,
+ *     neo4j: { connected: boolean, uri: string, user: string, graph_count: number|null, entity_count: number|null, error: string|null },
+ *     docs_url: string,
+ *   }
+ * }>}
+ */
+export const getMcpStatus = () => {
+  return service.get('/api/mcp/status')
+}

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -348,6 +348,115 @@
           </div>
         </section>
 
+        <!-- AI Integration (MCP) -->
+        <section class="settings-section ai-section">
+          <div class="section-header">
+            <span class="section-label">AI Integration · MCP</span>
+            <div class="status-badge" :class="mcpHealthClass">
+              <span class="badge-dot"></span>
+              {{ mcpHealthText }}
+            </div>
+          </div>
+
+          <div class="ai-intro">
+            Wire MiroShark's knowledge graph into Claude Desktop, Cursor, Windsurf,
+            or Continue. Pick your client, paste the snippet, restart the editor.
+          </div>
+
+          <div v-if="mcpLoading" class="ai-loading">Loading MCP catalog…</div>
+          <div v-else-if="mcpLoadError" class="ai-error">
+            {{ mcpLoadError }}
+            <button class="ai-retry" @click="loadMcpStatus">Retry</button>
+          </div>
+
+          <div v-else-if="mcpStatus" class="ai-body">
+            <!-- Health summary grid -->
+            <div class="ai-summary">
+              <div class="ai-summary-row">
+                <span class="ai-summary-key">Server file</span>
+                <span class="ai-summary-val" :class="mcpStatus.paths.mcp_script_exists ? '' : 'setup-missing'">
+                  {{ mcpStatus.paths.mcp_script_exists ? 'present' : 'missing' }}
+                </span>
+              </div>
+              <div class="ai-summary-row">
+                <span class="ai-summary-key">Tools exposed</span>
+                <span class="ai-summary-val">{{ mcpStatus.tool_count }}</span>
+              </div>
+              <div class="ai-summary-row">
+                <span class="ai-summary-key">Neo4j</span>
+                <span class="ai-summary-val" :class="mcpStatus.neo4j.connected ? '' : 'setup-missing'">
+                  {{ mcpStatus.neo4j.connected ? 'connected' : 'unreachable' }}
+                </span>
+              </div>
+              <div class="ai-summary-row" v-if="mcpStatus.neo4j.connected">
+                <span class="ai-summary-key">Graphs available</span>
+                <span class="ai-summary-val">
+                  {{ mcpStatus.neo4j.graph_count ?? 0 }}
+                  <span class="setup-aux" v-if="mcpStatus.neo4j.entity_count != null">
+                    ({{ mcpStatus.neo4j.entity_count }} entities)
+                  </span>
+                </span>
+              </div>
+              <div class="ai-summary-row" v-if="mcpStatus.neo4j.error">
+                <span class="ai-summary-key">Error</span>
+                <span class="ai-summary-val ai-error-text">{{ mcpStatus.neo4j.error }}</span>
+              </div>
+            </div>
+
+            <!-- Client tabs -->
+            <div class="ai-tabs" role="tablist">
+              <button
+                v-for="key in clientOrder"
+                :key="key"
+                class="ai-tab"
+                :class="{ active: activeClient === key }"
+                role="tab"
+                :aria-selected="activeClient === key"
+                @click="activeClient = key"
+              >
+                {{ mcpStatus.clients[key]?.label || key }}
+              </button>
+            </div>
+
+            <!-- Active client snippet -->
+            <div v-if="currentClient" class="ai-client">
+              <div class="ai-client-file">
+                <span class="ai-client-file-label">Config file:</span>
+                <code class="ai-client-file-path">{{ currentClient.file }}</code>
+              </div>
+              <div class="ai-snippet-wrap">
+                <pre class="ai-snippet"><code>{{ formatJson(currentClient.config) }}</code></pre>
+                <button
+                  class="ai-copy-btn"
+                  :class="{ ok: copyState === 'ok', fail: copyState === 'fail' }"
+                  @click="copySnippet"
+                >
+                  {{ copyButtonLabel }}
+                </button>
+              </div>
+              <div v-if="currentClient.notes" class="ai-client-notes">
+                {{ currentClient.notes }}
+              </div>
+            </div>
+
+            <!-- Tool catalog (collapsed by default) -->
+            <button class="ai-tools-toggle" @click="toolsOpen = !toolsOpen">
+              <span>{{ toolsOpen ? '▾' : '▸' }} {{ mcpStatus.tool_count }} tools available</span>
+            </button>
+            <ul v-if="toolsOpen" class="ai-tools-list">
+              <li v-for="t in mcpStatus.tools" :key="t.name" class="ai-tool">
+                <code class="ai-tool-name">{{ t.name }}</code>
+                <span class="ai-tool-desc">{{ t.description }}</span>
+              </li>
+            </ul>
+
+            <div class="ai-docs-link">
+              Need a deeper walkthrough?
+              <a :href="mcpStatus.docs_url" target="_blank" rel="noopener">Read the full MCP guide →</a>
+            </div>
+          </div>
+        </section>
+
         <!-- Footer -->
         <div class="modal-footer">
           <div v-if="saveError" class="save-error">{{ saveError }}</div>
@@ -368,6 +477,7 @@
 <script setup>
 import { ref, reactive, computed, watch } from 'vue'
 import { getSettings, updateSettings, testLlmConnection } from '../api/settings'
+import { getMcpStatus } from '../api/mcp'
 
 const props = defineProps({
   open: { type: Boolean, required: true }
@@ -413,6 +523,15 @@ const modelLoadError = ref('')
 const advancedOpen = ref(false)
 const inheritMarker = '— inherits default —'
 
+// MCP / AI Integration state
+const mcpStatus = ref(null)
+const mcpLoading = ref(false)
+const mcpLoadError = ref('')
+const clientOrder = ['claude_desktop', 'cursor', 'windsurf', 'continue', 'fallback_direct']
+const activeClient = ref('claude_desktop')
+const toolsOpen = ref(false)
+const copyState = ref('') // '' | 'ok' | 'fail'
+
 // Load current settings when panel opens
 watch(() => props.open, async (isOpen) => {
   if (isOpen) {
@@ -421,7 +540,8 @@ watch(() => props.open, async (isOpen) => {
     testResult.value = null
     form.preset = ''
     form.presetApiKey = ''
-    await loadCurrentSettings()
+    copyState.value = ''
+    await Promise.all([loadCurrentSettings(), loadMcpStatus()])
   }
 })
 
@@ -515,6 +635,75 @@ const testConnection = async () => {
     testResult.value = { success: false, error: e.message }
   } finally {
     testing.value = false
+  }
+}
+
+const loadMcpStatus = async () => {
+  mcpLoading.value = true
+  mcpLoadError.value = ''
+  try {
+    // Axios interceptor unwraps to { success, data }.
+    const res = await getMcpStatus()
+    if (res?.success && res.data) {
+      mcpStatus.value = res.data
+    } else {
+      mcpLoadError.value = res?.error || 'MCP status unavailable'
+    }
+  } catch (e) {
+    mcpLoadError.value = e?.message || 'MCP status request failed'
+  } finally {
+    mcpLoading.value = false
+  }
+}
+
+const currentClient = computed(() => {
+  if (!mcpStatus.value) return null
+  return mcpStatus.value.clients?.[activeClient.value] || null
+})
+
+const mcpHealthClass = computed(() => {
+  if (!mcpStatus.value) return 'idle'
+  if (!mcpStatus.value.paths.mcp_script_exists) return 'fail'
+  return mcpStatus.value.neo4j.connected ? 'ok' : 'fail'
+})
+
+const mcpHealthText = computed(() => {
+  if (!mcpStatus.value) return 'Loading'
+  if (!mcpStatus.value.paths.mcp_script_exists) return 'Server file missing'
+  return mcpStatus.value.neo4j.connected ? 'Ready' : 'Neo4j down'
+})
+
+const formatJson = (obj) => JSON.stringify(obj, null, 2)
+
+const copyButtonLabel = computed(() => {
+  if (copyState.value === 'ok') return '✓ Copied'
+  if (copyState.value === 'fail') return '✗ Copy failed'
+  return 'Copy snippet'
+})
+
+const copySnippet = async () => {
+  if (!currentClient.value) return
+  const text = formatJson(currentClient.value.config)
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+    } else {
+      // Fallback for older / non-secure-context browsers.
+      const ta = document.createElement('textarea')
+      ta.value = text
+      ta.style.position = 'fixed'
+      ta.style.opacity = '0'
+      document.body.appendChild(ta)
+      ta.select()
+      const ok = document.execCommand('copy')
+      document.body.removeChild(ta)
+      if (!ok) throw new Error('execCommand copy returned false')
+    }
+    copyState.value = 'ok'
+  } catch (_) {
+    copyState.value = 'fail'
+  } finally {
+    setTimeout(() => { copyState.value = '' }, 2200)
   }
 }
 
@@ -962,4 +1151,259 @@ const saveSettings = async () => {
 }
 .save-btn:hover:not(:disabled) { background: #FF6B1A; border-color: #FF6B1A; }
 .save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── AI Integration (MCP) ── */
+.ai-section {
+  background: #F5F5F5;
+}
+
+.ai-intro {
+  font-size: 12px;
+  line-height: 1.5;
+  color: rgba(10,10,10,0.65);
+  margin-bottom: 14px;
+}
+
+.ai-loading,
+.ai-error {
+  font-size: 12px;
+  padding: 12px 14px;
+  border: 2px dashed rgba(10,10,10,0.1);
+  background: #FAFAFA;
+}
+
+.ai-error {
+  color: #FF4444;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.ai-retry {
+  background: #0A0A0A;
+  color: #FAFAFA;
+  border: none;
+  padding: 6px 12px;
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.ai-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 2px dashed rgba(10,10,10,0.1);
+  padding: 12px 14px;
+  background: #FAFAFA;
+  margin-bottom: 14px;
+}
+
+.ai-summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  font-size: 12px;
+}
+
+.ai-summary-key {
+  color: rgba(10,10,10,0.5);
+  flex-shrink: 0;
+}
+
+.ai-summary-val {
+  color: #0A0A0A;
+  font-weight: 700;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.ai-error-text {
+  color: #FF4444;
+  font-weight: 400;
+  font-size: 11px;
+}
+
+.ai-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 0;
+  border-bottom: 2px solid rgba(10,10,10,0.08);
+}
+
+.ai-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  padding: 8px 12px;
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.45);
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+}
+
+.ai-tab:hover { color: #0A0A0A; }
+
+.ai-tab.active {
+  color: #0A0A0A;
+  border-bottom-color: #FF6B1A;
+}
+
+.ai-client {
+  padding-top: 14px;
+}
+
+.ai-client-file {
+  font-size: 11px;
+  color: rgba(10,10,10,0.55);
+  margin-bottom: 8px;
+  overflow-wrap: anywhere;
+}
+
+.ai-client-file-label {
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-right: 4px;
+}
+
+.ai-client-file-path {
+  font-family: 'Space Mono', monospace;
+  color: #0A0A0A;
+  background: #FAFAFA;
+  padding: 1px 5px;
+  border: 1px solid rgba(10,10,10,0.08);
+}
+
+.ai-snippet-wrap {
+  position: relative;
+}
+
+.ai-snippet {
+  background: #0A0A0A;
+  color: #FAFAFA;
+  padding: 14px 16px;
+  margin: 0;
+  font-family: 'Space Mono', 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-x: auto;
+  white-space: pre;
+  border: 2px solid #0A0A0A;
+}
+
+.ai-snippet code {
+  font: inherit;
+  color: inherit;
+}
+
+.ai-copy-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: #FAFAFA;
+  color: #0A0A0A;
+  border: 1px solid rgba(250,250,250,0.2);
+  padding: 4px 10px;
+  font-family: 'Space Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.ai-copy-btn:hover { background: #FF6B1A; color: #FAFAFA; }
+.ai-copy-btn.ok { background: #43C165; color: #FAFAFA; }
+.ai-copy-btn.fail { background: #FF4444; color: #FAFAFA; }
+
+.ai-client-notes {
+  font-size: 11px;
+  color: rgba(10,10,10,0.55);
+  margin-top: 8px;
+  line-height: 1.5;
+}
+
+.ai-tools-toggle {
+  display: block;
+  width: 100%;
+  background: none;
+  border: 2px dashed rgba(10,10,10,0.1);
+  padding: 8px 12px;
+  margin-top: 14px;
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: rgba(10,10,10,0.55);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.1s, color 0.1s;
+}
+
+.ai-tools-toggle:hover {
+  border-color: rgba(10,10,10,0.3);
+  color: #0A0A0A;
+}
+
+.ai-tools-list {
+  list-style: none;
+  padding: 12px 14px;
+  margin: 6px 0 0 0;
+  background: #FAFAFA;
+  border: 2px dashed rgba(10,10,10,0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ai-tool {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 12px;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.ai-tool-name {
+  color: #FF6B1A;
+  font-weight: 700;
+  font-family: 'Space Mono', monospace;
+}
+
+.ai-tool-desc {
+  color: rgba(10,10,10,0.7);
+  overflow-wrap: anywhere;
+}
+
+.ai-docs-link {
+  font-size: 11px;
+  color: rgba(10,10,10,0.55);
+  margin-top: 14px;
+  text-align: right;
+}
+
+.ai-docs-link a {
+  color: #0A0A0A;
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom: 1px solid #FF6B1A;
+}
+
+.ai-docs-link a:hover { color: #FF6B1A; }
+
+@media (max-width: 480px) {
+  .ai-tool {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+}
 </style>


### PR DESCRIPTION
## What

A new **Settings → AI Integration · MCP** panel that surfaces the bundled `backend/mcp_server.py` as a click-and-paste flow for **Claude Desktop**, **Cursor**, **Windsurf**, and **Continue**. The snippet is auto-stamped with the absolute paths on the user's host (no manual editing required), and a health badge tells them whether Neo4j is reachable before they even try.

The MCP server has been the most technically sophisticated capability MiroShark ships — bi-temporal graph, Leiden clusters, 8 retrieval tools — but it was completely invisible in the UI. This PR makes it the second thing a user sees in Settings, right after the LLM config.

## Why

- The graph memory + MCP stack landed as a direct push on Apr 21 and was extended by PR #41. Neither change wired up any in-app discovery.
- `docs/MCP.md` covered Claude Desktop only — Cursor / Windsurf / Continue users had to reverse-engineer the config shape.
- Repo-actions Apr 22 flagged this as the highest-leverage discovery gap besides the public gallery (which shipped in PR #43). Positions MiroShark as MCP-native at a moment when MCP adoption is accelerating across IDEs.

## Changes

### Backend
- **\`backend/app/api/mcp.py\`** (new) — \`GET /api/mcp/status\` returns:
  - 8-tool catalog with descriptions
  - resolved absolute paths (\`backend_dir\`, \`mcp_script\`, \`python_executable\`) so snippets are copy-paste ready
  - per-client config snippets: \`claude_desktop\`, \`cursor\`, \`windsurf\`, \`continue\`, \`fallback_direct\`
  - Neo4j liveness probe (\`connected\`, \`graph_count\`, \`entity_count\`, \`error\`) — never raises, so the panel renders even when Neo4j is down
- **\`backend/app/api/__init__.py\`** — register \`mcp_bp\`
- **\`backend/app/__init__.py\`** — mount at \`/api/mcp\`

### Frontend
- **\`frontend/src/components/SettingsPanel.vue\`** — new \`AI Integration · MCP\` section:
  - health badge (\`Ready\` / \`Neo4j down\` / \`Server file missing\`)
  - summary grid (server file, tool count, Neo4j state, graph count, entity count)
  - tabbed client picker
  - dark code block + copy button (with \`execCommand\` fallback for non-secure-context browsers)
  - per-client config-file path hint
  - collapsed tool catalog (\`▸ 8 tools available\`)
  - \`Read the full MCP guide →\` link to \`docs/MCP.md\`
- **\`frontend/src/api/mcp.js\`** (new) — \`getMcpStatus()\` wrapper

### Docs
- **\`docs/MCP.md\`** — expanded from Claude-Desktop-only to cover Cursor, Windsurf, Continue + a 5-row troubleshooting matrix and a tip pointing at the new Settings panel
- **\`README.md\`** — MCP row in the docs index now mentions the in-app integration

### Tests
- **\`backend/tests/test_unit_mcp_api.py\`** — 9 offline unit tests:
  - tool-catalog drift detection (regex-scrapes \`mcp_server.py\` to compare against the API's \`_TOOLS\`)
  - payload shape contract
  - resolved paths point at real files on disk
  - every supported client snippet is present and JSON-serializable
  - all \`mcpServers\`-shaped snippets register under \`miroshark\`
  - Continue snippet uses the distinct \`experimental.modelContextProtocolServers\` shape
  - \`fallback_direct\` wires \`python_executable\` + \`mcp_script\` literally
  - defensive defaults when no Neo4j probe is supplied
  - probe pass-through is verbatim

## Try it

1. \`cd backend && uv sync\`
2. \`python run.py\`
3. Open \`http://localhost:5173/\` → **⚙ Settings** → scroll to **AI Integration · MCP**
4. Pick your client tab → **Copy snippet** → paste into the file shown → restart the editor
5. Ask the LLM: *"List my MiroShark graphs."*

The MCP server runs over stdio — no port to open, no daemon to keep alive. The MCP client launches \`mcp_server.py\` on demand and inherits the backend's \`.env\`.

---
*Built autonomously by Aeon.*