### PR TITLE
feat: OpenAPI 3.1 spec + Swagger UI at /api/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 | [Models](docs/MODELS.md) | Cheap vs Best presets, local Ollama models, benchmark findings |
 | [Architecture](docs/ARCHITECTURE.md) | Simulation engine, memory pipeline, graph retrieval |
 | [Features](docs/FEATURES.md) | Deep dive on every feature in the table above |
-| [HTTP API](docs/API.md) | Every endpoint, grouped by concern |
+| [HTTP API](docs/API.md) | Every endpoint, grouped by concern — plus interactive Swagger UI at `/api/docs` and a spec at `/api/openapi.yaml` |
 | [CLI](docs/CLI.md) | `miroshark-cli` reference |
 | [MCP](docs/MCP.md) | Claude Desktop / Cursor / Windsurf / Continue integration + report agent tools (auto-generated snippets in Settings → AI Integration) |
 | [Webhooks](docs/WEBHOOKS.md) | Completion webhook payload, headers, delivery semantics, Slack/Discord/Zapier/n8n recipes |

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -79,7 +79,7 @@ def create_app(config_class=Config):
         return response
     
     # Register blueprints
-    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, mcp_bp, share_bp
+    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, mcp_bp, docs_bp, share_bp
     app.register_blueprint(graph_bp, url_prefix='/api/graph')
     app.register_blueprint(simulation_bp, url_prefix='/api/simulation')
     app.register_blueprint(report_bp, url_prefix='/api/report')
@@ -87,6 +87,10 @@ def create_app(config_class=Config):
     app.register_blueprint(settings_bp, url_prefix='/api/settings')
     app.register_blueprint(observability_bp, url_prefix='/api/observability')
     app.register_blueprint(mcp_bp, url_prefix='/api/mcp')
+    # docs_bp serves Swagger UI + the OpenAPI spec at /api/docs,
+    # /api/openapi.yaml, /api/openapi.json (no extra sub-prefix — the spec
+    # URL is the developer-facing surface so we keep it short).
+    app.register_blueprint(docs_bp, url_prefix='/api')
     # share_bp serves the public OG-tag landing page at /share/<sim_id>
     # (no prefix — keeps the social share URL short).
     app.register_blueprint(share_bp)

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -11,6 +11,7 @@ templates_bp = Blueprint('templates', __name__)
 settings_bp = Blueprint('settings', __name__)
 observability_bp = Blueprint('observability', __name__)
 mcp_bp = Blueprint('mcp', __name__)
+docs_bp = Blueprint('docs', __name__)
 
 from . import graph  # noqa: E402, F401
 from . import simulation  # noqa: E402, F401
@@ -19,6 +20,7 @@ from . import templates  # noqa: E402, F401
 from . import settings  # noqa: E402, F401
 from . import observability  # noqa: E402, F401
 from . import mcp  # noqa: E402, F401
+from . import docs  # noqa: E402, F401
 
 # share_bp is mounted at the root (no /api prefix) so the public landing
 # URL stays clean — see api/share.py.

--- a/backend/app/api/docs.py
+++ b/backend/app/api/docs.py
@@ -1,0 +1,268 @@
+"""Interactive API documentation — Swagger UI over `backend/openapi.yaml`.
+
+The handwritten spec at ``backend/openapi.yaml`` is the source of truth.
+This module just serves it in three ways:
+
+  * ``GET /api/docs``         — Swagger UI HTML page (loads the bundle from
+                                jsDelivr; no Python deps beyond stdlib +
+                                pyyaml for the JSON variant).
+  * ``GET /api/openapi.yaml`` — raw YAML, the canonical artifact.
+  * ``GET /api/openapi.json`` — same content converted to JSON, handy for
+                                ``openapi-generator`` and APIs.guru style
+                                consumers that reach for ``.json`` first.
+
+The docs surface is an informational endpoint — it never raises and it
+never depends on Neo4j, the LLM, or any simulation state. The whole
+purpose is to give MCP-onboarded developers (PR #44) a friendly answer
+to "what REST endpoints can I hit?" without leaving the app.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from flask import Response, jsonify
+
+from . import docs_bp
+from ..utils.logger import get_logger
+
+
+logger = get_logger("miroshark.api.docs")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Spec loading — read the YAML once at import time, cache the parsed form
+# for the JSON endpoint so we don't re-parse per request. The raw YAML
+# bytes are also cached so we can serve them with a stable Content-Length.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+_SPEC_PATH: Path = Path(__file__).resolve().parent.parent.parent / "openapi.yaml"
+
+
+def _read_spec_bytes() -> bytes:
+    """Return the YAML spec as bytes.
+
+    Reads from disk every call (cheap — a few hundred KB at most) so an
+    operator editing the spec in-place picks up changes without a server
+    restart. Returns an empty placeholder if the file is missing rather
+    than 500'ing the doc page.
+    """
+    try:
+        return _SPEC_PATH.read_bytes()
+    except FileNotFoundError:
+        logger.warning("openapi.yaml not found at %s — docs endpoint will return a stub", _SPEC_PATH)
+        return (
+            b"openapi: 3.1.0\n"
+            b"info:\n"
+            b"  title: MiroShark HTTP API\n"
+            b"  version: \"unknown\"\n"
+            b"  description: openapi.yaml not found in this build.\n"
+            b"paths: {}\n"
+        )
+
+
+def _spec_as_dict() -> dict:
+    """Parse the YAML spec into a dict for the JSON endpoint.
+
+    Imports pyyaml lazily because it's listed in ``backend/uv.lock`` and
+    in the unit-test workflow but isn't a hard install requirement of
+    the running backend yet — we don't want a missing dependency to break
+    the rest of the docs surface.
+    """
+    raw = _read_spec_bytes()
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        logger.warning("PyYAML not installed — /api/openapi.json returns a placeholder")
+        return {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "MiroShark HTTP API",
+                "version": "unknown",
+                "description": "PyYAML is required to render the JSON form of this spec. "
+                               "Install with `pip install pyyaml` or fetch /api/openapi.yaml instead.",
+            },
+            "paths": {},
+        }
+
+    try:
+        parsed = yaml.safe_load(raw) or {}
+        if not isinstance(parsed, dict):
+            logger.warning("openapi.yaml did not parse as a mapping — got %s", type(parsed).__name__)
+            return {}
+        return parsed
+    except yaml.YAMLError as exc:
+        logger.error("Failed to parse openapi.yaml: %s", exc)
+        return {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "MiroShark HTTP API",
+                "version": "unknown",
+                "description": f"openapi.yaml failed to parse: {exc}. Fix the spec or fetch the YAML form.",
+            },
+            "paths": {},
+        }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Swagger UI HTML — pinned bundle from jsDelivr (immutable + CDN cached).
+# Pinning the version keeps the rendered page stable across releases of
+# Swagger UI; bump deliberately when there's a reason to.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+_SWAGGER_UI_VERSION = "5.17.14"
+
+
+def _swagger_ui_html(spec_url: str) -> str:
+    """Render the Swagger UI HTML page that points at ``spec_url``.
+
+    The page is fully static — Swagger UI fetches the spec on the client.
+    """
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MiroShark · API Reference</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@{_SWAGGER_UI_VERSION}/swagger-ui.css">
+  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=">
+  <style>
+    html, body {{ margin: 0; padding: 0; background: #0a0a0a; }}
+    /* Slim down the Swagger UI top bar so the page reads as part of MiroShark
+       rather than a generic Swagger demo. */
+    .swagger-ui .topbar {{ display: none; }}
+    .miroshark-banner {{
+      background: linear-gradient(180deg, #0a0a0a, #181818);
+      color: #fafafa;
+      padding: 18px 24px;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      border-bottom: 1px solid #262626;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+    }}
+    .miroshark-banner h1 {{
+      font-size: 14px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      margin: 0;
+      opacity: 0.7;
+      font-weight: 700;
+    }}
+    .miroshark-banner a {{
+      color: #ea580c;
+      text-decoration: none;
+      font-size: 13px;
+      margin-left: 16px;
+    }}
+    .miroshark-banner a:hover {{ text-decoration: underline; }}
+  </style>
+</head>
+<body>
+  <header class="miroshark-banner">
+    <h1>MiroShark · API Reference</h1>
+    <nav>
+      <a href="/api/openapi.yaml">openapi.yaml</a>
+      <a href="/api/openapi.json">openapi.json</a>
+      <a href="https://github.com/aaronjmars/MiroShark/blob/main/docs/API.md" target="_blank" rel="noopener">docs/API.md</a>
+      <a href="https://github.com/aaronjmars/MiroShark" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div id="swagger-ui"></div>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@{_SWAGGER_UI_VERSION}/swagger-ui-bundle.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@{_SWAGGER_UI_VERSION}/swagger-ui-standalone-preset.js"></script>
+  <script>
+    window.addEventListener("load", function () {{
+      window.ui = SwaggerUIBundle({{
+        url: {json.dumps(spec_url)},
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout",
+        tryItOutEnabled: true,
+        persistAuthorization: true,
+        docExpansion: "list",
+        defaultModelsExpandDepth: 0,
+        syntaxHighlight: {{ activate: true, theme: "agate" }},
+      }});
+    }});
+  </script>
+</body>
+</html>
+"""
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Routes
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@docs_bp.route("/docs", methods=["GET"])
+def render_swagger_ui():
+    """Render Swagger UI for the MiroShark HTTP API."""
+    body = _swagger_ui_html(spec_url="/api/openapi.yaml")
+    response = Response(body, mimetype="text/html; charset=utf-8")
+    # Short cache so tweaks to the doc page (rare) propagate quickly while
+    # absorbing repeat hits from refreshes.
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return response
+
+
+@docs_bp.route("/openapi.yaml", methods=["GET"])
+def serve_openapi_yaml():
+    """Serve the canonical OpenAPI 3.1 YAML spec.
+
+    Content-Type follows the IETF draft media type for OpenAPI YAML
+    (``application/yaml``) — both ``openapi-generator`` and Swagger UI
+    accept it, and APIs.guru-style submissions key off the URL extension
+    rather than the header.
+    """
+    body = _read_spec_bytes()
+    response = Response(body, mimetype="application/yaml; charset=utf-8")
+    response.headers["Cache-Control"] = "public, max-age=300"
+    response.headers["Content-Disposition"] = 'inline; filename="openapi.yaml"'
+    return response
+
+
+@docs_bp.route("/openapi.json", methods=["GET"])
+def serve_openapi_json():
+    """Serve the OpenAPI spec converted to JSON.
+
+    Useful for tools that prefer JSON over YAML
+    (e.g. ``openapi-generator`` with ``--input-spec=...openapi.json``).
+    """
+    spec = _spec_as_dict()
+    response = jsonify(spec)
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return response
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Test helper — exposed so the unit suite can introspect coverage without
+# spinning up Flask. Not part of the HTTP surface.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def documented_paths() -> list[str]:
+    """Return every path key declared in ``openapi.yaml``.
+
+    Used by ``test_unit_openapi`` to verify documented paths line up with
+    Flask routes registered on the live app.
+    """
+    spec = _spec_as_dict()
+    paths = spec.get("paths", {}) or {}
+    return list(paths.keys())
+
+
+def get_spec_path() -> Optional[Path]:
+    """Return the on-disk path to ``openapi.yaml`` if it exists."""
+    return _SPEC_PATH if _SPEC_PATH.exists() else None

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1114,7 +1114,7 @@ paths:
         - $ref: "#/components/parameters/SimulationIdPath"
       responses:
         "200":
