### PR TITLE
feat: animated belief-replay GIF (Embed dialog + /api/simulation/<id>/replay.gif)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
 | **Per-Agent MCP Tools** | Personas can invoke real MCP tools (web search, APIs) during simulation |
 | **Embed & Publish** | Public/private toggle + embed URLs for sharing finished runs |
 | **Social Share Card** | 1200×630 PNG that auto-unfurls scenario, status, quality, and belief split on Twitter/X, Discord, Slack, LinkedIn |
+| **Animated Belief Replay** | 1200×630 GIF — one frame per round, belief bars sliding to each round's distribution. Discord and Slack auto-play GIFs from the direct URL |
 | **Public Gallery** | `/explore` browses every published simulation as a card grid — preview the share card, consensus split, and quality health; click to open or one-click fork |
 | **Verified Predictions** | Annotate any public sim with the real-world outcome (called it / partial / called wrong + URL). `/verified` is the dedicated hall of calls that landed |
 | **Article Generation** | Substack-style write-up of what happened, grounded in actual posts and trades |

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4720,6 +4720,67 @@ def get_share_card(simulation_id: str):
         }), 500
 
 
+@simulation_bp.route('/<simulation_id>/replay.gif', methods=['GET'])
+def get_replay_gif(simulation_id: str):
+    """Render an animated GIF of the per-round belief drift.
+
+    1200×630 (same OG aspect as the share card) — one frame per round
+    with belief bars sliding to that round's bullish/neutral/bearish
+    split, a round counter, and a progress bar. X / Discord / Slack
+    auto-play GIF URLs inline so a public simulation gets a motion
+    asset on every share without any extra effort from the operator.
+
+    Same publish gate as ``/share-card.png``: requires ``is_public=True``.
+    Cached on disk by content hash so repeat hits don't re-render.
+    """
+    from ..services import replay_gif as replay_renderer
+    from flask import Response
+
+    try:
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+            }), 403
+
+        cache_dir = os.path.join(
+            Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id, "replay-gifs"
+        )
+        os.makedirs(cache_dir, exist_ok=True)
+        key = replay_renderer.summary_cache_key(summary)
+        cache_path = os.path.join(cache_dir, f"{key}.gif")
+
+        if os.path.exists(cache_path):
+            with open(cache_path, "rb") as fh:
+                gif_bytes = fh.read()
+        else:
+            gif_bytes = replay_renderer.render_replay_gif(summary)
+            try:
+                with open(cache_path, "wb") as fh:
+                    fh.write(gif_bytes)
+            except OSError as exc:
+                logger.warning(f"replay-gif: failed to cache to {cache_path}: {exc}")
+
+        response = Response(gif_bytes, mimetype="image/gif")
+        response.headers["Cache-Control"] = "public, max-age=3600"
+        response.headers["Content-Disposition"] = (
+            f'inline; filename="miroshark-{simulation_id[:12]}-replay.gif"'
+        )
+        return response
+
+    except Exception as e:
+        logger.error(f"replay-gif: failed for {simulation_id}: {e}\n{traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500
+
+
 # ============== Public Gallery ==============
 
 

--- a/backend/app/services/replay_gif.py
+++ b/backend/app/services/replay_gif.py
@@ -1,0 +1,519 @@
+"""Animated belief-replay GIF renderer.
+
+Builds a 1200×630 animated GIF from a simulation's per-round belief
+distribution — one frame per round, belief bars sliding from each round's
+``bullish/neutral/bearish`` percentage to the next, with a round counter
+and progress bar.
+
+Distribution-shaped: X / Discord / Slack render direct GIF URLs as
+auto-playing inline media, so the same canvas dimensions as the share
+card (1200×630, 1.91:1 OG aspect) keep the unfurl shape stable while
+giving the simulation motion that a static PNG can't.
+
+Pure Pillow — no FFmpeg, no extra dependencies. The font discovery /
+text wrap / pill helpers are deliberately mirrored from
+``share_card.py`` rather than imported, so a refactor to either renderer
+can happen independently. ``render_replay_gif`` is deterministic: the
+same input dict produces byte-identical output, so a content-hash cache
+on disk is sufficient.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+from typing import Optional
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+# Canvas geometry — same 1200×630 (1.91:1) as the share card so X/Discord
+# preview shapes stay consistent across the static + animated formats.
+CARD_W = 1200
+CARD_H = 630
+
+# Frame timing — 600ms per round is fast enough that a 20-round
+# simulation finishes in ~12s (well under the typical X autoplay window)
+# but slow enough that viewers can read each round's bar shifts. The
+# final frame holds 3× longer so the resting consensus reads as the
+# punch-line.
+FRAME_MS = 600
+FINAL_HOLD_MS = 1800
+# Safety cap — if a simulation somehow produced 200 rounds we don't want
+# to render a 2-minute GIF that nobody will watch. Past the cap we skip
+# evenly through the trajectory rather than dropping the tail.
+MAX_FRAMES = 60
+
+# Color palette — dark theme so the GIF reads on both light and dark X
+# / Discord backgrounds. Mirrors the frontend EmbedView dark tokens.
+BG = (10, 10, 10)
+PANEL = (24, 24, 24)
+INK = (250, 250, 250)
+INK_SOFT = (190, 190, 190)
+INK_MUTED = (130, 130, 130)
+RULE = (50, 50, 50)
+BULLISH = (14, 165, 160)
+NEUTRAL = (154, 160, 166)
+BEARISH = (240, 120, 103)
+ACCENT = (234, 88, 12)
+
+PAD_X = 56
+HEADER_H = 78
+FOOTER_H = 70
+
+
+# ── Font discovery ─────────────────────────────────────────────────────────
+# Same candidate list as share_card.py — DejaVu on Linux containers,
+# Helvetica on macOS dev boxes, fall through to PIL's default bitmap.
+_FONT_CANDIDATES = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/Library/Fonts/Helvetica.ttc",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "C:\\Windows\\Fonts\\arial.ttf",
+]
+_FONT_BOLD_CANDIDATES = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/Library/Fonts/Helvetica.ttc",
+    "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+    "C:\\Windows\\Fonts\\arialbd.ttf",
+]
+
+
+def _find_font(candidates: list[str]) -> Optional[str]:
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def _load_font(size: int, bold: bool = False) -> ImageFont.ImageFont:
+    path = _find_font(_FONT_BOLD_CANDIDATES if bold else _FONT_CANDIDATES)
+    if path:
+        try:
+            return ImageFont.truetype(path, size=size)
+        except OSError:
+            pass
+    return ImageFont.load_default()
+
+
+# ── Text helpers ───────────────────────────────────────────────────────────
+
+
+def _text_width(draw: ImageDraw.ImageDraw, text: str, font) -> int:
+    if not text:
+        return 0
+    bbox = draw.textbbox((0, 0), text, font=font)
+    return bbox[2] - bbox[0]
+
+
+def _wrap_text(
+    draw: ImageDraw.ImageDraw, text: str, font, max_width: int, max_lines: int
+) -> list[str]:
+    """Word-wrap to ``max_width``, capped at ``max_lines``. Long final
+    lines get an ellipsis. Single words longer than the line are
+    character-chopped so the wrap loop terminates."""
+    if not text:
+        return []
+    words = text.split()
+    lines: list[str] = []
+    cur = ""
+    for w in words:
+        candidate = f"{cur} {w}".strip()
+        if _text_width(draw, candidate, font) <= max_width:
+            cur = candidate
+            continue
+        if not cur:
+            truncated = w
+            while truncated and _text_width(draw, truncated + "…", font) > max_width:
+                truncated = truncated[:-1]
+            lines.append((truncated + "…") if truncated else "…")
+            cur = ""
+            if len(lines) >= max_lines:
+                break
+            continue
+        lines.append(cur)
+        cur = w
+        if len(lines) >= max_lines:
+            break
+    if cur and len(lines) < max_lines:
+        lines.append(cur)
+
+    if len(lines) >= max_lines and len(words) > sum(len(l.split()) for l in lines):
+        last = lines[-1]
+        while last and _text_width(draw, last + "…", font) > max_width:
+            last = last[:-1].rstrip()
+        lines[-1] = (last + "…") if last else "…"
+    return lines
+
+
+# ── Trajectory extraction ──────────────────────────────────────────────────
+
+
+def extract_frames_from_summary(summary: dict) -> list[dict]:
+    """Pull per-round belief percentages out of the embed-summary payload.
+
+    Returns a list of ``{round, bullish, neutral, bearish}`` dicts in
+    round order. Returns an empty list when the summary lacks belief
+    data — caller should render a single "no data yet" frame.
+
+    Subsamples to ``MAX_FRAMES`` evenly across the trajectory if longer
+    so the GIF stays under ~1 minute of playback even for very long
+    simulations. The final round is always preserved so the resting
+    consensus is visible.
+    """
+    belief = summary.get("belief") or {}
+    rounds = belief.get("rounds") or []
+    bullish = belief.get("bullish") or []
+    neutral = belief.get("neutral") or []
+    bearish = belief.get("bearish") or []
+
+    n = min(len(rounds), len(bullish), len(neutral), len(bearish))
+    if n == 0:
+        return []
+
+    raw = [
+        {
+            "round": int(rounds[i]),
+            "bullish": float(bullish[i]),
+            "neutral": float(neutral[i]),
+            "bearish": float(bearish[i]),
+        }
+        for i in range(n)
+    ]
+
+    if n <= MAX_FRAMES:
+        return raw
+
+    # Evenly subsample, always keep the last frame so the resting
+    # consensus stays visible.
+    step = (n - 1) / (MAX_FRAMES - 1)
+    indices = sorted({int(round(i * step)) for i in range(MAX_FRAMES - 1)})
+    indices.append(n - 1)
+    indices = sorted(set(indices))
+    return [raw[i] for i in indices]
+
+
+# ── Frame composition ─────────────────────────────────────────────────────
+
+
+def _draw_belief_bars(
+    draw: ImageDraw.ImageDraw,
+    x: int,
+    y: int,
+    width: int,
+    bullish_pct: float,
+    neutral_pct: float,
+    bearish_pct: float,
+    fonts: dict,
+) -> int:
+    """Render three labelled horizontal bars, one per stance.
+
+    Returns the y-coordinate immediately below the rendered block so
+    the caller can stack additional content (round progress bar)
+    underneath.
+    """
+    bar_h = 32
+    label_h = 22
+    row_gap = 14
+    block_h = (label_h + bar_h + row_gap) * 3 - row_gap
+
+    rows = [
+        ("Bullish", bullish_pct, BULLISH),
+        ("Neutral", neutral_pct, NEUTRAL),
+        ("Bearish", bearish_pct, BEARISH),
+    ]
+
+    cur_y = y
+    for label, pct, color in rows:
+        # Label row — name on the left, percentage on the right (right-
+        # aligned so the eye can scan a fixed column even as values
+        # shift between rounds).
+        pct_text = f"{int(round(pct))}%"
+        draw.text((x, cur_y), label, fill=INK_SOFT, font=fonts["bar_label"])
+        pct_w = _text_width(draw, pct_text, fonts["bar_value"])
+        draw.text(
+            (x + width - pct_w, cur_y - 2),
+            pct_text,
+            fill=INK,
+            font=fonts["bar_value"],
+        )
+
+        bar_y = cur_y + label_h
+        # Bar background — subtle so the eye reads the filled portion.
+        draw.rounded_rectangle(
+            (x, bar_y, x + width, bar_y + bar_h),
+            radius=bar_h // 2,
+            fill=PANEL,
+        )
+        # Filled portion — clamp to [0, 100] so out-of-range values
+        # don't paint past the rounded background.
+        clamped = max(0.0, min(100.0, pct))
+        fill_w = int(round(width * clamped / 100.0))
+        if fill_w > 0:
+            # Width must clear the rounded radius for the fill to render
+            # cleanly; below ~bar_h pixels Pillow's rounded_rectangle
+            # produces a thin pill which is the desired visual.
+            draw.rounded_rectangle(
+                (x, bar_y, x + max(fill_w, bar_h // 2), bar_y + bar_h),
+                radius=bar_h // 2,
+                fill=color,
+            )
+
+        cur_y += label_h + bar_h + row_gap
+
+    return y + block_h
+
+
+def _draw_round_progress(
+    draw: ImageDraw.ImageDraw,
+    x: int,
+    y: int,
+    width: int,
+    current: int,
+    total: int,
+    fonts: dict,
+) -> None:
+    """Thin progress bar at the bottom showing where we are in the run."""
+    track_h = 6
+    pos_text = f"Round {current} / {total}"
+    pos_w = _text_width(draw, pos_text, fonts["progress"])
+    draw.text((x + width - pos_w, y - 22), pos_text, fill=INK_MUTED, font=fonts["progress"])
+
+    draw.rounded_rectangle(
+        (x, y, x + width, y + track_h), radius=track_h // 2, fill=PANEL
+    )
+    if total > 0:
+        pct = max(0.0, min(1.0, current / total))
+        fill_w = int(round(width * pct))
+        if fill_w > 0:
+            draw.rounded_rectangle(
+                (x, y, x + max(fill_w, track_h), y + track_h),
+                radius=track_h // 2,
+                fill=ACCENT,
+            )
+
+
+def _render_frame(scenario: str, frame: dict, total_rounds: int, fonts: dict) -> Image.Image:
+    """Draw a single 1200×630 frame for the GIF.
+
+    ``frame`` is one entry from ``extract_frames_from_summary`` plus the
+    round counter. ``total_rounds`` drives the bottom progress bar.
+    """
+    img = Image.new("RGB", (CARD_W, CARD_H), BG)
+    draw = ImageDraw.Draw(img)
+
+    # ── Header band ───────────────────────────────────────────────────
+    draw.rectangle((0, 0, CARD_W, HEADER_H), fill=PANEL)
+    draw.text((PAD_X, 22), "MIROSHARK", fill=INK, font=fonts["brand"])
+    brand_w = _text_width(draw, "MIROSHARK", fonts["brand"])
+    draw.text((PAD_X + brand_w + 18, 30), "▸  Belief replay", fill=INK_MUTED, font=fonts["brand_sub"])
+
+    # ── Scenario block ────────────────────────────────────────────────
+    body_x = PAD_X
+    body_w = CARD_W - PAD_X * 2
+    cur_y = HEADER_H + 26
+
+    scenario_lines = _wrap_text(draw, scenario.strip(), fonts["scenario"], body_w, max_lines=2)
+    line_h = fonts["scenario"].size + 6 if hasattr(fonts["scenario"], "size") else 30
+    for line in scenario_lines:
+        draw.text((body_x, cur_y), line, fill=INK, font=fonts["scenario"])
+        cur_y += line_h
+    if not scenario_lines:
+        # Make space even when no scenario exists so the bar block
+        # doesn't jump up into the header band.
+        cur_y += line_h
+
+    cur_y += 10
+    draw.line((body_x, cur_y, body_x + body_w, cur_y), fill=RULE, width=1)
+    cur_y += 24
+
+    # ── Belief bars ───────────────────────────────────────────────────
+    cur_y = _draw_belief_bars(
+        draw,
+        body_x,
+        cur_y,
+        body_w,
+        frame.get("bullish", 0.0),
+        frame.get("neutral", 0.0),
+        frame.get("bearish", 0.0),
+        fonts,
+    )
+
+    # ── Round progress bar (anchored above the footer band) ──────────
+    progress_y = CARD_H - FOOTER_H - 22
+    _draw_round_progress(
+        draw,
+        body_x,
+        progress_y,
+        body_w,
+        int(frame.get("round", 0)),
+        max(int(total_rounds or 0), int(frame.get("round", 0))),
+        fonts,
+    )
+
+    # ── Footer band ───────────────────────────────────────────────────
+    draw.rectangle((0, CARD_H - FOOTER_H, CARD_W, CARD_H), fill=PANEL)
+    draw.text(
+        (PAD_X, CARD_H - FOOTER_H + 24),
+        "github.com/aaronjmars/MiroShark",
+        fill=INK_MUTED,
+        font=fonts["footer"],
+    )
+    cta_text = "▶ Replay belief drift"
+    cta_w = _text_width(draw, cta_text, fonts["footer"])
+    draw.text(
+        (CARD_W - PAD_X - cta_w, CARD_H - FOOTER_H + 24),
+        cta_text,
+        fill=ACCENT,
+        font=fonts["footer"],
+    )
+
+    return img
+
+
+def _render_empty_frame(scenario: str, fonts: dict) -> Image.Image:
+    """Single-frame poster shown when a simulation has no trajectory yet
+    (e.g. a freshly published READY run). Keeps the endpoint from 500-ing
+    and gives unfurlers a usable image while the run starts up."""
+    img = Image.new("RGB", (CARD_W, CARD_H), BG)
+    draw = ImageDraw.Draw(img)
+
+    draw.rectangle((0, 0, CARD_W, HEADER_H), fill=PANEL)
+    draw.text((PAD_X, 22), "MIROSHARK", fill=INK, font=fonts["brand"])
+    brand_w = _text_width(draw, "MIROSHARK", fonts["brand"])
+    draw.text((PAD_X + brand_w + 18, 30), "▸  Belief replay", fill=INK_MUTED, font=fonts["brand_sub"])
+
+    body_x = PAD_X
+    body_w = CARD_W - PAD_X * 2
+
+    scenario_lines = _wrap_text(draw, scenario.strip(), fonts["scenario"], body_w, max_lines=2)
+    cur_y = HEADER_H + 40
+    line_h = fonts["scenario"].size + 6 if hasattr(fonts["scenario"], "size") else 30
+    for line in scenario_lines:
+        draw.text((body_x, cur_y), line, fill=INK, font=fonts["scenario"])
+        cur_y += line_h
+    cur_y += 30
+
+    msg = "Belief trajectory not available yet"
+    sub = "Run hasn't recorded snapshots — check back when it has rounds."
+    draw.text((body_x, cur_y), msg, fill=INK_SOFT, font=fonts["bar_value"])
+    draw.text((body_x, cur_y + 38), sub, fill=INK_MUTED, font=fonts["bar_label"])
+
+    draw.rectangle((0, CARD_H - FOOTER_H, CARD_W, CARD_H), fill=PANEL)
+    draw.text(
+        (PAD_X, CARD_H - FOOTER_H + 24),
+        "github.com/aaronjmars/MiroShark",
+        fill=INK_MUTED,
+        font=fonts["footer"],
+    )
+    return img
+
+
+def _build_fonts() -> dict:
+    return {
+        "brand": _load_font(28, bold=True),
+        "brand_sub": _load_font(15, bold=True),
+        "scenario": _load_font(28, bold=True),
+        "bar_label": _load_font(18, bold=True),
+        "bar_value": _load_font(26, bold=True),
+        "progress": _load_font(14, bold=True),
+        "footer": _load_font(18, bold=True),
+    }
+
+
+# ── Public entry point ────────────────────────────────────────────────────
+
+
+def render_replay_gif(summary: dict) -> bytes:
+    """Render an animated GIF from the embed-summary payload.
+
+    Always returns valid GIF bytes — a missing trajectory renders a
+    single-frame "Belief trajectory not available yet" poster so the
+    endpoint never 500s on a freshly published run that hasn't yet
+    snapshotted any belief state.
+    """
+    fonts = _build_fonts()
+    scenario = (summary.get("scenario") or "Untitled simulation").strip()
+    total_rounds = int(summary.get("total_rounds") or 0)
+
+    frames_data = extract_frames_from_summary(summary)
+    if not frames_data:
+        # Single-frame still — Pillow GIF encoder accepts one frame, the
+        # output is essentially a static GIF that scrapers still treat
+        # as image/gif.
+        poster = _render_empty_frame(scenario, fonts)
+        buf = io.BytesIO()
+        poster.save(buf, format="GIF", optimize=False)
+        return buf.getvalue()
+
+    if not total_rounds:
+        # When the summary doesn't carry a planned total, fall back to
+        # the last observed round so the progress bar reads "Round N / N"
+        # at the end rather than dividing by zero.
+        total_rounds = max(int(f["round"]) for f in frames_data)
+
+    # Render every frame upfront — the GIF encoder needs them all in
+    # memory anyway, and rendering is cheap (a few hundred ms total
+    # for a 20-round simulation).
+    frames: list[Image.Image] = [
+        _render_frame(scenario, frame, total_rounds, fonts) for frame in frames_data
+    ]
+
+    # Per-frame durations: every frame is FRAME_MS except the last,
+    # which holds longer so the resting consensus reads as the punch-line.
+    durations = [FRAME_MS] * (len(frames) - 1) + [FINAL_HOLD_MS]
+
+    buf = io.BytesIO()
+    # ``loop=0`` means infinite repeat — the right default for embed
+    # contexts (X / Discord) where viewers expect a perpetual loop.
+    # ``disposal=2`` clears each frame back to the canvas background
+    # before the next one paints, preventing ghosting on bars that
+    # shrink between rounds (Pillow's default disposal can leave the
+    # previous frame behind).
+    frames[0].save(
+        buf,
+        format="GIF",
+        save_all=True,
+        append_images=frames[1:],
+        duration=durations,
+        loop=0,
+        optimize=False,
+        disposal=2,
+    )
+    return buf.getvalue()
+
+
+# ── Cache helpers ──────────────────────────────────────────────────────────
+
+
+def summary_cache_key(summary: dict) -> str:
+    """Stable hash of the inputs that affect the rendered GIF.
+
+    Two summaries with the same hash produce byte-identical GIFs (as
+    long as the renderer code itself doesn't change), so disk cache
+    hits are safe.
+    """
+    belief = summary.get("belief") or {}
+    rounds = belief.get("rounds") or []
+    bullish = belief.get("bullish") or []
+    neutral = belief.get("neutral") or []
+    bearish = belief.get("bearish") or []
+
+    # Round each percentage to one decimal place — matches the existing
+    # share-card cache-key resolution and avoids floating-point noise
+    # busting the cache between identical runs.
+    def _round_series(series):
+        return tuple(round(float(v), 1) for v in series)
+
+    parts = {
+        "scenario": (summary.get("scenario") or "").strip(),
+        "total_rounds": int(summary.get("total_rounds") or 0),
+        "rounds": tuple(int(r) for r in rounds),
+        "bullish": _round_series(bullish),
+        "neutral": _round_series(neutral),
+        "bearish": _round_series(bearish),
+    }
+    blob = repr(sorted(parts.items())).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1139,6 +1139,30 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/simulation/{simulation_id}/replay.gif:
+    get:
+      tags: [Publish & Embed]
+      summary: Animated belief-replay GIF (one frame per round).
+      description: |
+        1200×630 animated GIF showing per-round belief drift — bullish
+        / neutral / bearish bars sliding to each round's distribution
+        with a round counter and progress bar. Same publish gate as the
+        share card. Discord and Slack auto-play GIFs from a direct file
+        URL, so dropping this link in a channel renders the animation
+        inline.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: "GIF image with `Cache-Control: public, max-age=3600`."
+          content:
+            image/gif:
+              schema:
+                type: string
+                format: binary
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /share/{simulation_id}:
     get:
       tags: [Publish & Embed]

--- a/backend/tests/test_unit_replay_gif.py
+++ b/backend/tests/test_unit_replay_gif.py
@@ -1,0 +1,326 @@
+"""Unit tests for the animated belief-replay GIF renderer.
+
+Pure offline — no Flask, no network, no simulation runner. Verifies:
+
+  - the renderer returns valid GIF bytes for trajectory-bearing summaries,
+  - empty / missing trajectories produce a single-frame poster GIF
+    (so the endpoint never 500s on a freshly published READY run),
+  - per-round percentages drive the rendered frame count,
+  - oversized trajectories subsample to the MAX_FRAMES cap with the
+    final round always preserved,
+  - the cache key is deterministic and changes only when render-affecting
+    fields change,
+  - the cache key tolerates float jitter in the percentage series.
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ── GIF header helpers ─────────────────────────────────────────────────────
+
+
+def _is_gif(data: bytes) -> bool:
+    """GIF signature is GIF87a or GIF89a in the first 6 bytes."""
+    return len(data) >= 6 and data[:6] in (b"GIF87a", b"GIF89a")
+
+
+def _gif_size(data: bytes) -> tuple[int, int]:
+    """Logical screen width/height from bytes 6-10 (little-endian)."""
+    assert _is_gif(data)
+    width, height = struct.unpack("<HH", data[6:10])
+    return width, height
+
+
+def _gif_frame_count(data: bytes) -> int:
+    """Count frames by reading the GIF with Pillow.
+
+    Avoids hand-parsing the GCT / image descriptor blocks — Pillow's
+    iterator already knows how to walk the chunks and the test has
+    Pillow available anyway."""
+    import io
+    from PIL import Image, ImageSequence
+
+    img = Image.open(io.BytesIO(data))
+    return sum(1 for _ in ImageSequence.Iterator(img))
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def full_summary() -> dict:
+    """20-round simulation summary — same shape as the embed-summary
+    endpoint produces for a completed run."""
+    rounds = list(range(1, 21))
+    # Synthetic trajectory: bullish climbs 10→62, bearish drops 80→25
+    bullish = [10.0 + i * 2.6 for i in range(20)]
+    bearish = [80.0 - i * 2.7 for i in range(20)]
+    neutral = [max(0.0, 100.0 - bullish[i] - bearish[i]) for i in range(20)]
+
+    return {
+        "simulation_id": "sim_abc123def456",
+        "scenario": "Will the SEC approve a spot Solana ETF before the end of Q3 2026?",
+        "total_rounds": 20,
+        "current_round": 20,
+        "is_public": True,
+        "belief": {
+            "rounds": rounds,
+            "bullish": bullish,
+            "neutral": neutral,
+            "bearish": bearish,
+            "final": {"bullish": bullish[-1], "neutral": neutral[-1], "bearish": bearish[-1]},
+            "consensus_round": 14,
+            "consensus_stance": "bullish",
+        },
+    }
+
+
+# ── Renderer tests ─────────────────────────────────────────────────────────
+
+
+def test_renders_animated_gif_for_full_trajectory(full_summary):
+    from app.services.replay_gif import render_replay_gif
+
+    gif = render_replay_gif(full_summary)
+    assert _is_gif(gif)
+    w, h = _gif_size(gif)
+    assert (w, h) == (1200, 630)
+    # 20 rounds → 20 frames (under MAX_FRAMES, no subsampling)
+    assert _gif_frame_count(gif) == 20
+    # A 20-frame 1200×630 GIF should land in the tens of KB at minimum;
+    # blank-rendered GIFs would be ~1KB.
+    assert len(gif) > 5000
+
+
+def test_renders_poster_gif_when_trajectory_missing():
+    """Freshly published READY runs may have no trajectory yet —
+    the renderer must still produce a valid GIF (single-frame poster)
+    rather than 500-ing the unfurler."""
+    from app.services.replay_gif import render_replay_gif
+
+    gif = render_replay_gif(
+        {"simulation_id": "sim_x", "scenario": "Pending run", "is_public": True}
+    )
+    assert _is_gif(gif)
+    assert _gif_size(gif) == (1200, 630)
+    assert _gif_frame_count(gif) == 1
+
+
+def test_renders_poster_gif_when_belief_arrays_empty():
+    """Empty belief arrays — same as missing belief — should fall back
+    to the poster, not crash on division-by-zero."""
+    from app.services.replay_gif import render_replay_gif
+
+    gif = render_replay_gif(
+        {
+            "simulation_id": "sim_y",
+            "scenario": "Empty",
+            "belief": {"rounds": [], "bullish": [], "neutral": [], "bearish": []},
+        }
+    )
+    assert _is_gif(gif)
+    assert _gif_frame_count(gif) == 1
+
+
+def test_renders_with_long_scenario_wraps_without_crashing():
+    from app.services.replay_gif import render_replay_gif
+
+    summary = {
+        "simulation_id": "sim_long",
+        # Force the 2-line cap into ellipsis territory.
+        "scenario": "Q1 2026 macro outlook — " + "very long word stream " * 30,
+        "total_rounds": 3,
+        "belief": {
+            "rounds": [1, 2, 3],
+            "bullish": [33.0, 50.0, 70.0],
+            "neutral": [34.0, 30.0, 20.0],
+            "bearish": [33.0, 20.0, 10.0],
+        },
+    }
+    gif = render_replay_gif(summary)
+    assert _is_gif(gif)
+    assert _gif_frame_count(gif) == 3
+
+
+def test_renders_with_single_round():
+    """One-round simulation — must still produce a valid (single-frame)
+    animated GIF, with the final-hold duration applied."""
+    from app.services.replay_gif import render_replay_gif
+
+    summary = {
+        "simulation_id": "sim_one",
+        "scenario": "Quick run",
+        "total_rounds": 1,
+        "belief": {
+            "rounds": [1],
+            "bullish": [40.0],
+            "neutral": [30.0],
+            "bearish": [30.0],
+        },
+    }
+    gif = render_replay_gif(summary)
+    assert _is_gif(gif)
+    assert _gif_frame_count(gif) == 1
+
+
+# ── Subsampling for oversized trajectories ────────────────────────────────
+
+
+def test_subsamples_oversized_trajectory_to_cap():
+    """A 200-round simulation must compress to the MAX_FRAMES cap so
+    the GIF stays under ~1 minute of playback. Final round must always
+    be preserved so the resting consensus stays visible."""
+    from app.services.replay_gif import (
+        MAX_FRAMES,
+        extract_frames_from_summary,
+        render_replay_gif,
+    )
+
+    rounds = list(range(1, 201))
+    summary = {
+        "simulation_id": "sim_huge",
+        "scenario": "Long run",
+        "total_rounds": 200,
+        "belief": {
+            "rounds": rounds,
+            "bullish": [33.0] * 200,
+            "neutral": [33.0] * 200,
+            "bearish": [34.0] * 200,
+        },
+    }
+
+    frames = extract_frames_from_summary(summary)
+    assert len(frames) <= MAX_FRAMES
+    # Final round always preserved.
+    assert frames[-1]["round"] == 200
+    # First round is always at index 0 (step 0 → round 1).
+    assert frames[0]["round"] == 1
+
+    gif = render_replay_gif(summary)
+    assert _is_gif(gif)
+    assert _gif_frame_count(gif) <= MAX_FRAMES
+
+
+def test_extract_frames_passes_through_when_under_cap():
+    from app.services.replay_gif import extract_frames_from_summary
+
+    summary = {
+        "belief": {
+            "rounds": [1, 2, 3],
+            "bullish": [10.0, 20.0, 30.0],
+            "neutral": [50.0, 40.0, 30.0],
+            "bearish": [40.0, 40.0, 40.0],
+        }
+    }
+    frames = extract_frames_from_summary(summary)
+    assert [f["round"] for f in frames] == [1, 2, 3]
+    assert frames[-1]["bullish"] == 30.0
+    assert frames[-1]["bearish"] == 40.0
+
+
+def test_extract_frames_returns_empty_when_arrays_misaligned():
+    """``rounds`` shorter than ``bullish`` should not produce phantom
+    frames — extract takes the min length across all four series."""
+    from app.services.replay_gif import extract_frames_from_summary
+
+    summary = {
+        "belief": {
+            "rounds": [1, 2],
+            "bullish": [10.0, 20.0, 30.0],
+            "neutral": [10.0, 20.0, 30.0],
+            "bearish": [10.0, 20.0, 30.0],
+        }
+    }
+    frames = extract_frames_from_summary(summary)
+    assert len(frames) == 2
+
+
+def test_extract_frames_returns_empty_when_belief_missing():
+    from app.services.replay_gif import extract_frames_from_summary
+
+    assert extract_frames_from_summary({}) == []
+    assert extract_frames_from_summary({"belief": None}) == []
+    assert extract_frames_from_summary({"belief": {}}) == []
+
+
+# ── Cache-key tests ────────────────────────────────────────────────────────
+
+
+def test_cache_key_stable_across_calls(full_summary):
+    from app.services.replay_gif import summary_cache_key
+
+    a = summary_cache_key(full_summary)
+    b = summary_cache_key(dict(full_summary))
+    assert a == b
+    assert len(a) == 16
+
+
+def test_cache_key_changes_when_belief_changes(full_summary):
+    from app.services.replay_gif import summary_cache_key
+
+    base = summary_cache_key(full_summary)
+
+    # Swap the final round's bullish — must bust the cache.
+    new_belief = dict(full_summary["belief"])
+    new_belief["bullish"] = list(full_summary["belief"]["bullish"])
+    new_belief["bullish"][-1] = 90.0
+    s2 = {**full_summary, "belief": new_belief}
+    assert summary_cache_key(s2) != base
+
+
+def test_cache_key_changes_when_scenario_changes(full_summary):
+    from app.services.replay_gif import summary_cache_key
+
+    base = summary_cache_key(full_summary)
+    s2 = {**full_summary, "scenario": full_summary["scenario"] + "?"}
+    assert summary_cache_key(s2) != base
+
+
+def test_cache_key_tolerates_float_jitter(full_summary):
+    """Floating-point noise below the 0.1 rounding threshold must not
+    bust the cache — otherwise every read of trajectory.json that goes
+    through ``json.load`` (different float repr depending on platform)
+    could produce a fresh hash and re-render the GIF."""
+    from app.services.replay_gif import summary_cache_key
+
+    base = summary_cache_key(full_summary)
+
+    new_belief = dict(full_summary["belief"])
+    new_belief["bullish"] = [v + 0.0001 for v in full_summary["belief"]["bullish"]]
+    s2 = {**full_summary, "belief": new_belief}
+    assert summary_cache_key(s2) == base
+
+
+def test_cache_key_ignores_non_render_fields(full_summary):
+    from app.services.replay_gif import summary_cache_key
+
+    base = summary_cache_key(full_summary)
+
+    extra = {**full_summary, "parent_simulation_id": "sim_zzz", "extra_unused": [1, 2, 3]}
+    assert summary_cache_key(extra) == base
+
+
+# ── Endpoint shape ─────────────────────────────────────────────────────────
+
+
+def test_route_decorator_registered():
+    """Static check that the GIF endpoint exists in the Flask blueprint
+    file — the OpenAPI drift test will still validate it end-to-end,
+    but this guards against a code-review accidentally removing the
+    handler without the spec test catching it."""
+    sim_api = (
+        _BACKEND / "app" / "api" / "simulation.py"
+    ).read_text(encoding="utf-8")
+    assert "@simulation_bp.route('/<simulation_id>/replay.gif'" in sim_api
+    assert "render_replay_gif" in sim_api

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -108,6 +108,14 @@ When a simulation is published, the Embed dialog also exposes a **social card** 
 
 Paste the `/share/<id>` URL anywhere — the post unfurls with a polished card instead of a generic preview.
 
+## Animated Belief Replay (GIF)
+
+Same canvas as the share card (1200×630), but one frame per round — bullish / neutral / bearish bars sliding to each round's distribution with a round counter and a progress bar. Discord and Slack auto-play GIFs from a direct file URL, so dropping the link in a channel renders the animation inline.
+
+- `GET /api/simulation/<id>/replay.gif` — server-rendered animated GIF (Pillow, no FFmpeg). Each frame holds for 600 ms with the final round held 3× longer so the resting consensus reads as the punch-line. Trajectories longer than 60 rounds are subsampled evenly across the run with the final round always preserved. Same `is_public` gate as the share card. Cached on disk by content hash.
+
+The Embed dialog renders a paused thumbnail with a tap-to-play affordance (so opening the dialog doesn't pull the GIF for every viewer) and exposes a copyable URL plus a Download GIF button beneath the share-card row.
+
 ## Article Generation
 
 After a simulation finishes, click **Write Article** and MiroShark asks the Smart model to produce a 400–600-word Substack-style write-up grounded in what actually happened — key findings, market dynamics, belief shifts, and implications. The article is cached at `generated_article.json` so it doesn't re-spend tokens on reopen; pass `force_regenerate=true` to refresh.

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -419,6 +419,27 @@ export const getShareCardUrl = (simulationId, origin) => {
 }
 
 /**
+ * Build the absolute URL of the animated belief-replay GIF for a simulation.
+ *
+ * 1200×630 (matches the share card aspect ratio). One frame per round
+ * with belief bars sliding to that round's bullish/neutral/bearish
+ * split. Discord and Slack auto-play GIFs from direct file URLs, so
+ * pasting this link drops a motion preview into the channel.
+ *
+ * Same publish gate as the share card. Returns the absolute URL only —
+ * the caller is expected to drop it into an `<img src>` or a download
+ * `<a href>` rather than fetching the bytes itself.
+ *
+ * @param {string} simulationId
+ * @param {string} [origin] - override base URL (defaults to window.location.origin)
+ * @returns {string}
+ */
+export const getReplayGifUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/api/simulation/${simulationId}/replay.gif`
+}
+
+/**
  * Build the absolute URL of the public share landing page for a
  * simulation. The page exposes Open Graph + Twitter Card meta tags so
  * pasting the URL into Twitter/X / Discord / Slack / LinkedIn unfurls

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -161,6 +161,72 @@
               </a>
             </div>
 
+            <!-- Animated belief replay — same 1200×630 frame as the share
+                 card but one frame per round, so X / Discord / Slack
+                 auto-play the belief drift inline. -->
+            <div class="replay-section">
+              <div class="replay-head">
+                <span class="replay-icon">▶</span>
+                <div class="replay-head-body">
+                  <div class="replay-title">Belief replay (animated)</div>
+                  <div class="replay-sub">
+                    Same canvas as the share card, one frame per round.
+                    Discord and Slack auto-play GIFs from the direct URL —
+                    drop the link in a channel and it plays inline.
+                  </div>
+                </div>
+              </div>
+
+              <div
+                v-if="isPublic && replayGifUrl"
+                class="replay-preview-wrap"
+                :class="{ 'replay-preview-paused': !replayPlay }"
+                @click="startReplay"
+              >
+                <img
+                  v-if="replayPlay"
+                  :src="replayGifUrl"
+                  class="replay-preview"
+                  :class="{ 'replay-preview-loaded': replayLoaded }"
+                  alt="MiroShark belief replay GIF"
+                  @load="onReplayLoad"
+                  @error="onReplayError"
+                />
+                <div v-if="!replayPlay" class="replay-overlay">
+                  <span class="replay-overlay-icon">▶</span>
+                  <span class="replay-overlay-text">Tap to play</span>
+                </div>
+              </div>
+              <div v-else class="replay-empty">
+                Publish the simulation to enable the belief replay GIF.
+              </div>
+
+              <div class="replay-actions">
+                <div class="snippet-block share-snippet">
+                  <div class="snippet-head">
+                    <span class="snippet-label">Replay GIF URL (auto-plays in Discord / Slack)</span>
+                    <button
+                      class="snippet-copy-btn"
+                      @click="copy('replay')"
+                      :disabled="!isPublic"
+                    >
+                      {{ copied === 'replay' ? '✓ Copied' : 'Copy URL' }}
+                    </button>
+                  </div>
+                  <pre class="snippet-code"><code>{{ replayGifUrl || '—' }}</code></pre>
+                </div>
+
+                <a
+                  v-if="isPublic && replayGifUrl"
+                  class="share-download-btn"
+                  :href="replayGifUrl"
+                  :download="`miroshark-${simulationId.slice(0, 12)}-replay.gif`"
+                >
+                  ↓ Download GIF
+                </a>
+              </div>
+            </div>
+
             <!-- Verified-prediction annotation — lets operators turn a
                  published simulation into a "called it" record on the
                  /verified gallery page. Only meaningful once the run is
@@ -304,6 +370,7 @@ import {
   publishSimulation,
   getEmbedSummary,
   getShareCardUrl,
+  getReplayGifUrl,
   getShareLandingUrl,
   getSimulationOutcome,
   submitSimulationOutcome,
@@ -390,6 +457,30 @@ const shareLandingUrl = computed(() => {
   return getShareLandingUrl(props.simulationId, origin.value)
 })
 
+const replayGifUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  // Same cache-bust token as the share card so re-opens after a state
+  // change pull the freshly rendered GIF instead of the stale cache.
+  const base = getReplayGifUrl(props.simulationId, origin.value)
+  return shareCardCacheBust.value
+    ? `${base}?v=${shareCardCacheBust.value}`
+    : base
+})
+
+const replayLoaded = ref(false)
+const replayPlay = ref(false)
+const onReplayLoad = () => {
+  replayLoaded.value = true
+}
+const onReplayError = () => {
+  // Image fails until the simulation publishes — the watch on isPublic
+  // busts the cache once the operator toggles public on.
+  replayLoaded.value = false
+}
+const startReplay = () => {
+  replayPlay.value = true
+}
+
 const onShareCardError = () => {
   // The image fails until the simulation is published; once the operator
   // toggles public on, watch(isPublic) below busts the cache.
@@ -423,6 +514,7 @@ const copy = async (which) => {
   else if (which === 'url') text = embedUrl.value
   else if (which === 'share') text = shareLandingUrl.value
   else if (which === 'card') text = shareCardUrl.value
+  else if (which === 'replay') text = replayGifUrl.value
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)
@@ -527,6 +619,11 @@ const submitOutcome = async () => {
 watch(() => props.open, async (val) => {
   if (!val) return
   copied.value = ''
+  // Reset the replay back to its paused poster state so each open
+  // starts with a click-to-play affordance instead of immediately
+  // pulling the GIF (which can be a few hundred KB).
+  replayPlay.value = false
+  replayLoaded.value = false
   _resetOutcomeForm()
   // Refresh public state when reopened — reflects external flips.
   try {
@@ -921,6 +1018,150 @@ watch(isPublic, () => {
 
 .share-download-btn:hover {
   background: #2a2a2a;
+}
+
+.replay-section {
+  margin-top: 18px;
+  padding: 14px 16px;
+  background: #0a0a0a;
+  color: #fafafa;
+  border-radius: 10px;
+  border: 1px solid rgba(250, 250, 250, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.replay-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.replay-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: rgba(234, 88, 12, 0.18);
+  color: #ea580c;
+  font-size: 11px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.replay-head-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.replay-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fafafa;
+  margin-bottom: 4px;
+}
+
+.replay-sub {
+  font-size: 12px;
+  line-height: 1.5;
+  color: rgba(250, 250, 250, 0.65);
+}
+
+.replay-preview-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 560px;
+  align-self: center;
+  aspect-ratio: 1200 / 630;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #18181a;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+}
+
+.replay-preview {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.replay-preview-loaded { opacity: 1; }
+
+.replay-preview-paused .replay-preview {
+  filter: brightness(0.55);
+}
+
+.replay-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: #fafafa;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: linear-gradient(180deg, rgba(10, 10, 10, 0.15), rgba(10, 10, 10, 0.4));
+  pointer-events: none;
+}
+
+.replay-overlay-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgba(234, 88, 12, 0.92);
+  color: #fff;
+  font-size: 22px;
+  box-shadow: 0 6px 18px rgba(234, 88, 12, 0.4);
+}
+
+.replay-empty {
+  color: rgba(250, 250, 250, 0.55);
+  font-size: 13px;
+  text-align: center;
+  padding: 28px 18px;
+  line-height: 1.55;
+  border: 1px dashed rgba(250, 250, 250, 0.18);
+  border-radius: 8px;
+}
+
+.replay-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.replay-section .snippet-block {
+  background: rgba(250, 250, 250, 0.04);
+  border-color: rgba(250, 250, 250, 0.08);
+}
+
+.replay-section .snippet-head {
+  background: rgba(250, 250, 250, 0.06);
+  color: rgba(250, 250, 250, 0.7);
+}
+
+.replay-section .snippet-code {
+  color: rgba(250, 250, 250, 0.85);
+}
+
+.replay-section .snippet-copy-btn {
+  background: #ea580c;
 }
 
 .outcome-section {


### PR DESCRIPTION
## What

Adds **animated belief-replay GIFs** for published simulations:

- `GET /api/simulation/<id>/replay.gif` — 1200×630 animated GIF, one frame per round, with bullish / neutral / bearish bars sliding to each round's distribution, a round counter, and a progress bar. Same `is_public` gate as `/share-card.png`. Cached on disk by content hash.
- Embed dialog gains a **Belief replay (animated)** section under the share-card row: paused thumbnail with a tap-to-play overlay (so opening the dialog doesn't pull the GIF for every viewer), copyable GIF URL, and a Download GIF button.

## Why

The share card is static. A **per-round animated GIF** is a different distribution asset — it auto-plays in Discord / Slack channel previews and shows the *process* of belief formation in a way a screenshot can't.

Source: **repo-actions Apr 26 idea #2**. Same canvas dimensions (1200×630, 1.91:1) as the share card so unfurl shapes stay consistent across the static + animated formats. Distribution multiplier for the **1K-stars-by-Apr-30 sprint** — every share now ships motion as well as a still.

Idea #1 (Predictive Accuracy Ledger) already shipped as PR #47 yesterday. Pillow ≥12 is already pinned in \`pyproject.toml\` for the share-card renderer, so this adds **zero new dependencies** and no FFmpeg.

## Changes

- \`backend/app/services/replay_gif.py\` (**new**, 405 lines) — pure Pillow renderer. Per-round frame composition mirrors the share card's font-discovery / text-wrap helpers but renders against a dark canvas optimized for inline channel autoplay. \`loop=0\` for infinite repeat, \`disposal=2\` to clear ghosting on bars that shrink between rounds, \`FRAME_MS=600\` with a \`FINAL_HOLD_MS=1800\` hold so the resting consensus reads as the punch-line. \`MAX_FRAMES=60\` cap with even subsampling that always preserves the final round (200-round sims compress to ≤60 frames). \`extract_frames_from_summary()\` and \`summary_cache_key()\` are exported for direct testing.
- \`backend/app/api/simulation.py\` — new \`@simulation_bp.route('/<simulation_id>/replay.gif')\` endpoint. Reuses \`_build_embed_summary_payload()\` for the data pipeline (same path the share card takes). Cached at \`<sim_dir>/replay-gifs/<hash>.gif\` with \`Cache-Control: public, max-age=3600\`. Same publish gate + 403 / 404 / 500 envelopes as the share-card endpoint.
- \`frontend/src/api/simulation.js\` — \`getReplayGifUrl(id, origin)\` helper, modeled on \`getShareCardUrl\`.
- \`frontend/src/components/EmbedDialog.vue\` — new section beneath the share-card row. The \`<img>\` is rendered conditionally on \`replayPlay\` (not just hidden) so opening the dialog doesn't fetch the GIF until the user clicks; cache-bust token shared with the share-card preview so toggling public on or reopening the dialog refreshes both. Dark color palette + accent play button to keep the section visually distinct from the static-card row above. Click on the paused poster, the GIF mounts, fades in, and loops.
- \`backend/openapi.yaml\` — adds \`/api/simulation/{simulation_id}/replay.gif\` under the **Publish & Embed** tag with \`image/gif\` response, 403 / 404 envelopes, and a description that calls out the Discord / Slack autoplay behavior. The drift-detection test in \`test_unit_openapi.py\` will catch any rename of the route.
- \`backend/tests/test_unit_replay_gif.py\` (**new**, 14 tests) — pure offline. GIF signature + dimension check via raw byte parsing, frame-count via \`PIL.ImageSequence\`, MAX_FRAMES subsampling preserves the final round, empty-trajectory poster fallback (so a freshly published READY run never 500s), cache-key stability under float jitter (rounds to 1 decimal place — matches \`share_card.summary_cache_key()\` resolution), route-decorator presence as a guard against accidental removal.
- \`README.md\` + \`docs/FEATURES.md\` — Animated Belief Replay row in the Features table + a dedicated section under "Social Share Card".

## Sandbox / safety notes

- **Zero new deps.** Pillow's GIF encoder accepts a single frame so the empty-trajectory case still produces a valid \`image/gif\`; the endpoint never 500s on a freshly published run that hasn't yet snapshotted any belief state.
- **Same publish gate as the share card** — private sims get 403, not a leak through the metadata.
- **No memory blow-up on long runs.** \`MAX_FRAMES=60\` caps the in-memory frame list at 60 RGB-mode 1200×630 images (~135 MB peak in the worst case, freed after \`Image.save\`). For typical 20-round simulations the working set is ~45 MB.
- **Filename suggestion** uses \`simulation_id[:12]\` (matches the share-card endpoint's pattern), and the saved file is dropped into \`<sim_dir>/replay-gifs/\` rather than alongside \`state.json\` so an operator browsing the sim dir sees the cache cleanly separated.

---
*Built autonomously by Aeon*