### PR TITLE
fix(observability): coerce pagination ints so bad query strings don't 500

### DIFF
--- a/backend/app/api/observability.py
+++ b/backend/app/api/observability.py
@@ -131,10 +131,12 @@ def get_events():
     sim_id = request.args.get('simulation_id')
     raw_types = request.args.get('event_types', '')
     event_types = set(t.strip() for t in raw_types.split(',') if t.strip()) or None
-    from_line = int(request.args.get('from_line', 0))
-    limit = int(request.args.get('limit', 200))
-    filter_agent = request.args.get('agent_id')
-    filter_round = request.args.get('round_num')
+    # Use Flask's type-coerced get so a malformed query string (e.g. ?limit=abc)
+    # falls back to the default rather than 500-ing the endpoint.
+    from_line = request.args.get('from_line', default=0, type=int)
+    limit = request.args.get('limit', default=200, type=int)
+    filter_agent = request.args.get('agent_id', type=int)
+    filter_round = request.args.get('round_num', type=int)
     filter_platform = request.args.get('platform')
 
     # Decide which file to read
@@ -147,8 +149,8 @@ def get_events():
     events, total_lines = _read_jsonl_paginated(
         path, from_line, limit,
         event_types=event_types,
-        agent_id=int(filter_agent) if filter_agent else None,
-        round_num=int(filter_round) if filter_round else None,
+        agent_id=filter_agent,
+        round_num=filter_round,
         platform=filter_platform,
     )
 
@@ -243,8 +245,8 @@ def get_llm_calls():
     caller_filter = request.args.get('caller')
     model_filter = request.args.get('model')
     min_latency = request.args.get('min_latency_ms', type=float)
-    from_line = int(request.args.get('from_line', 0))
-    limit = int(request.args.get('limit', 100))
+    from_line = request.args.get('from_line', default=0, type=int)
+    limit = request.args.get('limit', default=100, type=int)
 
     if sim_id:
         path = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, sim_id, 'events.jsonl')

--- a/backend/tests/test_unit_observability_routes.py
+++ b/backend/tests/test_unit_observability_routes.py
@@ -1,0 +1,114 @@
+"""Unit tests for the observability HTTP routes.
+
+These pin down the contract that ``/api/observability/events`` and
+``/api/observability/llm-calls`` accept malformed query-string integers
+(``?from_line=abc``, ``?limit=null``, ``?agent_id=foo``) without
+returning a 500.
+
+Pre-fix the routes called ``int(request.args.get(...))`` directly, which
+raises ``ValueError`` on any non-numeric value and propagates as a Flask
+500. Now they use Flask's ``type=int`` coercion, which silently falls
+back to the default on parse failure.
+
+Pure offline tests — no Flask app boot, no Neo4j, no LLM. They mount the
+``observability_bp`` blueprint on a stub Flask app and point
+``Config.WONDERWALL_SIMULATION_DATA_DIR`` at a temp dir so file reads
+succeed (returning empty results) instead of touching the host
+filesystem.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+@pytest.fixture
+def flask_app(tmp_path: Path, monkeypatch):
+    """Tiny Flask app with the observability blueprint mounted.
+
+    Importing ``app.api.observability`` is safe — it pulls in
+    ``EventLogger``/``FileTailer`` but neither touches Neo4j or the LLM
+    layer. Both ``LOG_DIR`` and the per-sim path key off
+    ``Config.WONDERWALL_SIMULATION_DATA_DIR`` / ``LOG_DIR`` from
+    ``event_logger``; we redirect both at temp dirs so the file reads
+    succeed (no path) and return empty results.
+    """
+    from flask import Flask
+
+    monkeypatch.setattr(
+        'app.utils.event_logger.LOG_DIR', str(tmp_path / 'logs'),
+        raising=False,
+    )
+
+    from app.config import Config
+    monkeypatch.setattr(
+        Config, 'WONDERWALL_SIMULATION_DATA_DIR', str(tmp_path / 'sims'),
+        raising=False,
+    )
+
+    # Importing app.api triggers the side-effectful registration of routes
+    # onto observability_bp via app.api.observability, so the blueprint is
+    # ready to mount.
+    from app.api import observability_bp
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(observability_bp, url_prefix='/api/observability')
+    return flask_app
+
+
+def test_events_accepts_garbage_from_line(flask_app):
+    """``?from_line=abc`` falls back to the default 0 instead of 500-ing."""
+    client = flask_app.test_client()
+    resp = client.get('/api/observability/events?from_line=not-a-number')
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['success'] is True
+    assert body['from_line'] == 0
+
+
+def test_events_accepts_garbage_limit(flask_app):
+    client = flask_app.test_client()
+    resp = client.get('/api/observability/events?limit=null')
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True
+
+
+def test_events_accepts_garbage_agent_and_round(flask_app):
+    client = flask_app.test_client()
+    resp = client.get(
+        '/api/observability/events?agent_id=foo&round_num=bar'
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True
+
+
+def test_events_passes_through_valid_ints(flask_app):
+    client = flask_app.test_client()
+    resp = client.get(
+        '/api/observability/events?from_line=10&limit=5&agent_id=42'
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['success'] is True
+    assert body['from_line'] == 10
+
+
+def test_llm_calls_accepts_garbage_pagination(flask_app):
+    """Pre-fix ``int(request.args.get('from_line', 0))`` 500'd on bad input."""
+    client = flask_app.test_client()
+    resp = client.get(
+        '/api/observability/llm-calls?from_line=abc&limit=xyz'
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['success'] is True
+    assert body['from_line'] == 0
+    assert body['count'] == 0


### PR DESCRIPTION
## Summary

`GET /api/observability/events` and `GET /api/observability/llm-calls` cast `from_line` / `limit` / `agent_id` / `round_num` directly with `int(request.args.get(...))`. Any non-numeric value (`?from_line=abc`, `?limit=null`, `?agent_id=foo`) raises `ValueError` and propagates as a Flask 500 — even though the OpenAPI spec advertises these params as `integer` with sensible defaults.

The same `get_llm_calls()` handler already coerces `min_latency_ms` correctly with `request.args.get(..., type=float)`, which silently falls back to the default on parse failure. The bare `int(...)` calls on either side of it were the inconsistency.

## Changes

- `backend/app/api/observability.py` — switch `from_line`, `limit`, `agent_id`, `round_num` (events) and `from_line`, `limit` (llm-calls) to `request.args.get(name, default=N, type=int)`.
- `backend/tests/test_unit_observability_routes.py` — new pure-offline unit suite. Mounts `observability_bp` on a stub Flask app, points `LOG_DIR` and `WONDERWALL_SIMULATION_DATA_DIR` at a `tmp_path`, and pins the no-500 contract on both endpoints for `?from_line=abc`, `?limit=null`, `?agent_id=foo`, `?round_num=bar`. Also confirms valid ints still pass through.

## Context

Code-review pass — no open issues across MiroShark / MiroShark-api / aeon / soul.md / web3-research-mcp. The bare `int(...)` casts were the most exposed crasher in the API surface: any client (or the OpenAPI Swagger UI introspection at `/api/docs`) that hits the endpoint with a malformed integer gets a 500 instead of the documented integer-with-fallback behaviour.

Verified test layout matches the existing `test_unit_*.py` conventions — same `_BACKEND` sys.path bootstrap, same Flask app mounting pattern as `test_unit_admin_auth.py`, same `monkeypatch` style as `test_unit_webhook.py`. Runs under the existing CI dependency set (no new deps, no Neo4j, no LLM).

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)