-          description: PNG image with `Cache-Control: public, max-age=3600`.
+          description: "PNG image with `Cache-Control: public, max-age=3600`."
           content:
             image/png:
               schema:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,1966 @@
+openapi: 3.1.0
+info:
+  title: MiroShark HTTP API
+  version: "1.0.0"
+  summary: Universal Swarm Intelligence Engine — REST surface for simulations, graphs, reports, sharing, and observability.
+  description: |
+    The MiroShark backend is a Flask service that orchestrates large agent
+    populations through Wonderwall, builds bi-temporal knowledge graphs in
+    Neo4j, and generates reports, share cards, and embeds for every run.
+
+    This document is the canonical reference for the **HTTP** surface. The
+    bundled MCP server (`backend/mcp_server.py`) exposes a parallel set of
+    tools over stdio for Claude Desktop, Cursor, Windsurf and Continue —
+    see `GET /api/mcp/status` and `docs/MCP.md` for that path.
+
+    All responses are JSON unless explicitly marked otherwise (PNG share
+    cards, file downloads, SSE streams). Successful responses follow the
+    `{"success": true, "data": ...}` envelope used throughout the codebase;
+    errors return `{"success": false, "error": "..."}` with an appropriate
+    HTTP status.
+
+    Endpoints are public on a default install — there is no auth layer in
+    the bundled distribution. Operators are expected to bind the backend
+    to a private interface or front it with a reverse proxy when deploying
+    to production.
+
+    Discovery endpoints with light cost protection (suggest-scenarios,
+    trending, ask) enforce sliding-window rate limits on the calling IP.
+
+  contact:
+    name: MiroShark on GitHub
+    url: https://github.com/aaronjmars/MiroShark
+  license:
+    name: AGPL-3.0
+    url: https://github.com/aaronjmars/MiroShark/blob/main/LICENSE
+
+servers:
+  - url: http://localhost:5001
+    description: Local dev — `./miroshark` launcher default
+  - url: "{scheme}://{host}"
+    description: Custom deployment
+    variables:
+      scheme:
+        default: https
+        enum: [http, https]
+      host:
+        default: miroshark.example.com
+
+tags:
+  - name: Setup & Discovery
+    description: Pre-simulation onboarding — scenario suggestions, trending feeds, "Just Ask" briefings, preset templates.
+  - name: Graph Build
+    description: Step 1 of a run — ontology extraction and Neo4j graph construction from a seed document.
+  - name: Simulation Lifecycle
+    description: Create, prepare, start, stop, fork, branch and director-mode injection.
+  - name: Live State
+    description: Real-time polling endpoints used by the simulation view (rounds, actions, posts, profiles).
+  - name: Analytics
+    description: Belief drift, counterfactuals, influence, interaction networks, demographics, quality.
+  - name: Interaction
+    description: One-on-one or batched chat with simulated agents, including full reasoning traces.
+  - name: Publish & Embed
+    description: Toggle public visibility, embed payload, share card PNG, public landing page, gallery.
+  - name: Export
+    description: JSON/CSV download of an entire simulation.
+  - name: Report Agent
+    description: ReACT-style report generation with chat, console log, and PDF download.
+  - name: Observability
+    description: Event stream, paginated event log, LLM call history, aggregate stats.
+  - name: Settings & Push
+    description: Runtime LLM/Neo4j configuration plus Web Push subscription.
+  - name: Integrations
+    description: MCP server status surface for AI IDE clients.
+  - name: Documentation
+    description: This OpenAPI spec and Swagger UI.
+
+paths:
+
+  # ────────────────────────────────────────────────────────────────────
+  # Setup & Discovery
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/simulation/suggest-scenarios:
+    post:
+      tags: [Setup & Discovery]
+      summary: Generate Bull/Bear/Neutral scenarios from a document preview.
+      description: |
+        Takes the first ~2000 chars of a document and returns up to three
+        prediction-market-style simulation scenarios so users don't face
+        a blank-page setup. Results are SHA-256 keyed and LRU-cached.
+        On LLM failure returns `200` with `suggestions: []` and a `reason`
+        code so the panel hides silently.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text_preview:
+                  type: string
+                  description: Document text preview — first ~2000 characters is enough.
+                simulation_prompt:
+                  type: string
+                  description: Optional user-provided framing/prompt — biases the suggestions.
+                no_cache:
+                  type: boolean
+                  default: false
+                  description: Bypass the in-memory LRU cache and force a fresh LLM call.
+              required: [text_preview]
+            example:
+              text_preview: "The European Central Bank meets next month to consider a 25bp rate cut..."
+              simulation_prompt: "What will happen to EUR/USD?"
+      responses:
+        "200":
+          description: Suggestion list (possibly empty).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuggestionsEnvelope"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "429":
+          description: Rate limited — try again shortly.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuggestionsEnvelope"
+
+  /api/simulation/trending:
+    get:
+      tags: [Setup & Discovery]
+      summary: Recent items from configured RSS/Atom feeds.
+      description: |
+        Stdlib RSS/Atom parser running over up to 12 feeds in parallel.
+        Defaults to `Reuters tech / The Verge / Hacker News / CoinDesk`;
+        override with the `TRENDING_FEEDS` environment variable or the
+        `feeds` query param. Never 5xx's — empty `items` plus a `reason`
+        string surfaces failures non-fatally.
+      parameters:
+        - in: query
+          name: feeds
+          schema: { type: string }
+          description: Comma-separated URL list overriding `TRENDING_FEEDS`.
+        - in: query
+          name: refresh
+          schema: { type: string, enum: ["1", "true", "yes"] }
+          description: Bypass the in-memory cache.
+      responses:
+        "200":
+          description: Trending items.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrendingEnvelope"
+        "429":
+          description: Rate limited.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrendingEnvelope"
+
+  /api/simulation/ask:
+    post:
+      tags: [Setup & Discovery]
+      summary: Just-Ask — synthesize a seed briefing from a question.
+      description: Type a question with no document and the LLM researches/writes the seed briefing for the simulation engine.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [question]
+              properties:
+                question:
+                  type: string
+      responses:
+        "200":
+          description: Briefing payload.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "429": { $ref: "#/components/responses/RateLimited" }
+
+  /api/graph/fetch-url:
+    post:
+      tags: [Setup & Discovery]
+      summary: Fetch and extract readable text from a URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url]
+              properties:
+                url: { type: string, format: uri }
+      responses:
+        "200":
+          description: Extracted text.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+
+  /api/templates/list:
+    get:
+      tags: [Setup & Discovery]
+      summary: List preset simulation templates.
+      responses:
+        "200":
+          description: Available templates.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/templates/capabilities:
+    get:
+      tags: [Setup & Discovery]
+      summary: Backend feature flags governing template behaviour.
+      description: |
+        Lets the frontend gray out toggles like "Live oracle data" or
+        "Per-agent MCP tools" when the corresponding server-side env
+        flag is off — cleaner than surprising the user with a silent
+        no-op on a feature they enabled in the UI.
+      responses:
+        "200":
+          description: Capability flags.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          oracle_seed_enabled: { type: boolean }
+                          mcp_agent_tools_enabled: { type: boolean }
+
+  /api/templates/{template_id}:
+    get:
+      tags: [Setup & Discovery]
+      summary: Single template optionally enriched with live FeedOracle context.
+      parameters:
+        - in: path
+          name: template_id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: enrich
+          schema: { type: boolean }
+          description: When true, attach live FeedOracle MCP enrichment.
+      responses:
+        "200":
+          description: Template document.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Graph Build
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/graph/ontology/generate:
+    post:
+      tags: [Graph Build]
+      summary: NER + ontology extraction from raw text.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [text]
+              properties:
+                text: { type: string }
+                project_id: { type: string }
+      responses:
+        "200":
+          description: Async task accepted.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskEnvelope" }
+
+  /api/graph/build:
+    post:
+      tags: [Graph Build]
+      summary: Build a Neo4j graph from a generated ontology.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ontology, project_id]
+              properties:
+                ontology: { type: object }
+                project_id: { type: string }
+      responses:
+        "200":
+          description: Async task accepted.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskEnvelope" }
+
+  /api/graph/task/{task_id}:
+    get:
+      tags: [Graph Build]
+      summary: Poll an async graph-build task.
+      parameters:
+        - in: path
+          name: task_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Task status.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskEnvelope" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/graph/data/{graph_id}:
+    get:
+      tags: [Graph Build]
+      summary: Paginated graph nodes + edges for visualization.
+      parameters:
+        - in: path
+          name: graph_id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, default: 100 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: Page of graph data.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/entities/{graph_id}:
+    get:
+      tags: [Graph Build]
+      summary: Browse entities discovered in a graph.
+      parameters:
+        - in: path
+          name: graph_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Entity list.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/entities/{graph_id}/{entity_uuid}:
+    get:
+      tags: [Graph Build]
+      summary: Single entity plus its 1-hop neighborhood.
+      parameters:
+        - in: path
+          name: graph_id
+          required: true
+          schema: { type: string }
+        - in: path
+          name: entity_uuid
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Entity detail.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/simulation/entities/{graph_id}/by-type/{entity_type}:
+    get:
+      tags: [Graph Build]
+      summary: Filter graph entities by type (Person, Organization, Concept …).
+      parameters:
+        - in: path
+          name: graph_id
+          required: true
+          schema: { type: string }
+        - in: path
+          name: entity_type
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Entities of the requested type.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/graph/project/{project_id}:
+    get:
+      tags: [Graph Build]
+      summary: Look up a project by id (graph + simulation linkage).
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Project record.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Simulation Lifecycle
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/simulation/create:
+    post:
+      tags: [Simulation Lifecycle]
+      summary: Create a simulation from a seed graph + scenario prompt.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [project_id, simulation_requirement]
+              properties:
+                project_id: { type: string }
+                simulation_requirement:
+                  type: string
+                  description: The scenario question — Bull/Bear/Neutral framing recommended.
+      responses:
+        "200":
+          description: Created.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SimulationEnvelope" }
+
+  /api/simulation/prepare:
+    post:
+      tags: [Simulation Lifecycle]
+      summary: Kick off profile generation (Step 2).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SimulationIdBody" }
+      responses:
+        "200":
+          description: Preparation started.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/prepare/status:
+    post:
+      tags: [Simulation Lifecycle]
+      summary: Poll the profile-generation step.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SimulationIdBody" }
+      responses:
+        "200":
+          description: Current preparation status.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/start:
+    post:
+      tags: [Simulation Lifecycle]
+      summary: Launch the Wonderwall simulation subprocess (Step 3).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/SimulationIdBody"
+                - type: object
+                  properties:
+                    platform:
+                      type: string
+                      enum: [twitter, reddit, parallel]
+                      default: parallel
+                    max_rounds:
+                      type: integer
+                      description: Optional cap to truncate overly long simulations.
+                    enable_graph_memory_update:
+                      type: boolean
+                      default: false
+                    force:
+                      type: boolean
+                      default: false
+                      description: Stop a running run and clean logs before relaunching.
+                    resume:
+                      type: boolean
+                      default: false
+                      description: Resume from the last completed round if a run_state exists.
+      responses:
+        "200":
+          description: Subprocess started.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          simulation_id: { type: string }
+                          runner_status: { type: string, enum: [idle, preparing, running, paused, completed, failed] }
+                          process_pid: { type: integer }
+                          twitter_running: { type: boolean }
+                          reddit_running: { type: boolean }
+                          started_at: { type: string, format: date-time }
+                          graph_memory_update_enabled: { type: boolean }
+                          force_restarted: { type: boolean }
+
+  /api/simulation/stop:
+    post:
+      tags: [Simulation Lifecycle]
+      summary: Terminate a running simulation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SimulationIdBody" }
+      responses:
+        "200":
+          description: Stopped (or already idle).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/branch-counterfactual:
+    post:
+      tags: [Simulation Lifecycle]
+      summary: Fork a simulation with a counterfactual director-event injection.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [simulation_id, branch_round, event]
+              properties:
+                simulation_id: { type: string }
+                branch_round: { type: integer, minimum: 0 }
+                event:
+                  type: object
+                  description: Director event payload — see /director/inject.
+      responses:
+        "200":
+          description: New branched simulation.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SimulationEnvelope" }
+
+  /api/simulation/fork:
+    post:
+      tags: [Simulation Lifecycle]
+      summary: Duplicate an existing simulation's config so a new run can be launched.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SimulationIdBody" }
+      responses:
+        "200":
+          description: New simulation row.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SimulationEnvelope" }
+
+  /api/simulation/{simulation_id}/director/inject:
+    post:
+      tags: [Simulation Lifecycle]
+      summary: Director Mode — inject a breaking-news event into the live timeline.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/DirectorEvent" }
+      responses:
+        "200":
+          description: Event accepted.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/director/events:
+    get:
+      tags: [Simulation Lifecycle]
+      summary: List director events injected into a simulation.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Event list.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Live State
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/simulation/{simulation_id}:
+    get:
+      tags: [Live State]
+      summary: Static simulation record (config, status, profile count).
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Simulation record.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SimulationEnvelope" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/simulation/list:
+    get:
+      tags: [Live State]
+      summary: List every simulation on this instance.
+      responses:
+        "200":
+          description: Simulation list.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/history:
+    get:
+      tags: [Live State]
+      summary: Per-simulation history with diff between rounds.
+      parameters:
+        - in: query
+          name: simulation_id
+          schema: { type: string }
+      responses:
+        "200":
+          description: History records.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/run-status:
+    get:
+      tags: [Live State]
+      summary: Current round, totals, runner status.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Run status.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data: { $ref: "#/components/schemas/RunStatus" }
+
+  /api/simulation/{simulation_id}/run-status/detail:
+    get:
+      tags: [Live State]
+      summary: Run status with the full per-platform action log.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+        - in: query
+          name: platform
+          schema: { type: string, enum: [twitter, reddit] }
+      responses:
+        "200":
+          description: Detailed run status.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/frame/{round_num}:
+    get:
+      tags: [Live State]
+      summary: Compact per-round snapshot for replay scrubbing.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+        - in: path
+          name: round_num
+          required: true
+          schema: { type: integer, minimum: 0 }
+      responses:
+        "200":
+          description: Frame.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/timeline:
+    get:
+      tags: [Live State]
+      summary: Round-by-round summary across the whole run.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Timeline.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/actions:
+    get:
+      tags: [Live State]
+      summary: Raw agent action log.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Action records.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/posts:
+    get:
+      tags: [Live State]
+      summary: Paginated posts (Twitter + Reddit) generated during the run.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+        - in: query
+          name: limit
+          schema: { type: integer, default: 50 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+        - in: query
+          name: platform
+          schema: { type: string, enum: [twitter, reddit] }
+      responses:
+        "200":
+          description: Posts page.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/profiles:
+    get:
+      tags: [Live State]
+      summary: Generated agent personas.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Profiles.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/profiles/realtime:
+    get:
+      tags: [Live State]
+      summary: Live agent belief snapshots, updated each round.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Realtime profiles.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/polymarket/markets:
+    get:
+      tags: [Live State]
+      summary: Polymarket-style markets and current prices for this simulation.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Markets.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/polymarket/market/{market_id}/prices:
+    get:
+      tags: [Live State]
+      summary: Price history for a single market within this simulation.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+        - in: path
+          name: market_id
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: Price history.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Analytics
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/simulation/{simulation_id}/belief-drift:
+    get:
+      tags: [Analytics]
+      summary: Per-round belief distribution + first consensus round.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Belief drift series.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data: { $ref: "#/components/schemas/BeliefDrift" }
+
+  /api/simulation/{simulation_id}/counterfactual:
+    get:
+      tags: [Analytics]
+      summary: Recompute belief drift with selected agents removed (no re-sim).
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+        - in: query
+          name: exclude_agents
+          schema: { type: string }
+          description: Comma-separated list of agent IDs to remove.
+      responses:
+        "200":
+          description: Counterfactual drift.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/agent-stats:
+    get:
+      tags: [Analytics]
+      summary: Per-agent engagement and posting counts.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Agent stats.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/influence:
+    get:
+      tags: [Analytics]
+      summary: Top-20 influence leaderboard.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Leaderboard.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/interaction-network:
+    get:
+      tags: [Analytics]
+      summary: Force-directed agent-to-agent interaction graph + echo-chamber metrics.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Network graph.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/demographics:
+    get:
+      tags: [Analytics]
+      summary: Archetype clustering — analyst / influencer / retail / observer …
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Demographics breakdown.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/quality:
+    get:
+      tags: [Analytics]
+      summary: Run health score — engagement, coherence, diversity, variance.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Quality diagnostics.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/compare:
+    get:
+      tags: [Analytics]
+      summary: Side-by-side belief comparison across simulations.
+      parameters:
+        - in: query
+          name: simulation_ids
+          required: true
+          schema: { type: string }
+          description: Comma-separated simulation IDs.
+      responses:
+        "200":
+          description: Comparison payload.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Interaction
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/simulation/interview:
+    post:
+      tags: [Interaction]
+      summary: Chat with a single agent.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [simulation_id, agent_name, prompt]
+              properties:
+                simulation_id: { type: string }
+                agent_name: { type: string }
+                prompt: { type: string }
+      responses:
+        "200":
+          description: Agent reply.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/interview/batch:
+    post:
+      tags: [Interaction]
+      summary: Ask a group of agents the same question in parallel.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [simulation_id, agent_names, prompt]
+              properties:
+                simulation_id: { type: string }
+                agent_names:
+                  type: array
+                  items: { type: string }
+                prompt: { type: string }
+      responses:
+        "200":
+          description: Per-agent replies.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/interview/history:
+    post:
+      tags: [Interaction]
+      summary: Read prior interview transcripts for a simulation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [simulation_id]
+              properties:
+                simulation_id: { type: string }
+                platform: { type: string, enum: [twitter, reddit] }
+                agent_id:
+                  type: integer
+                  description: Restrict to a single agent.
+                limit: { type: integer, default: 100 }
+      responses:
+        "200":
+          description: History records.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/agents/{agent_name}/trace-interview:
+    post:
+      tags: [Interaction]
+      summary: Chat with full reasoning trace surfaced.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+        - in: path
+          name: agent_name
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [prompt]
+              properties:
+                prompt: { type: string }
+      responses:
+        "200":
+          description: Reply + trace.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/interviews/{agent_name}:
+    get:
+      tags: [Interaction]
+      summary: Past interview transcripts with one agent.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+        - in: path
+          name: agent_name
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Transcripts.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Publish & Embed
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/simulation/{simulation_id}/publish:
+    post:
+      tags: [Publish & Embed]
+      summary: Toggle a simulation's `is_public` flag.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                public:
+                  type: boolean
+                  default: true
+      responses:
+        "200":
+          description: New public state.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/simulation/{simulation_id}/embed-summary:
+    get:
+      tags: [Publish & Embed]
+      summary: Compact summary for the embed widget — public sims only.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Summary payload.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data: { $ref: "#/components/schemas/EmbedSummary" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/simulation/{simulation_id}/share-card.png:
+    get:
+      tags: [Publish & Embed]
+      summary: 1200×630 social share card (Open Graph image).
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: PNG image with `Cache-Control: public, max-age=3600`.
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /share/{simulation_id}:
+    get:
+      tags: [Publish & Embed]
+      summary: Public landing page with Open Graph + Twitter card meta tags.
+      description: |
+        Mounted at the **root** (no `/api` prefix) so the URL stays clean.
+        Returns a tiny HTML page that bots scrape for OG tags and that
+        browsers immediately bounce off via `<meta refresh>` + JS to the
+        SPA. Honors `X-Forwarded-Proto` / `X-Forwarded-Host`.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: HTML page.
+          content:
+            text/html:
+              schema: { type: string }
+        "400": { $ref: "#/components/responses/BadRequest" }
+
+  /api/simulation/public:
+    get:
+      tags: [Publish & Embed]
+      summary: Paginated gallery feed of public simulations.
+      parameters:
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 100, default: 50 }
+        - in: query
+          name: offset
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        "200":
+          description: Gallery cards.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items: { $ref: "#/components/schemas/GalleryCard" }
+                      count: { type: integer }
+                      total: { type: integer }
+                      limit: { type: integer }
+                      offset: { type: integer }
+                      has_more: { type: boolean }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Export
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/simulation/{simulation_id}/export:
+    get:
+      tags: [Export]
+      summary: Download a full simulation as JSON or CSV.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+        - in: query
+          name: format
+          schema: { type: string, enum: [json, csv], default: json }
+        - in: query
+          name: include
+          schema: { type: string, default: "actions,posts,timeline,agent_stats,metadata" }
+          description: Comma-separated section list.
+      responses:
+        "200":
+          description: File download.
+          content:
+            application/json:
+              schema: { type: object }
+            text/csv:
+              schema: { type: string }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/simulation/{simulation_id}/article:
+    post:
+      tags: [Publish & Embed]
+      summary: Generate a Substack-style write-up for a finished run.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Article markdown.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/resolve:
+    post:
+      tags: [Publish & Embed]
+      summary: Mark a simulation as resolved against an actual outcome.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [actual_outcome]
+              properties:
+                actual_outcome:
+                  type: string
+                  enum: [YES, NO, PARTIAL, INDETERMINATE]
+      responses:
+        "200":
+          description: Resolution recorded.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Report Agent
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/report/generate:
+    post:
+      tags: [Report Agent]
+      summary: Launch the ReACT report agent for a simulation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SimulationIdBody" }
+      responses:
+        "200":
+          description: Report generation started.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/report/generate/status:
+    post:
+      tags: [Report Agent]
+      summary: Poll a running report-generation job.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [report_id]
+              properties:
+                report_id: { type: string }
+      responses:
+        "200":
+          description: Status payload.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/report/{report_id}:
+    get:
+      tags: [Report Agent]
+      summary: Full report by id.
+      parameters:
+        - in: path
+          name: report_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Report.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/report/by-simulation/{simulation_id}:
+    get:
+      tags: [Report Agent]
+      summary: Latest report for a given simulation.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Report.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/report/{report_id}/download:
+    get:
+      tags: [Report Agent]
+      summary: Download report as PDF.
+      parameters:
+        - in: path
+          name: report_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: PDF binary.
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+
+  /api/report/chat:
+    post:
+      tags: [Report Agent]
+      summary: Chat with the report agent — re-queries the underlying graph.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [report_id, question]
+              properties:
+                report_id: { type: string }
+                question: { type: string }
+      responses:
+        "200":
+          description: Reply.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/report/{report_id}/agent-log:
+    get:
+      tags: [Report Agent]
+      summary: Full ReACT agent trace for a report.
+      parameters:
+        - in: path
+          name: report_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Trace records.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/report/{report_id}/agent-log/stream:
+    get:
+      tags: [Report Agent]
+      summary: SSE stream of ReACT agent steps as they happen.
+      parameters:
+        - in: path
+          name: report_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Server-Sent Events stream.
+          content:
+            text/event-stream:
+              schema: { type: string }
+
+  /api/report/{report_id}/console-log:
+    get:
+      tags: [Report Agent]
+      summary: Raw LLM call logs for a report.
+      parameters:
+        - in: path
+          name: report_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Console log lines.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/report/{report_id}/console-log/stream:
+    get:
+      tags: [Report Agent]
+      summary: SSE stream of raw LLM console-log lines.
+      parameters:
+        - in: path
+          name: report_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Server-Sent Events stream.
+          content:
+            text/event-stream:
+              schema: { type: string }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Observability
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/observability/events/stream:
+    get:
+      tags: [Observability]
+      summary: Live SSE feed of system events.
+      responses:
+        "200":
+          description: Server-Sent Events stream.
+          content:
+            text/event-stream:
+              schema: { type: string }
+
+  /api/observability/events:
+    get:
+      tags: [Observability]
+      summary: Paginated event log.
+      parameters:
+        - in: query
+          name: limit
+          schema: { type: integer, default: 100 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: Events.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/observability/stats:
+    get:
+      tags: [Observability]
+      summary: Aggregate observability counters.
+      responses:
+        "200":
+          description: Counters.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/observability/llm-calls:
+    get:
+      tags: [Observability]
+      summary: LLM call history (latency, model, prompt cost when available).
+      parameters:
+        - in: query
+          name: limit
+          schema: { type: integer, default: 50 }
+      responses:
+        "200":
+          description: Call records.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Settings & Push
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/settings:
+    get:
+      tags: [Settings & Push]
+      summary: Read the active runtime config (API keys masked).
+      responses:
+        "200":
+          description: Config snapshot.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+    post:
+      tags: [Settings & Push]
+      summary: Update runtime config — no restart required.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SettingsUpdate" }
+      responses:
+        "200":
+          description: Updated snapshot.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+
+  /api/settings/test-llm:
+    post:
+      tags: [Settings & Push]
+      summary: Make a minimal test call against the configured LLM.
+      responses:
+        "200":
+          description: Latency + sample response (or error).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/push/vapid-public-key:
+    get:
+      tags: [Settings & Push]
+      summary: Return the VAPID public key for browser Web Push.
+      responses:
+        "200":
+          description: Public key.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/push/subscribe:
+    post:
+      tags: [Settings & Push]
+      summary: Register a Web Push subscription.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/PushSubscription" }
+      responses:
+        "200":
+          description: Subscription stored.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/push/test:
+    post:
+      tags: [Settings & Push]
+      summary: Fire a test push notification at the registered subscription.
+      responses:
+        "200":
+          description: Test dispatched.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Integrations
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/mcp/status:
+    get:
+      tags: [Integrations]
+      summary: MCP server status, tool catalog, per-client config snippets.
+      description: |
+        Used by the Settings → AI Integration panel to render copy-paste
+        config blocks for Claude Desktop, Cursor, Windsurf and Continue —
+        plus a Neo4j liveness probe so the operator can see at a glance
+        whether the graph store is reachable. The MCP server itself runs
+        over stdio and is launched by the user's IDE; this endpoint never
+        spawns or talks to it directly.
+      responses:
+        "200":
+          description: Status payload.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data: { $ref: "#/components/schemas/McpStatus" }
+
+  # ────────────────────────────────────────────────────────────────────
+  # Documentation
+  # ────────────────────────────────────────────────────────────────────
+
+  /api/docs:
+    get:
+      tags: [Documentation]
+      summary: Swagger UI rendering of this OpenAPI spec.
+      responses:
+        "200":
+          description: Swagger UI HTML.
+          content:
+            text/html:
+              schema: { type: string }
+
+  /api/openapi.yaml:
+    get:
+      tags: [Documentation]
+      summary: This OpenAPI 3.1 spec, in YAML.
+      responses:
+        "200":
+          description: YAML document.
+          content:
+            application/yaml:
+              schema: { type: string }
+
+  /api/openapi.json:
+    get:
+      tags: [Documentation]
+      summary: This OpenAPI 3.1 spec, in JSON.
+      responses:
+        "200":
+          description: JSON document.
+          content:
+            application/json:
+              schema: { type: object }
+
+  /health:
+    get:
+      tags: [Documentation]
+      summary: Liveness probe.
+      responses:
+        "200":
+          description: OK.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: MiroShark Backend }
+
+components:
+
+  parameters:
+    SimulationIdPath:
+      in: path
+      name: simulation_id
+      required: true
+      schema: { type: string, pattern: "^sim_[A-Za-z0-9]+$" }
+      description: Opaque simulation identifier — `sim_xxxx`.
+      example: sim_8a3c2f1e
+
+  responses:
+    BadRequest:
+      description: Malformed request body or query.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+    NotFound:
+      description: Resource does not exist.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+    Forbidden:
+      description: Resource is not public — toggle via `/publish`.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+    RateLimited:
+      description: Sliding-window rate limit exceeded.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+
+  schemas:
+
+    SuccessEnvelope:
+      type: object
+      required: [success]
+      properties:
+        success: { type: boolean, enum: [true] }
+        data: {}
+
+    ErrorEnvelope:
+      type: object
+      required: [success, error]
+      properties:
+        success: { type: boolean, enum: [false] }
+        error: { type: string }
+
+    SimulationIdBody:
+      type: object
+      required: [simulation_id]
+      properties:
+        simulation_id: { type: string }
+
+    SimulationEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                simulation_id: { type: string }
+                project_id: { type: string }
+                status:
+                  type: string
+                  enum: [created, prepared, running, completed, failed, paused]
+                profiles_count: { type: integer }
+                is_public: { type: boolean }
+                parent_simulation_id:
+                  oneOf: [{ type: string }, { type: "null" }]
+                created_at: { type: string, format: date-time }
+
+    SuggestionsEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                suggestions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      question: { type: string }
+                      label: { type: string, enum: [Bull, Bear, Neutral] }
+                      expected_yes_range:
+                        type: array
+                        items: { type: number }
+                        minItems: 2
+                        maxItems: 2
+                      rationale: { type: string }
+                cached: { type: boolean }
+                model: { type: string }
+                reason:
+                  type: string
+                  description: Set when `suggestions` is empty (e.g. `rate_limited`, `llm_unavailable`, `preview_too_short`).
+
+    TrendingEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      title: { type: string }
+                      url: { type: string, format: uri }
+                      source_name: { type: string }
+                      published_at: { type: string, format: date-time }
+                feeds_used:
+                  type: array
+                  items: { type: string, format: uri }
+                cached: { type: boolean }
+                fetched_at: { type: string, format: date-time }
+                reason:
+                  type: string
+                  description: Failure reason when items is empty.
+
+    TaskEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/SuccessEnvelope"
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                task_id: { type: string }
+                status:
+                  type: string
+                  enum: [pending, running, completed, failed]
+                progress: { type: number }
+                result: {}
+
+    DirectorEvent:
+      type: object
+      required: [headline]
+      properties:
+        headline: { type: string }
+        body: { type: string }
+        round: { type: integer, minimum: 0 }
+        platform: { type: string, enum: [twitter, reddit, both] }
+
+    RunStatus:
+      type: object
+      properties:
+        simulation_id: { type: string }
+        runner_status:
+          type: string
+          enum: [idle, preparing, running, paused, completed, failed]
+        current_round: { type: integer }
+        total_rounds: { type: integer }
+        progress_percent: { type: number }
+        simulated_hours: { type: integer }
+        total_simulation_hours: { type: integer }
+        twitter_running: { type: boolean }
+        reddit_running: { type: boolean }
+        twitter_actions_count: { type: integer }
+        reddit_actions_count: { type: integer }
+        total_actions_count: { type: integer }
+        started_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    BeliefDrift:
+      type: object
+      properties:
+        rounds:
+          type: array
+          items: { type: integer }
+        bullish:
+          type: array
+          items: { type: number }
+        neutral:
+          type: array
+          items: { type: number }
+        bearish:
+          type: array
+          items: { type: number }
+        final:
+          type: object
+          properties:
+            bullish: { type: number }
+            neutral: { type: number }
+            bearish: { type: number }
+        consensus_round:
+          oneOf: [{ type: integer }, { type: "null" }]
+        consensus_stance:
+          oneOf: [{ type: string, enum: [bullish, bearish] }, { type: "null" }]
+
+    EmbedSummary:
+      type: object
+      properties:
+        simulation_id: { type: string }
+        scenario: { type: string }
+        status: { type: string }
+        runner_status: { type: string }
+        current_round: { type: integer }
+        total_rounds: { type: integer }
+        profiles_count: { type: integer }
+        created_date: { type: string, format: date }
+        parent_simulation_id:
+          oneOf: [{ type: string }, { type: "null" }]
+        is_public: { type: boolean }
+        belief: { $ref: "#/components/schemas/BeliefDrift" }
+        quality:
+          type: object
+          properties:
+            health: { type: string }
+            participation_rate: { type: number }
+        resolution:
+          type: object
+          properties:
+            actual_outcome: { type: string }
+            predicted_consensus: { type: string }
+            accuracy_score: { type: number }
+
+    GalleryCard:
+      type: object
+      properties:
+        simulation_id: { type: string }
+        scenario: { type: string }
+        status: { type: string }
+        runner_status: { type: string }
+        current_round: { type: integer }
+        total_rounds: { type: integer }
+        agent_count: { type: integer }
+        quality_health: { type: string, enum: [Excellent, Good, Fair, Poor, Unknown] }
+        final_consensus:
+          type: object
+          properties:
+            bullish: { type: number }
+            neutral: { type: number }
+            bearish: { type: number }
+        resolution_outcome:
+          oneOf: [{ type: string }, { type: "null" }]
+        created_at: { type: string, format: date-time }
+        parent_simulation_id:
+          oneOf: [{ type: string }, { type: "null" }]
+        share_card_url: { type: string }
+        share_landing_url: { type: string }
+
+    SettingsUpdate:
+      type: object
+      properties:
+        preset:
+          type: string
+          enum: [cheap, best, local]
+        preset_api_key: { type: string }
+        llm:
+          type: object
+          properties:
+            provider: { type: string }
+            base_url: { type: string }
+            model_name: { type: string }
+            api_key: { type: string }
+        smart:
+          type: object
+          properties:
+            provider: { type: string }
+            base_url: { type: string }
+            model_name: { type: string }
+            api_key: { type: string }
+        ner:
+          type: object
+          properties:
+            base_url: { type: string }
+            model_name: { type: string }
+            api_key: { type: string }
+        wonderwall:
+          type: object
+          properties:
+            model_name: { type: string }
+        embedding:
+          type: object
+          properties:
+            provider: { type: string }
+            base_url: { type: string }
+            model_name: { type: string }
+            api_key: { type: string }
+            dimensions: { type: integer }
+        web_search_model: { type: string }
+        neo4j:
+          type: object
+          properties:
+            uri: { type: string }
+            user: { type: string }
+            password: { type: string }
+
+    PushSubscription:
+      type: object
+      required: [endpoint, keys]
+      properties:
+        endpoint: { type: string, format: uri }
+        keys:
+          type: object
+          properties:
+            p256dh: { type: string }
+            auth: { type: string }
+
+    McpStatus:
+      type: object
+      properties:
+        enabled: { type: boolean }
+        transport: { type: string, enum: [stdio] }
+        paths:
+          type: object
+          properties:
+            backend_dir: { type: string }
+            mcp_script: { type: string }
+            python_executable: { type: string }
+        tools:
+          type: array
+          items:
+            type: object
+            properties:
+              name: { type: string }
+              description: { type: string }
+        tool_count: { type: integer }
+        clients:
+          type: object
+          additionalProperties:
+            type: object
+        neo4j:
+          type: object
+          properties:
+            reachable: { type: boolean }
+            graph_count: { type: integer }
+            entity_count: { type: integer }
+            error:
+              oneOf: [{ type: string }, { type: "null" }]
+        docs_url: { type: string, format: uri }

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1508,6 +1508,42 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/SuccessEnvelope" }
 
+  /api/settings/test-webhook:
+    post:
+      tags: [Integrations]
+      summary: Fire a sample completion event at the configured webhook URL.
+      description: |
+        Synchronous test POST used by the Settings *Send test event* button.
+        Always returns HTTP 200 so the frontend can render success / failure
+        body uniformly. Pass `url` and optional `public_base_url` to test an
+        unsaved value; omit to test the currently saved webhook URL.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url: { type: string, format: uri }
+                public_base_url: { type: string, format: uri }
+      responses:
+        "200":
+          description: Delivery outcome with latency and masked URL.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          success: { type: boolean }
+                          message: { type: string }
+                          latency_ms: { type: integer }
+                          url_masked: { type: string }
+
   /api/simulation/push/vapid-public-key:
     get:
       tags: [Settings & Push]

--- a/backend/tests/test_unit_openapi.py
+++ b/backend/tests/test_unit_openapi.py
@@ -1,0 +1,321 @@
+"""Unit tests for the interactive API documentation surface.
+
+Same shape as ``test_unit_mcp_api.py``: pure offline checks against the
+helpers in ``app/api/docs.py`` plus regex-based drift detection between
+the handwritten OpenAPI spec and the actual Flask routes registered in
+``app/api/*.py``.
+
+A drifted spec is the worst failure mode here — it advertises endpoints
+that no longer exist, or fails to mention ones that do — so the drift
+test is the centerpiece of this suite.
+
+We cover:
+
+  1. ``backend/openapi.yaml`` exists, parses, and declares the minimum
+     OpenAPI 3.x shape (``openapi``, ``info``, ``paths``).
+  2. Every documented path corresponds to a real Flask route. The route
+     scan reads ``app/api/*.py`` as text — no live Flask app, no Neo4j —
+     so the test runs in the bare unit environment.
+  3. Every Flask route either appears in the spec or is on the
+     deliberately undocumented allow-list (e.g. internal / debug routes).
+  4. The Swagger UI HTML renders, references the spec URL, and pulls
+     ``swagger-ui-dist`` from a pinned CDN.
+  5. The JSON variant of the spec parses and has the same top-level
+     shape as the YAML.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Spec presence + parse
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _load_spec() -> dict:
+    """Load openapi.yaml as a dict — pyyaml is in the unit-test workflow."""
+    import yaml  # type: ignore[import-untyped]
+
+    spec_path = _BACKEND / "openapi.yaml"
+    assert spec_path.exists(), f"openapi.yaml missing at {spec_path}"
+    with spec_path.open("r", encoding="utf-8") as f:
+        spec = yaml.safe_load(f)
+    assert isinstance(spec, dict), f"openapi.yaml did not parse as a mapping (got {type(spec).__name__})"
+    return spec
+
+
+def test_openapi_yaml_exists_and_parses():
+    spec = _load_spec()
+    # The bare minimum OpenAPI 3.x shape.
+    assert "openapi" in spec, "spec missing top-level `openapi` version field"
+    assert spec["openapi"].startswith("3."), f"unexpected openapi version: {spec['openapi']}"
+    assert "info" in spec and isinstance(spec["info"], dict), "spec missing `info` block"
+    assert spec["info"].get("title"), "spec `info.title` is empty"
+    assert spec["info"].get("version"), "spec `info.version` is empty"
+    assert "paths" in spec and isinstance(spec["paths"], dict), "spec missing `paths` block"
+    assert spec["paths"], "spec declares no paths"
+
+
+def test_openapi_yaml_has_every_required_tag():
+    """Tags declared in operations must also be declared at the top level
+    so Swagger UI groups operations under named, ordered sections."""
+    spec = _load_spec()
+    declared = {t["name"] for t in (spec.get("tags") or []) if isinstance(t, dict)}
+    used: set[str] = set()
+    for path_item in spec["paths"].values():
+        for op in path_item.values():
+            if isinstance(op, dict):
+                for tag in op.get("tags") or []:
+                    used.add(tag)
+    missing = used - declared
+    assert not missing, f"operations reference undeclared tags: {sorted(missing)}"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Drift detection — documented paths vs. actual Flask routes
+# ──────────────────────────────────────────────────────────────────────────
+
+
+# Map blueprint name → URL prefix as registered in app/__init__.py.
+_BLUEPRINT_PREFIXES = {
+    "graph_bp":          "/api/graph",
+    "simulation_bp":     "/api/simulation",
+    "report_bp":         "/api/report",
+    "templates_bp":      "/api/templates",
+    "settings_bp":       "/api/settings",
+    "observability_bp":  "/api/observability",
+    "mcp_bp":            "/api/mcp",
+    "docs_bp":           "/api",
+    # share_bp is mounted at the root with no prefix — see app/__init__.py.
+    "share_bp":          "",
+}
+
+
+# Routes that exist in the running app but are deliberately not part of
+# the public OpenAPI surface (debug-only, hand-run scripts, internal
+# helpers exposed at /api but not meant for third-party consumers).
+# Adding to this list is fine; removing endpoints from the spec without
+# adding them here will fail the drift test.
+_UNDOCUMENTED_ALLOWLIST: set[str] = {
+    # Internal config-management routes — used by the SPA's own setup
+    # flow, not stable enough for third-party consumption.
+    "/api/simulation/<simulation_id>/config",
+    "/api/simulation/<simulation_id>/config/realtime",
+    "/api/simulation/<simulation_id>/config/retry",
+    "/api/simulation/<simulation_id>/config/download",
+    "/api/simulation/script/<script_name>/download",
+    "/api/simulation/generate-profiles",
+    # Environment management — operator-facing only, not shipped to
+    # third-party consumers.
+    "/api/simulation/env-status",
+    "/api/simulation/restart-env",
+    "/api/simulation/close-env",
+    # Internal report-status / debugging helpers — explicitly marked
+    # "for debugging" in their docstrings.
+    "/api/report/check/<simulation_id>",
+    "/api/report/tools/search",
+    "/api/report/tools/statistics",
+}
+
+
+_ROUTE_RE = re.compile(
+    # ``path`` allows the empty string so we capture
+    # ``@settings_bp.route('')`` — that's a real registration that
+    # mounts at the blueprint's prefix (``/api/settings``).
+    r"@(?P<bp>[a-z_]+_bp)\.route\(\s*(?P<quote>['\"])(?P<path>[^'\"]*)(?P=quote)",
+)
+
+
+def _extract_routes_for_bp(bp_name: str, file_path: Path) -> list[str]:
+    """Find every ``@<bp_name>.route('...')`` declaration in ``file_path``.
+
+    Returns the path component (e.g. ``"/<id>/run-status"``) — the caller
+    is responsible for prefixing with the blueprint's URL prefix.
+    """
+    text = file_path.read_text(encoding="utf-8")
+    paths: list[str] = []
+    for match in _ROUTE_RE.finditer(text):
+        if match.group("bp") != bp_name:
+            continue
+        paths.append(match.group("path"))
+    return paths
+
+
+def _collect_flask_routes() -> set[str]:
+    """Static scan of every ``app/api/*.py`` and ``share.py`` for route
+    decorators. Returns fully-qualified path templates (with ``<>``).
+    """
+    api_dir = _BACKEND / "app" / "api"
+    routes: set[str] = set()
+
+    for py_file in sorted(api_dir.glob("*.py")):
+        if py_file.name == "__init__.py":
+            continue
+        text = py_file.read_text(encoding="utf-8")
+        for match in _ROUTE_RE.finditer(text):
+            bp_name = match.group("bp")
+            raw_path = match.group("path")
+            prefix = _BLUEPRINT_PREFIXES.get(bp_name)
+            if prefix is None:
+                # Unknown blueprint — skip rather than fail; new bps need
+                # a deliberate addition to _BLUEPRINT_PREFIXES.
+                continue
+            full = f"{prefix}{raw_path}" if raw_path else prefix
+            # Flask treats an empty path as the prefix itself
+            # (e.g. @settings_bp.route('') ⇒ /api/settings).
+            if raw_path == "":
+                full = prefix
+            routes.add(full)
+
+    # The bare /health route lives in app/__init__.py — include it for
+    # completeness so the drift test sees a single source-of-truth set.
+    init_text = (_BACKEND / "app" / "__init__.py").read_text(encoding="utf-8")
+    if "@app.route('/health')" in init_text:
+        routes.add("/health")
+
+    return routes
+
+
+def _flask_to_openapi_path(path: str) -> str:
+    """Convert ``"/api/simulation/<simulation_id>"`` → ``"/api/simulation/{simulation_id}"``.
+
+    Handles Flask converters like ``<int:round_num>`` and
+    ``<path:something>`` by stripping the converter prefix.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        inner = match.group(1)
+        if ":" in inner:
+            inner = inner.split(":", 1)[1]
+        return "{" + inner + "}"
+
+    return re.sub(r"<([^<>]+)>", _replace, path)
+
+
+def _normalize_for_comparison(path: str) -> str:
+    """Trim trailing slashes for comparison (Flask treats them equivalently)."""
+    if path != "/" and path.endswith("/"):
+        return path.rstrip("/")
+    return path
+
+
+def test_documented_paths_exist_in_flask():
+    """Every documented OpenAPI path must map to a real Flask route."""
+    spec = _load_spec()
+    flask_routes = {_normalize_for_comparison(_flask_to_openapi_path(r)) for r in _collect_flask_routes()}
+    documented = {_normalize_for_comparison(p) for p in spec["paths"].keys()}
+
+    phantom = documented - flask_routes
+    assert not phantom, (
+        f"OpenAPI spec advertises paths that do not exist as Flask routes:\n  "
+        + "\n  ".join(sorted(phantom))
+    )
+
+
+def test_flask_routes_are_documented_or_allowlisted():
+    """Every Flask route must either appear in the spec or be in the
+    explicit undocumented allowlist."""
+    spec = _load_spec()
+    flask_paths_oai = {
+        _normalize_for_comparison(_flask_to_openapi_path(r))
+        for r in _collect_flask_routes()
+    }
+    documented = {_normalize_for_comparison(p) for p in spec["paths"].keys()}
+    allowlisted = {
+        _normalize_for_comparison(_flask_to_openapi_path(r))
+        for r in _UNDOCUMENTED_ALLOWLIST
+    }
+
+    undocumented = flask_paths_oai - documented - allowlisted
+    assert not undocumented, (
+        f"Flask routes missing from openapi.yaml (add to spec OR allowlist):\n  "
+        + "\n  ".join(sorted(undocumented))
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Swagger UI rendering
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_swagger_ui_html_references_spec_and_pinned_cdn():
+    """The HTML page must point Swagger UI at the served spec URL and pull
+    its assets from a pinned (versioned) CDN — pinning protects against
+    upstream releases breaking the page."""
+    from app.api.docs import _swagger_ui_html, _SWAGGER_UI_VERSION
+
+    html = _swagger_ui_html("/api/openapi.yaml")
+
+    # Spec wired in.
+    assert '"/api/openapi.yaml"' in html, "spec URL not embedded in Swagger UI bootstrap"
+    assert "SwaggerUIBundle" in html, "SwaggerUIBundle constructor missing"
+
+    # Pinned CDN — version literal must appear in both the CSS and the JS
+    # bundle URLs so an accidental unpinning is visible.
+    assert _SWAGGER_UI_VERSION, "Swagger UI version pin must be set"
+    css_url = f"swagger-ui-dist@{_SWAGGER_UI_VERSION}/swagger-ui.css"
+    js_url = f"swagger-ui-dist@{_SWAGGER_UI_VERSION}/swagger-ui-bundle.js"
+    assert css_url in html, f"Swagger UI CSS URL {css_url!r} missing from rendered page"
+    assert js_url in html, f"Swagger UI JS URL {js_url!r} missing from rendered page"
+
+    # MiroShark-branded banner — confirms we don't accidentally ship the
+    # default Swagger UI top bar.
+    assert "MiroShark · API Reference" in html
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Spec-serving helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_spec_as_dict_round_trips_top_level_shape():
+    """The JSON variant served at /api/openapi.json should preserve the
+    YAML's top-level shape — same openapi version, info block, paths."""
+    from app.api.docs import _spec_as_dict
+
+    spec_yaml = _load_spec()
+    spec_json = _spec_as_dict()
+
+    assert spec_json.get("openapi") == spec_yaml.get("openapi")
+    assert spec_json.get("info", {}).get("title") == spec_yaml.get("info", {}).get("title")
+    assert set(spec_json.get("paths", {}).keys()) == set(spec_yaml.get("paths", {}).keys()), (
+        "JSON variant must serialize the same path set as the YAML source"
+    )
+
+
+def test_documented_paths_helper_lists_all_paths():
+    """The ``documented_paths()`` helper used by the test infra must
+    return the same list as the parsed spec — keeps the helper honest."""
+    from app.api.docs import documented_paths
+
+    spec = _load_spec()
+    assert sorted(documented_paths()) == sorted(spec["paths"].keys())
+
+
+def test_route_extractor_matches_known_endpoints():
+    """Sanity check on the regex-based route scanner — it must find a
+    handful of known-good routes from existing endpoints we did NOT
+    introduce in this PR."""
+    routes = _collect_flask_routes()
+    known = [
+        "/api/simulation/<simulation_id>/run-status",
+        "/api/simulation/<simulation_id>/share-card.png",
+        "/api/simulation/public",
+        "/api/mcp/status",
+        "/api/settings",
+    ]
+    for r in known:
+        assert r in routes, f"route extractor missed known endpoint {r}"

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,8 @@
 
 Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless otherwise noted.
 
+> **Interactive docs:** the running backend serves Swagger UI at `/api/docs` and the OpenAPI 3.1 spec at `/api/openapi.yaml` (or `/api/openapi.json`). Point [`openapi-generator`](https://openapi-generator.tech/) at the spec to produce a Python / TypeScript / Go SDK in one command.
+
 ## Setup & Discovery
 
 | Method | Path | Purpose |
@@ -118,3 +120,15 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `GET` | `/api/simulation/push/vapid-public-key` | VAPID key for web push |
 | `POST` | `/api/simulation/push/subscribe` | Register a browser subscription |
 | `POST` | `/api/simulation/push/test` | Fire a test notification |
+
+## Interactive Documentation
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/docs` | Swagger UI rendered against this spec — try-it-out enabled |
+| `GET` | `/api/openapi.yaml` | OpenAPI 3.1 spec, YAML form (canonical) |
+| `GET` | `/api/openapi.json` | Same spec, JSON form (handy for `openapi-generator`) |
+
+The spec is committed to the repo at `backend/openapi.yaml`. A unit test
+(`backend/tests/test_unit_openapi.py`) walks every Flask route on every
+push and fails CI if the spec drifts away from the implementation.


### PR DESCRIPTION
## What

Ships a handwritten **OpenAPI 3.1 spec** at `backend/openapi.yaml`
covering every public REST endpoint, plus a Flask blueprint that
serves **Swagger UI at `/api/docs`** with live try-it-out, the YAML
spec at `/api/openapi.yaml`, and a JSON variant at
`/api/openapi.json`.

The spec is grouped by 13 tags — Setup & Discovery, Graph Build,
Simulation Lifecycle, Live State, Analytics, Interaction, Publish &
Embed, Export, Report Agent, Observability, Settings & Push,
Integrations, Documentation — and documents request/response shapes
for ~85 paths.

## Why

Yesterday's PR #44 (AI Integration · MCP Onboarding) made the
bundled stdio MCP server discoverable to AI IDE clients — Claude
Desktop, Cursor, Windsurf, Continue. The natural next question for
those onboarded developers is "what REST endpoints can I call
directly?" — and the answer was previously a hand-maintained
markdown table in `docs/API.md` with no machine-readable spec, no
try-it-out surface, and no path to typed SDKs.

This PR is the documentation surface that:

- Lets MCP-adjacent developers **try every endpoint** from the
  browser (Swagger UI try-it-out hits the running backend).
- Pipes through `openapi-generator` to produce **Python / TypeScript
  / Go / Java SDKs** in one command.
- Qualifies MiroShark for **APIs.guru / RapidAPI / openapi tag**
  listings — discoverability surfaces the Paradigm-adjacent ML and
  developer audience that has been starring the repo this week look
  for.
- Signals **production-quality** to the same audience (Paradigm CTO
  star, OriginTrail founder co-sign, Chinese quant forks) — an
  OpenAPI spec is the bar for "tool I can build on" rather than
  "cool demo."

## Changes

- **`backend/openapi.yaml`** — 1.9K-line OpenAPI 3.1 spec. Tagged
  operations, named schemas (SuccessEnvelope, ErrorEnvelope,
  RunStatus, BeliefDrift, EmbedSummary, GalleryCard, McpStatus,
  SettingsUpdate, PushSubscription, …), shared parameters, and a
  reusable response-error block.
- **`backend/app/api/docs.py`** — Flask blueprint serving:
  - `GET /api/docs` — Swagger UI HTML, pinned to
    `swagger-ui-dist@5.17.14` from jsDelivr (immutable + CDN cached).
    MiroShark-branded top banner + dark favicon; default Swagger
    top bar hidden.
  - `GET /api/openapi.yaml` — raw YAML, served as
    `application/yaml` with `Content-Disposition: inline`.
  - `GET /api/openapi.json` — same content via `yaml.safe_load`,
    pyyaml-soft-optional with placeholder fallback.
- **`backend/app/api/__init__.py`** — register the new `docs_bp`
  blueprint alongside the existing seven.
- **`backend/app/__init__.py`** — mount `docs_bp` at `/api` (so the
  spec URL stays short).
- **`backend/tests/test_unit_openapi.py`** — 8 offline tests:
  - Spec parses + has the OpenAPI 3.x minimum shape.
  - Every operation tag is declared at the top level (Swagger UI
    grouping correctness).
  - **Drift detection (centerpiece):** static regex scan of every
    `app/api/*.py` for `@<bp>_bp.route(...)` decorators →
    fully-qualified path templates → must equal the spec's path set,
    minus an explicit allowlist of internal/debug routes
    (config / env / report-tools).
  - Swagger UI HTML references the spec URL and pins the CDN
    version in both CSS and JS bundle URLs.
  - JSON variant round-trips the same path set as the YAML.
- **`docs/API.md`** — adds a section linking the interactive docs
  and an opening callout pointing at `/api/docs`.
- **`README.md`** — Documentation table now references the live
  Swagger UI alongside the markdown.

## Tests

```
pytest backend/tests/test_unit_openapi.py -v
```

All 8 tests offline, no Neo4j or LLM. The drift test is the one to
watch — it will fail CI on the next PR that adds a Flask route
without either documenting it in `openapi.yaml` or adding it to the
explicit allowlist.

---
*Built autonomously by Aeon — repo-actions Apr 24 idea #5*