### PR TITLE
Tag every OpenRouter call with Langfuse-grouping metadata

### DIFF
--- a/backend/app/services/graph_builder.py
+++ b/backend/app/services/graph_builder.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from ..models.task import TaskManager, TaskStatus
 from ..storage import GraphStorage
 from ..utils.event_logger import EventLogger
+from ..utils.trace_context import TraceContext
 from .text_processor import TextProcessor
 
 logger = logging.getLogger('miroshark.graph_builder')
@@ -152,9 +153,16 @@ class GraphBuilderService:
                     'message': msg,
                 })
 
+            # Tag every NER/graph-extract LLM call inside the worker pool
+            # so Langfuse can isolate this phase. add_text_batches uses a
+            # ThreadPoolExecutor and TraceContext is thread-local, so the
+            # parent thread's set is sufficient (workers inherit via the
+            # wrapper inside add_text_batches when present).
+            TraceContext.set(sim_phase="setup", prompt_type="graph_extract")
             episode_uuids = self.add_text_batches(
                 graph_id, chunks, max_workers, _progress_with_events
             )
+            TraceContext.set(sim_phase="", prompt_type="")
 
             # 5. Wait for processing (no-op for Neo4j — already synchronous)
             self.storage.wait_for_processing(episode_uuids)
@@ -240,13 +248,18 @@ class GraphBuilderService:
             )
             return episode_id
 
+        # Snapshot the caller's TraceContext so workers see the same
+        # sim_phase / prompt_type / simulation_id (threading.local does
+        # not propagate across pool workers).
+        _process_chunk_traced = TraceContext.wrap_fn(_process_chunk)
+
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {}
             for i, chunk in enumerate(chunks):
                 if not chunk or not chunk.strip():
                     continue
                 chunk_idx = i + 1
-                future = pool.submit(_process_chunk, chunk_idx, chunk)
+                future = pool.submit(_process_chunk_traced, chunk_idx, chunk)
                 futures[future] = chunk_idx
 
             for future in as_completed(futures):

--- a/backend/app/services/simulation_manager.py
+++ b/backend/app/services/simulation_manager.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from enum import Enum
 
 from ..utils.logger import get_logger
+from ..utils.trace_context import TraceContext
 from ..utils.validation import validate_simulation_id
 from .entity_reader import EntityReader
 from .wonderwall_profile_generator import WonderwallProfileGenerator
@@ -299,6 +300,10 @@ class SimulationManager:
             state.status = SimulationStatus.PREPARING
             self._save_simulation_state(state)
 
+            # Pin simulation_id for the whole prep pipeline so every
+            # downstream LLM call lands under the same Langfuse session.
+            TraceContext.set(simulation_id=simulation_id)
+
             sim_dir = self._get_simulation_dir(simulation_id)
 
             # ========== Phase 1: Read and filter entities ==========
@@ -345,6 +350,8 @@ class SimulationManager:
                     current=0,
                     total=total_entities
                 )
+
+            TraceContext.set(sim_phase="setup", prompt_type="persona_generation")
 
             # Pass graph_id to enable graph retrieval for richer context
             generator = WonderwallProfileGenerator(
@@ -435,8 +442,10 @@ class SimulationManager:
                     total=3
                 )
             
+            TraceContext.set(sim_phase="setup", prompt_type="sim_config")
+
             config_generator = SimulationConfigGenerator()
