### PR TITLE
feat: completion webhook (Slack / Discord / Zapier / n8n / custom)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -244,6 +244,19 @@ OPENAI_API_BASE_URL=http://localhost:11434/v1
 # Event verbosity: debug|info|warn (default: info)
 # MIROSHARK_LOG_LEVEL=info
 
+# ===== Outbound webhook (optional) =====
+# POST a JSON summary to this URL the moment a simulation completes or fails.
+# Wires Slack (Incoming Webhooks), Discord (channel webhooks), Zapier, Make,
+# n8n, IFTTT, or a custom endpoint — no bot, no OAuth.
+# Empty disables the webhook. Editable at runtime via Settings → Integrations.
+# WEBHOOK_URL=https://hooks.slack.com/services/T0…/B0…/abc
+#
+# Public base URL of this deployment (e.g. https://miroshark.app). When set,
+# the webhook payload includes absolute share_url + share_card_url fields so
+# Slack / Discord auto-unfurl with the simulation card. Without it, only
+# relative paths are sent.
+# PUBLIC_BASE_URL=https://miroshark.app
+
 # ===== Docker-mode overrides =====
 # Uncomment these when running ALL services inside Docker
 # (backend container talks to neo4j/ollama containers by service name)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
 | **History Database** | Search, clone, export, or delete any past simulation |
 | **Trace Interview** | See the full reasoning chain behind an agent's reply, not just the reply |
 | **Push Notifications** | Web-push alerts when long-running graph / sim / report jobs finish |
+| **Completion Webhook** | POST a JSON summary the moment a sim finishes — wires Slack, Discord, Zapier, Make, n8n, or any custom endpoint with one URL field |
 
 Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 
@@ -125,6 +126,7 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 | [HTTP API](docs/API.md) | Every endpoint, grouped by concern |
 | [CLI](docs/CLI.md) | `miroshark-cli` reference |
 | [MCP](docs/MCP.md) | Claude Desktop / Cursor / Windsurf / Continue integration + report agent tools (auto-generated snippets in Settings → AI Integration) |
+| [Webhooks](docs/WEBHOOKS.md) | Completion webhook payload, headers, delivery semantics, Slack/Discord/Zapier/n8n recipes |
 | [Observability](docs/OBSERVABILITY.md) | Debug panel, event stream, logging |
 | [Contributing](CONTRIBUTING.md) | Tests and development |
 

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -11,6 +11,12 @@ from flask import request, jsonify
 
 from . import settings_bp
 from ..config import Config
+from ..services import webhook_service  # noqa: F401 — kept for namespace-style access
+from ..services.webhook_service import (
+    mask_url as mask_webhook_url,
+    send_test_webhook,
+    validate_url as validate_webhook_url,
+)
 from ..utils.logger import get_logger
 
 logger = get_logger('miroshark.api.settings')
@@ -133,6 +139,13 @@ def _current_snapshot() -> dict:
             'uri': Config.NEO4J_URI,
             'user': Config.NEO4J_USER,
         },
+        'integrations': {
+            'webhook': {
+                'configured': bool((Config.WEBHOOK_URL or '').strip()),
+                'url_masked': mask_webhook_url(Config.WEBHOOK_URL or ''),
+                'public_base_url': Config.PUBLIC_BASE_URL or '',
+            },
+        },
         'available_presets': [
             {'id': k, 'label': v['label']} for k, v in _PRESETS.items()
         ],
@@ -222,6 +235,25 @@ def update_settings():
     if neo4j.get('user'): Config.NEO4J_USER = neo4j['user']
     if neo4j.get('password'): Config.NEO4J_PASSWORD = neo4j['password']
 
+    integrations = body.get('integrations') or {}
+    webhook = integrations.get('webhook') or {}
+    if 'url' in webhook and webhook['url'] is not None:
+        new_url = (webhook['url'] or '').strip()
+        err = validate_webhook_url(new_url)
+        if err:
+            return jsonify({'success': False, 'error': err}), 400
+        Config.WEBHOOK_URL = new_url
+    if 'public_base_url' in webhook and webhook['public_base_url'] is not None:
+        new_base = (webhook['public_base_url'] or '').strip().rstrip('/')
+        if new_base:
+            lowered = new_base.lower()
+            if not (lowered.startswith('http://') or lowered.startswith('https://')):
+                return jsonify({
+                    'success': False,
+                    'error': 'public_base_url must start with http:// or https://',
+                }), 400
+        Config.PUBLIC_BASE_URL = new_base
+
     logger.info(
         "Settings updated: preset=%s provider=%s model=%s base_url=%s",
         preset_id or '—', Config.LLM_PROVIDER, Config.LLM_MODEL_NAME, Config.LLM_BASE_URL,
@@ -269,3 +301,47 @@ def test_llm():
             'success': False,
             'error': str(e),
         }), 200  # Return 200 so the frontend can read the error body
+
+
+@settings_bp.route('/test-webhook', methods=['POST'])
+def test_webhook():
+    """Fire a sample ``simulation.test`` event at the user-supplied
+    webhook URL and return delivery details.
+
+    Body:
+        {"url": "https://hooks.slack.com/...", "public_base_url": "..."}
+
+    When ``url`` is omitted the currently saved ``Config.WEBHOOK_URL`` is
+    tested instead — convenient for verifying that a previously saved
+    endpoint is still reachable. Always returns HTTP 200 so the frontend
+    can render the success / failure body uniformly.
+    """
+    body = request.get_json(silent=True) or {}
+    url = (body.get('url') or '').strip() or (Config.WEBHOOK_URL or '').strip()
+    base_url = (body.get('public_base_url') or '').strip() or (Config.PUBLIC_BASE_URL or '').strip() or None
+
+    if not url:
+        return jsonify({
+            'success': False,
+            'error': 'No webhook URL configured — provide one in the request or save it in Settings first.',
+        }), 200
+
+    err = validate_webhook_url(url)
+    if err:
+        return jsonify({'success': False, 'error': err}), 200
+
+    try:
+        result = send_test_webhook(url, base_url=base_url)
+    except Exception as exc:
+        logger.warning("Webhook test failed: %s", exc)
+        return jsonify({
+            'success': False,
+            'error': str(exc),
+        }), 200
+
+    return jsonify({
+        'success': bool(result.get('ok')),
+        'message': result.get('message', ''),
+        'latency_ms': result.get('latency_ms'),
+        'url_masked': mask_webhook_url(url),
+    }), 200

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -180,6 +180,23 @@ class Config:
     REPORT_AGENT_MAX_TOOL_CALLS = int(os.environ.get('REPORT_AGENT_MAX_TOOL_CALLS', '5'))
     REPORT_AGENT_MAX_REFLECTION_ROUNDS = int(os.environ.get('REPORT_AGENT_MAX_REFLECTION_ROUNDS', '2'))
     REPORT_AGENT_TEMPERATURE = float(os.environ.get('REPORT_AGENT_TEMPERATURE', '0.5'))
+
+    # Outbound webhook fired when a simulation reaches a terminal state.
+    # When set, MiroShark POSTs a JSON summary (scenario, final consensus,
+    # quality, share URL, …) to this URL the moment the run completes or
+    # fails. Slot for Zapier / Make / n8n / IFTTT / Slack Incoming Webhooks
+    # / Discord channel webhooks / custom listeners — no bot, no OAuth.
+    # Empty string disables it entirely. Editable at runtime via the
+    # Settings modal — see app/services/webhook_service.py.
+    WEBHOOK_URL = os.environ.get('WEBHOOK_URL', '')
+
+    # Public base URL of this deployment (e.g. ``https://miroshark.app``).
+    # When set, the outbound webhook payload includes absolute
+    # ``share_url`` + ``share_card_url`` fields so Slack / Discord
+    # consumers get rich unfurling out of the box. Without it, only the
+    # relative ``share_path`` is included and the consumer must build the
+    # absolute URL themselves.
+    PUBLIC_BASE_URL = os.environ.get('PUBLIC_BASE_URL', '')
     
     @classmethod
     def validate(cls):

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -619,6 +619,19 @@ class SimulationRunner:
                     )
                 except Exception as _push_err:
                     logger.warning(f"Push notification dispatch failed: {_push_err}")
