### PR TITLE
Stop tool retry loop and bound research-call context

### DIFF
--- a/backend/app/services/web_enrichment.py
+++ b/backend/app/services/web_enrichment.py
@@ -161,6 +161,14 @@ class WebEnricher:
         self._cache[cache_key] = result
         return result
 
+    # Cap the simulation_requirement copy in entity-research prompts so a
+    # multi-KB user briefing doesn't get pasted into every research call.
+    # The model only needs a couple hundred tokens of "what's this sim
+    # about" to ground per-entity research; anything more is wasted input.
+    # Previous Langfuse traces showed 60-80k input tokens per entity from
+    # this leak alone.
+    _SIM_REQUIREMENT_CHAR_CAP = 1500
+
     def _research(
         self,
         entity_name: str,
@@ -180,7 +188,10 @@ class WebEnricher:
         parts.append(f"**Type:** {entity_type}")
 
         if simulation_requirement:
-            parts.append(f"**Simulation context:** {simulation_requirement}")
+            sr = simulation_requirement.strip()
+            if len(sr) > self._SIM_REQUIREMENT_CHAR_CAP:
+                sr = sr[: self._SIM_REQUIREMENT_CHAR_CAP].rstrip() + " […]"
+            parts.append(f"**Simulation context:** {sr}")
 
         if existing_context and len(existing_context.strip()) > 20:
             # Give the LLM what we already know so it doesn't repeat it

--- a/backend/wonderwall/social_agent/agent.py
+++ b/backend/wonderwall/social_agent/agent.py
@@ -71,7 +71,12 @@ class SocialAgent(ChatAgent):
                  agent_graph: "AgentGraph" = None,
                  available_actions: list[ActionType] = None,
                  tools: Optional[List[Union[FunctionTool, Callable]]] = None,
-                 max_iteration: int = 1,
+                 # CAMEL ReAct iteration cap. Previously this attribute
+                 # was stored but never plumbed to CAMEL, so runtime was
+                 # unbounded (and idempotent tool errors looped 4+ times).
+                 # 3 covers observe → tool → synthesize while bounding the
+                 # blast radius of any future loop bug.
+                 max_iteration: int = 3,
                  interview_record: bool = False,
                  # --- New: generic simulation support ---
                  simulation=None):
@@ -139,11 +144,19 @@ class SocialAgent(ChatAgent):
                 ]
             ]
         all_tools = (tools or []) + (self.action_tools or [])
+        # Cap CAMEL's per-step ReAct loop and prune tool messages from
+        # memory after each step. Without this the agent could fire the
+        # same tool 4+ times per round on idempotent failures, ballooning
+        # the conversation history past 40k input tokens (see Langfuse
+        # retry-loop investigation; the no-op success returns from
+        # platform.py also stop the loop at the source).
         super().__init__(
             system_message=system_message,
             model=model,
             scheduling_strategy='random_model',
             tools=all_tools,
+            max_iteration=max_iteration,
+            prune_tool_calls_from_memory=True,
         )
         self.max_iteration = max_iteration
         self.interview_record = interview_record

--- a/backend/wonderwall/social_platform/platform.py
+++ b/backend/wonderwall/social_platform/platform.py
@@ -444,10 +444,12 @@ class Platform:
                                               (post_id, user_id))
             if self.db_cursor.fetchone():
                 # for common and quote post, check if the post has been
-                # reposted
+                # reposted — return no-op success so the agent moves on
+                # instead of retrying (see Langfuse retry-loop bug).
                 return {
-                    "success": False,
-                    "error": "Repost record already exists."
+                    "success": True,
+                    "noop": True,
+                    "reason": "Repost record already exists."
                 }
 
             post_type_result = self.pl_utils._get_post_type(post_id)
@@ -477,10 +479,12 @@ class Platform:
                     (post_type_result['root_post_id'], user_id))
 
                 if self.db_cursor.fetchone():
-                    # for repost post, check if the post has been reposted
+                    # for repost post, check if the post has been reposted —
+                    # treat as no-op success so the agent doesn't loop.
                     return {
-                        "success": False,
-                        "error": "Repost record already exists."
+                        "success": True,
+                        "noop": True,
+                        "reason": "Repost record already exists."
                     }
 
                 self.pl_utils._execute_db_command(
@@ -577,10 +581,13 @@ class Platform:
             self.pl_utils._execute_db_command(like_check_query,
                                               (post_id, user_id))
             if self.db_cursor.fetchone():
-                # Like record already exists
+                # Like record already exists — return no-op success so the
+                # agent moves on instead of retrying (which previously
+                # ballooned conversation history to 40k+ tokens per round).
                 return {
-                    "success": False,
-                    "error": "Like record already exists."
+                    "success": True,
+                    "noop": True,
+                    "reason": "Like record already exists."
                 }
 
             # Check if the post to be liked is self-posted
@@ -630,10 +637,12 @@ class Platform:
             result = self.db_cursor.fetchone()
 
             if not result:
-                # No like record exists
+                # No like record exists — desired state already true,
+                # report no-op success so the agent doesn't retry.
                 return {
-                    "success": False,
-                    "error": "Like record does not exist."
+                    "success": True,
+                    "noop": True,
+                    "reason": "Like record does not exist."
                 }
 
             # Get the `like_id`
@@ -681,10 +690,11 @@ class Platform:
             self.pl_utils._execute_db_command(like_check_query,
                                               (post_id, user_id))
             if self.db_cursor.fetchone():
-                # Dislike record already exists
+                # Dislike record already exists — no-op success.
                 return {
-                    "success": False,
-                    "error": "Dislike record already exists."
+                    "success": True,
+                    "noop": True,
+                    "reason": "Dislike record already exists."
                 }
 
             # Check if the post to be disliked is self-posted
@@ -734,10 +744,11 @@ class Platform:
             result = self.db_cursor.fetchone()
 
             if not result:
-                # No dislike record exists
+                # No dislike record exists — desired state already true.
                 return {
-                    "success": False,
-                    "error": "Dislike record does not exist."
+                    "success": True,
+                    "noop": True,
+                    "reason": "Dislike record does not exist."
                 }
 
             # Get the `dislike_id`
@@ -870,10 +881,11 @@ class Platform:
             self.pl_utils._execute_db_command(follow_check_query,
                                               (user_id, followee_id))
             if self.db_cursor.fetchone():
-                # Follow record already exists
+                # Follow record already exists — no-op success.
                 return {
-                    "success": False,
-                    "error": "Follow record already exists."
+                    "success": True,
+                    "noop": True,
+                    "reason": "Follow record already exists."
                 }
 
             # Add a record in the follow table
@@ -924,9 +936,11 @@ class Platform:
                                               (user_id, followee_id))
             follow_record = self.db_cursor.fetchone()
             if not follow_record:
