### PR TITLE
feat: Predictive Accuracy Ledger + /verified gallery hall

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
 | **Embed & Publish** | Public/private toggle + embed URLs for sharing finished runs |
 | **Social Share Card** | 1200×630 PNG that auto-unfurls scenario, status, quality, and belief split on Twitter/X, Discord, Slack, LinkedIn |
 | **Public Gallery** | `/explore` browses every published simulation as a card grid — preview the share card, consensus split, and quality health; click to open or one-click fork |
+| **Verified Predictions** | Annotate any public sim with the real-world outcome (called it / partial / called wrong + URL). `/verified` is the dedicated hall of calls that landed |
 | **Article Generation** | Substack-style write-up of what happened, grounded in actual posts and trades |
 | **Interaction Network** | Force-directed agent-to-agent graph with echo-chamber metrics |
 | **Demographics** | Archetype clustering (analyst / influencer / retail / observer…) |

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4613,6 +4613,49 @@ def get_share_card(simulation_id: str):
 # ============== Public Gallery ==============
 
 
+_VALID_OUTCOME_LABELS = ("correct", "incorrect", "partial")
+
+
+def _read_outcome_file(sim_dir: str) -> dict | None:
+    """Read ``<sim_dir>/outcome.json`` if it exists.
+
+    Returns the parsed dict (with the public fields the gallery + embed
+    surfaces care about) or ``None`` when the file is absent or malformed.
+    Never raises — a corrupt artifact must not blank out the gallery.
+    """
+    outcome_path = os.path.join(sim_dir, "outcome.json")
+    if not os.path.exists(outcome_path):
+        return None
+    try:
+        with open(outcome_path, 'r', encoding='utf-8') as f:
+            data = json.load(f) or {}
+    except Exception:
+        return None
+
+    label = (data.get("label") or "").strip().lower()
+    if label not in _VALID_OUTCOME_LABELS:
+        # Silently ignore an artifact with an unknown label — same posture
+        # as the rest of the gallery helper: render the card without it.
+        return None
+
+    summary = (data.get("outcome_summary") or "").strip()
+    if len(summary) > 280:
+        summary = summary[:277].rstrip() + "…"
+
+    url = (data.get("outcome_url") or "").strip()
+    # Only echo URLs we recognize — protects readers from a malformed
+    # ``javascript:``/``file://`` value sneaking onto the gallery card.
+    if url and not (url.startswith("http://") or url.startswith("https://")):
+        url = ""
+
+    return {
+        "label": label,
+        "outcome_url": url,
+        "outcome_summary": summary,
+        "submitted_at": data.get("submitted_at") or "",
+    }
+
+
 def _build_gallery_card_payload(state, sim_dir: str) -> dict:
     """Assemble the minimal card-friendly payload for the public gallery.
 
@@ -4710,6 +4753,8 @@ def _build_gallery_card_payload(state, sim_dir: str) -> dict:
         except Exception:
             pass
 
+    outcome = _read_outcome_file(sim_dir)
+
     return {
         "simulation_id": state.simulation_id,
         "scenario": scenario,
@@ -4721,6 +4766,7 @@ def _build_gallery_card_payload(state, sim_dir: str) -> dict:
         "quality_health": quality_health,
         "final_consensus": final_consensus,
         "resolution_outcome": resolution_outcome,
+        "outcome": outcome,
         "created_at": state.created_at,
         "parent_simulation_id": state.parent_simulation_id,
         "share_card_url": f"/api/simulation/{state.simulation_id}/share-card.png",
@@ -4740,6 +4786,9 @@ def list_public_simulations():
     Query parameters:
         limit: max items to return (default 50, clamped to [1, 100])
         offset: pagination offset (default 0)
+        verified: when truthy ("1", "true", "yes"), filter to simulations
+            with a recorded outcome annotation (see
+            ``POST /api/simulation/<id>/outcome``).
 
     Response shape::
 
@@ -4781,11 +4830,25 @@ def list_public_simulations():
         limit = max(1, min(100, int(limit or 50)))
         offset = max(0, int(offset or 0))
 
+        verified_raw = (request.args.get('verified') or "").strip().lower()
+        verified_only = verified_raw in ("1", "true", "yes", "on")
+
         manager = SimulationManager()
         all_sims = manager.list_simulations()
 
         public_sims = [s for s in all_sims if bool(getattr(s, "is_public", False))]
         public_sims.sort(key=lambda s: s.created_at or "", reverse=True)
+
+        if verified_only:
+            # Filter on disk before paginating so ``total`` reflects the
+            # filtered set — otherwise the "X remaining" hint and
+            # ``has_more`` flag would lie about how much is left.
+            verified_sims = []
+            for s in public_sims:
+                sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, s.simulation_id)
+                if _read_outcome_file(sim_dir) is not None:
+                    verified_sims.append(s)
+            public_sims = verified_sims
 
         total = len(public_sims)
         page = public_sims[offset:offset + limit]
@@ -4810,6 +4873,7 @@ def list_public_simulations():
             "limit": limit,
             "offset": offset,
             "has_more": offset + len(items) < total,
+            "verified_only": verified_only,
         })
         # Short cache so newly-published simulations show up quickly while
         # still absorbing repeat hits from bots/social unfurlers.
@@ -5849,6 +5913,116 @@ def resolve_simulation(simulation_id: str):
             "success": False,
             "error": str(e),
             "traceback": traceback.format_exc()
+        }), 500
+
+
+# ============== Predictive Accuracy Ledger ==============
+
+
+@simulation_bp.route('/<simulation_id>/outcome', methods=['POST', 'GET'])
+def simulation_outcome(simulation_id: str):
+    """Verified-Prediction annotation layer for public simulations.
+
+    A lightweight successor to ``/resolve``: that one writes a binary
+    YES/NO Polymarket-aligned resolution, this one accepts an open-ended
+    "did this run predict a real event?" annotation. The two are
+    complementary — a simulation can have both — and outcome.json is the
+    record the public gallery and ``/verified`` filter read from.
+
+    Body (POST):
+
+        {
+            "label": "correct" | "incorrect" | "partial",   // required
+            "outcome_url": "https://...",                    // optional
+            "outcome_summary": "Tweet-sized description"      // ≤280 chars
+        }
+
+    Returns the saved outcome on success. Submission requires
+    ``is_public=True`` on the simulation (toggle via ``/publish``).
+
+    GET returns the current outcome (or ``data: null``) — no publish
+    gate so the embed dialog can show the existing annotation when the
+    operator re-opens it.
+    """
+    try:
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+
+        if request.method == 'GET':
+            outcome = _read_outcome_file(sim_dir)
+            return jsonify({"success": True, "data": outcome})
+
+        if not bool(getattr(state, "is_public", False)):
+            return jsonify({
+                "success": False,
+                "error": "Simulation must be public to record an outcome. POST /api/simulation/<id>/publish to enable.",
+            }), 403
+
+        data = request.get_json(force=True, silent=True) or {}
+        label = (data.get("label") or "").strip().lower()
+        if label not in _VALID_OUTCOME_LABELS:
+            return jsonify({
+                "success": False,
+                "error": "label must be one of: correct, incorrect, partial",
+            }), 400
+
+        outcome_url = (data.get("outcome_url") or "").strip()
+        if outcome_url and not (outcome_url.startswith("http://") or outcome_url.startswith("https://")):
+            return jsonify({
+                "success": False,
+                "error": "outcome_url must be an http(s) URL",
+            }), 400
+        if len(outcome_url) > 500:
+            return jsonify({
+                "success": False,
+                "error": "outcome_url must be 500 characters or fewer",
+            }), 400
+
+        outcome_summary = (data.get("outcome_summary") or "").strip()
+        if len(outcome_summary) > 280:
+            return jsonify({
+                "success": False,
+                "error": "outcome_summary must be 280 characters or fewer",
+            }), 400
+
+        try:
+            os.makedirs(sim_dir, exist_ok=True)
+        except OSError as exc:
+            logger.error(f"outcome: failed to ensure sim_dir for {simulation_id}: {exc}")
+            return jsonify({"success": False, "error": "Could not persist outcome."}), 500
+
+        record = {
+            "simulation_id": simulation_id,
+            "label": label,
+            "outcome_url": outcome_url,
+            "outcome_summary": outcome_summary,
+            "submitted_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        outcome_path = os.path.join(sim_dir, "outcome.json")
+        try:
+            with open(outcome_path, 'w', encoding='utf-8') as f:
+                json.dump(record, f, ensure_ascii=False, indent=2)
+        except OSError as exc:
+            logger.error(f"outcome: failed to write {outcome_path}: {exc}")
+            return jsonify({"success": False, "error": "Could not persist outcome."}), 500
+
+        logger.info(
+            f"outcome: recorded label={label} for {simulation_id} (url_set={bool(outcome_url)})"
+        )
+
+        return jsonify({"success": True, "data": _read_outcome_file(sim_dir)})
+
+    except Exception as e:
+        logger.error(f"Failed to handle outcome for {simulation_id}: {str(e)}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+            "traceback": traceback.format_exc(),
         }), 500
 
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1153,6 +1153,13 @@ paths:
         - in: query
           name: offset
           schema: { type: integer, minimum: 0, default: 0 }
+        - in: query
+          name: verified
+          description: |
+            Truthy values (`1`, `true`, `yes`, `on`) restrict the listing to
+            simulations with a recorded outcome annotation — i.e. the
+            "Verified Prediction" hall.
+          schema: { type: string }
       responses:
         "200":
           description: Gallery cards.
@@ -1171,6 +1178,7 @@ paths:
                       limit: { type: integer }
                       offset: { type: integer }
                       has_more: { type: boolean }
+                      verified_only: { type: boolean }
 
   # ────────────────────────────────────────────────────────────────────
   # Export
@@ -1235,6 +1243,83 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+
+  /api/simulation/{simulation_id}/outcome:
+    get:
+      tags: [Publish & Embed]
+      summary: Read the verified-prediction annotation for a simulation.
+      description: |
+        Returns the saved outcome (or `data: null` when the simulation has
+        none). Distinct from `/resolve`, which is binary (YES/NO) and tied
+        to Polymarket consensus. This annotation is open-ended, gallery-
+        facing, and the source for the `?verified=1` filter on
+        `/api/simulation/public`.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Outcome (may be null when none has been submitted).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        oneOf:
+                          - $ref: "#/components/schemas/SimulationOutcome"
+                          - type: "null"
+        "404": { $ref: "#/components/responses/NotFound" }
+    post:
+      tags: [Publish & Embed]
+      summary: Record a verified-prediction annotation for a public simulation.
+      description: |
+        Requires `is_public=true` on the simulation (POST `/publish` to
+        enable). Submitting again overwrites the previous annotation —
+        operators can correct a wrong call without leaving stale records.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [label]
+              properties:
+                label:
+                  type: string
+                  enum: [correct, incorrect, partial]
+                  description: How the agent consensus held up against reality.
+                outcome_url:
+                  type: string
+                  format: uri
+                  maxLength: 500
+                  description: Optional pointer to the article/tweet/dashboard that confirmed the outcome.
+                outcome_summary:
+                  type: string
+                  maxLength: 280
+                  description: Tweet-sized human description of what really happened.
+            example:
+              label: correct
+              outcome_url: https://example.com/aave-incident
+              outcome_summary: "Aave's GHO peg broke under the simulated stress scenario on 2026-04-25, matching the agent consensus."
+      responses:
+        "200":
+          description: Outcome saved.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data: { $ref: "#/components/schemas/SimulationOutcome" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "403":
+          description: Simulation is not public.
+        "404": { $ref: "#/components/responses/NotFound" }
 
   # ────────────────────────────────────────────────────────────────────
   # Report Agent
@@ -1904,11 +1989,36 @@ components:
             bearish: { type: number }
         resolution_outcome:
           oneOf: [{ type: string }, { type: "null" }]
+        outcome:
+          oneOf:
+            - $ref: "#/components/schemas/SimulationOutcome"
+            - type: "null"
         created_at: { type: string, format: date-time }
         parent_simulation_id:
           oneOf: [{ type: string }, { type: "null" }]
         share_card_url: { type: string }
         share_landing_url: { type: string }
+
+    SimulationOutcome:
+      type: object
+      description: |
+        Verified-prediction annotation written by the operator after a
+        public simulation's real-world counterpart resolved. Drives the
+        ◎ Verified badge on the gallery and the `/verified` filter view.
+      properties:
+        label:
+          type: string
+          enum: [correct, incorrect, partial]
+        outcome_url:
+          type: string
+          format: uri
+          description: External link confirming the outcome (may be empty).
+        outcome_summary:
+          type: string
+          description: Tweet-sized human description (≤280 chars).
+        submitted_at:
+          type: string
+          format: date-time
 
     SettingsUpdate:
       type: object

--- a/backend/tests/test_unit_outcome.py
+++ b/backend/tests/test_unit_outcome.py
@@ -1,0 +1,209 @@
+"""Unit tests for the Predictive Accuracy Ledger.
+
+The ledger writes a single ``<sim_dir>/outcome.json`` file per public
+simulation, and the gallery helper + ``?verified=1`` filter both read
+from it. These tests exercise the helpers directly (no Flask, no DB)
+so they run in the bare unit environment.
+
+We cover:
+
+  1. ``_read_outcome_file`` parses well-formed records and returns
+     ``None`` for missing / malformed / unknown-label artifacts.
+  2. ``_read_outcome_file`` truncates oversized summaries and rejects
+     non-http URL schemes — defense-in-depth against a corrupt file
+     leaking ``javascript:`` onto the gallery.
+  3. ``_build_gallery_card_payload`` surfaces the ``outcome`` field on
+     the card so the explore grid can render the ◎ Verified pill.
+  4. ``_build_gallery_card_payload`` keeps degrading gracefully — a
+     missing or corrupt outcome.json must not raise.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+class _FakeStatus:
+    value = "completed"
+
+
+def _make_state(simulation_id: str = "sim_outcome_test"):
+    """Lightweight stand-in for SimulationState — only the attributes the
+    gallery helper reads."""
+    class _State:
+        pass
+    s = _State()
+    s.simulation_id = simulation_id
+    s.is_public = True
+    s.profiles_count = 200
+    s.created_at = "2026-04-26T12:00:00"
+    s.parent_simulation_id = None
+    s.status = _FakeStatus()
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _no_runner_state():
+    """Bypass SimulationRunner.get_run_state — same trick as the gallery
+    test file, so the helper falls back to disk-only data."""
+    from app.api import simulation as sim_mod
+    with patch.object(sim_mod.SimulationRunner, "get_run_state", return_value=None):
+        yield
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _read_outcome_file
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_read_outcome_returns_none_when_missing(tmp_path: Path):
+    """No outcome.json on disk ⇒ no outcome on the card. The helper must
+    return ``None`` rather than raise — corrupt-or-missing states are the
+    common case for any sim that hasn't been annotated."""
+    from app.api.simulation import _read_outcome_file
+
+    assert _read_outcome_file(str(tmp_path)) is None
+
+
+def test_read_outcome_parses_valid_record(tmp_path: Path):
+    from app.api.simulation import _read_outcome_file
+
+    (tmp_path / "outcome.json").write_text(json.dumps({
+        "label": "correct",
+        "outcome_url": "https://example.com/aave-incident",
+        "outcome_summary": "Aave's GHO peg broke as the agents predicted.",
+        "submitted_at": "2026-04-27T10:00:00+00:00",
+    }))
+
+    out = _read_outcome_file(str(tmp_path))
+    assert out is not None
+    assert out["label"] == "correct"
+    assert out["outcome_url"] == "https://example.com/aave-incident"
+    assert "Aave" in out["outcome_summary"]
+    assert out["submitted_at"].startswith("2026-04-27")
+
+
+def test_read_outcome_drops_unknown_label(tmp_path: Path):
+    """An artifact with an out-of-vocabulary label must not render — the
+    gallery contract is correct/incorrect/partial, period."""
+    from app.api.simulation import _read_outcome_file
+
+    (tmp_path / "outcome.json").write_text(json.dumps({
+        "label": "MAYBE",
+        "outcome_summary": "ambiguous",
+    }))
+
+    assert _read_outcome_file(str(tmp_path)) is None
+
+
+def test_read_outcome_swallows_corrupt_json(tmp_path: Path):
+    """A corrupt outcome.json shouldn't take down the gallery. Same
+    posture as the rest of the gallery helper."""
+    from app.api.simulation import _read_outcome_file
+
+    (tmp_path / "outcome.json").write_text("{this is not json")
+
+    assert _read_outcome_file(str(tmp_path)) is None
+
+
+def test_read_outcome_truncates_oversized_summary(tmp_path: Path):
+    """A 280-char summary cap protects the gallery layout. The helper
+    truncates with an ellipsis when the file on disk is longer than that
+    — defensive, since the writer also enforces the cap."""
+    from app.api.simulation import _read_outcome_file
+
+    long_summary = "X" * 320
+    (tmp_path / "outcome.json").write_text(json.dumps({
+        "label": "partial",
+        "outcome_summary": long_summary,
+    }))
+
+    out = _read_outcome_file(str(tmp_path))
+    assert out is not None
+    assert len(out["outcome_summary"]) <= 280
+    assert out["outcome_summary"].endswith("…")
+
+
+def test_read_outcome_drops_non_http_url(tmp_path: Path):
+    """Only http(s) URLs make it onto the card — we never want a stored
+    ``javascript:`` or ``file://`` value to round-trip into a gallery
+    pill that links to it."""
+    from app.api.simulation import _read_outcome_file
+
+    (tmp_path / "outcome.json").write_text(json.dumps({
+        "label": "correct",
+        "outcome_url": "javascript:alert(1)",
+        "outcome_summary": "ok",
+    }))
+
+    out = _read_outcome_file(str(tmp_path))
+    assert out is not None
+    assert out["outcome_url"] == ""
+    assert out["label"] == "correct"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Gallery card integration
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_gallery_card_includes_outcome_when_present(tmp_path: Path):
+    """Once an outcome is recorded, the gallery card surfaces it under an
+    ``outcome`` key so the /explore grid can render the verified pill."""
+    from app.api.simulation import _build_gallery_card_payload
+
+    (tmp_path / "simulation_config.json").write_text(json.dumps({
+        "simulation_requirement": "Will Aave's GHO depeg under stress?",
+        "time_config": {"minutes_per_round": 60, "total_simulation_hours": 12},
+    }))
+    (tmp_path / "outcome.json").write_text(json.dumps({
+        "label": "correct",
+        "outcome_url": "https://example.com/aave-incident",
+        "outcome_summary": "Depegged within 4 hours of the simulated stress.",
+    }))
+
+    state = _make_state()
+    card = _build_gallery_card_payload(state, str(tmp_path))
+
+    assert "outcome" in card, "gallery card must always include the outcome key"
+    assert card["outcome"] is not None
+    assert card["outcome"]["label"] == "correct"
+    assert "Aave" in card["outcome"]["outcome_summary"] or "Depegged" in card["outcome"]["outcome_summary"]
+
+
+def test_gallery_card_outcome_is_none_without_artifact(tmp_path: Path):
+    """No outcome.json ⇒ ``outcome: None`` on the card. The /explore grid
+    branches on this to decide whether to render the pill."""
+    from app.api.simulation import _build_gallery_card_payload
+
+    state = _make_state()
+    card = _build_gallery_card_payload(state, str(tmp_path))
+
+    assert "outcome" in card
+    assert card["outcome"] is None
+
+
+def test_gallery_card_swallows_corrupt_outcome(tmp_path: Path):
+    """A corrupt outcome.json must not blank out the gallery — one bad
+    sim shouldn't blank out the whole /explore page (the same invariant
+    that motivates ``test_malformed_artifact_json_is_swallowed`` over in
+    ``test_unit_public_gallery``)."""
+    from app.api.simulation import _build_gallery_card_payload
+
+    (tmp_path / "outcome.json").write_text("{not json")
+
+    state = _make_state()
+    card = _build_gallery_card_payload(state, str(tmp_path))
+
+    assert card["simulation_id"] == state.simulation_id
+    assert card["outcome"] is None

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -85,6 +85,20 @@ Failed calls become `{"_error": "..."}` payloads rather than exceptions — agen
 
 `EmbedDialog` has a `Public / Private` toggle backed by `is_public` on the simulation state. Embed URLs return `403` on unpublished simulations — flip the toggle (or `POST /api/simulation/<id>/publish`) to make them publicly embeddable. Defaults to private so existing sims are unaffected.
 