+
+                # Fire outbound webhook (Zapier / n8n / Slack / Discord / …)
+                try:
+                    from .webhook_service import fire_webhook_for_simulation
+                    fire_webhook_for_simulation(
+                        simulation_id,
+                        "completed",
+                        sim_dir=sim_dir,
+                        state=state,
+                        completed_at=state.completed_at,
+                    )
+                except Exception as _wh_err:
+                    logger.warning(f"Webhook dispatch failed: {_wh_err}")
             else:
                 state.runner_status = RunnerStatus.FAILED
                 # Read error info from main log file
@@ -632,6 +645,21 @@ class SimulationRunner:
                     pass
                 state.error = f"Process exit code: {exit_code}, error: {error_info}"
                 logger.error(f"Simulation failed: {simulation_id}, error={state.error}")
+
+                # Fire outbound webhook for the failure path too — operators
+                # who hooked Slack/Discord want to know either way.
+                try:
+                    from .webhook_service import fire_webhook_for_simulation
+                    fire_webhook_for_simulation(
+                        simulation_id,
+                        "failed",
+                        sim_dir=sim_dir,
+                        state=state,
+                        completed_at=datetime.now().isoformat(),
+                        error=state.error,
+                    )
+                except Exception as _wh_err:
+                    logger.warning(f"Webhook dispatch failed: {_wh_err}")
             
             state.twitter_running = False
             state.reddit_running = False
@@ -754,6 +782,20 @@ class SimulationRunner:
                                             )
                                         except Exception as e:
                                             logger.warning(f"Failed to generate run summary: {e}")
+
+                                        # Outbound webhook notification — deduped against
+                                        # the exit-code path in the monitor loop, so it's
+                                        # safe to fire from both.
+                                        try:
+                                            from .webhook_service import fire_webhook_for_simulation
+                                            fire_webhook_for_simulation(
+                                                state.simulation_id,
+                                                "completed",
+                                                state=state,
+                                                completed_at=state.completed_at,
+                                            )
+                                        except Exception as _wh_err:
+                                            logger.warning(f"Webhook dispatch failed: {_wh_err}")
                                 
                                 # Update round info (from round_end event)
                                 elif event_type == "round_end":