+                # Already not following — no-op success.
                 return {
-                    "success": False,
-                    "error": "Follow record does not exist."
+                    "success": True,
+                    "noop": True,
+                    "reason": "Follow record does not exist."
                 }
             # Assuming ID is in the first column of the result
             follow_id = follow_record[0]
@@ -977,10 +991,11 @@ class Platform:
             self.pl_utils._execute_db_command(mute_check_query,
                                               (user_id, mutee_id))
             if self.db_cursor.fetchone():
-                # Mute record already exists
+                # Mute record already exists — no-op success.
                 return {
-                    "success": False,
-                    "error": "Mute record already exists."
+                    "success": True,
+                    "noop": True,
+                    "reason": "Mute record already exists."
                 }
             # Add a record in the mute table
             mute_insert_query = (
@@ -1126,10 +1141,11 @@ class Platform:
             self.pl_utils._execute_db_command(like_check_query,
                                               (comment_id, user_id))
             if self.db_cursor.fetchone():
-                # Like record already exists
+                # Like record already exists — no-op success.
                 return {
-                    "success": False,
-                    "error": "Comment like record already exists.",
+                    "success": True,
+                    "noop": True,
+                    "reason": "Comment like record already exists.",
                 }
 
             # Check if the comment to be liked was posted by oneself
@@ -1181,10 +1197,11 @@ class Platform:
             result = self.db_cursor.fetchone()
 
             if not result:
-                # No like record exists
+                # No like record exists — desired state already true.
                 return {
-                    "success": False,
-                    "error": "Comment like record does not exist.",
+                    "success": True,
+                    "noop": True,
+                    "reason": "Comment like record does not exist.",
                 }
             # Get the `comment_like_id`
             comment_like_id = result[0]
@@ -1234,10 +1251,11 @@ class Platform:
             self.pl_utils._execute_db_command(dislike_check_query,
                                               (comment_id, user_id))
             if self.db_cursor.fetchone():
-                # Dislike record already exists
+                # Dislike record already exists — no-op success.
                 return {
-                    "success": False,
-                    "error": "Comment dislike record already exists.",
+                    "success": True,
+                    "noop": True,
+                    "reason": "Comment dislike record already exists.",
                 }
 
             # Check if the comment to be disliked was posted by oneself
@@ -1294,10 +1312,11 @@ class Platform:
                                               (comment_id, user_id))
             dislike_record = self.db_cursor.fetchone()
             if not dislike_record:
-                # No dislike record exists
+                # No dislike record exists — desired state already true.
                 return {
-                    "success": False,
-                    "error": "Comment dislike record does not exist.",
+                    "success": True,
+                    "noop": True,
+                    "reason": "Comment dislike record does not exist.",
                 }
             comment_dislike_id = dislike_record[0]
 
@@ -1408,9 +1427,11 @@ class Platform:
             self.pl_utils._execute_db_command(check_report_query,
                                               (user_id, post_id))
             if self.db_cursor.fetchone():
+                # Report already filed — no-op success.
                 return {
-                    "success": False,
-                    "error": "Report record already exists."
+                    "success": True,
+                    "noop": True,
+                    "reason": "Report record already exists."
                 }
 
             if not post_type_result:


### PR DESCRIPTION
## Summary
Three fixes the Langfuse cost-investigation surfaced (see retry-loop / context-bloat findings).

1. **`wonderwall/social_platform/platform.py`** — like / dislike / repost / follow / mute / report and their inverses now return `{success: True, noop: True, reason: ...}` when the action is already in the desired state. Returning `success: False` made agents retry the same tool 4+ times per round, ballooning conversation history to 40k+ input tokens.

2. **`wonderwall/social_agent/agent.py`** — plumb the existing `max_iteration` parameter through to CAMEL `ChatAgent` (previously stored but never passed, so the per-step ReAct loop was unbounded). Default is now 3 — covers observe → tool → synthesize while bounding any future loop bug. Also enables `prune_tool_calls_from_memory` so old tool messages don't accumulate across iterations.

3. **`app/services/web_enrichment.py`** — cap the `simulation_requirement` string copied into each entity-research prompt at 1500 chars. A multi-KB user briefing was getting pasted into every research call, contributing to 60-80k input tokens per entity.

## Expected impact
- Estimated 30-40% sim-cost reduction from the no-op fix.
- Estimated ~$0.30/sim from the research-context cap.
- Bounds runaway-loop blast radius even on future tool errors.

## Test plan
- [ ] Run a sim and verify Langfuse traces show shorter agent conversations (no repeated identical tool calls), and entity-research input tokens drop to ~5k from ~70k.
- [ ] Spot-check that idempotent actions (re-following an already-followed user) succeed silently with `noop: true` rather than erroring.