### PR TITLE
feat: admin-token auth on /publish, /resolve, /outcome (#48)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -238,6 +238,28 @@ OPENAI_API_BASE_URL=http://localhost:11434/v1
 # Cached server-side for 15 minutes; per-feed timeout 5s.
 # TRENDING_FEEDS=https://techcrunch.com/feed/,https://www.theverge.com/rss/index.xml,https://hnrss.org/frontpage,https://www.coindesk.com/arc/outboundfeeds/rss/
 
+# ===== Admin authentication (mutation endpoints) =====
+# Shared operator secret guarding the three write endpoints that change
+# a simulation's public state on disk:
+#   POST /api/simulation/<id>/publish
+#   POST /api/simulation/<id>/resolve
+#   POST /api/simulation/<id>/outcome
+#
+# Read endpoints (including GET /outcome, the public gallery, embed
+# summary) stay public — only writes are gated.
+#
+# Send the value as `Authorization: Bearer <token>`. Compared in
+# constant time on the server (hmac.compare_digest) so a network
+# attacker can't time-trial it.
+#
+# *** FAIL-CLOSED ***
+# If MIROSHARK_ADMIN_TOKEN is unset/empty, the gated endpoints return
+# 503 ("admin auth not configured") rather than silently allowing the
+# request. There is no implicit "no auth" fallback — an operator who
+# forgot to set this would otherwise ship an open mutation surface.
+# Pick something long and random (e.g. `openssl rand -hex 32`).
+# MIROSHARK_ADMIN_TOKEN=
+
 # ===== Observability =====
 # Log full LLM prompts/responses to events.jsonl (large files, debug only)
 # MIROSHARK_LOG_PROMPTS=true

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -6,9 +6,11 @@ Step 2: Entity reading and filtering, Wonderwall simulation preparation and exec
 import os
 import io
 import csv
+import hmac
 import json
 import traceback
 from datetime import datetime, timezone
+from functools import wraps
 from flask import request, jsonify, send_file, current_app
 
 from . import simulation_bp
@@ -36,6 +38,111 @@ def _validate_url_simulation_id():
             validate_simulation_id(sim_id)
         except ValueError as exc:
             return jsonify({"success": False, "error": str(exc)}), 400
+
+
+# ============== Admin Auth (mutation endpoints) ==============
+#
+# Mutation endpoints that write to a simulation's on-disk state
+# (/publish, /resolve, /outcome) require a shared admin secret —
+# ``MIROSHARK_ADMIN_TOKEN`` — supplied via the ``Authorization: Bearer
+# <token>`` header. This is the lightest-weight option from issue #48
+# (per-sim ownership tokens / full account auth were also discussed,
+# but a shared operator secret matches the deployment model: a single
+# operator runs MiroShark behind a reverse proxy or on localhost, and
+# any mutation is theirs).
+#
+# Fail-closed semantics: if ``MIROSHARK_ADMIN_TOKEN`` is unset or empty
+# in the process environment, the dependency returns **503**, NOT 200.
+# We deliberately do not silently fall back to "no auth required" — an
+# operator who forgot to configure the secret would otherwise ship an
+# open mutation surface and never know. The 503 message is generic on
+# purpose so the failure is visible without leaking config detail to a
+# probe.
+#
+# We use ``hmac.compare_digest`` for the actual comparison so a network
+# attacker can't time-trial the token byte by byte.
+
+
+_ADMIN_TOKEN_ENV_VAR = "MIROSHARK_ADMIN_TOKEN"
+
+
+def _load_admin_token() -> str:
+    """Read ``MIROSHARK_ADMIN_TOKEN`` from the environment at *call* time.
+
+    Resolved per-request rather than module-import time so tests can
+    monkeypatch ``os.environ`` without re-importing the module, and so
+    operators rotating the token via a process restart don't need a
+    code reload.
+    """
+    return (os.environ.get(_ADMIN_TOKEN_ENV_VAR) or "").strip()
+
+
+def _extract_bearer_token() -> str:
+    """Pull the token from the ``Authorization: Bearer <token>`` header.
+
+    Returns the empty string when the header is missing or malformed —
+    the caller treats both as "no token", which then resolves to a 401.
+    """
+    auth_header = request.headers.get("Authorization", "") or ""
+    parts = auth_header.split(None, 1)
+    if len(parts) != 2:
+        return ""
+    scheme, token = parts
+    if scheme.lower() != "bearer":
+        return ""
+    return token.strip()
+
+
+def require_admin_token(view_func):
+    """Decorator: gate a Flask view on a valid admin bearer token.
+
+    Behaviour matrix:
+
+    * ``MIROSHARK_ADMIN_TOKEN`` unset/empty in env → **503**
+      (fail-closed; the deploy is misconfigured and we refuse to serve
+      the mutation rather than silently allowing it).
+    * ``Authorization`` header missing or wrong / token mismatch →
+      **401** with a generic "Unauthorized" message. We deliberately do
+      not distinguish "missing" from "wrong" so a probe can't tell
+      whether it found a valid endpoint.
+    * Match → forward to the wrapped view.
+
+    The constant-time comparison via :func:`hmac.compare_digest` keeps
+    a network attacker from byte-trialing the token.
+
+    Reusable across blueprints — apply to any future mutation endpoint
+    that should share the same operator-secret gate.
+    """
+
+    @wraps(view_func)
+    def _wrapper(*args, **kwargs):
+        expected = _load_admin_token()
+        if not expected:
+            logger.error(
+                "Mutation endpoint %s reached but %s is unset — refusing "
+                "to serve (fail-closed). Set the env var to enable.",
+                request.path, _ADMIN_TOKEN_ENV_VAR,
+            )
+            return jsonify({
+                "success": False,
+                "error": "Admin authentication is not configured on this deployment.",
+            }), 503
+
+        provided = _extract_bearer_token()
+        # ``hmac.compare_digest`` requires equal-length operands of the
+        # same type to do its constant-time work; encode both sides to
+        # bytes and let the function handle short-circuiting safely.
+        if not provided or not hmac.compare_digest(
+            provided.encode("utf-8"), expected.encode("utf-8")
+        ):
+            return jsonify({
+                "success": False,
+                "error": "Unauthorized",
+            }), 401
+
+        return view_func(*args, **kwargs)
+
+    return _wrapper
 
 
 def _get_simulation_id_or_400(data: dict) -> tuple:
@@ -4351,11 +4458,14 @@ def polymarket_market_prices(simulation_id: str, market_id: int):
 # ============== Embed Widget ==============
 
 @simulation_bp.route('/<simulation_id>/publish', methods=['POST'])
+@require_admin_token
 def publish_simulation(simulation_id: str):
     """Mark a simulation as publicly embeddable.
 
     Body (optional): ``{"public": false}`` to unpublish instead of publish.
     Returns the new public state.
+
+    Auth: requires ``Authorization: Bearer $MIROSHARK_ADMIN_TOKEN``.
     """
     try:
         manager = SimulationManager()
@@ -5782,9 +5892,12 @@ def compare_simulations():
 # ============== Prediction Resolution Endpoint ==============
 
 @simulation_bp.route('/<simulation_id>/resolve', methods=['POST'])
+@require_admin_token
 def resolve_simulation(simulation_id: str):
     """
     Record the real-world outcome of a simulation prediction.
+
+    Auth: requires ``Authorization: Bearer $MIROSHARK_ADMIN_TOKEN``.
 
     Body:
         {
@@ -5943,7 +6056,30 @@ def simulation_outcome(simulation_id: str):
     GET returns the current outcome (or ``data: null``) — no publish
     gate so the embed dialog can show the existing annotation when the
     operator re-opens it.
+
+    Auth: POST requires ``Authorization: Bearer $MIROSHARK_ADMIN_TOKEN``.
+    GET is unauthenticated — the gallery and embed widgets read this.
     """
+    # Gate POST writes on the admin token (GET stays public — the
+    # gallery reads this and the embed dialog re-renders the existing
+    # annotation when an operator re-opens it).
+    if request.method == 'POST':
+        expected = _load_admin_token()
+        if not expected:
+            logger.error(
+                "outcome POST reached but %s is unset — refusing to "
+                "serve (fail-closed).", _ADMIN_TOKEN_ENV_VAR,
+            )
+            return jsonify({
+                "success": False,
+                "error": "Admin authentication is not configured on this deployment.",
+            }), 503
+        provided = _extract_bearer_token()
+        if not provided or not hmac.compare_digest(
+            provided.encode("utf-8"), expected.encode("utf-8")
+        ):
+            return jsonify({"success": False, "error": "Unauthorized"}), 401
+
     try:
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -24,6 +24,15 @@ info:
     to a private interface or front it with a reverse proxy when deploying
     to production.
 
+    **Mutation endpoints** that write to a simulation's on-disk state
+    (`POST /publish`, `POST /resolve`, `POST /outcome`) are gated on a
+    shared operator secret supplied via `Authorization: Bearer
+    $MIROSHARK_ADMIN_TOKEN`. The token is read from the process
+    environment at request time. If `MIROSHARK_ADMIN_TOKEN` is unset or
+    empty the endpoints **fail closed** with `503 — admin auth not
+    configured` rather than silently allowing the mutation. See
+    `AdminToken` under `components.securitySchemes`.
+
     Discovery endpoints with light cost protection (suggest-scenarios,
     trending, ask) enforce sliding-window rate limits on the calling IP.
 
@@ -1066,6 +1075,11 @@ paths:
     post:
       tags: [Publish & Embed]
       summary: Toggle a simulation's `is_public` flag.
+      description: |
+        Mutation endpoint — gated on `Authorization: Bearer
+        $MIROSHARK_ADMIN_TOKEN`. See the `AdminToken` security scheme.
+      security:
+        - AdminToken: []
       parameters:
         - $ref: "#/components/parameters/SimulationIdPath"
       requestBody:
@@ -1084,7 +1098,9 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
         "404": { $ref: "#/components/responses/NotFound" }
+        "503": { $ref: "#/components/responses/AdminAuthNotConfigured" }
 
   /api/simulation/{simulation_id}/embed-summary:
     get:
@@ -1224,6 +1240,11 @@ paths:
     post:
       tags: [Publish & Embed]
       summary: Mark a simulation as resolved against an actual outcome.
+      description: |
+        Mutation endpoint — gated on `Authorization: Bearer
+        $MIROSHARK_ADMIN_TOKEN`. See the `AdminToken` security scheme.
+      security:
+        - AdminToken: []
       parameters:
         - $ref: "#/components/parameters/SimulationIdPath"
       requestBody:
@@ -1243,6 +1264,8 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/SuccessEnvelope" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "503": { $ref: "#/components/responses/AdminAuthNotConfigured" }
 
   /api/simulation/{simulation_id}/outcome:
     get:
@@ -1278,6 +1301,13 @@ paths:
         Requires `is_public=true` on the simulation (POST `/publish` to
         enable). Submitting again overwrites the previous annotation —
         operators can correct a wrong call without leaving stale records.
+
+        Mutation endpoint — gated on `Authorization: Bearer
+        $MIROSHARK_ADMIN_TOKEN`. See the `AdminToken` security scheme.
+        `GET /outcome` (above) is **not** gated — the gallery and embed
+        widgets read this without a token.
+      security:
+        - AdminToken: []
       parameters:
         - $ref: "#/components/parameters/SimulationIdPath"
       requestBody:
@@ -1317,9 +1347,11 @@ paths:
                     properties:
                       data: { $ref: "#/components/schemas/SimulationOutcome" }
         "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
         "403":
           description: Simulation is not public.
         "404": { $ref: "#/components/responses/NotFound" }
+        "503": { $ref: "#/components/responses/AdminAuthNotConfigured" }
 
   # ────────────────────────────────────────────────────────────────────
   # Report Agent
@@ -1748,6 +1780,29 @@ paths:
 
 components:
 
+  securitySchemes:
+    AdminToken:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+      description: |
+        Shared operator secret read from `MIROSHARK_ADMIN_TOKEN` in the
+        backend process environment. Sent as `Authorization: Bearer
+        <token>`. Compared in constant time on the server.
+
+        Required on every mutation endpoint that writes to a
+        simulation's on-disk state — `POST /publish`, `POST /resolve`,
+        `POST /outcome`. Read endpoints (including `GET /outcome`)
+        remain public.
+
+        Fail-closed: when `MIROSHARK_ADMIN_TOKEN` is unset or empty in
+        the deployment's environment, the gated endpoints return
+        `503 — admin auth not configured` rather than allowing the
+        request through. This is intentional — an operator who forgot
+        to set the secret would otherwise ship an open mutation
+        surface. Configure the token before exposing the backend
+        publicly.
+
   parameters:
     SimulationIdPath:
       in: path
@@ -1775,6 +1830,24 @@ components:
           schema: { $ref: "#/components/schemas/ErrorEnvelope" }
     RateLimited:
       description: Sliding-window rate limit exceeded.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+    Unauthorized:
+      description: |
+        Admin token missing or invalid. The response body is generic
+        (`{"success": false, "error": "Unauthorized"}`) — the server
+        deliberately does not distinguish "missing" from "wrong" so a
+        probe can't tell the difference.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+    AdminAuthNotConfigured:
+      description: |
+        `MIROSHARK_ADMIN_TOKEN` is unset or empty on the backend —
+        mutation endpoints fail closed rather than allowing
+        unauthenticated writes. Operator must set the env var and
+        restart the process.
       content:
         application/json:
           schema: { $ref: "#/components/schemas/ErrorEnvelope" }

--- a/backend/tests/test_unit_admin_auth.py
+++ b/backend/tests/test_unit_admin_auth.py
@@ -1,0 +1,275 @@
+"""Unit tests for the admin-auth gate on mutation endpoints.
+
+Issue #48 added a shared operator secret (``MIROSHARK_ADMIN_TOKEN``)
+guarding ``POST /publish``, ``POST /resolve``, and ``POST /outcome``.
+This file pins down the contract — if any of these properties drift,
+the deploy goes from "auth-gated mutations" back to "any caller can
+overwrite a verified prediction", which is the regression the issue
+called out.
+
+Tested directly against the helpers + decorator in
+``app.api.simulation`` (no full Flask app boot, no Neo4j) by mounting
+the decorator on a throwaway view inside a minimal Flask app. This
+keeps the suite in the bare unit environment alongside the other
+``test_unit_*.py`` files.
+
+Coverage:
+
+  1. ``_extract_bearer_token`` parses ``Authorization: Bearer <t>``
+     and returns "" for missing / wrong-scheme / malformed headers.
+  2. ``_load_admin_token`` reads from the env at call time and
+     normalises whitespace.
+  3. ``require_admin_token`` returns 503 when the env var is unset
+     **even if the caller sent a token** — fail-closed is the whole
+     point of issue #48 and a silent fallback would re-open the hole.
+  4. ``require_admin_token`` returns 401 (generic message) for both
+     "no header" and "wrong token" so a probe can't tell them apart.
+  5. ``require_admin_token`` lets a matching bearer token through to
+     the wrapped view.
+  6. The error envelope on every failure path matches the
+     ``{"success": false, "error": "..."}`` shape used elsewhere in
+     the codebase — front-end clients branch on it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Header parsing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _make_app():
+    """Tiny Flask app with one view gated by ``require_admin_token``.
+
+    We can't import the full ``create_app`` factory here because it
+    boots Neo4j and the simulation runner — both unavailable in the
+    unit environment. Mounting the decorator on a stub view exercises
+    the same code path with zero infra.
+    """
+    from flask import Flask, jsonify
+
+    from app.api.simulation import require_admin_token
+
+    app = Flask(__name__)
+
+    @app.route("/_test/protected", methods=["POST"])
+    @require_admin_token
+    def _protected():
+        return jsonify({"success": True, "data": {"ok": True}}), 200
+
+    return app
+
+
+def test_extract_bearer_token_parses_valid_header():
+    from flask import Flask
+    from app.api.simulation import _extract_bearer_token
+
+    app = Flask(__name__)
+    with app.test_request_context(headers={"Authorization": "Bearer abc123"}):
+        assert _extract_bearer_token() == "abc123"
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "",                      # absent
+        "Basic abc123",          # wrong scheme
+        "Bearer",                # no token portion
+        "Bearer ",               # blank token
+        "Token abc123",          # close but wrong scheme
+    ],
+)
+def test_extract_bearer_token_rejects_bad_headers(header: str):
+    from flask import Flask
+    from app.api.simulation import _extract_bearer_token
+
+    app = Flask(__name__)
+    headers = {"Authorization": header} if header else {}
+    with app.test_request_context(headers=headers):
+        assert _extract_bearer_token() == ""
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Env var loading
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_load_admin_token_reads_env(monkeypatch: pytest.MonkeyPatch):
+    from app.api.simulation import _load_admin_token
+
+    monkeypatch.setenv("MIROSHARK_ADMIN_TOKEN", "  s3cret  ")
+    # Whitespace stripped — operators sometimes paste with stray spaces
+    # and we don't want a constant-time compare to fail on that.
+    assert _load_admin_token() == "s3cret"
+
+
+def test_load_admin_token_unset_returns_empty(monkeypatch: pytest.MonkeyPatch):
+    from app.api.simulation import _load_admin_token
+
+    monkeypatch.delenv("MIROSHARK_ADMIN_TOKEN", raising=False)
+    assert _load_admin_token() == ""
+
+
+def test_load_admin_token_blank_returns_empty(monkeypatch: pytest.MonkeyPatch):
+    """An explicit empty string in env counts as unset — same fail-closed
+    posture as a missing var."""
+    from app.api.simulation import _load_admin_token
+
+    monkeypatch.setenv("MIROSHARK_ADMIN_TOKEN", "   ")
+    assert _load_admin_token() == ""
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Decorator behaviour — the meat of the issue
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_decorator_fails_closed_when_env_unset(monkeypatch: pytest.MonkeyPatch):
+    """Issue #48's central invariant: with no ``MIROSHARK_ADMIN_TOKEN``
+    in the environment the endpoint must return 503, **not** allow the
+    request through. Even a caller presenting a token must be denied
+    — the deploy is misconfigured and we refuse to play guess-the-secret.
+    """
+    monkeypatch.delenv("MIROSHARK_ADMIN_TOKEN", raising=False)
+
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/_test/protected",
+        headers={"Authorization": "Bearer anything"},
+    )
+    assert res.status_code == 503
+    body = res.get_json()
+    assert body["success"] is False
+    assert "not configured" in body["error"].lower()
+
+
+def test_decorator_fails_closed_with_no_header(monkeypatch: pytest.MonkeyPatch):
+    """Same invariant when the caller didn't send a header either —
+    503 takes precedence over 401 because the deploy itself is broken."""
+    monkeypatch.delenv("MIROSHARK_ADMIN_TOKEN", raising=False)
+
+    app = _make_app()
+    res = app.test_client().post("/_test/protected")
+    assert res.status_code == 503
+
+
+def test_decorator_returns_401_for_missing_header(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MIROSHARK_ADMIN_TOKEN", "right-token")
+
+    app = _make_app()
+    res = app.test_client().post("/_test/protected")
+    assert res.status_code == 401
+    body = res.get_json()
+    assert body["success"] is False
+    # Generic message — we deliberately do not say "missing".
+    assert body["error"] == "Unauthorized"
+
+
+def test_decorator_returns_401_for_wrong_token(monkeypatch: pytest.MonkeyPatch):
+    """Same response shape as missing-header so a probe can't
+    distinguish 'no token sent' from 'wrong token'."""
+    monkeypatch.setenv("MIROSHARK_ADMIN_TOKEN", "right-token")
+
+    app = _make_app()
+    res = app.test_client().post(
+        "/_test/protected",
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert res.status_code == 401
+    body = res.get_json()
+    assert body["error"] == "Unauthorized"
+
+
+def test_decorator_passes_through_with_matching_token(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MIROSHARK_ADMIN_TOKEN", "right-token")
+
+    app = _make_app()
+    res = app.test_client().post(
+        "/_test/protected",
+        headers={"Authorization": "Bearer right-token"},
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["success"] is True
+    assert body["data"]["ok"] is True
+
+
+def test_decorator_uses_constant_time_compare(monkeypatch: pytest.MonkeyPatch):
+    """Smoke test that the comparison goes through ``hmac.compare_digest``.
+
+    We don't try to measure timing — that's flaky in CI — but we do
+    confirm the function is *the* one being called by patching it and
+    asserting it ran. If a future refactor swaps in ``==`` we want to
+    know loudly.
+    """
+    import app.api.simulation as sim_mod
+
+    monkeypatch.setenv("MIROSHARK_ADMIN_TOKEN", "tok")
+
+    calls: list[tuple[bytes, bytes]] = []
+    real = sim_mod.hmac.compare_digest
+
+    def _spy(a, b):
+        calls.append((a, b))
+        return real(a, b)
+
+    monkeypatch.setattr(sim_mod.hmac, "compare_digest", _spy)
+
+    app = _make_app()
+    res = app.test_client().post(
+        "/_test/protected",
+        headers={"Authorization": "Bearer tok"},
+    )
+    assert res.status_code == 200
+    assert calls, "compare_digest must be on the auth path"
+    assert calls[0] == (b"tok", b"tok")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Wiring check: every gated endpoint actually carries the gate
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_publish_and_resolve_views_have_gate_applied():
+    """Static check: the ``publish`` and ``resolve`` views are wrapped
+    by ``require_admin_token``. The decorator stores the original
+    function on ``__wrapped__`` (via ``functools.wraps``) so we can
+    detect it without firing a request.
+    """
+    from app.api.simulation import publish_simulation, resolve_simulation
+
+    for view in (publish_simulation, resolve_simulation):
+        assert hasattr(view, "__wrapped__"), (
+            f"{view.__name__} is not wrapped — admin auth gate missing"
+        )
+
+
+def test_outcome_post_is_gated_get_is_not(monkeypatch: pytest.MonkeyPatch):
+    """``POST /outcome`` shares its view with ``GET /outcome`` so we
+    can't use the decorator on the whole function. The view inlines
+    the check on the POST branch only — verify that contract directly.
+    """
+    import inspect
+
+    from app.api.simulation import simulation_outcome
+
+    src = inspect.getsource(simulation_outcome)
+    # POST gate: env load + bearer extraction + constant-time compare.
+    assert "_load_admin_token()" in src
+    assert "_extract_bearer_token()" in src
+    assert "hmac.compare_digest" in src
+    # And it has to be guarded by the method check or every GET would
+    # fail with 503 too — which would break the gallery and embed.
+    assert "request.method == 'POST'" in src or 'request.method == "POST"' in src

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -146,7 +146,40 @@ OPENAI_API_BASE_URL=http://localhost:11434/v1
 # (large JSONL files — disable in production)
 # MIROSHARK_LOG_PROMPTS=true
 # MIROSHARK_LOG_LEVEL=info          # debug|info|warn
+
+# ─── Admin auth (mutation endpoints) ───
+# Shared operator secret guarding POST /publish, /resolve, /outcome.
+# Send as `Authorization: Bearer <token>`. Compared in constant time.
+# UNSET ⇒ those endpoints return 503 (fail-closed). See "Admin auth"
+# below for the full story.
+# MIROSHARK_ADMIN_TOKEN=
 ```
+
+## Admin auth (mutation endpoints)
+
+Three endpoints write to a simulation's on-disk state and are gated on
+a shared operator secret:
+
+- `POST /api/simulation/<id>/publish` — toggles `is_public`
+- `POST /api/simulation/<id>/resolve` — records the actual outcome
+- `POST /api/simulation/<id>/outcome` — verified-prediction annotation
+
+Send the secret as `Authorization: Bearer $MIROSHARK_ADMIN_TOKEN`. The
+server compares it with `hmac.compare_digest` so the comparison is
+constant-time. Read endpoints (including `GET /outcome`, the public
+gallery, and the embed widget) stay unauthenticated.
+
+**Fail-closed.** If `MIROSHARK_ADMIN_TOKEN` is unset or empty in the
+backend's process environment, the gated endpoints return
+`503 — admin auth not configured` rather than silently allowing the
+mutation. There is no implicit "no auth required" fallback. An operator
+who forgot to set the secret would otherwise ship an open mutation
+surface with no warning — the 503 makes the misconfig loud.
+
+Generate a token with `openssl rand -hex 32` (or any sufficiently long
+random string), set it in `.env`, and restart the backend. The token is
+read at request time so a process restart after rotation is enough — no
+code reload required.
 
 ## Feature flags summary
 


### PR DESCRIPTION
## Summary

Closes #48. Adds a shared operator-secret gate on the three mutation
endpoints flagged in that issue:

- `POST /api/simulation/<id>/publish`
- `POST /api/simulation/<id>/resolve`
- `POST /api/simulation/<id>/outcome` *(POST only — GET stays public for the gallery + embed)*

The secret comes from `MIROSHARK_ADMIN_TOKEN` in the backend's process
environment and is sent as `Authorization: Bearer <token>`. Comparison
runs through `hmac.compare_digest` so the token can't be time-trialed.

## Design choice — Option 2 from the issue

Issue #48 listed three options (per-sim ownership tokens, shared
operator secret, full account auth). Picked **Option 2 — shared admin
secret** because it matches the deployment model: a single operator
runs MiroShark behind a reverse proxy or on localhost, and any
mutation is theirs. Per-sim tokens add client-side state for no real
gain, and full sessions/accounts are heavyweight for a single-tenant
service.

## Fail-closed behaviour

If `MIROSHARK_ADMIN_TOKEN` is unset or empty, the gated endpoints
return **503** (`admin auth not configured`) rather than silently
allowing the request. There is no implicit "no auth required"
fallback. An operator who forgot to set the secret would otherwise
ship an open mutation surface with no warning — the 503 makes the
misconfig loud.

401 vs. 503:
- `MIROSHARK_ADMIN_TOKEN` unset → **503**, regardless of whether the
  caller sent a token (deploy is broken; we don't play guess-the-secret).
- Token set, header missing or wrong → **401** with a generic
  `"Unauthorized"` body. We deliberately do not distinguish "missing"
  from "wrong" so a probe can't tell the difference.

## Note on FastAPI dep vs. Flask decorator

Spec called for a FastAPI `Depends(...)` — the codebase is Flask, so
implemented as a `@require_admin_token` decorator with the same
"reusable, applies to each route" property. Same shape, different
framework. The `POST /outcome` view shares its function with `GET
/outcome`, so that one inlines the check on the POST branch only —
documented in the view's docstring.

## Files

- `backend/app/api/simulation.py` — `require_admin_token` decorator,
  helpers (`_load_admin_token`, `_extract_bearer_token`), gate applied
  to `publish_simulation` + `resolve_simulation`, inlined gate in
  `simulation_outcome` for POST-only.
- `backend/openapi.yaml` — `AdminToken` securityScheme, `Unauthorized`
  + `AdminAuthNotConfigured` response components, `security` + 401 +
  503 entries on each gated operation, intro paragraph in `info.description`.
- `.env.example` — new "Admin authentication" section with
  fail-closed warning and `openssl rand -hex 32` recipe.
- `docs/CONFIGURATION.md` — env-var entry + dedicated "Admin auth"
  section.
- `backend/tests/test_unit_admin_auth.py` — 17 new unit tests.

## Test plan

- [x] `cd backend && pytest` → 149 passed, 17 skipped (integration), 0 failed.
- [x] New `test_unit_admin_auth.py` covers: header parsing, env loading,
      fail-closed (503) when env unset even with a token sent, generic 401
      for missing / wrong token (same shape so probes can't distinguish),
      constant-time compare wiring, and that each gated view actually
      carries the gate.
- [x] `test_unit_openapi.py` still passes — spec parses, paths still
      align with Flask routes.
- [ ] Manual smoke (operator):
  ```
  export MIROSHARK_ADMIN_TOKEN="$(openssl rand -hex 32)"
  curl -X POST localhost:5001/api/simulation/sim_x/publish      # → 401
  curl -X POST -H "Authorization: Bearer $MIROSHARK_ADMIN_TOKEN" \
       localhost:5001/api/simulation/sim_x/publish              # → 200
  unset MIROSHARK_ADMIN_TOKEN; <restart backend>
  curl -X POST -H "Authorization: Bearer anything" \
       localhost:5001/api/simulation/sim_x/publish              # → 503
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)