--- a/backend/app/services/webhook_service.py
+++ b/backend/app/services/webhook_service.py
@@ -1,0 +1,457 @@
+"""Outbound webhook for simulation completion.
+
+Fires a one-shot ``POST {WEBHOOK_URL}`` with a JSON summary the moment a
+simulation reaches a terminal state (``completed`` or ``failed``). The URL
+is read from ``Config.WEBHOOK_URL`` so a single env var (or a Settings
+modal save) wires up Zapier, Make, n8n, IFTTT, Slack via Incoming Webhooks,
+Discord via Bot/Channel webhooks, custom dashboards, or a plain Cloud Run
+listener — no bot, no OAuth, no hosted infrastructure.
+
+Design notes
+------------
+
+* **Fire-and-forget.** Runs in a daemon thread so a slow webhook endpoint
+  never delays the simulation runner.
+* **Never raises.** Every failure is logged and swallowed. The webhook is
+  a *notification*, not a critical path.
+* **Idempotent.** Per-process dedup keyed on ``(sim_id, status)`` so the
+  exit-code path and the ``simulation_end``-event path in the runner can
+  both call this without firing twice.
+* **Minimal disk reads.** Reuses the same artifact files the share card
+  and gallery card already consume — no DB, no LLM.
+* **Stdlib only.** ``urllib.request`` for the POST. No new dependencies.
+
+Payload shape::
+
+    {
+      "event": "simulation.completed" | "simulation.failed",
+      "sim_id": "sim_xxx",
+      "scenario": "Will the SEC approve …",         # truncated to 280 chars
+      "status": "completed" | "failed",
+      "current_round": 20,
+      "total_rounds": 20,
+      "agent_count": 248,
+      "quality_health": "Excellent" | null,
+      "final_consensus": {                            # null if no trajectory
+        "bullish": 62.0,
+        "neutral": 13.0,
+        "bearish": 25.0
+      },
+      "resolution_outcome": "YES" | null,
+      "share_path": "/share/sim_xxx",
+      "share_card_path": "/api/simulation/sim_xxx/share-card.png",
+      "share_url": "https://host/share/sim_xxx",     # only if PUBLIC_BASE_URL set
+      "share_card_url": "https://host/...png",       # only if PUBLIC_BASE_URL set
+      "created_at": "2026-04-26T10:12:34",
+      "completed_at": "2026-04-26T10:35:11",
+      "fired_at": "2026-04-26T10:35:12.482912+00:00"
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+from ..utils.logger import get_logger
+
+logger = get_logger('miroshark.webhook')
+
+
+WEBHOOK_USER_AGENT = "MiroShark-Webhook/1.0"
+WEBHOOK_TIMEOUT_SECONDS = 5.0
+WEBHOOK_MAX_SCENARIO_CHARS = 280
+
+
+# Per-process dedup. The runner's exit-code path and the ``simulation_end``
+# event path can both fire for the same terminal status — keep only the
+# first one per (sim_id, status). Bounded to avoid unbounded growth in
+# very long-lived processes.
+_FIRED: set[Tuple[str, str]] = set()
+_FIRED_LOCK = threading.Lock()
+_FIRED_MAX = 4096
+
+
+def _mark_fired(sim_id: str, status: str) -> bool:
+    """Record (sim_id, status) and return True if this is the first time."""
+    key = (sim_id, status)
+    with _FIRED_LOCK:
+        if key in _FIRED:
+            return False
+        if len(_FIRED) >= _FIRED_MAX:
+            # Drop one arbitrary entry to bound memory. Cheap; we don't
+            # need LRU semantics for a notification dedup.
+            _FIRED.pop()
+        _FIRED.add(key)
+        return True
+
+
+def reset_dedup_for_tests() -> None:
+    """Clear the in-process dedup set. Test-only convenience."""
+    with _FIRED_LOCK:
+        _FIRED.clear()
+
+
+def mask_url(url: str) -> str:
+    """Show only the scheme + host of a webhook URL.
+
+    The full URL often carries an opaque secret in the path
+    (``hooks.slack.com/services/T0…/B0…/abcXYZ``); never echo it back to
+    the frontend. ``https://hooks.slack.com/services/T0…/***`` is enough
+    for the user to recognize their own hook.
+    """
+    if not url:
+        return ''
+    try:
+        from urllib.parse import urlsplit
+        parts = urlsplit(url)
+        if not parts.scheme or not parts.netloc:
+            return '***'
+        return f"{parts.scheme}://{parts.netloc}/***"
+    except Exception:
+        return '***'
+
+
+def validate_url(url: str) -> Optional[str]:
+    """Return ``None`` if the URL is acceptable, else an error message.
+
+    Empty string is valid (treated as "disable webhook").
+    """
+    if not url:
+        return None
+    if not isinstance(url, str):
+        return "Webhook URL must be a string"
+    stripped = url.strip()
+    if not stripped:
+        return None
+    if len(stripped) > 2048:
+        return "Webhook URL is too long (max 2048 chars)"
+    lowered = stripped.lower()
+    if not (lowered.startswith('http://') or lowered.startswith('https://')):
+        return "Webhook URL must start with http:// or https://"
+    return None
+
+
+def _read_json(path: str) -> Optional[Dict[str, Any]]:
+    """Best-effort JSON load — returns ``None`` on any failure."""
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def _final_consensus_from_trajectory(trajectory: Optional[Dict[str, Any]]) -> Optional[Dict[str, float]]:
+    """Walk the trajectory snapshots in reverse and pick the last one with
+    computable belief positions, then bucket stances into bullish / neutral
+    / bearish percentages.
+
+    Mirrors the same threshold (±0.2) used by the gallery / share-card
+    helpers so the consensus the webhook reports matches what users see
+    in the share card image.
+    """
+    if not trajectory:
+        return None
+    snapshots = trajectory.get("snapshots") or []
+    if not isinstance(snapshots, list):
+        return None
+    for snap in reversed(snapshots):
+        positions = (snap or {}).get("belief_positions") or {}
+        if not positions:
+            continue
+        stances = []
+        for p in positions.values():
+            if p:
+                stances.append(sum(p.values()) / len(p))
+        if not stances:
+            continue
+        total = len(stances)
+        nb = sum(1 for s in stances if s > 0.2)
+        nbe = sum(1 for s in stances if s < -0.2)
+        nn = total - nb - nbe
+        return {
+            "bullish": round(nb / total * 100, 1),
+            "neutral": round(nn / total * 100, 1),
+            "bearish": round(nbe / total * 100, 1),
+        }
+    return None
+
+
+def build_payload(
+    simulation_id: str,
+    status: str,
+    sim_dir: str,
+    *,
+    state: Optional[Any] = None,
+    base_url: Optional[str] = None,
+    completed_at: Optional[str] = None,
+    error: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Assemble the webhook JSON payload for one simulation.
+
+    Reads ``simulation_config.json``, ``quality.json``, ``trajectory.json``,
+    ``resolution.json``, ``state.json`` from ``sim_dir`` — every artifact
+    is optional. Missing files degrade gracefully into ``None`` /
+    sensible defaults; the webhook always fires with at least the
+    identifier and status.
+
+    ``state`` is the optional in-memory ``SimulationState``-like object
+    the runner already has — when provided, ``agent_count``,
+    ``created_at``, and ``parent_simulation_id`` come from there;
+    otherwise they're loaded from ``state.json``.
+    """
+    config = _read_json(os.path.join(sim_dir, "simulation_config.json"))
+    quality = _read_json(os.path.join(sim_dir, "quality.json"))
+    trajectory = _read_json(os.path.join(sim_dir, "trajectory.json"))
+    resolution = _read_json(os.path.join(sim_dir, "resolution.json"))
+    on_disk_state = _read_json(os.path.join(sim_dir, "state.json"))
+
+    scenario = ""
+    total_rounds = 0
+    if config:
+        scenario = (config.get("simulation_requirement") or "").strip()
+        time_config = config.get("time_config") or {}
+        try:
+            mpr = max(int(time_config.get("minutes_per_round", 60) or 60), 1)
+            hours = int(time_config.get("total_simulation_hours", 0) or 0)
+            total_rounds = int(hours * 60 / mpr)
+        except Exception:
+            total_rounds = 0
+    if scenario and len(scenario) > WEBHOOK_MAX_SCENARIO_CHARS:
+        scenario = scenario[:WEBHOOK_MAX_SCENARIO_CHARS - 1].rstrip() + "…"
+
+    # Prefer the live in-memory state object when the caller has one —
+    # it's freshly written, no race with disk flushes.
+    agent_count = 0
+    created_at = None
+    parent_simulation_id = None
+    current_round = 0
+    if state is not None:
+        agent_count = getattr(state, "profiles_count", 0) or 0
+        created_at = getattr(state, "created_at", None)
+        parent_simulation_id = getattr(state, "parent_simulation_id", None)
+        current_round = getattr(state, "current_round", 0) or 0
+        runner_total = getattr(state, "total_rounds", 0) or 0
+        if runner_total:
+            total_rounds = runner_total
+    if (agent_count == 0 or created_at is None) and on_disk_state:
+        if not agent_count:
+            agent_count = on_disk_state.get("profiles_count") or 0
+        if created_at is None:
+            created_at = on_disk_state.get("created_at")
+        if parent_simulation_id is None:
+            parent_simulation_id = on_disk_state.get("parent_simulation_id")
+
+    quality_health = (quality or {}).get("health")
+    resolution_outcome = (resolution or {}).get("actual_outcome")
+    final_consensus = _final_consensus_from_trajectory(trajectory)
+
+    share_path = f"/share/{simulation_id}"
+    share_card_path = f"/api/simulation/{simulation_id}/share-card.png"
+
+    payload: Dict[str, Any] = {
+        "event": f"simulation.{status}",
+        "sim_id": simulation_id,
+        "scenario": scenario,
+        "status": status,
+        "current_round": current_round,
+        "total_rounds": total_rounds,
+        "agent_count": agent_count,
+        "quality_health": quality_health,
+        "final_consensus": final_consensus,
+        "resolution_outcome": resolution_outcome,
+        "share_path": share_path,
+        "share_card_path": share_card_path,
+        "created_at": created_at,
+        "completed_at": completed_at,
+        "parent_simulation_id": parent_simulation_id,
+        "fired_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    if error:
+        # Trim long stack traces — the webhook payload is meant for a
+        # notification body, not full debug output.
+        err_text = str(error)
+        if len(err_text) > 1000:
+            err_text = err_text[:997].rstrip() + "…"
+        payload["error"] = err_text
+
+    if base_url:
+        base = base_url.rstrip('/')
+        payload["share_url"] = f"{base}{share_path}"
+        payload["share_card_url"] = f"{base}{share_card_path}"
+
+    return payload
+
+
+def _post_json(url: str, payload: Dict[str, Any], timeout: float) -> Tuple[bool, str]:
+    """Issue the POST. Returns ``(ok, message)`` — never raises."""
+    try:
+        body = json.dumps(payload).encode('utf-8')
+    except Exception as exc:
+        return False, f"Could not serialize payload: {exc}"
+
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method='POST',
+        headers={
+            'Content-Type': 'application/json; charset=utf-8',
+            'User-Agent': WEBHOOK_USER_AGENT,
+            'X-MiroShark-Event': payload.get('event', 'simulation.unknown'),
+            'X-MiroShark-Sim-Id': payload.get('sim_id', ''),
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status_code = resp.getcode()
+            if 200 <= status_code < 300:
+                return True, f"HTTP {status_code}"
+            return False, f"HTTP {status_code}"
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code}"
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, 'reason', exc)
+        return False, f"URL error: {reason}"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+def _resolve_webhook_url() -> str:
+    """Read the configured webhook URL — late-binding so runtime Settings
+    updates take effect immediately without needing to re-import."""
+    try:
+        from ..config import Config
+        return (getattr(Config, 'WEBHOOK_URL', '') or '').strip()
+    except Exception:
+        return ''
+
+
+def _resolve_base_url() -> str:
+    """Read PUBLIC_BASE_URL — used to build absolute ``share_url`` /
+    ``share_card_url`` fields when no Flask request context is available
+    (the runner fires from a background thread)."""
+    try:
+        from ..config import Config
+        return (getattr(Config, 'PUBLIC_BASE_URL', '') or '').strip()
+    except Exception:
+        return ''
+
+
+def fire_webhook_for_simulation(
+    simulation_id: str,
+    status: str,
+    *,
+    sim_dir: Optional[str] = None,
+    state: Optional[Any] = None,
+    completed_at: Optional[str] = None,
+    error: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> None:
+    """Fire-and-forget webhook for a simulation that just reached a
+    terminal state.
+
+    Safe to call from inside the simulation monitor thread — work happens
+    in its own daemon thread. No-op if no webhook URL is configured or if
+    this (sim_id, status) pair has already fired in this process.
+    """
+    if status not in {"completed", "failed"}:
+        logger.warning(f"Webhook ignored — unsupported status: {status}")
+        return
+
+    url = _resolve_webhook_url()
+    if not url:
+        return
+
+    if not _mark_fired(simulation_id, status):
+        return
+
+    if sim_dir is None:
+        # Mirror the path SimulationRunner.RUN_STATE_DIR uses.
+        try:
+            from ..config import Config
+            sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        except Exception:
+            sim_dir = simulation_id
+
+    if base_url is None:
+        base_url = _resolve_base_url()
+
+    payload = build_payload(
+        simulation_id,
+        status,
+        sim_dir,
+        state=state,
+        base_url=base_url,
+        completed_at=completed_at,
+        error=error,
+    )
+
+    def _send() -> None:
+        ok, msg = _post_json(url, payload, WEBHOOK_TIMEOUT_SECONDS)
+        if ok:
+            logger.info(f"Webhook fired for {simulation_id} ({status}) → {mask_url(url)} [{msg}]")
+        else:
+            logger.warning(f"Webhook delivery failed for {simulation_id} ({status}) → {mask_url(url)}: {msg}")
+
+    threading.Thread(
+        target=_send,
+        daemon=True,
+        name=f'webhook-{simulation_id}',
+    ).start()
+
+
+def send_test_webhook(url: str, base_url: Optional[str] = None) -> Dict[str, Any]:
+    """Synchronously POST a sample payload to ``url`` and return the
+    result. Used by the Settings ``Send test event`` button so the user
+    gets immediate feedback on whether their endpoint is reachable.
+
+    Returns ``{ok, message, status_code, latency_ms}``.
+    """
+    err = validate_url(url)
+    if err:
+        return {"ok": False, "message": err}
+    if not url.strip():
+        return {"ok": False, "message": "Webhook URL is empty"}
+
+    payload = {
+        "event": "simulation.test",
+        "sim_id": "sim_test_event",
+        "scenario": "Test event from MiroShark — your webhook is configured correctly.",
+        "status": "test",
+        "current_round": 0,
+        "total_rounds": 0,
+        "agent_count": 0,
+        "quality_health": None,
+        "final_consensus": None,
+        "resolution_outcome": None,
+        "share_path": "/share/sim_test_event",
+        "share_card_path": "/api/simulation/sim_test_event/share-card.png",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "parent_simulation_id": None,
+        "fired_at": datetime.now(timezone.utc).isoformat(),
+        "test": True,
+    }
+    if base_url:
+        base = base_url.rstrip('/')
+        payload["share_url"] = f"{base}/share/sim_test_event"
+        payload["share_card_url"] = f"{base}/api/simulation/sim_test_event/share-card.png"
+
+    started = datetime.now()
+    ok, msg = _post_json(url.strip(), payload, WEBHOOK_TIMEOUT_SECONDS)
+    latency_ms = int((datetime.now() - started).total_seconds() * 1000)
+
+    return {
+        "ok": ok,
+        "message": msg,
+        "latency_ms": latency_ms,
+    }

--- a/backend/tests/test_unit_webhook.py
+++ b/backend/tests/test_unit_webhook.py
@@ -1,0 +1,441 @@
+"""Unit tests for the outbound completion webhook.
+
+Pure offline tests — no Flask app, no real HTTP. They cover the four
+properties the runner depends on:
+
+  1. ``build_payload`` reads the same on-disk artifacts the share card +
+     gallery card consume, and degrades gracefully when files are missing
+     or malformed (the webhook must never raise).
+  2. URL validation accepts ``http(s)://`` and rejects everything else.
+  3. URL masking only echoes scheme + host (the path of a Slack or
+     Discord webhook URL is the secret).
+  4. ``fire_webhook_for_simulation`` is fire-and-forget, deduped per
+     ``(sim_id, status)``, and a no-op when no URL is configured — even
+     when the network would 500.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ── Payload tests ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def populated_sim_dir(tmp_path: Path) -> Path:
+    """A simulation directory with every artifact the webhook reads."""
+    (tmp_path / "simulation_config.json").write_text(json.dumps({
+        "simulation_requirement": "Will the SEC approve a spot Solana ETF before Q3 2026?",
+        "time_config": {"minutes_per_round": 60, "total_simulation_hours": 20},
+    }))
+    (tmp_path / "quality.json").write_text(json.dumps({
+        "health": "Excellent",
+        "participation_rate": 0.92,
+    }))
+    (tmp_path / "trajectory.json").write_text(json.dumps({
+        "snapshots": [
+            {
+                "round_num": 0,
+                "belief_positions": {
+                    "a": {"topic": 0.0},
+                    "b": {"topic": 0.0},
+                    "c": {"topic": 0.0},
+                },
+            },
+            {
+                "round_num": 1,
+                "belief_positions": {
+                    "a": {"topic": 0.6},
+                    "b": {"topic": 0.4},
+                    "c": {"topic": -0.5},
+                    "d": {"topic": 0.0},
+                },
+            },
+        ],
+    }))
+    (tmp_path / "resolution.json").write_text(json.dumps({
+        "actual_outcome": "YES",
+        "predicted_consensus": "YES",
+        "accuracy_score": 1.0,
+    }))
+    (tmp_path / "state.json").write_text(json.dumps({
+        "profiles_count": 248,
+        "created_at": "2026-04-26T10:12:34",
+        "parent_simulation_id": None,
+    }))
+    return tmp_path
+
+
+def test_payload_reads_every_artifact(populated_sim_dir: Path):
+    from app.services.webhook_service import build_payload
+
+    payload = build_payload(
+        "sim_abc123",
+        "completed",
+        str(populated_sim_dir),
+        completed_at="2026-04-26T10:35:11",
+    )
+
+    assert payload["event"] == "simulation.completed"
+    assert payload["sim_id"] == "sim_abc123"
+    assert payload["status"] == "completed"
+    assert payload["scenario"].startswith("Will the SEC approve")
+    assert payload["total_rounds"] == 20  # 20h * 60m / 60m
+    assert payload["agent_count"] == 248
+    assert payload["created_at"] == "2026-04-26T10:12:34"
+    assert payload["completed_at"] == "2026-04-26T10:35:11"
+    assert payload["quality_health"] == "Excellent"
+    assert payload["resolution_outcome"] == "YES"
+    # 2/4 stances > 0.2 = bullish; 1/4 < -0.2 = bearish; 1/4 neutral.
+    assert payload["final_consensus"] == {"bullish": 50.0, "neutral": 25.0, "bearish": 25.0}
+    assert payload["share_path"] == "/share/sim_abc123"
+    assert payload["share_card_path"] == "/api/simulation/sim_abc123/share-card.png"
+    # No base_url passed → no absolute URL fields.
+    assert "share_url" not in payload
+    assert "share_card_url" not in payload
+
+
+def test_payload_includes_absolute_urls_when_base_set(populated_sim_dir: Path):
+    from app.services.webhook_service import build_payload
+
+    payload = build_payload(
+        "sim_xyz",
+        "completed",
+        str(populated_sim_dir),
+        base_url="https://miroshark.app/",  # trailing slash should be stripped
+    )
+
+    assert payload["share_url"] == "https://miroshark.app/share/sim_xyz"
+    assert payload["share_card_url"] == "https://miroshark.app/api/simulation/sim_xyz/share-card.png"
+
+
+def test_payload_truncates_long_scenario(tmp_path: Path):
+    from app.services.webhook_service import build_payload, WEBHOOK_MAX_SCENARIO_CHARS
+
+    long_text = "A " * 400  # 800 chars
+    (tmp_path / "simulation_config.json").write_text(json.dumps({
+        "simulation_requirement": long_text,
+        "time_config": {"minutes_per_round": 60, "total_simulation_hours": 5},
+    }))
+
+    payload = build_payload("sim_x", "completed", str(tmp_path))
+    assert len(payload["scenario"]) <= WEBHOOK_MAX_SCENARIO_CHARS
+    assert payload["scenario"].endswith("…")
+
+
+def test_payload_failure_includes_truncated_error(populated_sim_dir: Path):
+    from app.services.webhook_service import build_payload
+
+    long_err = "stack trace " * 200
+    payload = build_payload(
+        "sim_err",
+        "failed",
+        str(populated_sim_dir),
+        error=long_err,
+    )
+
+    assert payload["event"] == "simulation.failed"
+    assert payload["status"] == "failed"
+    assert "error" in payload
+    assert len(payload["error"]) <= 1000
+    assert payload["error"].endswith("…")
+
+
+def test_payload_falls_back_to_state_json_when_no_state_object(populated_sim_dir: Path):
+    """When the runner doesn't pass an in-memory state, agent_count and
+    created_at must come from the on-disk state.json."""
+    from app.services.webhook_service import build_payload
+
+    payload = build_payload("sim_disk", "completed", str(populated_sim_dir))
+    assert payload["agent_count"] == 248
+    assert payload["created_at"] == "2026-04-26T10:12:34"
+
+
+def test_payload_state_object_takes_precedence(populated_sim_dir: Path):
+    from app.services.webhook_service import build_payload
+
+    class _State:
+        profiles_count = 999
+        created_at = "2026-04-26T11:00:00"
+        parent_simulation_id = "sim_parent"
+        current_round = 17
+        total_rounds = 30
+
+    payload = build_payload(
+        "sim_pref",
+        "completed",
+        str(populated_sim_dir),
+        state=_State(),
+    )
+    assert payload["agent_count"] == 999
+    assert payload["created_at"] == "2026-04-26T11:00:00"
+    assert payload["parent_simulation_id"] == "sim_parent"
+    assert payload["current_round"] == 17
+    assert payload["total_rounds"] == 30  # state.total_rounds wins over config
+
+
+def test_payload_handles_missing_artifacts(tmp_path: Path):
+    """Empty sim_dir → all-optional fields are None / 0, no exception."""
+    from app.services.webhook_service import build_payload
+
+    payload = build_payload("sim_empty", "completed", str(tmp_path))
+    assert payload["scenario"] == ""
+    assert payload["quality_health"] is None
+    assert payload["final_consensus"] is None
+    assert payload["resolution_outcome"] is None
+    assert payload["agent_count"] == 0
+    assert payload["total_rounds"] == 0
+
+
+def test_payload_handles_corrupt_artifacts(tmp_path: Path):
+    """Malformed JSON anywhere doesn't take the webhook down."""
+    from app.services.webhook_service import build_payload
+
+    (tmp_path / "simulation_config.json").write_text("{not json")
+    (tmp_path / "quality.json").write_text("totally broken")
+    (tmp_path / "trajectory.json").write_text("[[[")
+    (tmp_path / "resolution.json").write_text("{")
+    (tmp_path / "state.json").write_text("nope")
+
+    payload = build_payload("sim_corrupt", "completed", str(tmp_path))
+    assert payload["sim_id"] == "sim_corrupt"
+    assert payload["scenario"] == ""
+    assert payload["quality_health"] is None
+    assert payload["final_consensus"] is None
+
+
+def test_payload_event_name_matches_status():
+    """The ``event`` field is the conventional ``noun.verb`` shape — keep
+    it in sync with ``status`` so consumers can route on either."""
+    from app.services.webhook_service import build_payload
+
+    completed = build_payload("sim_a", "completed", "/nonexistent")
+    failed = build_payload("sim_b", "failed", "/nonexistent")
+    assert completed["event"] == "simulation.completed"
+    assert failed["event"] == "simulation.failed"
+
+
+# ── URL validation + masking ───────────────────────────────────────────────
+
+
+def test_validate_url_accepts_http_and_https():
+    from app.services.webhook_service import validate_url
+
+    assert validate_url("https://hooks.slack.com/services/T0/B0/abc") is None
+    assert validate_url("http://internal.svc:8080/hook") is None
+    # Empty disables the webhook — that's a valid configuration.
+    assert validate_url("") is None
+    assert validate_url("   ") is None
+
+
+def test_validate_url_rejects_other_schemes():
+    from app.services.webhook_service import validate_url
+
+    assert validate_url("ftp://example.com/hook") is not None
+    assert validate_url("javascript:alert(1)") is not None
+    assert validate_url("file:///etc/passwd") is not None
+    assert validate_url("hooks.slack.com/abc") is not None  # no scheme
+
+
+def test_validate_url_rejects_overlong():
+    from app.services.webhook_service import validate_url
+
+    assert validate_url("https://x.com/" + "a" * 5000) is not None
+
+
+def test_mask_url_hides_path():
+    from app.services.webhook_service import mask_url
+
+    masked = mask_url("https://hooks.slack.com/services/T0XXX/B0YYY/abcSECRETxyz")
+    assert masked == "https://hooks.slack.com/***"
+    assert "abcSECRETxyz" not in masked
+    assert "T0XXX" not in masked
+
+
+def test_mask_url_handles_empty_and_garbage():
+    from app.services.webhook_service import mask_url
+
+    assert mask_url("") == ""
+    assert mask_url("not a url") == "***"
+
+
+# ── fire_webhook_for_simulation behavior ───────────────────────────────────
+
+
+def test_fire_is_no_op_without_configured_url(populated_sim_dir: Path):
+    """If WEBHOOK_URL is empty, the function must not call _post_json."""
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    with patch.object(webhook_service, '_resolve_webhook_url', return_value=''), \
+         patch.object(webhook_service, '_post_json') as mock_post:
+        webhook_service.fire_webhook_for_simulation(
+            "sim_noop",
+            "completed",
+            sim_dir=str(populated_sim_dir),
+        )
+    assert mock_post.call_count == 0
+
+
+def test_fire_dispatches_in_background_thread(populated_sim_dir: Path):
+    """The POST happens on a daemon thread — the call returns immediately
+    even if the network would block forever."""
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    started = threading.Event()
+    finished = threading.Event()
+
+    def slow_post(url, payload, timeout):
+        started.set()
+        # Simulate a slow webhook endpoint — but bounded so the test
+        # actually completes if something goes wrong.
+        finished.wait(timeout=2.0)
+        return True, "HTTP 200"
+
+    with patch.object(webhook_service, '_resolve_webhook_url',
+                      return_value='https://example.com/hook'), \
+         patch.object(webhook_service, '_post_json', side_effect=slow_post):
+        webhook_service.fire_webhook_for_simulation(
+            "sim_async",
+            "completed",
+            sim_dir=str(populated_sim_dir),
+        )
+        # The fire call must have returned even though _post_json is still
+        # blocked. Wait briefly for the daemon thread to pick up the work.
+        assert started.wait(timeout=2.0), "Background thread never ran"
+        finished.set()  # let the mocked POST return
+
+
+def test_fire_dedups_per_sim_and_status(populated_sim_dir: Path):
+    """Two fire_webhook calls with the same (sim_id, status) → one POST.
+    Different status (completed vs failed) → two POSTs."""
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    calls: list = []
+    done = threading.Event()
+    counter = {'n': 0}
+
+    def record_post(url, payload, timeout):
+        calls.append(payload['event'])
+        counter['n'] += 1
+        if counter['n'] >= 2:
+            done.set()
+        return True, "HTTP 200"
+
+    with patch.object(webhook_service, '_resolve_webhook_url',
+                      return_value='https://example.com/hook'), \
+         patch.object(webhook_service, '_post_json', side_effect=record_post):
+        webhook_service.fire_webhook_for_simulation(
+            "sim_dedup", "completed", sim_dir=str(populated_sim_dir),
+        )
+        webhook_service.fire_webhook_for_simulation(
+            "sim_dedup", "completed", sim_dir=str(populated_sim_dir),
+        )
+        webhook_service.fire_webhook_for_simulation(
+            "sim_dedup", "failed", sim_dir=str(populated_sim_dir),
+        )
+        # Wait for both expected fires (completed + failed) — the second
+        # completed call is deduped and never reaches _post_json.
+        assert done.wait(timeout=3.0), f"Only {counter['n']} POSTs fired"
+
+    assert sorted(calls) == ["simulation.completed", "simulation.failed"]
+
+
+def test_fire_swallows_post_failures(populated_sim_dir: Path):
+    """A POST that raises mid-flight must not crash the background thread
+    or propagate to the caller."""
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    finished = threading.Event()
+
+    def boom(url, payload, timeout):
+        finished.set()
+        raise RuntimeError("simulated network blip")
+
+    with patch.object(webhook_service, '_resolve_webhook_url',
+                      return_value='https://example.com/hook'), \
+         patch.object(webhook_service, '_post_json', side_effect=boom):
+        # The fire call itself must not raise even though _post_json will.
+        webhook_service.fire_webhook_for_simulation(
+            "sim_boom", "completed", sim_dir=str(populated_sim_dir),
+        )
+        assert finished.wait(timeout=2.0)
+
+
+def test_fire_ignores_unknown_status(populated_sim_dir: Path):
+    """Only ``completed`` / ``failed`` are valid terminal statuses."""
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    with patch.object(webhook_service, '_resolve_webhook_url',
+                      return_value='https://example.com/hook'), \
+         patch.object(webhook_service, '_post_json') as mock_post:
+        webhook_service.fire_webhook_for_simulation(
+            "sim_running", "running", sim_dir=str(populated_sim_dir),
+        )
+    assert mock_post.call_count == 0
+
+
+# ── send_test_webhook ──────────────────────────────────────────────────────
+
+
+def test_test_webhook_returns_validation_error_for_bad_url():
+    from app.services.webhook_service import send_test_webhook
+
+    result = send_test_webhook("not-a-url")
+    assert result["ok"] is False
+    assert "http://" in result["message"]
+
+
+def test_test_webhook_posts_sample_payload():
+    from app.services import webhook_service
+
+    captured: dict = {}
+
+    def capture(url, payload, timeout):
+        captured["url"] = url
+        captured["payload"] = payload
+        return True, "HTTP 204"
+
+    with patch.object(webhook_service, '_post_json', side_effect=capture):
+        result = webhook_service.send_test_webhook(
+            "https://example.com/hook",
+            base_url="https://miroshark.app",
+        )
+
+    assert result["ok"] is True
+    assert "latency_ms" in result
+    assert captured["url"] == "https://example.com/hook"
+    assert captured["payload"]["event"] == "simulation.test"
+    assert captured["payload"]["test"] is True
+    assert captured["payload"]["share_url"].startswith("https://miroshark.app/share/")
+
+
+# ── Sanity that the runner's import path still works ──────────────────────
+
+
+def test_runner_can_import_webhook_service():
+    """Catches accidental rename / refactor that would break the late
+    import inside SimulationRunner._monitor_simulation."""
+    from app.services.webhook_service import fire_webhook_for_simulation
+    assert callable(fire_webhook_for_simulation)

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -1,0 +1,181 @@
+# Webhooks
+
+MiroShark fires an outbound HTTP **POST** to a URL of your choosing the moment a simulation reaches a terminal state — `completed` or `failed`. The payload includes the scenario, final consensus, quality assessment, and a public share-card URL so consumers like Slack and Discord auto-unfurl with a rich preview.
+
+> **Tip:** open MiroShark → **Settings → Integrations · Webhook** to paste your URL and fire a test event without leaving the app. The same URL is read by the runner for live runs.
+
+---
+
+## Why a webhook
+
+The completion webhook is the integration surface for everything that lives outside MiroShark itself:
+
+- **Slack / Discord / Teams** — paste an Incoming Webhook URL; chat channels light up the moment a long simulation finishes, with the share-card image inline.
+- **Zapier / Make / n8n / IFTTT** — point the Zap/Scenario/Workflow at MiroShark and fan out from there: email digests, Notion rows, Airtable records, Google Sheet updates, custom dashboards.
+- **Custom apps** — your own Cloud Run / Lambda / Express endpoint receives the JSON; do whatever you like with it (kick off downstream analysis, append to a queue, write to BigQuery, …).
+
+No bot, no OAuth, no hosted infrastructure. One URL field.
+
+---
+
+## Configuration
+
+Either set environment variables before launching MiroShark:
+
+```bash
+WEBHOOK_URL=https://hooks.slack.com/services/T0XXX/B0YYY/abcSECRETxyz
+PUBLIC_BASE_URL=https://miroshark.app           # optional, see below
+```
+
+…or open **Settings → Integrations · Webhook** and paste the URL there. Settings changes apply at runtime — no restart.
+
+`PUBLIC_BASE_URL` is the publicly-reachable base of your MiroShark deployment (e.g. `https://miroshark.app`). When set, the payload contains absolute `share_url` and `share_card_url` fields so Slack / Discord auto-unfurl with the simulation card. Leave it blank if you only need relative paths and your consumer can build absolute URLs itself.
+
+---
+
+## Payload schema
+
+```json
+{
+  "event": "simulation.completed",
+  "sim_id": "sim_abc123def456",
+  "scenario": "Will the SEC approve a spot Solana ETF before Q3 2026?",
+  "status": "completed",
+  "current_round": 20,
+  "total_rounds": 20,
+  "agent_count": 248,
+  "quality_health": "Excellent",
+  "final_consensus": {
+    "bullish": 62.0,
+    "neutral": 13.0,
+    "bearish": 25.0
+  },
+  "resolution_outcome": "YES",
+  "share_path": "/share/sim_abc123def456",
+  "share_card_path": "/api/simulation/sim_abc123def456/share-card.png",
+  "share_url": "https://miroshark.app/share/sim_abc123def456",
+  "share_card_url": "https://miroshark.app/api/simulation/sim_abc123def456/share-card.png",
+  "created_at": "2026-04-26T10:12:34",
+  "completed_at": "2026-04-26T10:35:11",
+  "parent_simulation_id": null,
+  "fired_at": "2026-04-26T10:35:11.842113+00:00"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `event` | string | `simulation.completed`, `simulation.failed`, or `simulation.test` |
+| `sim_id` | string | Stable identifier — also in the `X-MiroShark-Sim-Id` header |
+| `scenario` | string | Truncated to 280 characters with a Unicode ellipsis |
+| `status` | string | `completed`, `failed`, or `test` |
+| `current_round` | int | Last completed round at completion time |
+| `total_rounds` | int | Configured total — `0` if not yet known |
+| `agent_count` | int | Number of agent profiles |
+| `quality_health` | string \| null | `Excellent` / `Good` / `Fair` / `Poor`, or `null` if assessment skipped |
+| `final_consensus` | object \| null | Bullish / neutral / bearish percentages from the last belief snapshot |
+| `resolution_outcome` | string \| null | Set when the run had a polymarket resolution (`YES` / `NO`) |
+| `share_path` | string | Always relative; safe to log |
+| `share_card_path` | string | Always relative |
+| `share_url` | string \| absent | Only present when `PUBLIC_BASE_URL` is set |
+| `share_card_url` | string \| absent | Only present when `PUBLIC_BASE_URL` is set |
+| `created_at` | string \| null | ISO 8601, simulation creation time |
+| `completed_at` | string \| null | ISO 8601, terminal-state time |
+| `parent_simulation_id` | string \| null | Set when this run was forked from another |
+| `fired_at` | string | ISO 8601 with timezone, when the webhook left MiroShark |
+| `error` | string \| absent | Only on `simulation.failed` — truncated to 1000 chars |
+| `test` | bool \| absent | `true` only on the `simulation.test` event |
+
+### HTTP headers
+
+| Header | Value |
+|---|---|
+| `Content-Type` | `application/json; charset=utf-8` |
+| `User-Agent` | `MiroShark-Webhook/1.0` |
+| `X-MiroShark-Event` | The same value as `event` |
+| `X-MiroShark-Sim-Id` | The same value as `sim_id` |
+
+---
+
+## Delivery semantics
+
+- **Fire-and-forget** — the POST runs on a daemon thread, so a slow endpoint never delays the simulation runner.
+- **Best-effort, no retries** — a single attempt with a 5-second timeout. Consumers that need durability should accept the webhook into a queue and acknowledge with HTTP 2xx as fast as possible.
+- **Deduped per process** — the runner can detect completion via two paths (process exit code + per-platform `simulation_end` events). Both call into the webhook service; only the first fire per `(sim_id, status)` actually sends.
+- **`completed` and `failed` only** — pause / resume / running events are *not* delivered.
+- **2xx = success** — anything else is logged as a delivery failure but never raised.
+
+---
+
+## Examples
+
+### Slack
+
+```bash
+WEBHOOK_URL=https://hooks.slack.com/services/T0XXX/B0YYY/abcSECRETxyz
+PUBLIC_BASE_URL=https://miroshark.example.com
+```
+
+The Slack message will unfurl `share_url` automatically into the OG card produced by `GET /api/simulation/<id>/share-card.png` (1200×630 PNG with scenario, consensus split, and quality badge). No additional formatting needed.
+
+### Discord
+
+```bash
+WEBHOOK_URL=https://discord.com/api/webhooks/123456789/abcSECRETxyz
+PUBLIC_BASE_URL=https://miroshark.example.com
+```
+
+Discord channel webhooks accept the same JSON body. The `share_url` unfurls in the channel.
+
+### Zapier / Make / n8n
+
+Create a "Webhook by Zapier" / "Webhooks · Custom webhook" / "Webhook" trigger node and copy its URL into `WEBHOOK_URL`. Every simulation completion becomes a fresh trigger event with the full payload above — fan out to email, Notion, Sheets, or any of the 5,000+ integrations they offer.
+
+### Custom listener (Python)
+
+```python
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+@app.post("/miroshark-webhook")
+async def receive(req: Request):
+    payload = await req.json()
+    if payload["event"] == "simulation.completed":
+        print(f"{payload['sim_id']}: {payload['scenario']!r} → {payload['final_consensus']}")
+    return {"ok": True}
+```
+
+---
+
+## Testing your endpoint
+
+The fastest path is the **Send test event** button in **Settings → Integrations · Webhook** — it POSTs the same shape with `event: "simulation.test"` and `test: true`, and shows the response status / latency inline.
+
+The same call is exposed as `POST /api/settings/test-webhook` for scripting:
+
+```bash
+curl -s -X POST http://localhost:5000/api/settings/test-webhook \
+     -H 'Content-Type: application/json' \
+     -d '{"url": "https://example.com/hook"}'
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "message": "HTTP 200",
+  "latency_ms": 142,
+  "url_masked": "https://example.com/***"
+}
+```
+
+Omit the body to test the currently saved `WEBHOOK_URL`.
+
+---
+
+## Security notes
+
+- The full webhook URL is treated as a secret — `GET /api/settings` only returns the masked form (`https://hooks.slack.com/***`). The path is never echoed back.
+- Webhook calls go straight from your MiroShark instance to your endpoint — no Anthropic or third-party hop.
+- Validation rejects any URL that doesn't start with `http://` or `https://`. JavaScript / file / FTP URLs are blocked at the API layer.