+## Predictive Accuracy Ledger (Verified Predictions)
+
+Every public simulation can be annotated with the real-world outcome it called. From the Embed dialog, choose **Called it / Partial / Called wrong**, paste the article/tweet/dashboard URL that confirmed the outcome, add a one-sentence summary (≤280 chars), and submit. The annotation lands on `<sim_dir>/outcome.json` and immediately surfaces:
+
+- A **📍 Verified** / **⚠ Called wrong** / **◑ Partial** pill on the gallery card (the pill links straight to the outcome URL when one is provided).
+- A coloured left-edge accent on the card so the verified hall reads at a glance when scrolling fast.
+- A **Verified only** filter chip on `/explore` that flips the listing to the curated set.
+- A dedicated **`/verified`** URL — same component as `/explore` but pre-filtered to the hall of accurate calls. Drop this link into a thread when you want a single page that proves the simulations work.
+
+The annotation is open-ended on purpose — distinct from the binary `/resolve` endpoint, which is YES/NO and tied to Polymarket consensus. A simulation can have both: the binary resolution drives the existing accuracy_score, the outcome annotation drives the gallery credibility surface.
+
+- **Endpoints:** `POST /api/simulation/<id>/outcome` (publish-gated), `GET /api/simulation/<id>/outcome` (read-only, no gate), `GET /api/simulation/public?verified=1` (filtered gallery).
+- **UI:** "Mark outcome" panel inside the Embed dialog; **Verified only** filter chip + 📍 pills on `/explore`; dedicated `/verified` route.
+
 ## Social Share Card
 
 When a simulation is published, the Embed dialog also exposes a **social card** that can be auto-unfurled by Twitter/X, Discord, Slack, LinkedIn, and any other Open-Graph-aware client. Two endpoints back it:

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -565,24 +565,46 @@ export const suggestScenarios = (data) => {
  *     data: [
  *       { simulation_id, scenario, status, runner_status, current_round,
  *         total_rounds, agent_count, quality_health, final_consensus,
- *         resolution_outcome, created_at, parent_simulation_id,
+ *         resolution_outcome, outcome, created_at, parent_simulation_id,
  *         share_card_url, share_landing_url }
  *     ],
  *     count: number,        // items on this page
  *     total: number,        // total public simulations
  *     limit: number,
  *     offset: number,
- *     has_more: boolean
+ *     has_more: boolean,
+ *     verified_only: boolean
  *   }
  *
  * An empty `data` array is normal (render the empty state).