-            
+
             if progress_callback:
                 progress_callback(
                     "generating_config", 30,
@@ -483,6 +492,10 @@ class SimulationManager:
 
             # Note: run scripts remain in backend/scripts/ directory, no longer copied to simulation directory
             # When starting simulation, simulation_runner will run scripts from the scripts/ directory
+
+            # Clear per-phase tags so a follow-up call (e.g., re-prepare,
+            # report generation) doesn't inherit "setup" context.
+            TraceContext.set(sim_phase="", prompt_type="")
 
             # Update status
             state.status = SimulationStatus.READY

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -489,7 +489,18 @@ class SimulationRunner:
             env['PYTHONIOENCODING'] = 'utf-8'  # Ensure stdout/stderr use UTF-8
             env['MIROSHARK_SIM_DIR'] = sim_dir  # Observability: tell agents where to write events.jsonl
             env['MIROSHARK_SIMULATION_ID'] = simulation_id  # Observability: tag Wonderwall events with sim ID
-            
+            # Forward run_id (when the orchestrator has set one) so the
+            # subprocess's Langfuse `metadata.run_id` / `tags` line up with
+            # the orchestrator-side calls — both ends end up under the same
+            # sim's session, sliceable by run.
+            try:
+                from ..utils.trace_context import TraceContext as _TC
+                run_id_env = _TC.get('run_id', '') or ''
+                if run_id_env:
+                    env['MIROSHARK_RUN_ID'] = str(run_id_env)
+            except Exception:
+                pass
+
             # Set working directory to simulation directory (database files etc. will be generated here)
             # Use start_new_session=True to create new process group, ensuring all child processes can be terminated via os.killpg
             process = subprocess.Popen(

--- a/backend/app/services/wonderwall_profile_generator.py
+++ b/backend/app/services/wonderwall_profile_generator.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from ..config import Config
 from ..utils.llm_client import create_llm_client
 from ..utils.logger import get_logger
+from ..utils.trace_context import TraceContext
 from .entity_reader import EntityNode
 from .web_enrichment import WebEnricher
 from ..storage import GraphStorage
@@ -1109,11 +1110,16 @@ IMPORTANT: Do NOT include karma, friend_count, follower_count, or statuses_count
         print(f"Starting Agent persona generation - {total} entities, parallelism: {parallel_count}")
         print(f"{'='*60}\n")
 
+        # Snapshot caller's TraceContext into worker threads — sim_phase/
+        # prompt_type are thread-local and would otherwise be lost across
+        # the ThreadPoolExecutor boundary, dropping the Langfuse tags.
+        generate_single_profile_traced = TraceContext.wrap_fn(generate_single_profile)
+
         # Use thread pool for parallel execution
         with concurrent.futures.ThreadPoolExecutor(max_workers=parallel_count) as executor:
             # Submit all tasks
             future_to_entity = {
-                executor.submit(generate_single_profile, idx, entity): (idx, entity)
+                executor.submit(generate_single_profile_traced, idx, entity): (idx, entity)
                 for idx, entity in enumerate(entities)
             }
             

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -16,6 +16,58 @@ from ..config import Config
 from .event_logger import EventLogger, LOG_PROMPTS
 
 
+# Map auto-detected `module.function` callers → friendly prompt_type labels
+# that Langfuse can group by. Keep this list explicit instead of guessing —
+# every entry maps to a concrete observability question we want to ask.
+_CALLER_PROMPT_TYPES: Dict[str, str] = {
+    "report_agent.plan_outline":                     "report_outline",
+    "report_agent._generate_outline":                "report_outline",
+    "report_agent._generate_section_react":          "report_section",
+    "report_agent._generate_section_content":        "report_section",
+    "report_agent._generate_synthesis":              "report_synthesis",
+    "report_agent.chat":                             "report_chat",
+    "ontology_generator.generate":                   "ontology_design",
+    "ontology_generator._generate_with_llm":         "ontology_design",
+    "text_processor.extract_entities":               "ner_extraction",
+    "text_processor._extract_with_llm":              "ner_extraction",
+    "wonderwall_profile_generator._generate_profile_with_llm": "persona_generation",
+    "simulation_config_generator._call_llm_with_retry": "sim_config",
+    "simulation_config_generator.generate_config":   "sim_config",
+    "graph_builder.add_text_batches":                "graph_extract",
+    "web_enrichment._research":                      "web_research",
+    "SocialAgent.perform_action_by_llm":             "agent_action",
+}
+
+# Map prompt_type → broad simulation phase ("setup"/"round"/"report"/"ingest")
+# so Langfuse filters can roll up at either granularity. Used as a fallback
+# when TraceContext.sim_phase isn't explicitly set by the caller.
+_PROMPT_TYPE_PHASES: Dict[str, str] = {
+    "ontology_design":     "setup",
+    "ner_extraction":      "setup",
+    "graph_extract":       "setup",
+    "persona_generation":  "setup",
+    "sim_config":          "setup",
+    "web_research":        "setup",
+    "agent_action":        "round",
+    "report_outline":      "report",
+    "report_section":      "report",
+    "report_synthesis":    "report",
+    "report_chat":         "report",
+}
+
+
+def _prompt_type_from_caller(caller: str) -> str:
+    """Best-effort caller → prompt_type. Falls back to the function name."""
+    if caller in _CALLER_PROMPT_TYPES:
+        return _CALLER_PROMPT_TYPES[caller]
+    fn = caller.split(".")[-1].lstrip("_")
+    return fn or "unknown"
+
+
+def _phase_from_prompt_type(prompt_type: str) -> str:
+    return _PROMPT_TYPE_PHASES.get(prompt_type, "")
+
+
 def create_llm_client(
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
@@ -234,7 +286,10 @@ class LLMClient:
                 "options": {"num_ctx": self._num_ctx}
             }
 
-        # OpenRouter metadata: tag each generation with caller/simulation context
+        # OpenRouter metadata: tag each generation with caller/simulation
+        # context. Specifically structured so OpenRouter forwards it cleanly
+        # to Langfuse — `user` becomes Langfuse `sessionId`, `metadata`
+        # becomes the trace metadata block, `tags` powers the filter UI.
         if not self._is_ollama() and 'openrouter' in (self.base_url or ''):
             # Detect caller for metadata
             caller = 'unknown'
@@ -246,19 +301,47 @@ class LLMClient:
                     break
 
             from .trace_context import TraceContext
-            sim_id = TraceContext.get('simulation_id', '')
-            agent_name = TraceContext.get('agent_name', '')
-            round_num = TraceContext.get('round_num', '')
+            sim_id = TraceContext.get('simulation_id', '') or ''
+            run_id = TraceContext.get('run_id', '') or ''
+            agent_name = TraceContext.get('agent_name', '') or ''
+            agent_id = TraceContext.get('agent_id', '') or ''
+            round_num = TraceContext.get('round_num', None)
+            sim_phase = TraceContext.get('sim_phase', '') or ''
+            prompt_type = TraceContext.get('prompt_type', '') or _prompt_type_from_caller(caller)
+            effective_phase = sim_phase or _phase_from_prompt_type(prompt_type)
 
             extra = kwargs.get("extra_body", {})
-            extra["metadata"] = {
+            metadata = {
                 "caller": caller,
+                "prompt_type": prompt_type,
+                "sim_phase": effective_phase,
+                "run_id": run_id,
                 "simulation_id": sim_id,
                 "agent_name": str(agent_name)[:64],
-                "round": str(round_num),
+                "agent_id": str(agent_id) if agent_id else "",
+                "round": (int(round_num) if isinstance(round_num, int)
+                          else (int(round_num) if (isinstance(round_num, str)
+                                and round_num.isdigit()) else None)),
             }
+            extra["metadata"] = {k: v for k, v in metadata.items()
+                                 if v not in ("", None)}
+            # OpenRouter forwards `user` as the Langfuse sessionId, which
+            # is how we group every call from one sim into one session.
             if sim_id:
-                extra["session_id"] = sim_id
+                extra["user"] = sim_id
+            # Tags surface in Langfuse's filter sidebar. Keep it short —
+            # just the things we actually want to slice by.
+            tags = ["miroshark"]
+            if prompt_type:
+                tags.append(prompt_type)
+            if effective_phase:
+                tags.append(f"phase:{effective_phase}")
+            if run_id:
+                tags.append(f"run:{run_id}")
+            extra["tags"] = tags
+            # Trace name: gives Langfuse's list view a useful label per
+            # call instead of every row reading "OpenRouter Request".
+            extra["name"] = prompt_type or caller
             # Disable chain-of-thought on reasoning-capable models by default —
             # we want short, deterministic outputs, not a 100-token <think>
             # trace padding every call. Saves 50-80% latency on Qwen3/Grok-4.1

--- a/backend/app/utils/trace_context.py
+++ b/backend/app/utils/trace_context.py
@@ -6,10 +6,18 @@ Usage:
     # ... deep in the call stack, llm_client reads this automatically:
     sim_id = TraceContext.get("simulation_id")
     TraceContext.clear()
+
+Thread-pool caveat: Python's ``threading.local`` doesn't propagate across
+``ThreadPoolExecutor`` worker threads. For Langfuse correlation to survive
+work spawned inside a pool, the caller must either explicitly snapshot+
+restore or use the ``wrap_fn`` helper below, which captures the parent
+thread's context and re-applies it inside the worker.
 """
 
+import functools
 import threading
 import uuid
+from typing import Callable
 
 _context = threading.local()
 
@@ -19,7 +27,7 @@ class TraceContext:
 
     @staticmethod
     def set(**kwargs):
-        """Set one or more context fields (simulation_id, round_num, agent_id, agent_name, platform, trace_id)."""
+        """Set one or more context fields (simulation_id, round_num, agent_id, agent_name, platform, trace_id, run_id, sim_phase, prompt_type)."""
         for k, v in kwargs.items():
             setattr(_context, k, v)
 
@@ -44,3 +52,29 @@ class TraceContext:
     def clear():
         """Remove all context fields."""
         _context.__dict__.clear()
+
+    @staticmethod
+    def wrap_fn(fn: Callable) -> Callable:
+        """Snapshot the caller's context; restore it in the wrapped fn.
+
+        Use this when submitting to a ThreadPoolExecutor so that child
+        threads inherit ``simulation_id`` / ``sim_phase`` / etc. for
+        Langfuse correlation. Example:
+
+            snapshot_fn = TraceContext.wrap_fn(_process_chunk)
+            executor.submit(snapshot_fn, chunk_idx, chunk)
+
+        The wrapper overwrites the worker thread's existing context —
+        thread-pool threads are reused, so stale context from a previous
+        task would otherwise leak into the next.
+        """
+        snapshot = TraceContext.get_all()
+
+        @functools.wraps(fn)
+        def _wrapped(*args, **kwargs):
+            _context.__dict__.clear()
+            for k, v in snapshot.items():
+                setattr(_context, k, v)
+            return fn(*args, **kwargs)
+
+        return _wrapped

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -1423,6 +1423,13 @@ async def run_twitter_simulation(
                 main_logger.info(f"Received shutdown signal, stopping simulation at round {round_num + 1}")
             break
 
+        # Surface the current round to every LLM call inside the subprocess
+        # via an env var — the only context channel that reaches CAMEL's
+        # OpenRouter call site cleanly without reworking its signature.
+        # `SocialAgent._aget_model_response` reads this and forwards it to
+        # Langfuse as `metadata.round`.
+        os.environ['MIROSHARK_ROUND_NUM'] = str(round_num + 1)
+
         simulated_minutes = round_num * minutes_per_round
         simulated_hour = (simulated_minutes // 60) % 24
         simulated_day = simulated_minutes // (60 * 24) + 1
@@ -1738,6 +1745,13 @@ async def run_reddit_simulation(
             if main_logger:
                 main_logger.info(f"Received shutdown signal, stopping simulation at round {round_num + 1}")
             break
+
+        # Surface the current round to every LLM call inside the subprocess
+        # via an env var — the only context channel that reaches CAMEL's
+        # OpenRouter call site cleanly without reworking its signature.
+        # `SocialAgent._aget_model_response` reads this and forwards it to
+        # Langfuse as `metadata.round`.
+        os.environ['MIROSHARK_ROUND_NUM'] = str(round_num + 1)
 
         simulated_minutes = round_num * minutes_per_round
         simulated_hour = (simulated_minutes // 60) % 24
@@ -2145,6 +2159,9 @@ async def run_polymarket_simulation(
                 )
             break
 
+        # Surface round number to subprocess LLM calls for Langfuse metadata
+        os.environ['MIROSHARK_ROUND_NUM'] = str(round_num + 1)
+
         simulated_minutes = round_num * minutes_per_round
         simulated_hour = (simulated_minutes // 60) % 24
         simulated_day = simulated_minutes // (60 * 24) + 1
@@ -2520,6 +2537,9 @@ async def run_synchronized_simulation(
         if _shutdown_event and _shutdown_event.is_set():
             log_info(f"Shutdown signal at round {round_num + 1}")
             break
+
+        # Surface round number to subprocess LLM calls for Langfuse metadata
+        os.environ['MIROSHARK_ROUND_NUM'] = str(round_num + 1)
 
         simulated_minutes = round_num * minutes_per_round
         simulated_hour = (simulated_minutes // 60) % 24

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -698,10 +698,13 @@ class RedditSimulationRunner:
         start_time = datetime.now()
         
         for round_num in range(total_rounds):
+            # Surface round number to subprocess LLM calls for Langfuse metadata
+            os.environ['MIROSHARK_ROUND_NUM'] = str(round_num + 1)
+
             simulated_minutes = round_num * minutes_per_round
             simulated_hour = (simulated_minutes // 60) % 24
             simulated_day = simulated_minutes // (60 * 24) + 1
-            
+
             active_agents = self._get_active_agents_for_round(
                 self.env, simulated_hour, round_num
             )

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -637,6 +637,9 @@ class TwitterSimulationRunner:
         start_time = datetime.now()
         
         for round_num in range(total_rounds):
+            # Surface round number to subprocess LLM calls for Langfuse metadata
+            os.environ['MIROSHARK_ROUND_NUM'] = str(round_num + 1)
+
             # Calculate current simulated time
             simulated_minutes = round_num * minutes_per_round
             simulated_hour = (simulated_minutes // 60) % 24

--- a/backend/wonderwall/social_agent/agent.py
+++ b/backend/wonderwall/social_agent/agent.py
@@ -171,22 +171,44 @@ class SocialAgent(ChatAgent):
         if not filtered:
             filtered = [{"role": "user", "content": "(empty context)"}]
 
-        # Inject OpenRouter metadata per-call so each generation is tagged
+        # Inject OpenRouter metadata per-call so each generation is tagged.
+        # Structured for Langfuse: `user` becomes the Langfuse sessionId,
+        # `metadata` lands on the trace, `tags` powers the filter sidebar.
         base_url = _os.environ.get('OPENAI_API_BASE_URL', '')
         if 'openrouter' in base_url:
             try:
-                sim_id = _os.environ.get('MIROSHARK_SIMULATION_ID', '')
+                sim_id = _os.environ.get('MIROSHARK_SIMULATION_ID', '') or ''
+                run_id = _os.environ.get('MIROSHARK_RUN_ID', '') or ''
+                round_env = _os.environ.get('MIROSHARK_ROUND_NUM', '')
+                round_num: Optional[int]
+                try:
+                    round_num = int(round_env) if round_env else None
+                except (TypeError, ValueError):
+                    round_num = None
                 agent_name = str(getattr(self.user_info, 'name', ''))[:64]
+                prompt_type = 'agent_action'
+                sim_phase = 'round'
                 config = self.model_backend.model_config_dict
                 extra = config.get('extra_body', {})
-                extra['metadata'] = {
+                metadata = {
                     'caller': 'SocialAgent.perform_action_by_llm',
+                    'prompt_type': prompt_type,
+                    'sim_phase': sim_phase,
+                    'run_id': run_id,
                     'simulation_id': sim_id,
                     'agent_name': agent_name,
                     'agent_id': str(self.social_agent_id or ''),
+                    'round': round_num,
                 }
+                extra['metadata'] = {k: v for k, v in metadata.items()
+                                     if v not in ('', None)}
                 if sim_id:
-                    extra['session_id'] = sim_id
+                    extra['user'] = sim_id  # OpenRouter → Langfuse sessionId
+                tags = ['miroshark', prompt_type, f'phase:{sim_phase}']
+                if run_id:
+                    tags.append(f'run:{run_id}')
+                extra['tags'] = tags
+                extra['name'] = prompt_type
                 config['extra_body'] = extra
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- Threads `sim_id` / `run_id` / `round` / `agent_id` / `prompt_type` / `sim_phase` through `TraceContext` and into every OpenRouter call, so Langfuse gets a real `sessionId`, useful tags, and a `name` instead of every row reading "OpenRouter Request".
- Updates `wonderwall/social_agent/agent.py` (subprocess side) to emit the same payload, with `MIROSHARK_ROUND_NUM` / `MIROSHARK_RUN_ID` env vars forwarded by `simulation_runner` and the round loops.
- Adds `TraceContext.wrap_fn` and applies it to the `ThreadPoolExecutor` submit calls in `graph_builder` and `wonderwall_profile_generator` so worker threads inherit the parent's context.
- Mirrors the setup that's already running in MiroShark-api (#18).

## Test plan
- [ ] Run a sim against an OpenRouter key and confirm Langfuse traces show `sessionId = sim_id`, tags include `miroshark` / `phase:setup` / `phase:round` / <prompt_type>, and `name` is the prompt_type.
- [ ] Verify the filter sidebar populates with `prompt_type`, `sim_phase`, `round`, `agent_id`.