--- a/frontend/src/api/settings.js
+++ b/frontend/src/api/settings.js
@@ -34,3 +34,19 @@ export const updateSettings = (data) => {
 export const testLlmConnection = () => {
   return service.post('/api/settings/test-llm')
 }
+
+/**
+ * Fire a sample event at a webhook URL — used by the Settings
+ * "Send test event" button. Pass a URL to test an unsaved value;
+ * omit it to test the currently saved Config.WEBHOOK_URL.
+ *
+ * @param {string} [url]
+ * @param {string} [publicBaseUrl]
+ * @returns {Promise<{ success, message, latency_ms, url_masked }>}
+ */
+export const testWebhook = (url, publicBaseUrl) => {
+  const body = {}
+  if (url) body.url = url
+  if (publicBaseUrl) body.public_base_url = publicBaseUrl
+  return service.post('/api/settings/test-webhook', body)
+}

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -348,6 +348,79 @@
           </div>
         </section>
 
+        <!-- Outbound webhook · Slack / Discord / Zapier / n8n / custom -->
+        <section class="settings-section ai-section">
+          <div class="section-header">
+            <span class="section-label">Integrations · Webhook</span>
+            <div class="status-badge" :class="webhookSavedClass">
+              <span class="badge-dot"></span>
+              {{ webhookSavedText }}
+            </div>
+          </div>
+
+          <div class="ai-intro">
+            POST a JSON summary to your URL the moment a simulation finishes —
+            wires Slack, Discord, Zapier, Make, n8n, IFTTT, or any custom listener.
+            Empty to disable. Payload includes scenario, final consensus, quality,
+            and the share-card URL so links auto-unfurl.
+          </div>
+
+          <div class="field-row">
+            <label class="field-label">Webhook URL</label>
+            <input
+              v-model="form.integrations.webhook.url"
+              class="field-input"
+              type="text"
+              :placeholder="webhookPlaceholder"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div class="field-hint">
+              e.g.
+              <code>https://hooks.slack.com/services/T0…/B0…/abc</code>
+              or any URL that accepts a POST.
+              See <a href="https://github.com/aaronjmars/MiroShark/blob/main/docs/WEBHOOKS.md"
+                     target="_blank" rel="noopener">the webhook docs</a>
+              for the payload schema.
+            </div>
+          </div>
+
+          <div class="field-row">
+            <label class="field-label">Public base URL <span class="field-label-optional">(optional)</span></label>
+            <input
+              v-model="form.integrations.webhook.public_base_url"
+              class="field-input"
+              type="text"
+              placeholder="https://miroshark.app"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div class="field-hint">
+              When set, the payload includes absolute <code>share_url</code> +
+              <code>share_card_url</code> so Slack &amp; Discord auto-unfurl
+              with the simulation card. Leave blank for relative paths only.
+            </div>
+          </div>
+
+          <div class="field-row webhook-actions">
+            <button
+              class="ai-retry"
+              :disabled="webhookTesting || !webhookCanTest"
+              @click="testWebhookFire"
+            >
+              {{ webhookTesting ? 'Sending…' : 'Send test event' }}
+            </button>
+            <span v-if="webhookTestResult" class="webhook-test-result" :class="webhookTestResult.success ? 'ok' : 'fail'">
+              <template v-if="webhookTestResult.success">
+                ✓ Delivered ({{ webhookTestResult.latency_ms }}ms)
+              </template>
+              <template v-else>
+                ✗ {{ webhookTestResult.error || webhookTestResult.message || 'Failed' }}
+              </template>
+            </span>
+          </div>
+        </section>
+
         <!-- AI Integration (MCP) -->
         <section class="settings-section ai-section">
           <div class="section-header">
@@ -476,7 +549,7 @@
 
 <script setup>
 import { ref, reactive, computed, watch } from 'vue'
-import { getSettings, updateSettings, testLlmConnection } from '../api/settings'
+import { getSettings, updateSettings, testLlmConnection, testWebhook } from '../api/settings'
 import { getMcpStatus } from '../api/mcp'
 
 const props = defineProps({
@@ -508,6 +581,12 @@ const form = reactive({
     user: '',
     password: '',
   },
+  integrations: {
+    webhook: {
+      url: '',
+      public_base_url: '',
+    },
+  },
 })
 
 // UI state
@@ -522,6 +601,10 @@ const loadingModels = ref(false)
 const modelLoadError = ref('')
 const advancedOpen = ref(false)
 const inheritMarker = '— inherits default —'
+
+// Webhook integration state
+const webhookTesting = ref(false)
+const webhookTestResult = ref(null)
 
 // MCP / AI Integration state
 const mcpStatus = ref(null)
@@ -538,6 +621,7 @@ watch(() => props.open, async (isOpen) => {
     saveError.value = ''
     saveSuccess.value = false
     testResult.value = null
+    webhookTestResult.value = null
     form.preset = ''
     form.presetApiKey = ''
     copyState.value = ''
@@ -566,6 +650,11 @@ const loadCurrentSettings = async () => {
       form.neo4j.uri = d.neo4j?.uri || ''
       form.neo4j.user = d.neo4j?.user || ''
       form.neo4j.password = ''
+      // Webhook URL is masked server-side — never round-trip the masked
+      // form back as a value the user could accidentally save. Leave the
+      // input blank when configured so editing is explicit.
+      form.integrations.webhook.url = ''
+      form.integrations.webhook.public_base_url = d.integrations?.webhook?.public_base_url || ''
     }
   } catch (_) {
     // Non-fatal
@@ -717,6 +806,45 @@ const testStatusText = computed(() => {
   return testResult.value.success ? 'Connected' : 'Failed'
 })
 
+const webhookConfigured = computed(() =>
+  Boolean(currentSettings.value.integrations?.webhook?.configured)
+)
+
+const webhookSavedClass = computed(() => (webhookConfigured.value ? 'ok' : 'idle'))
+const webhookSavedText = computed(() =>
+  webhookConfigured.value ? 'Configured' : 'Not configured'
+)
+
+const webhookPlaceholder = computed(() => {
+  if (webhookConfigured.value) {
+    const masked = currentSettings.value.integrations?.webhook?.url_masked
+    return masked
+      ? `${masked} — leave blank to keep, type to replace`
+      : 'Leave blank to keep saved URL, type to replace'
+  }
+  return 'https://hooks.slack.com/services/T0…/B0…/abc'
+})
+
+// The button can fire when there's a typed URL OR a saved one to retry.
+const webhookCanTest = computed(() =>
+  Boolean(form.integrations.webhook.url?.trim()) || webhookConfigured.value
+)
+
+const testWebhookFire = async () => {
+  webhookTesting.value = true
+  webhookTestResult.value = null
+  try {
+    const url = form.integrations.webhook.url?.trim() || ''
+    const baseUrl = form.integrations.webhook.public_base_url?.trim() || ''
+    const res = await testWebhook(url, baseUrl)
+    webhookTestResult.value = res
+  } catch (e) {
+    webhookTestResult.value = { success: false, error: e?.message || 'Network error' }
+  } finally {
+    webhookTesting.value = false
+  }
+}
+
 const saveSettings = async () => {
   saving.value = true
   saveError.value = ''
@@ -752,6 +880,17 @@ const saveSettings = async () => {
     }
     if (form.neo4j.password) payload.neo4j.password = form.neo4j.password
 
+    // Webhook integration — only send `url` when the user actually typed
+    // something (blank input means "keep what's saved"). The base URL is
+    // always sent because clearing it should be a deliberate action.
+    const wh = {}
+    const typedUrl = form.integrations.webhook.url?.trim()
+    if (typedUrl !== undefined && typedUrl !== '') {
+      wh.url = typedUrl
+    }
+    wh.public_base_url = form.integrations.webhook.public_base_url?.trim() || ''
+    payload.integrations = { webhook: wh }
+
     const res = await updateSettings(payload)
     if (res?.success && res.data) {
       saveSuccess.value = true
@@ -759,6 +898,9 @@ const saveSettings = async () => {
       form.llm.api_key = ''
       form.presetApiKey = ''
       form.neo4j.password = ''
+      // Reset the webhook URL input so the placeholder shows the new
+      // masked value and we don't accidentally re-save the same string.
+      form.integrations.webhook.url = ''
       setTimeout(() => { saveSuccess.value = false }, 4000)
     } else {
       saveError.value = res?.error || 'Save failed'
@@ -1151,6 +1293,31 @@ const saveSettings = async () => {
 }
 .save-btn:hover:not(:disabled) { background: #FF6B1A; border-color: #FF6B1A; }
 .save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Webhook integration row ── */
+.webhook-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.webhook-test-result {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+}
+
+.webhook-test-result.ok { color: #15803D; }
+.webhook-test-result.fail { color: #FF4444; }
+
+.field-label-optional {
+  color: rgba(10,10,10,0.4);
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 11px;
+}
 
 /* ── AI Integration (MCP) ── */
 .ai-section {


### PR DESCRIPTION
## What

Outbound HTTP webhook fired when a simulation reaches a terminal state
(``completed`` or ``failed``). One URL field in **Settings → Integrations
· Webhook** wires up Slack Incoming Webhooks, Discord channel webhooks,
Zapier / Make / n8n / IFTTT triggers, or any custom listener — no bot,
no OAuth, no hosted infrastructure.

The payload includes the scenario, final consensus split (bullish /
neutral / bearish %), quality assessment, polymarket resolution
outcome, and — when ``PUBLIC_BASE_URL`` is set — absolute ``share_url``
+ ``share_card_url`` fields so Slack and Discord auto-unfurl with the
1200×630 OG card produced by PR #42.

## Why

Researchers running long simulations (50+ agents, 20+ rounds) close the
tab and come back later — they miss the moment of completion. Until
now the only way to know a run finished was the in-app browser push
notification or polling the simulation view. Browser push reaches one
device; the operator's Slack channel reaches the whole team plus their
automation stack.

The completion webhook is a strict superset of the
single-Discord/Slack post-button idea also raised in the Apr 24
repo-actions batch — pointing the same URL at a Zapier / Make / n8n
trigger fans out to email, Notion, Airtable, Sheets, custom dashboards,
or any of the 5,000+ integrations they offer. One URL field, several
distribution surfaces.

Direct lever for the 1K-stars-by-Apr-30 sprint: production-grade
"webhook on completion" is on the checklist developers and ML
researchers run when evaluating a tool as infrastructure rather than
demo, and the Apr 24 ``Webhooks (n8n / Zapier / Make)`` keyword
combination drives organic discovery from the integration-platform
audiences.

## Changes

- **``backend/app/services/webhook_service.py``** *(new)* — fire-and-forget
  service with:
  - ``build_payload()`` — minimal disk reads of
    ``simulation_config.json`` / ``quality.json`` / ``trajectory.json``
    / ``resolution.json`` / ``state.json``; mirrors the
    ``±0.2`` stance threshold used by the gallery card and share-card
    helpers so the webhook reports the same consensus the user sees.
    Long scenarios truncated to 280 chars; failure payload trims
    error to 1000 chars.
  - ``fire_webhook_for_simulation()`` — daemon-thread POST, deduped
    per ``(sim_id, status)`` so the runner's exit-code path and
    ``simulation_end``-event path can both call it without firing
    twice. No-op when ``Config.WEBHOOK_URL`` is empty.
  - ``send_test_webhook()`` — synchronous sample POST used by the
    Settings *Send test event* button. Returns ``{ok, message,
    latency_ms}``.
  - ``validate_url()`` / ``mask_url()`` — accept ``http(s)://`` only,
    reject ``javascript:`` / ``file:`` / ``ftp:`` / scheme-less /
    overlong; mask saved URLs to ``scheme://host/***`` so the secret
    portion of a Slack or Discord webhook URL is never echoed back.
  - Stdlib only (``urllib.request``) — zero new dependencies.
- **``backend/app/services/simulation_runner.py``** — ``fire_webhook_for_simulation``
  call alongside the existing ``send_push_notification`` in both
  terminal paths: the exit-code path (``RunnerStatus.COMPLETED`` /
  ``FAILED``) and the per-platform ``simulation_end`` event path. All
  ``try`` / ``except`` blocks log + swallow so a failing webhook never
  takes down the runner.
- **``backend/app/config.py``** — adds ``WEBHOOK_URL`` (default ``""``,
  empty disables) and ``PUBLIC_BASE_URL`` (default ``""``).
- **``backend/app/api/settings.py``** —
  - ``GET /api/settings`` returns
    ``integrations.webhook = {configured, url_masked, public_base_url}``.
  - ``POST /api/settings`` accepts
    ``{integrations: {webhook: {url, public_base_url}}}`` with URL
    validation (returns HTTP 400 on bad scheme).
  - ``POST /api/settings/test-webhook`` — fires the sample event,
    returns ``{success, message, latency_ms, url_masked}``. Always
    HTTP 200 so the frontend can render success / failure body
    uniformly.
- **``frontend/src/components/SettingsPanel.vue``** — new
  *Integrations · Webhook* section above *AI Integration · MCP* with
  status badge (Configured / Not configured), URL input that
  pre-renders the masked saved value as the placeholder, optional
  *Public base URL*, and a *Send test event* button that surfaces
  ``✓ Delivered (Nms)`` or the failure reason inline.
- **``frontend/src/api/settings.js``** — ``testWebhook(url, publicBaseUrl)``
  helper.
- **``docs/WEBHOOKS.md``** *(new)* — full payload schema, HTTP headers,
  delivery semantics (fire-and-forget, no retries, dedup, 5s timeout,
  2xx = success), and Slack / Discord / Zapier / n8n / custom-listener
  recipes.
- **``README.md``** — Features table gets a *Completion Webhook* row;
  Documentation table gets a [Webhooks](docs/WEBHOOKS.md) row.
- **``.env.example``** — ``WEBHOOK_URL`` and ``PUBLIC_BASE_URL`` blocks
  with examples.
- **``backend/tests/test_unit_webhook.py``** *(new, 18 tests)* — payload
  shape (full / minimal / corrupt / long-scenario / failure), URL
  validation + masking, ``fire_webhook_for_simulation`` no-op when
  unconfigured, async dispatch (caller returns before slow POST
  completes), per-(sim_id, status) dedup, exception-swallowing,
  unknown-status guard, and ``send_test_webhook`` end-to-end. Mocks
  ``_post_json`` so no real HTTP fires.

## Tests

```
pytest backend/tests/test_unit_webhook.py -v
```

All offline. The dedup test exercises both the ``completed`` and
``failed`` paths to confirm different-status events are *not* deduped.

## Notes

- Coexists cleanly with the in-flight PR #45 OpenAPI spec: when both
  merge, the new ``POST /api/settings/test-webhook`` route needs to be
  added to ``backend/openapi.yaml`` (or to its drift-detection
  allowlist) — happy to follow up with that on whichever PR merges
  second.
- Kept entirely additive — no existing endpoints, services, or UI rows
  changed. ``send_push_notification`` continues to fire alongside.

---
*Built autonomously by Aeon — repo-actions Apr 24 idea #3*