- * @param {Object} options - { limit?: number, offset?: number }
+ * @param {Object} options - { limit?: number, offset?: number, verifiedOnly?: boolean }
  */
 export const getPublicSimulations = (options = {}) => {
   const params = {}
   if (Number.isFinite(options.limit)) params.limit = options.limit
   if (Number.isFinite(options.offset)) params.offset = options.offset
+  if (options.verifiedOnly) params.verified = '1'
   return service.get('/api/simulation/public', { params, timeout: 15000 })
+}
+
+/**
+ * Read the verified-prediction annotation for a simulation.
+ * Returns `data: null` when none has been submitted yet.
+ * @param {string} simulationId
+ */
+export const getSimulationOutcome = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/outcome`)
+}
+
+/**
+ * Record a verified-prediction annotation for a public simulation.
+ * Submitting again overwrites the previous annotation. Requires the
+ * simulation to be public.
+ * @param {string} simulationId
+ * @param {Object} data - { label: 'correct' | 'incorrect' | 'partial', outcome_url?: string, outcome_summary?: string }
+ */
+export const submitSimulationOutcome = (simulationId, data) => {
+  return service.post(`/api/simulation/${simulationId}/outcome`, data)
 }
 
 /**

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -161,6 +161,94 @@
               </a>
             </div>
 
+            <!-- Verified-prediction annotation — lets operators turn a
+                 published simulation into a "called it" record on the
+                 /verified gallery page. Only meaningful once the run is
+                 public, so the inputs are disabled until then. -->
+            <div class="outcome-section" :class="{ 'outcome-section-live': isPublic }">
+              <div class="outcome-head">
+                <span class="outcome-icon">📍</span>
+                <div class="outcome-head-body">
+                  <div class="outcome-title">
+                    Mark outcome
+                    <span v-if="outcome && outcome.label" class="outcome-saved-tag">
+                      ✓ {{ outcomeLabelText(outcome.label) }}
+                    </span>
+                  </div>
+                  <div class="outcome-sub">
+                    Did this simulation predict a real event? Annotate it and
+                    your run lands on
+                    <a href="/verified" target="_blank" rel="noopener">/verified</a>
+                    — the public hall of calls that landed.
+                  </div>
+                </div>
+              </div>
+
+              <div class="outcome-fields" :class="{ 'outcome-fields-disabled': !isPublic }">
+                <fieldset class="outcome-radio-group" :disabled="!isPublic">
+                  <label
+                    v-for="opt in outcomeOptions"
+                    :key="opt.value"
+                    class="outcome-radio"
+                    :class="{ 'outcome-radio-active': outcomeForm.label === opt.value }"
+                  >
+                    <input
+                      type="radio"
+                      :value="opt.value"
+                      v-model="outcomeForm.label"
+                    />
+                    <span class="outcome-radio-icon">{{ opt.icon }}</span>
+                    <span class="outcome-radio-label">{{ opt.label }}</span>
+                  </label>
+                </fieldset>
+
+                <input
+                  v-model="outcomeForm.outcome_url"
+                  type="url"
+                  placeholder="Outcome URL (article, tweet, dashboard) — optional"
+                  class="outcome-input"
+                  :disabled="!isPublic"
+                  maxlength="500"
+                />
+                <textarea
+                  v-model="outcomeForm.outcome_summary"
+                  placeholder="What happened, in one or two sentences (max 280 chars)"
+                  class="outcome-textarea"
+                  :disabled="!isPublic"
+                  maxlength="280"
+                  rows="2"
+                ></textarea>
+                <div class="outcome-summary-counter">
+                  {{ outcomeForm.outcome_summary.length }}/280
+                </div>
+
+                <div class="outcome-actions">
+                  <button
+                    class="outcome-submit"
+                    @click="submitOutcome"
+                    :disabled="!isPublic || !outcomeForm.label || outcomeSubmitting"
+                  >
+                    <span v-if="outcomeSubmitting">Saving…</span>
+                    <span v-else-if="outcome">Update outcome</span>
+                    <span v-else>Save outcome</span>
+                  </button>
+                  <a
+                    v-if="outcome"
+                    href="/verified"
+                    target="_blank"
+                    rel="noopener"
+                    class="outcome-link"
+                  >
+                    View on /verified ↗
+                  </a>
+                </div>
+
+                <div v-if="outcomeMessage" class="outcome-message" :class="outcomeMessageClass">
+                  {{ outcomeMessage }}
+                </div>
+              </div>
+            </div>
+
             <!-- Gallery callout — appears once the simulation is public so the
                  operator knows their run is visible on /explore, and offers a
                  one-click jump to see it in situ alongside other public runs. -->
@@ -211,8 +299,15 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
-import { publishSimulation, getEmbedSummary, getShareCardUrl, getShareLandingUrl } from '../api/simulation'
+import { reactive, ref, computed, watch } from 'vue'
+import {
+  publishSimulation,
+  getEmbedSummary,
+  getShareCardUrl,
+  getShareLandingUrl,
+  getSimulationOutcome,
+  submitSimulationOutcome,
+} from '../api/simulation'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -350,9 +445,89 @@ const copy = async (which) => {
   }
 }
 
+// ── Verified-prediction outcome submission ─────────────────────────────
+const outcomeOptions = [
+  { value: 'correct', label: 'Called it', icon: '📍' },
+  { value: 'partial', label: 'Partial', icon: '◑' },
+  { value: 'incorrect', label: 'Called wrong', icon: '⚠' },
+]
+
+const outcomeForm = reactive({
+  label: '',
+  outcome_url: '',
+  outcome_summary: '',
+})
+
+const outcome = ref(null)
+const outcomeSubmitting = ref(false)
+const outcomeMessage = ref('')
+const outcomeMessageClass = ref('')
+
+const outcomeLabelText = (label) => {
+  const opt = outcomeOptions.find((o) => o.value === label)
+  return opt ? opt.label : label || ''
+}
+
+const _applyOutcomeToForm = (data) => {
+  outcome.value = data || null
+  if (data && data.label) {
+    outcomeForm.label = data.label
+    outcomeForm.outcome_url = data.outcome_url || ''
+    outcomeForm.outcome_summary = data.outcome_summary || ''
+  }
+}
+
+const _resetOutcomeForm = () => {
+  outcomeForm.label = ''
+  outcomeForm.outcome_url = ''
+  outcomeForm.outcome_summary = ''
+  outcome.value = null
+  outcomeMessage.value = ''
+  outcomeMessageClass.value = ''
+}
+
+const loadOutcome = async () => {
+  try {
+    const res = await getSimulationOutcome(props.simulationId)
+    _applyOutcomeToForm(res?.data || null)
+  } catch (err) {
+    // 404 here means the simulation doesn't exist yet — surface nothing.
+    outcome.value = null
+  }
+}
+
+const submitOutcome = async () => {
+  if (!isPublic.value || !outcomeForm.label) return
+  outcomeSubmitting.value = true
+  outcomeMessage.value = ''
+  try {
+    const res = await submitSimulationOutcome(props.simulationId, {
+      label: outcomeForm.label,
+      outcome_url: outcomeForm.outcome_url.trim(),
+      outcome_summary: outcomeForm.outcome_summary.trim(),
+    })
+    if (res?.success && res.data) {
+      _applyOutcomeToForm(res.data)
+      outcomeMessage.value =
+        'Outcome saved — your simulation is visible in the Verified filter.'
+      outcomeMessageClass.value = 'outcome-message-success'
+    } else {
+      outcomeMessage.value = res?.error || 'Could not save outcome.'
+      outcomeMessageClass.value = 'outcome-message-error'
+    }
+  } catch (err) {
+    outcomeMessage.value =
+      err?.response?.data?.error || err?.message || 'Could not save outcome.'
+    outcomeMessageClass.value = 'outcome-message-error'
+  } finally {
+    outcomeSubmitting.value = false
+  }
+}
+
 watch(() => props.open, async (val) => {
   if (!val) return
   copied.value = ''
+  _resetOutcomeForm()
   // Refresh public state when reopened — reflects external flips.
   try {
     const res = await getEmbedSummary(props.simulationId)
@@ -360,6 +535,9 @@ watch(() => props.open, async (val) => {
   } catch (err) {
     if (err?.response?.status === 403) isPublic.value = false
   }
+  // Always pull the saved outcome — the GET endpoint is publish-gate-free
+  // so even private sims will reflect a previously recorded annotation.
+  await loadOutcome()
   // Bust the share-card image cache so the preview reloads with whatever
   // state the simulation is in right now (resolution may have landed
   // since the dialog was last opened).
@@ -743,6 +921,225 @@ watch(isPublic, () => {
 
 .share-download-btn:hover {
   background: #2a2a2a;
+}
+
+.outcome-section {
+  margin-top: 18px;
+  padding: 14px 16px;
+  background: #fafafa;
+  border: 1px dashed rgba(10, 10, 10, 0.18);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.outcome-section-live {
+  background: rgba(255, 107, 26, 0.04);
+  border-color: rgba(255, 107, 26, 0.3);
+  border-style: solid;
+}
+
+.outcome-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.outcome-icon {
+  font-size: 18px;
+  line-height: 1;
+  padding-top: 2px;
+}
+
+.outcome-head-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.outcome-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0a0a0a;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.outcome-saved-tag {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: var(--color-orange, #ff6b1a);
+  background: rgba(255, 107, 26, 0.1);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.outcome-sub {
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #4a4a4a;
+}
+
+.outcome-sub a {
+  color: var(--color-orange, #ff6b1a);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.outcome-sub a:hover { text-decoration: underline; }
+
+.outcome-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.outcome-fields-disabled { opacity: 0.55; }
+
+.outcome-radio-group {
+  display: flex;
+  gap: 6px;
+  border: none;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+}
+
+.outcome-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid rgba(10, 10, 10, 0.16);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.outcome-radio input {
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(10, 10, 10, 0.35);
+  position: relative;
+}
+
+.outcome-radio input:checked {
+  border-color: var(--color-orange, #ff6b1a);
+  background: var(--color-orange, #ff6b1a);
+  box-shadow: inset 0 0 0 2px #fff;
+}
+
+.outcome-radio-active {
+  border-color: var(--color-orange, #ff6b1a);
+  background: rgba(255, 107, 26, 0.08);
+}
+
+.outcome-radio-icon { font-family: sans-serif; }
+
+.outcome-input,
+.outcome-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid rgba(10, 10, 10, 0.14);
+  border-radius: 8px;
+  font-size: 12.5px;
+  font-family: inherit;
+  background: #fff;
+  color: #0a0a0a;
+  resize: vertical;
+}
+
+.outcome-input:focus,
+.outcome-textarea:focus {
+  outline: none;
+  border-color: var(--color-orange, #ff6b1a);
+  box-shadow: 0 0 0 3px rgba(255, 107, 26, 0.12);
+}
+
+.outcome-input:disabled,
+.outcome-textarea:disabled {
+  background: rgba(10, 10, 10, 0.03);
+  color: #6b6b6b;
+  cursor: not-allowed;
+}
+
+.outcome-summary-counter {
+  align-self: flex-end;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10.5px;
+  color: #6b6b6b;
+  margin-top: -4px;
+}
+
+.outcome-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.outcome-submit {
+  padding: 8px 16px;
+  background: var(--color-orange, #ff6b1a);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.outcome-submit:hover:not(:disabled) {
+  background: #0a0a0a;
+}
+
+.outcome-submit:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.outcome-link {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  color: var(--color-orange, #ff6b1a);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.outcome-link:hover { text-decoration: underline; }
+
+.outcome-message {
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+
+.outcome-message-success {
+  background: rgba(67, 193, 101, 0.12);
+  color: #1f6b35;
+}
+
+.outcome-message-error {
+  background: rgba(255, 68, 68, 0.12);
+  color: #b22020;
 }
 
 .gallery-callout {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -59,6 +59,16 @@ const routes = [
     path: '/explore',
     name: 'Explore',
     component: () => import('../views/ExploreView.vue')
+  },
+  {
+    // Dedicated URL for the "Verified Prediction" hall — same component
+    // as /explore but with the verified filter pre-applied. Keep it as a
+    // top-level path so it's a clean link to drop into threads about
+    // pre-incident simulations.
+    path: '/verified',
+    name: 'Verified',
+    component: () => import('../views/ExploreView.vue'),
+    props: { verifiedOnly: true }
   }
 ]
 

--- a/frontend/src/views/ExploreView.vue
+++ b/frontend/src/views/ExploreView.vue
@@ -22,25 +22,53 @@
       <!-- Header -->
       <header class="explore-header">
         <div class="tag-row">
-          <span class="orange-tag">◎ Explore</span>
+          <span class="orange-tag">{{ verifiedOnly ? '📍 Verified' : '◎ Explore' }}</span>
           <span class="meta-sep">·</span>
-          <span class="meta-text">Public simulation gallery</span>
+          <span class="meta-text">
+            {{ verifiedOnly ? 'Predictions that called real events' : 'Public simulation gallery' }}
+          </span>
         </div>
-        <h1 class="page-title">Simulations the community ran.</h1>
+        <h1 class="page-title">{{ verifiedOnly ? 'Calls that landed.' : 'Simulations the community ran.' }}</h1>
         <p class="page-subtitle">
-          Every card is a real MiroShark run someone published. Open one to see
-          the full belief drift, agent network, and prediction outcome — or fork
-          it in one click and run your own variant with the same agent population.
+          <template v-if="verifiedOnly">
+            Each card is a public MiroShark run whose operator marked the
+            real-world outcome. Hover the badge for the source link, open
+            one to see how the agent consensus formed, or fork it to test
+            the same agent population on a fresh scenario.
+          </template>
+          <template v-else>
+            Every card is a real MiroShark run someone published. Open one to see
+            the full belief drift, agent network, and prediction outcome — or fork
+            it in one click and run your own variant with the same agent population.
+          </template>
         </p>
         <div class="stats-row">
           <span class="stat-chip">
             <span class="stat-num">{{ loading ? '…' : total }}</span>
-            <span class="stat-label">published</span>
+            <span class="stat-label">{{ verifiedOnly ? 'verified' : 'published' }}</span>
           </span>
-          <span v-if="!loading && items.length > 0" class="stat-chip">
+          <span v-if="!verifiedOnly && !loading && items.length > 0" class="stat-chip">
             <span class="stat-num">{{ resolvedCount }}</span>
             <span class="stat-label">resolved</span>
           </span>
+          <span v-if="!verifiedOnly && !loading && items.length > 0" class="stat-chip">
+            <span class="stat-num">{{ verifiedCount }}</span>
+            <span class="stat-label">verified</span>
+          </span>
+
+          <!-- Verified filter chip — toggles a `?verified=1` fetch + the
+               /verified URL so the view is shareable. -->
+          <button
+            class="filter-chip"
+            :class="{ 'filter-chip-active': verifiedFilter }"
+            @click="toggleVerifiedFilter"
+            :disabled="loading"
+            :title="verifiedFilter ? 'Show all public simulations' : 'Show only simulations with a recorded outcome'"
+          >
+            <span class="filter-chip-icon">📍</span>
+            <span>Verified only</span>
+          </button>
+
           <button
             class="refresh-btn"
             @click="refresh"
@@ -70,13 +98,28 @@
 
       <!-- Empty -->
       <div v-else-if="items.length === 0" class="gallery-empty">
-        <div class="empty-icon">◇</div>
-        <div class="empty-title">No public simulations yet.</div>
-        <div class="empty-msg">
-          Yours could be first. Run a simulation, click the share icon on the
-          result page, toggle "Public" — it'll appear here within 30 seconds.
+        <div class="empty-icon">{{ verifiedFilter ? '📍' : '◇' }}</div>
+        <div class="empty-title">
+          {{ verifiedFilter ? 'No verified predictions yet.' : 'No public simulations yet.' }}
         </div>
-        <router-link to="/" class="empty-cta">Run a simulation →</router-link>
+        <div class="empty-msg">
+          <template v-if="verifiedFilter">
+            Once an operator marks a public simulation's real-world outcome
+            from the Embed dialog, it shows up here. In the meantime, browse
+            every published run on
+            <router-link to="/explore" class="inline-link">/explore</router-link>.
+          </template>
+          <template v-else>
+            Yours could be first. Run a simulation, click the share icon on the
+            result page, toggle "Public" — it'll appear here within 30 seconds.
+          </template>
+        </div>
+        <router-link
+          :to="verifiedFilter ? '/explore' : '/'"
+          class="empty-cta"
+        >
+          {{ verifiedFilter ? 'Browse all public sims →' : 'Run a simulation →' }}
+        </router-link>
       </div>
 
       <!-- Grid -->
@@ -85,7 +128,12 @@
           v-for="item in items"
           :key="item.simulation_id"
           class="gallery-card"
-          :class="{ 'card-resolved': item.resolution_outcome }"
+          :class="{
+            'card-resolved': item.resolution_outcome,
+            'card-verified-correct': item.outcome && item.outcome.label === 'correct',
+            'card-verified-incorrect': item.outcome && item.outcome.label === 'incorrect',
+            'card-verified-partial': item.outcome && item.outcome.label === 'partial',
+          }"
         >
           <!-- Thumbnail: the server-rendered share card PNG -->
           <router-link
@@ -110,6 +158,20 @@
             </h2>
 
             <div class="card-pills">
+              <component
+                v-if="item.outcome && item.outcome.label"
+                :is="item.outcome.outcome_url ? 'a' : 'span'"
+                :href="item.outcome.outcome_url || undefined"
+                :target="item.outcome.outcome_url ? '_blank' : undefined"
+                :rel="item.outcome.outcome_url ? 'noopener noreferrer' : undefined"
+                class="pill pill-verified"
+                :class="outcomePillClass(item.outcome.label)"
+                :title="outcomePillTitle(item.outcome)"
+                @click.stop
+              >
+                {{ outcomePillIcon(item.outcome.label) }}
+                {{ outcomePillLabel(item.outcome.label) }}
+              </component>
               <span
                 v-if="item.quality_health"
                 class="pill"
@@ -232,13 +294,20 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   getPublicSimulations,
   forkSimulation,
   getShareCardUrl,
 } from '../api/simulation'
+
+const props = defineProps({
+  // When true, the view boots in verified-only mode. Wired to the
+  // `/verified` route; users on `/explore` can also flip it on via the
+  // filter chip in the header.
+  verifiedOnly: { type: Boolean, default: false },
+})
 
 const router = useRouter()
 
@@ -251,9 +320,14 @@ const loadingMore = ref(false)
 const error = ref('')
 const forkingId = ref('')
 const forkErrors = ref({})
+const verifiedFilter = ref(props.verifiedOnly)
 
 const resolvedCount = computed(
   () => items.value.filter((item) => item.resolution_outcome).length,
+)
+
+const verifiedCount = computed(
+  () => items.value.filter((item) => item.outcome && item.outcome.label).length,
 )
 
 const shareCardSrc = (item) => {
@@ -332,8 +406,41 @@ const formatDate = (iso) => {
   return String(iso).slice(0, 10)
 }
 
+const outcomePillLabel = (label) => {
+  if (label === 'correct') return 'Verified'
+  if (label === 'incorrect') return 'Called wrong'
+  if (label === 'partial') return 'Partial'
+  return ''
+}
+
+const outcomePillIcon = (label) => {
+  if (label === 'correct') return '📍'
+  if (label === 'incorrect') return '⚠'
+  if (label === 'partial') return '◑'
+  return ''
+}
+
+const outcomePillClass = (label) => {
+  if (label === 'correct') return 'pill-verified-correct'
+  if (label === 'incorrect') return 'pill-verified-incorrect'
+  if (label === 'partial') return 'pill-verified-partial'
+  return ''
+}
+
+const outcomePillTitle = (outcome) => {
+  if (!outcome) return ''
+  const summary = (outcome.outcome_summary || '').trim()
+  const link = outcome.outcome_url ? ` — ${outcome.outcome_url}` : ''
+  if (summary) return summary + link
+  return outcomePillLabel(outcome.label) + link
+}
+
 const loadPage = async (offset = 0) => {
-  const res = await getPublicSimulations({ limit, offset })
+  const res = await getPublicSimulations({
+    limit,
+    offset,
+    verifiedOnly: verifiedFilter.value,
+  })
   if (!res?.success) {
     throw new Error(res?.error || 'Request failed')
   }
@@ -343,6 +450,30 @@ const loadPage = async (offset = 0) => {
     hasMore: !!res.has_more,
   }
 }
+
+const toggleVerifiedFilter = () => {
+  verifiedFilter.value = !verifiedFilter.value
+  // Keep the URL in lockstep with the filter so the page is shareable —
+  // /verified for the curated hall, /explore for everything.
+  if (verifiedFilter.value) {
+    if (router.currentRoute.value.path !== '/verified') {
+      router.replace({ name: 'Verified' })
+    }
+  } else if (router.currentRoute.value.path !== '/explore') {
+    router.replace({ name: 'Explore' })
+  }
+  refresh()
+}
+
+watch(
+  () => props.verifiedOnly,
+  (next) => {
+    if (verifiedFilter.value !== next) {
+      verifiedFilter.value = next
+      refresh()
+    }
+  },
+)
 
 const refresh = async () => {
   loading.value = true
@@ -793,6 +924,111 @@ onMounted(refresh)
 .pill-status {
   background: rgba(10, 10, 10, 0.06);
   color: rgba(10, 10, 10, 0.55);
+}
+
+/* Verified-prediction pills — slightly stronger visual weight than the
+   generic pills so the credibility signal lands at a glance. */
+.pill-verified {
+  text-decoration: none;
+  cursor: default;
+  letter-spacing: 0.6px;
+}
+
+a.pill-verified {
+  cursor: pointer;
+}
+
+a.pill-verified:hover {
+  filter: brightness(0.92);
+}
+
+.pill-verified-correct {
+  background: var(--color-orange);
+  color: var(--color-white);
+}
+
+.pill-verified-incorrect {
+  background: rgba(255, 68, 68, 0.18);
+  color: #c52d2d;
+  outline: 1px solid rgba(255, 68, 68, 0.35);
+  outline-offset: -1px;
+}
+
+.pill-verified-partial {
+  background: rgba(255, 179, 71, 0.22);
+  color: #8a4a0a;
+  outline: 1px solid rgba(255, 179, 71, 0.5);
+  outline-offset: -1px;
+}
+
+/* Card-level accent strip — same idea as .card-resolved (a thin coloured
+   left border) but using the outcome palette so the verified hall reads
+   at a glance even when scrolling fast. */
+.card-verified-correct {
+  border-left: 3px solid var(--color-orange);
+}
+
+.card-verified-incorrect {
+  border-left: 3px solid var(--color-red);
+}
+
+.card-verified-partial {
+  border-left: 3px solid #f59e0b;
+}
+
+/* Filter chip in the stats row — toggles `?verified=1`. Active state
+   leans on the brand orange so it reads as the primary call-to-action
+   when an operator is hunting for credibility-anchored sims. */
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: transparent;
+  border: var(--border-medium);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.5px;
+  color: rgba(10, 10, 10, 0.7);
+  cursor: pointer;
+  transition: var(--transition-fast);
+  text-transform: uppercase;
+}
+
+.filter-chip:hover:not(:disabled) {
+  border-color: var(--color-orange);
+  color: var(--color-orange);
+}
+
+.filter-chip-active {
+  background: var(--color-orange);
+  border-color: var(--color-orange);
+  color: var(--color-white);
+}
+
+.filter-chip-active:hover:not(:disabled) {
+  background: var(--color-black);
+  border-color: var(--color-black);
+  color: var(--color-white);
+}
+
+.filter-chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.filter-chip-icon {
+  font-family: sans-serif;
+}
+
+.inline-link {
+  color: var(--color-orange);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.inline-link:hover {
+  text-decoration: underline;
 }
 
 /* ── Consensus bar ── */


### PR DESCRIPTION
## What

Adds a **Verified Prediction** annotation layer on top of every public simulation, plus a dedicated `/verified` gallery URL that surfaces only the runs operators have marked as having called a real-world event.

From the Embed dialog, an operator picks **Called it / Partial / Called wrong**, optionally pastes the article/tweet/dashboard URL that confirmed the outcome, adds a one-sentence summary (≤280 chars), and submits. The annotation lands on `<sim_dir>/outcome.json` and immediately:

- Renders a 📍 **Verified** / ⚠ **Called wrong** / ◑ **Partial** pill on the gallery card (the pill links to the outcome URL when one is set).
- Adds a coloured left-edge accent on the card so the verified hall reads at a glance when scrolling fast.
- Counts toward a new **verified** stat chip on the Explore header.
- Becomes filterable via a new **Verified only** chip and a dedicated `/verified` URL.

## Why

The Bankr Terminal v2 thread that cited MiroShark's Aave vulnerability simulation was the project's strongest external credibility signal — but the citation lives on X and nowhere in the product. A `/verified` page full of real-event predictions is the single most compelling link to drop into a thread about pre-incident simulations: researchers evaluating MiroShark want to see that the simulations actually worked, not just that they can run.

This pivots from repo-actions Apr 26 idea #1 (Predictive Accuracy Ledger). Idea #2 (Animated GIF) and #3 (Thread Formatter) build on top of this once it lands; #4 (Python SDK) and #5 (Director Event Overlay) are independent.

The annotation is intentionally distinct from the existing `/resolve` endpoint, which is binary YES/NO and tied to Polymarket consensus. A simulation can have both — the binary resolution drives `accuracy_score`, the outcome annotation drives the gallery credibility surface.

## Changes

**Backend (`backend/app/api/simulation.py`)**
- `POST /api/simulation/<id>/outcome` (publish-gated) and `GET /api/simulation/<id>/outcome` (read-only) — opaque to the operator's choice of label vocabulary, validates `correct/incorrect/partial`, http(s)-only outcome URLs (≤500 chars), summaries ≤280 chars.
- `_read_outcome_file()` helper: parses, validates, truncates oversized summaries with an ellipsis, and strips any non-http URL — defense-in-depth so a corrupt artifact never lands a `javascript:` value on the gallery.
- `_build_gallery_card_payload()` surfaces a new `outcome` field on every card.
- `GET /api/simulation/public?verified=1` filters the listing to simulations with a recorded outcome and reflects `verified_only` back in the response.

**Spec (`backend/openapi.yaml`)**
- New path `/api/simulation/{simulation_id}/outcome` with both `GET` and `POST` operations.
- New `SimulationOutcome` schema; `GalleryCard` gains an `outcome` field; `/api/simulation/public` gains the `verified` query param + `verified_only` response field.
- The handwritten regex-driven drift-detection test continues to pass because the new Flask route is documented.

**Frontend**
- `frontend/src/api/simulation.js` — `getSimulationOutcome`, `submitSimulationOutcome`, plus `verifiedOnly` option on `getPublicSimulations`.
- `frontend/src/views/ExploreView.vue` — Verified-only filter chip with active state, 📍/⚠/◑ outcome pills (clickable to outcome URL), coloured left-edge accent per outcome label, dynamic page title/copy/empty-state for verified-only mode, `verifiedCount` stat chip.
- `frontend/src/components/EmbedDialog.vue` — new "Mark outcome" panel: 3-way label radio group, URL input, 280-char-limit textarea with live counter, success/error inline message, "View on /verified ↗" link once saved. Inputs are disabled until the simulation is published.
- `frontend/src/router/index.js` — `/verified` route mapped to ExploreView with `verifiedOnly` prop.

**Tests + Docs**
- `backend/tests/test_unit_outcome.py` (8 cases) — valid record, unknown label, corrupt JSON, missing file, oversized-summary truncation, non-http URL stripping, gallery-card integration with and without an outcome, plus corrupt-artifact graceful degradation.
- `docs/FEATURES.md` — new "Predictive Accuracy Ledger (Verified Predictions)" section.
- `README.md` — new feature row.

---
*Built autonomously by Aeon*