### PR TITLE
feat: simulation transcript export (Markdown + JSON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
 | **Embed & Publish** | Public/private toggle + embed URLs for sharing finished runs |
 | **Social Share Card** | 1200×630 PNG that auto-unfurls scenario, status, quality, and belief split on Twitter/X, Discord, Slack, LinkedIn |
 | **Animated Belief Replay** | 1200×630 GIF — one frame per round, belief bars sliding to each round's distribution. Discord and Slack auto-play GIFs from the direct URL |
+| **Transcript Export** | Per-round agent posts + stance labels as Markdown (YAML front matter for Notion / Obsidian / Substack) or structured JSON (for SDKs and LLM-as-judge pipelines) |
 | **Public Gallery** | `/explore` browses every published simulation as a card grid — preview the share card, consensus split, and quality health; click to open or one-click fork |
 | **Verified Predictions** | Annotate any public sim with the real-world outcome (called it / partial / called wrong + URL). `/verified` is the dedicated hall of calls that landed |
 | **Article Generation** | Substack-style write-up of what happened, grounded in actual posts and trades |

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4826,6 +4826,92 @@ def get_replay_gif(simulation_id: str):
         }), 500
 
 
+def _serve_transcript(simulation_id: str, fmt: str):
+    """Shared body for the transcript.md / transcript.json routes.
+
+    Both endpoints share the same publish gate, the same data assembly
+    (``transcript.build_transcript_data``), and only diverge in the
+    encoding step. Extracted so the two route handlers stay one-line
+    wrappers — the decorator presence is what the OpenAPI drift test
+    scans for, but the actual logic lives here.
+    """
+    from ..services import transcript as transcript_renderer
+    from flask import Response
+
+    try:
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+            }), 403
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        data = transcript_renderer.build_transcript_data(summary, sim_dir)
+
+        if fmt == "json":
+            payload = transcript_renderer.render_json_bytes(data)
+            mimetype = "application/json; charset=utf-8"
+            filename = f"miroshark-{simulation_id[:12]}-transcript.json"
+        else:
+            payload = transcript_renderer.render_markdown_bytes(data)
+            mimetype = "text/markdown; charset=utf-8"
+            filename = f"miroshark-{simulation_id[:12]}-transcript.md"
+
+        response = Response(payload, mimetype=mimetype)
+        # Short cache — the transcript can change every round on a
+        # live run, but unfurlers / curl loops shouldn't hammer the
+        # disk reads either. 60s matches the embed-summary cadence.
+        response.headers["Cache-Control"] = "public, max-age=60"
+        # Inline so a click from the frontend renders in-tab; the UI
+        # uses an explicit ``download`` attribute on its anchor when it
+        # wants a save-as.
+        response.headers["Content-Disposition"] = (
+            f'inline; filename="{filename}"'
+        )
+        return response
+
+    except Exception as e:
+        logger.error(f"transcript: failed for {simulation_id}: {e}\n{traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500
+
+
+@simulation_bp.route('/<simulation_id>/transcript.md', methods=['GET'])
+def get_transcript_md(simulation_id: str):
+    """Citable Markdown transcript of the simulation.
+
+    Per-round agent posts + stance labels + final consensus, served as
+    ``text/markdown`` so Notion / Obsidian / Bear / Substack import the
+    YAML front matter as page metadata. Same publish gate as the share
+    card and replay GIF — the underlying ``is_public`` flag controls
+    who can read the agent posts.
+
+    Pairs with ``share-card.png`` (preview), ``replay.gif`` (motion),
+    and this endpoint (text) as the three quote-friendly share formats.
+    """
+    return _serve_transcript(simulation_id, "md")
+
+
+@simulation_bp.route('/<simulation_id>/transcript.json', methods=['GET'])
+def get_transcript_json(simulation_id: str):
+    """Same transcript payload as ``transcript.md`` but as JSON.
+
+    Same publish gate. Pretty-printed (indent=2) so a ``curl`` to a
+    file is immediately readable. Intended for SDK / pipeline consumers
+    (Python client SDK, downstream LLM-as-judge eval pipelines, etc.)
+    that need a structured form rather than the human-readable
+    Markdown.
+    """
+    return _serve_transcript(simulation_id, "json")
+
+
 # ============== Public Gallery ==============
 
 

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -1,0 +1,615 @@
+"""Simulation transcript renderer.
+
+Turns a simulation's on-disk artifacts (``simulation_config.json``,
+``trajectory.json``, ``quality.json``, ``resolution.json``,
+``outcome.json``, ``reddit_profiles.json``) into a citable, readable
+transcript in either Markdown (for Notion / Obsidian / Substack /
+research papers) or JSON (for SDKs / pipelines).
+
+Pairs with the share card and replay GIF as the third quote-friendly
+share format — the static PNG covers preview, the animated GIF covers
+motion, the transcript covers text. Until now the only way to quote a
+simulation in prose was a screenshot.
+
+Pure stdlib (json + io). Reads the same artifacts the embed summary,
+share card, and gallery card already share, with the same ±0.2 stance
+threshold so consensus labels stay consistent across the four surfaces.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from typing import Any, Optional
+
+
+# Same threshold the embed-summary, share card, replay GIF, gallery
+# card, and webhook all use — keep these surfaces in sync so an agent
+# tagged "bullish" on the gallery is the same agent tagged "bullish"
+# in the transcript.
+STANCE_THRESHOLD = 0.2
+
+# Per-post excerpt cap. Agent posts in MiroShark can be a few hundred
+# characters. 400 keeps the round sections quotable as pull-quotes
+# without truncating most posts; longer ones get the ellipsis.
+POST_EXCERPT_CHARS = 400
+
+# Cap rounds rendered in the markdown body. A 200-round simulation
+# would produce a transcript no one reads. Past the cap, the rendered
+# md keeps the first/last set + a "skipped N rounds" note so the
+# document still reads cleanly. The JSON form keeps every round.
+MAX_MD_ROUNDS = 80
+
+
+# ── Stance helpers ─────────────────────────────────────────────────────────
+
+
+def _classify_stance(value: float) -> str:
+    """Bucket a continuous belief position into bullish/neutral/bearish.
+
+    Mirrors the ±0.2 threshold used elsewhere — keeps the transcript's
+    per-agent labels consistent with the gallery, share card, and
+    webhook payloads.
+    """
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "neutral"
+    if v > STANCE_THRESHOLD:
+        return "bullish"
+    if v < -STANCE_THRESHOLD:
+        return "bearish"
+    return "neutral"
+
+
+def _avg_position(positions: dict | None) -> Optional[float]:
+    """Mean of an agent's per-topic belief positions for one round.
+
+    ``positions`` is a ``{topic: float}`` dict; we collapse to one
+    scalar so the transcript can label the agent's stance without
+    listing every topic.
+    """
+    if not positions:
+        return None
+    values = [float(v) for v in positions.values() if isinstance(v, (int, float))]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+# ── On-disk artifact loaders ──────────────────────────────────────────────
+
+
+def _safe_load_json(path: str) -> Any:
+    """Read a JSON file, returning ``None`` on missing/corrupt input.
+
+    Never raises — every artifact except ``trajectory.json`` is
+    optional, and a corrupt artifact must degrade the transcript
+    rather than 500 the endpoint.
+    """
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def _load_profile_names(sim_dir: str) -> dict[int, str]:
+    """``user_id → display name`` lookup for the simulation's agents.
+
+    Reads ``reddit_profiles.json`` first (every run produces it), then
+    ``polymarket_profiles.json`` as a secondary source (some runs add
+    polymarket-only personas). Each profile has ``user_id`` (int) and a
+    ``name`` field; we coerce both, skip malformed rows, and merge
+    additively so a polymarket-only id can resolve even when the same
+    ``user_id`` is missing from reddit_profiles.
+    """
+    out: dict[int, str] = {}
+    for filename in ("reddit_profiles.json", "polymarket_profiles.json"):
+        data = _safe_load_json(os.path.join(sim_dir, filename))
+        if not isinstance(data, list):
+            continue
+        for row in data:
+            if not isinstance(row, dict):
+                continue
+            uid_raw = row.get("user_id")
+            try:
+                uid = int(uid_raw)
+            except (TypeError, ValueError):
+                continue
+            name = (row.get("name") or row.get("username") or "").strip()
+            if not name:
+                continue
+            # First-write wins so reddit_profiles takes precedence — it
+            # carries the canonical display name on every run.
+            out.setdefault(uid, name)
+    return out
+
+
+def _excerpt(text: str, limit: int = POST_EXCERPT_CHARS) -> str:
+    """Trim a post to ``limit`` chars with a single-character ellipsis.
+
+    Trims at a word boundary when one is within 30 chars of the cap so
+    we don't end mid-word; falls back to a hard cut otherwise.
+    """
+    s = (text or "").strip()
+    if len(s) <= limit:
+        return s
+    cut = s[:limit]
+    space = cut.rfind(" ")
+    if space >= limit - 30:
+        cut = cut[:space]
+    return cut.rstrip().rstrip(",.;:—-") + "…"
+
+
+# ── Round assembly ────────────────────────────────────────────────────────
+
+
+def _round_stance_split(snapshot: dict) -> dict:
+    """Compute the round's bullish/neutral/bearish percent split.
+
+    Same algorithm the embed-summary endpoint runs over the full
+    trajectory — average each agent's per-topic positions, bucket on
+    ±0.2, return percentages.
+    """
+    positions = snapshot.get("belief_positions") or {}
+    stances = []
+    for agent_positions in positions.values():
+        avg = _avg_position(agent_positions)
+        if avg is not None:
+            stances.append(avg)
+    total = len(stances)
+    if total == 0:
+        return {"bullish": 0.0, "neutral": 0.0, "bearish": 0.0}
+    n_bull = sum(1 for s in stances if s > STANCE_THRESHOLD)
+    n_bear = sum(1 for s in stances if s < -STANCE_THRESHOLD)
+    n_neut = total - n_bull - n_bear
+    return {
+        "bullish": round(n_bull / total * 100, 1),
+        "neutral": round(n_neut / total * 100, 1),
+        "bearish": round(n_bear / total * 100, 1),
+    }
+
+
+def _build_round(snapshot: dict, profile_names: dict[int, str]) -> dict:
+    """Project one trajectory snapshot into a transcript round entry."""
+    round_num = int(snapshot.get("round_num", 0) or 0)
+    positions = snapshot.get("belief_positions") or {}
+
+    # Per-agent stance map — keyed by str so it lines up with the
+    # ``user_id`` on viral_posts (which json.load deserializes as int).
+    agent_stance: dict[int, tuple[str, float]] = {}
+    for agent_id_str, agent_positions in positions.items():
+        try:
+            agent_id = int(agent_id_str)
+        except (TypeError, ValueError):
+            continue
+        avg = _avg_position(agent_positions)
+        if avg is None:
+            continue
+        agent_stance[agent_id] = (_classify_stance(avg), round(avg, 3))
+
+    posts: list[dict] = []
+    for vp in snapshot.get("viral_posts") or []:
+        if not isinstance(vp, dict):
+            continue
+        try:
+            user_id = int(vp.get("user_id"))
+        except (TypeError, ValueError):
+            continue
+        content = (vp.get("content") or "").strip()
+        if not content:
+            continue
+        stance, stance_val = agent_stance.get(user_id, ("neutral", 0.0))
+        posts.append(
+            {
+                "post_id": vp.get("post_id"),
+                "agent_id": user_id,
+                "agent_name": profile_names.get(user_id, f"Agent {user_id}"),
+                "stance": stance,
+                "stance_value": stance_val,
+                "content": _excerpt(content),
+                "likes": int(vp.get("num_likes") or 0),
+                "dislikes": int(vp.get("num_dislikes") or 0),
+            }
+        )
+
+    return {
+        "round": round_num,
+        "timestamp": (snapshot.get("timestamp") or "").strip(),
+        "total_posts": int(snapshot.get("total_posts_created") or 0),
+        "total_engagements": int(snapshot.get("total_engagements") or 0),
+        "active_agent_count": int(snapshot.get("active_agent_count") or 0),
+        "stance_split": _round_stance_split(snapshot),
+        "posts": posts,
+    }
+
+
+# ── Outcome helpers (mirrors api/simulation._read_outcome_file) ───────────
+
+
+_VALID_OUTCOME_LABELS = ("correct", "incorrect", "partial")
+
+
+def _load_outcome(sim_dir: str) -> Optional[dict]:
+    """Load + sanitize ``outcome.json`` exactly like the gallery does.
+
+    Re-implemented (rather than imported) so the transcript service
+    has no dependency on ``api/simulation``; keeps the import graph
+    one-way (api → service, never the other way).
+    """
+    data = _safe_load_json(os.path.join(sim_dir, "outcome.json"))
+    if not isinstance(data, dict):
+        return None
+    label = (data.get("label") or "").strip().lower()
+    if label not in _VALID_OUTCOME_LABELS:
+        return None
+    summary = (data.get("outcome_summary") or "").strip()
+    if len(summary) > 280:
+        summary = summary[:277].rstrip() + "…"
+    url = (data.get("outcome_url") or "").strip()
+    if url and not (url.startswith("http://") or url.startswith("https://")):
+        url = ""
+    return {
+        "label": label,
+        "outcome_url": url,
+        "outcome_summary": summary,
+        "submitted_at": data.get("submitted_at") or "",
+    }
+
+
+# ── Top-level builders ────────────────────────────────────────────────────
+
+
+def build_transcript_data(summary: dict, sim_dir: str) -> dict:
+    """Assemble the full transcript payload from the embed summary +
+    on-disk artifacts.
+
+    The ``summary`` arg is the same dict ``_build_embed_summary_payload``
+    produces — caller is responsible for the ``is_public`` gate before
+    invoking this. ``sim_dir`` is the canonical simulation directory
+    (``WONDERWALL_SIMULATION_DATA_DIR/<simulation_id>``).
+
+    Returns a JSON-serializable dict — the markdown renderer reads from
+    it directly, and the JSON endpoint emits it as-is.
+    """
+    profile_names = _load_profile_names(sim_dir)
+
+    rounds: list[dict] = []
+    trajectory = _safe_load_json(os.path.join(sim_dir, "trajectory.json")) or {}
+    snapshots = trajectory.get("snapshots") or []
+    for snap in snapshots:
+        if not isinstance(snap, dict):
+            continue
+        rounds.append(_build_round(snap, profile_names))
+
+    belief = summary.get("belief") or {}
+    final = belief.get("final") or {}
+    consensus = {
+        "bullish": float(final.get("bullish") or 0.0),
+        "neutral": float(final.get("neutral") or 0.0),
+        "bearish": float(final.get("bearish") or 0.0),
+        "round": belief.get("consensus_round"),
+        "label": belief.get("consensus_stance"),
+    }
+    # Derive a final-stance label even when no >50% threshold was
+    # crossed, so the transcript header always carries a one-word call.
+    if not consensus["label"]:
+        if consensus["bullish"] >= consensus["bearish"] and consensus["bullish"] >= consensus["neutral"]:
+            consensus["label"] = "bullish"
+        elif consensus["bearish"] >= consensus["bullish"] and consensus["bearish"] >= consensus["neutral"]:
+            consensus["label"] = "bearish"
+        else:
+            consensus["label"] = "neutral"
+
+    quality = summary.get("quality") or {}
+    resolution = summary.get("resolution") or {}
+    outcome = _load_outcome(sim_dir)
+
+    return {
+        "sim_id": summary.get("simulation_id") or "",
+        "scenario": (summary.get("scenario") or "").strip(),
+        "created_date": summary.get("created_date") or "",
+        "agent_count": int(summary.get("profiles_count") or 0),
+        "total_rounds": int(summary.get("total_rounds") or len(rounds)),
+        "rounds_recorded": len(rounds),
+        "consensus": consensus,
+        "quality": {
+            "health": quality.get("health"),
+            "participation_rate": quality.get("participation_rate"),
+        },
+        "resolution": resolution if any(resolution.values()) else None,
+        "outcome": outcome,
+        "rounds": rounds,
+    }
+
+
+# ── Markdown renderer ─────────────────────────────────────────────────────
+
+
+_LABEL_ICON = {
+    "correct": "📍",
+    "partial": "◑",
+    "incorrect": "⚠",
+}
+
+
+def _md_yaml_value(value: Any) -> str:
+    """Quote-safe, single-line YAML scalar for the front-matter block.
+
+    Wraps strings in double quotes (escaping internal double quotes +
+    backslashes) and falls through scalars unchanged.
+    """
+    if value is None:
+        return '""'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    s = str(value)
+    s = s.replace("\\", "\\\\").replace('"', '\\"')
+    # YAML scalars in our output are always single-line — strip newlines
+    # so an embedded one in scenario doesn't break the front matter.
+    s = s.replace("\n", " ").replace("\r", " ")
+    return f'"{s}"'
+
+
+def _md_pct_line(split: dict) -> str:
+    return (
+        f"🔵 {split.get('bullish', 0.0):.1f}% Bullish · "
+        f"⚪ {split.get('neutral', 0.0):.1f}% Neutral · "
+        f"🔴 {split.get('bearish', 0.0):.1f}% Bearish"
+    )
+
+
+def _md_outcome_line(outcome: Optional[dict]) -> Optional[str]:
+    if not outcome:
+        return None
+    icon = _LABEL_ICON.get(outcome["label"], "•")
+    pieces = [f"{icon} **{outcome['label'].capitalize()}**"]
+    if outcome.get("outcome_summary"):
+        pieces.append(f"— {outcome['outcome_summary']}")
+    if outcome.get("outcome_url"):
+        pieces.append(f"([source]({outcome['outcome_url']}))")
+    return " ".join(pieces)
+
+
+def _md_resolution_line(resolution: Optional[dict]) -> Optional[str]:
+    if not resolution:
+        return None
+    actual = resolution.get("actual_outcome")
+    predicted = resolution.get("predicted_consensus")
+    score = resolution.get("accuracy_score")
+    if actual is None and predicted is None and score is None:
+        return None
+    bits = []
+    if predicted:
+        bits.append(f"predicted **{predicted}**")
+    if actual:
+        bits.append(f"actual **{actual}**")
+    if isinstance(score, (int, float)):
+        bits.append(f"accuracy **{score:.2f}**")
+    return "Polymarket resolution: " + " · ".join(bits) if bits else None
+
+
+def _select_md_rounds(rounds: list[dict]) -> tuple[list[dict], int]:
+    """Pick which rounds to render in the markdown body.
+
+    Returns ``(rounds_to_render, skipped_count)``. Under the cap we
+    render every round; over the cap we keep the first 20 and last 20
+    so the header build-up and the resting consensus both stay legible,
+    and the gap is annotated in the body.
+    """
+    if len(rounds) <= MAX_MD_ROUNDS:
+        return rounds, 0
+    head = rounds[:20]
+    tail = rounds[-20:]
+    skipped = len(rounds) - len(head) - len(tail)
+    return head + tail, skipped
+
+
+def _render_markdown_round(round_data: dict, lines: list[str]) -> None:
+    """Append a `## Round N` block to ``lines``."""
+    rn = round_data["round"]
+    split = round_data.get("stance_split") or {}
+    lines.append(f"## Round {rn}")
+    meta_bits = []
+    if round_data.get("active_agent_count"):
+        meta_bits.append(f"{round_data['active_agent_count']} agents active")
+    if round_data.get("total_posts"):
+        meta_bits.append(f"{round_data['total_posts']} posts")
+    if round_data.get("total_engagements"):
+        meta_bits.append(f"{round_data['total_engagements']} engagements")
+    if meta_bits:
+        lines.append(f"*{' · '.join(meta_bits)}*")
+    lines.append("")
+    lines.append(f"**Stance split:** {_md_pct_line(split)}")
+    lines.append("")
+
+    posts = round_data.get("posts") or []
+    if not posts:
+        lines.append("*No notable posts this round.*")
+        lines.append("")
+        return
+
+    for post in posts:
+        stance = post.get("stance", "neutral")
+        name = post.get("agent_name") or f"Agent {post.get('agent_id', '?')}"
+        lines.append(f"### {name} — *{stance}*")
+        # Block-quote each line of the post so multi-line content stays
+        # in the quote. Single-line posts are the common case but agents
+        # do occasionally produce paragraph breaks.
+        body = (post.get("content") or "").strip() or "*(empty post)*"
+        for body_line in body.splitlines() or [body]:
+            lines.append(f"> {body_line}")
+        engagement = []
+        if post.get("likes"):
+            engagement.append(f"❤ {post['likes']}")
+        if post.get("dislikes"):
+            engagement.append(f"✗ {post['dislikes']}")
+        if engagement:
+            lines.append(f"> *— {' · '.join(engagement)}*")
+        lines.append("")
+
+
+def render_markdown(data: dict) -> str:
+    """Render the transcript payload as Markdown.
+
+    Layout:
+
+      - YAML front-matter so Notion / Obsidian / Bear pick up the
+        scenario, sim_id, agent count, etc. as metadata.
+      - Header (scenario, run summary, consensus, outcome, resolution).
+      - One ``## Round N`` block per round.
+      - Trailing ``## Consensus`` block restating the final state +
+        ``--- ` separator + footer link back to the SPA.
+    """
+    sim_id = data.get("sim_id") or ""
+    scenario = data.get("scenario") or ""
+    rounds = data.get("rounds") or []
+    consensus = data.get("consensus") or {}
+    outcome = data.get("outcome")
+    resolution = data.get("resolution")
+    quality = data.get("quality") or {}
+
+    lines: list[str] = []
+
+    # ── Front matter ────────────────────────────────────────────────
+    lines.append("---")
+    lines.append(f"sim_id: {_md_yaml_value(sim_id)}")
+    lines.append(f"scenario: {_md_yaml_value(scenario)}")
+    lines.append(f"agent_count: {_md_yaml_value(data.get('agent_count') or 0)}")
+    lines.append(f"total_rounds: {_md_yaml_value(data.get('total_rounds') or 0)}")
+    lines.append(f"rounds_recorded: {_md_yaml_value(data.get('rounds_recorded') or 0)}")
+    lines.append(f"created_date: {_md_yaml_value(data.get('created_date') or '')}")
+    lines.append(f"consensus_label: {_md_yaml_value(consensus.get('label') or '')}")
+    if consensus.get("round") is not None:
+        lines.append(f"consensus_round: {_md_yaml_value(consensus['round'])}")
+    if quality.get("health"):
+        lines.append(f"quality_health: {_md_yaml_value(quality['health'])}")
+    if outcome and outcome.get("label"):
+        lines.append(f"outcome_label: {_md_yaml_value(outcome['label'])}")
+    lines.append("source: MiroShark")
+    lines.append("---")
+    lines.append("")
+
+    # ── Header ──────────────────────────────────────────────────────
+    lines.append("# MiroShark Simulation Transcript")
+    lines.append("")
+    if scenario:
+        lines.append(f"**Scenario.** {scenario}")
+        lines.append("")
+
+    run_bits: list[str] = []
+    ac = data.get("agent_count") or 0
+    if ac:
+        run_bits.append(f"{ac} agents")
+    tr = data.get("total_rounds") or 0
+    if tr:
+        run_bits.append(f"{tr} rounds")
+    if data.get("created_date"):
+        run_bits.append(f"created {data['created_date']}")
+    if run_bits:
+        lines.append(f"**Run.** {' · '.join(run_bits)}")
+        lines.append("")
+
+    lines.append(
+        f"**Final consensus.** {_md_pct_line(consensus)}"
+        + (f" — **{consensus['label']}**" if consensus.get("label") else "")
+    )
+    if consensus.get("round") is not None:
+        lines.append("")
+        lines.append(f"*Threshold crossed at round {consensus['round']}.*")
+    lines.append("")
+
+    if quality.get("health"):
+        q_pieces = [f"**{quality['health']}**"]
+        pr = quality.get("participation_rate")
+        if isinstance(pr, (int, float)):
+            q_pieces.append(f"({pr * 100:.0f}% participation)")
+        lines.append(f"**Quality.** {' '.join(q_pieces)}")
+        lines.append("")
+
+    res_line = _md_resolution_line(resolution)
+    if res_line:
+        lines.append(f"**{res_line}**")
+        lines.append("")
+
+    out_line = _md_outcome_line(outcome)
+    if out_line:
+        lines.append(f"**Verified outcome.** {out_line}")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+
+    # ── Rounds ──────────────────────────────────────────────────────
+    if not rounds:
+        lines.append("*No round snapshots recorded yet — the simulation has")
+        lines.append("been published but the runner hasn't completed any rounds.*")
+        lines.append("")
+    else:
+        rendered_rounds, skipped = _select_md_rounds(rounds)
+        head_count = min(20, len(rendered_rounds)) if skipped else len(rendered_rounds)
+        for idx, rd in enumerate(rendered_rounds):
+            if skipped and idx == head_count:
+                lines.append("---")
+                lines.append("")
+                lines.append(
+                    f"*({skipped} middle rounds omitted from this Markdown view "
+                    f"to keep the document readable. The full per-round series "
+                    f"is available in the JSON form: ``GET /api/simulation/{sim_id}/transcript.json``)*"
+                )
+                lines.append("")
+                lines.append("---")
+                lines.append("")
+            _render_markdown_round(rd, lines)
+
+    # ── Footer ──────────────────────────────────────────────────────
+    lines.append("---")
+    lines.append("")
+    lines.append("## Consensus")
+    lines.append("")
+    lines.append(
+        f"**Final split:** {_md_pct_line(consensus)}"
+        + (f" — **{consensus['label']}**" if consensus.get("label") else "")
+    )
+    lines.append("")
+    if consensus.get("round") is not None:
+        lines.append(f"**Threshold crossed:** round {consensus['round']}.")
+        lines.append("")
+    if quality.get("health"):
+        lines.append(f"**Quality health:** {quality['health']}.")
+        lines.append("")
+    if res_line:
+        lines.append(res_line + ".")
+        lines.append("")
+    if out_line:
+        lines.append(f"**Verified outcome.** {out_line}")
+        lines.append("")
+    if sim_id:
+        lines.append(f"*Source: [`/share/{sim_id}`](/share/{sim_id}) · "
+                     f"[gallery](/explore) · [verified](/verified) · "
+                     f"transcript built from MiroShark on-disk artifacts.*")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ── Encoded byte-output helpers (route layer expects bytes) ───────────────
+
+
+def render_markdown_bytes(data: dict) -> bytes:
+    return render_markdown(data).encode("utf-8")
+
+
+def render_json_bytes(data: dict) -> bytes:
+    """JSON form — pretty-printed (indent=2) so a curl into a file is
+    immediately readable. Sorting is left in payload order so rounds
+    stay chronological."""
+    buf = io.StringIO()
+    json.dump(data, buf, ensure_ascii=False, indent=2)
+    return buf.getvalue().encode("utf-8")

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1163,6 +1163,60 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/simulation/{simulation_id}/transcript.md:
+    get:
+      tags: [Publish & Embed]
+      summary: Citable Markdown transcript of the simulation.
+      description: |
+        Per-round agent posts + stance labels + final consensus rendered
+        as Markdown with a YAML front-matter block (`sim_id`, `scenario`,
+        `agent_count`, `total_rounds`, `consensus_label`, …). Notion,
+        Obsidian, Bear, and Substack import the front matter as page
+        metadata.
+
+        Pairs with `share-card.png` (preview) and `replay.gif` (motion)
+        as the third quote-friendly share format. Same publish gate as
+        the share card — requires `is_public=true` on the simulation
+        state.
+
+        Trajectories longer than ~80 rounds get the middle rounds
+        elided in the rendered Markdown body (the JSON form preserves
+        every round) so the document stays readable.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: "Markdown document with `Cache-Control: public, max-age=60`."
+          content:
+            text/markdown:
+              schema:
+                type: string
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/simulation/{simulation_id}/transcript.json:
+    get:
+      tags: [Publish & Embed]
+      summary: Structured JSON transcript of the simulation.
+      description: |
+        Same payload the Markdown transcript renders from, but as JSON
+        so SDK consumers and downstream pipelines (LLM-as-judge evals,
+        Python client SDK, …) can consume the per-round agent posts +
+        stance labels without parsing Markdown.
+
+        Same publish gate as the Markdown transcript. Pretty-printed
+        (`indent=2`) so a `curl` to a file is immediately readable.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: "JSON transcript with `Cache-Control: public, max-age=60`."
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SimulationTranscript" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /share/{simulation_id}:
     get:
       tags: [Publish & Embed]
@@ -2095,6 +2149,95 @@ components:
           oneOf: [{ type: string }, { type: "null" }]
         share_card_url: { type: string }
         share_landing_url: { type: string }
+
+    SimulationTranscript:
+      type: object
+      description: |
+        Citable per-round agent transcript. Same payload backs both the
+        Markdown (`transcript.md`) and JSON (`transcript.json`) export
+        endpoints — assembled from `trajectory.json`, `quality.json`,
+        `resolution.json`, `outcome.json`, and the simulation profiles
+        with the same ±0.2 stance threshold the gallery and webhook use,
+        so a "bullish" agent here matches the same agent's tag on every
+        other surface.
+      properties:
+        sim_id: { type: string }
+        scenario: { type: string }
+        created_date:
+          type: string
+          description: Run creation date (YYYY-MM-DD), per the simulation state.
+        agent_count: { type: integer }
+        total_rounds:
+          type: integer
+          description: Planned round count (from `time_config`).
+        rounds_recorded:
+          type: integer
+          description: Actual snapshots committed to disk so far.
+        consensus:
+          type: object
+          description: Final-round belief split + threshold-cross round.
+          properties:
+            bullish: { type: number }
+            neutral: { type: number }
+            bearish: { type: number }
+            label:
+              type: string
+              enum: [bullish, neutral, bearish]
+            round:
+              type: integer
+              nullable: true
+        quality:
+          type: object
+          properties:
+            health: { type: string, nullable: true }
+            participation_rate: { type: number, nullable: true }
+        resolution:
+          type: object
+          nullable: true
+          description: Polymarket resolution snapshot when present.
+          properties:
+            actual_outcome: { type: string }
+            predicted_consensus: { type: string }
+            accuracy_score: { type: number }
+        outcome:
+          $ref: "#/components/schemas/SimulationOutcome"
+          nullable: true
+        rounds:
+          type: array
+          description: One entry per recorded round, in chronological order.
+          items:
+            type: object
+            properties:
+              round: { type: integer }
+              timestamp: { type: string }
+              total_posts: { type: integer }
+              total_engagements: { type: integer }
+              active_agent_count: { type: integer }
+              stance_split:
+                type: object
+                properties:
+                  bullish: { type: number }
+                  neutral: { type: number }
+                  bearish: { type: number }
+              posts:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    post_id: { type: integer, nullable: true }
+                    agent_id: { type: integer }
+                    agent_name: { type: string }
+                    stance:
+                      type: string
+                      enum: [bullish, neutral, bearish]
+                    stance_value:
+                      type: number
+                      description: Agent's mean per-topic position for this round (-1..+1).
+                    content:
+                      type: string
+                      description: Post body, excerpted to ~400 chars with an ellipsis.
+                    likes: { type: integer }
+                    dislikes: { type: integer }
 
     SimulationOutcome:
       type: object

--- a/backend/tests/test_unit_transcript.py
+++ b/backend/tests/test_unit_transcript.py
@@ -1,0 +1,493 @@
+"""Unit tests for the simulation transcript export service.
+
+Pure offline — no Flask, no network, no simulation runner. Cover the
+five properties the transcript endpoints depend on:
+
+  1. ``build_transcript_data`` produces a clean payload from the same
+     on-disk artifacts the share card + replay GIF + gallery card
+     consume, and degrades gracefully when files are missing or
+     malformed (the route handlers must never 500 on the assembly step).
+  2. The ±0.2 stance threshold matches what the embed summary, share
+     card, replay GIF, gallery card, and webhook all use — a "bullish"
+     agent in the transcript is the same agent's tag everywhere else.
+  3. The Markdown renderer always returns a well-formed document with a
+     YAML front-matter block (so Notion / Obsidian / Bear pick up
+     metadata) and at least one ``## Round`` block per recorded round.
+  4. The Markdown renderer truncates oversized trajectories (>80
+     rounds) but always preserves the head + tail and emits a
+     "skipped N rounds" annotation, so the resting consensus stays
+     visible.
+  5. The route decorators exist in ``app/api/simulation.py`` — the
+     OpenAPI drift test will validate spec ↔ route equality, but this
+     guards against an accidental decorator removal that the spec test
+     wouldn't catch in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def populated_sim_dir(tmp_path: Path) -> Path:
+    """Simulation directory with the artifacts the transcript reads:
+    profiles, trajectory (3 snapshots, viral_posts on each), quality,
+    resolution, outcome."""
+    (tmp_path / "reddit_profiles.json").write_text(json.dumps([
+        {"user_id": 1, "username": "sarahc", "name": "Sarah Chen", "bio": "analyst"},
+        {"user_id": 2, "username": "miker",  "name": "Mike Rodriguez", "bio": "trader"},
+        {"user_id": 3, "username": "ja",     "name": "Jamal Adeyemi", "bio": "researcher"},
+    ]), encoding="utf-8")
+    (tmp_path / "polymarket_profiles.json").write_text(json.dumps([
+        {"user_id": 4, "name": "Elena Park", "description": "trader"},
+    ]), encoding="utf-8")
+    (tmp_path / "quality.json").write_text(json.dumps({
+        "health": "excellent",
+        "participation_rate": 0.92,
+    }), encoding="utf-8")
+    (tmp_path / "trajectory.json").write_text(json.dumps({
+        "snapshots": [
+            {
+                "round_num": 1,
+                "timestamp": "2026-04-29T10:00:00Z",
+                "total_posts_created": 4,
+                "total_engagements": 12,
+                "active_agent_count": 3,
+                "belief_positions": {
+                    "1": {"topic_a": 0.0,  "topic_b": -0.1},
+                    "2": {"topic_a": -0.5, "topic_b": -0.4},
+                    "3": {"topic_a": 0.3,  "topic_b": 0.4},
+                },
+                "viral_posts": [
+                    {"post_id": 11, "user_id": 1, "content": "Looking at the protocol's TVL curve over the last 6 hours, this could be the same MEV exploit pattern from Euler. Or just normal weekend rebalancing.", "num_likes": 4, "num_dislikes": 1},
+                    {"post_id": 12, "user_id": 2, "content": "TVL drawdown matches the Euler exploit signature. Withdrawing.", "num_likes": 6, "num_dislikes": 0},
+                ],
+            },
+            {
+                "round_num": 2,
+                "timestamp": "2026-04-29T10:01:00Z",
+                "total_posts_created": 5,
+                "total_engagements": 18,
+                "active_agent_count": 3,
+                "belief_positions": {
+                    "1": {"topic_a": -0.4, "topic_b": -0.5},
+                    "2": {"topic_a": -0.7, "topic_b": -0.6},
+                    "3": {"topic_a": -0.3, "topic_b": -0.2},
+                },
+                "viral_posts": [
+                    {"post_id": 21, "user_id": 3, "content": "Reversing my call — saw the multisig drain.", "num_likes": 9, "num_dislikes": 0},
+                ],
+            },
+            {
+                "round_num": 3,
+                "timestamp": "2026-04-29T10:02:00Z",
+                "total_posts_created": 3,
+                "total_engagements": 22,
+                "active_agent_count": 4,
+                "belief_positions": {
+                    "1": {"topic_a": -0.6},
+                    "2": {"topic_a": -0.8},
+                    "3": {"topic_a": -0.5},
+                    "4": {"topic_a": -0.7},
+                },
+                "viral_posts": [
+                    {"post_id": 31, "user_id": 4, "content": "Polymarket bid hit 88c on YES_HALT.", "num_likes": 11, "num_dislikes": 1},
+                ],
+            },
+        ],
+    }), encoding="utf-8")
+    (tmp_path / "outcome.json").write_text(json.dumps({
+        "label": "correct",
+        "outcome_url": "https://example.com/aave-halted",
+        "outcome_summary": "Aave halted withdrawals 2 hours after the simulation closed.",
+        "submitted_at": "2026-04-29T12:00:00Z",
+    }), encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def populated_summary() -> dict:
+    """The same dict ``_build_embed_summary_payload`` returns for the
+    populated simulation."""
+    return {
+        "simulation_id": "sim_aave_001",
+        "scenario": "A major lending protocol has paused withdrawals following anomalous outflows exceeding $200M in 4 hours.",
+        "status": "completed",
+        "runner_status": "finished",
+        "current_round": 3,
+        "total_rounds": 3,
+        "profiles_count": 3,
+        "created_date": "2026-04-29",
+        "is_public": True,
+        "belief": {
+            "rounds": [1, 2, 3],
+            "bullish": [33.3, 0.0, 0.0],
+            "neutral": [33.3, 0.0, 0.0],
+            "bearish": [33.3, 100.0, 100.0],
+            "final": {"bullish": 0.0, "neutral": 0.0, "bearish": 100.0},
+            "consensus_round": 2,
+            "consensus_stance": "bearish",
+        },
+        "quality": {"health": "excellent", "participation_rate": 0.92},
+        "resolution": None,
+    }
+
+
+# ── Stance bucketing ───────────────────────────────────────────────────────
+
+
+def test_classify_stance_uses_same_threshold_as_other_surfaces():
+    from app.services.transcript import _classify_stance, STANCE_THRESHOLD
+
+    assert STANCE_THRESHOLD == 0.2
+    assert _classify_stance(0.21) == "bullish"
+    assert _classify_stance(-0.21) == "bearish"
+    assert _classify_stance(0.2) == "neutral"
+    assert _classify_stance(-0.2) == "neutral"
+    assert _classify_stance(0.0) == "neutral"
+
+
+def test_classify_stance_handles_garbage():
+    from app.services.transcript import _classify_stance
+
+    assert _classify_stance(None) == "neutral"
+    assert _classify_stance("not-a-number") == "neutral"
+
+
+# ── Profile name resolution ────────────────────────────────────────────────
+
+
+def test_load_profile_names_merges_reddit_and_polymarket(populated_sim_dir):
+    from app.services.transcript import _load_profile_names
+
+    names = _load_profile_names(str(populated_sim_dir))
+    assert names[1] == "Sarah Chen"
+    assert names[2] == "Mike Rodriguez"
+    assert names[3] == "Jamal Adeyemi"
+    # Polymarket-only id should still resolve so its viral_posts get
+    # a real name in the transcript.
+    assert names[4] == "Elena Park"
+
+
+def test_load_profile_names_missing_dir_is_empty(tmp_path):
+    from app.services.transcript import _load_profile_names
+
+    assert _load_profile_names(str(tmp_path)) == {}
+
+
+def test_load_profile_names_skips_corrupt_rows(tmp_path):
+    from app.services.transcript import _load_profile_names
+
+    (tmp_path / "reddit_profiles.json").write_text(json.dumps([
+        {"user_id": "not-an-int", "name": "Bad"},
+        {"user_id": 7, "name": ""},          # empty name → skip
+        {"user_id": 8, "name": "Good"},
+    ]), encoding="utf-8")
+    names = _load_profile_names(str(tmp_path))
+    assert names == {8: "Good"}
+
+
+# ── Transcript data assembly ───────────────────────────────────────────────
+
+
+def test_build_transcript_data_full_pipeline(populated_sim_dir, populated_summary):
+    from app.services.transcript import build_transcript_data
+
+    data = build_transcript_data(populated_summary, str(populated_sim_dir))
+
+    assert data["sim_id"] == "sim_aave_001"
+    assert data["scenario"].startswith("A major lending protocol")
+    assert data["agent_count"] == 3
+    assert data["total_rounds"] == 3
+    assert data["rounds_recorded"] == 3
+    assert data["consensus"]["label"] == "bearish"
+    assert data["consensus"]["round"] == 2
+    assert data["quality"]["health"] == "excellent"
+    assert data["outcome"]["label"] == "correct"
+    assert data["outcome"]["outcome_url"] == "https://example.com/aave-halted"
+
+    assert len(data["rounds"]) == 3
+    r1 = data["rounds"][0]
+    assert r1["round"] == 1
+    assert r1["total_posts"] == 4
+    assert len(r1["posts"]) == 2
+    # Sarah's avg position is (-0.05) → neutral; Mike's avg is -0.45 → bearish
+    sarah = next(p for p in r1["posts"] if p["agent_name"] == "Sarah Chen")
+    mike = next(p for p in r1["posts"] if p["agent_name"] == "Mike Rodriguez")
+    assert sarah["stance"] == "neutral"
+    assert mike["stance"] == "bearish"
+    # Stance split is computed from the same threshold — round 1 is
+    # 1 bullish (Jamal) / 1 neutral (Sarah) / 1 bearish (Mike).
+    assert r1["stance_split"]["bullish"] == pytest.approx(33.3, abs=0.5)
+    assert r1["stance_split"]["bearish"] == pytest.approx(33.3, abs=0.5)
+
+
+def test_build_transcript_data_resolves_polymarket_only_agent(populated_sim_dir, populated_summary):
+    """A viral post by a polymarket-only agent (user_id 4 in the
+    fixture) must come through with the real name, not ``Agent 4``."""
+    from app.services.transcript import build_transcript_data
+
+    data = build_transcript_data(populated_summary, str(populated_sim_dir))
+    r3 = data["rounds"][2]
+    elena = r3["posts"][0]
+    assert elena["agent_name"] == "Elena Park"
+    assert elena["agent_id"] == 4
+
+
+def test_build_transcript_data_missing_trajectory(tmp_path, populated_summary):
+    """A freshly published READY run hasn't snapshotted yet — the
+    transcript must still assemble (with empty rounds) rather than
+    raise. Mirrors the same posture the replay GIF takes."""
+    from app.services.transcript import build_transcript_data
+
+    data = build_transcript_data(populated_summary, str(tmp_path))
+    assert data["rounds"] == []
+    assert data["rounds_recorded"] == 0
+    # Consensus still falls back to the embed summary's belief block.
+    assert data["consensus"]["label"] == "bearish"
+
+
+def test_build_transcript_data_corrupt_outcome_silently_ignored(populated_sim_dir, populated_summary):
+    from app.services.transcript import build_transcript_data
+
+    (populated_sim_dir / "outcome.json").write_text("{ this is not json", encoding="utf-8")
+    data = build_transcript_data(populated_summary, str(populated_sim_dir))
+    assert data["outcome"] is None
+
+
+def test_build_transcript_data_strips_unsafe_outcome_url(populated_sim_dir, populated_summary):
+    """Defense-in-depth: a corrupt outcome with a ``javascript:`` URL
+    must come out empty rather than landing on the transcript. Mirrors
+    the gallery card's defense."""
+    from app.services.transcript import build_transcript_data
+
+    (populated_sim_dir / "outcome.json").write_text(json.dumps({
+        "label": "correct",
+        "outcome_url": "javascript:alert(1)",
+        "outcome_summary": "fine",
+    }), encoding="utf-8")
+    data = build_transcript_data(populated_summary, str(populated_sim_dir))
+    assert data["outcome"] is not None
+    assert data["outcome"]["outcome_url"] == ""
+
+
+def test_build_transcript_data_excerpts_long_posts(tmp_path):
+    """Posts longer than the per-post char cap get the ellipsis."""
+    from app.services.transcript import (
+        POST_EXCERPT_CHARS,
+        build_transcript_data,
+    )
+
+    long_text = "word " * 200  # well over 400 chars
+    (tmp_path / "trajectory.json").write_text(json.dumps({
+        "snapshots": [
+            {
+                "round_num": 1,
+                "belief_positions": {"1": {"t": 0.0}},
+                "viral_posts": [
+                    {"post_id": 1, "user_id": 1, "content": long_text, "num_likes": 0, "num_dislikes": 0},
+                ],
+            }
+        ],
+    }), encoding="utf-8")
+    summary = {
+        "simulation_id": "sim_long",
+        "scenario": "x",
+        "is_public": True,
+        "profiles_count": 1,
+        "total_rounds": 1,
+        "belief": {"final": {"bullish": 0.0, "neutral": 100.0, "bearish": 0.0}},
+    }
+    data = build_transcript_data(summary, str(tmp_path))
+    body = data["rounds"][0]["posts"][0]["content"]
+    assert body.endswith("…")
+    # Ellipsis adds 1 char beyond the cap; word-boundary trim is at
+    # most 30 chars before the cap, so the body is bounded.
+    assert len(body) <= POST_EXCERPT_CHARS + 1
+
+
+# ── Markdown renderer ─────────────────────────────────────────────────────
+
+
+def test_render_markdown_has_yaml_front_matter(populated_sim_dir, populated_summary):
+    from app.services.transcript import build_transcript_data, render_markdown
+
+    md = render_markdown(build_transcript_data(populated_summary, str(populated_sim_dir)))
+
+    # Front matter delimiters at start of doc.
+    assert md.startswith("---\n")
+    end_idx = md.index("\n---\n", 4)
+    front = md[4:end_idx]
+    # Notion / Obsidian look for these specific keys; pin them.
+    for key in (
+        "sim_id:",
+        "scenario:",
+        "agent_count:",
+        "total_rounds:",
+        "rounds_recorded:",
+        "consensus_label:",
+        "source: MiroShark",
+    ):
+        assert key in front, f"front matter missing `{key}` line"
+
+
+def test_render_markdown_escapes_quotes_and_newlines_in_scenario(tmp_path):
+    """A scenario containing a double quote or an embedded newline
+    must produce parseable YAML — otherwise tools that read the front
+    matter (Obsidian, Bear, Substack) error on import."""
+    from app.services.transcript import build_transcript_data, render_markdown
+
+    summary = {
+        "simulation_id": "sim_q",
+        "scenario": 'A "quoted" headline\nwith a newline',
+        "is_public": True,
+        "profiles_count": 0,
+        "total_rounds": 0,
+        "belief": {"final": {"bullish": 0.0, "neutral": 100.0, "bearish": 0.0}},
+    }
+    md = render_markdown(build_transcript_data(summary, str(tmp_path)))
+    front = md.split("\n---\n", 1)[0]
+    scenario_line = next(line for line in front.splitlines() if line.startswith("scenario:"))
+    # Embedded `"` must be escaped, embedded newline must be flattened.
+    assert '\\"quoted\\"' in scenario_line
+    assert "\n" not in scenario_line
+
+
+def test_render_markdown_emits_one_section_per_recorded_round(populated_sim_dir, populated_summary):
+    from app.services.transcript import build_transcript_data, render_markdown
+
+    md = render_markdown(build_transcript_data(populated_summary, str(populated_sim_dir)))
+    headings = re.findall(r"^## Round \d+", md, flags=re.MULTILINE)
+    assert headings == ["## Round 1", "## Round 2", "## Round 3"]
+    # Posts render as block quotes with a `### Agent — *stance*` header.
+    assert "### Sarah Chen — *neutral*" in md
+    assert "### Mike Rodriguez — *bearish*" in md
+    assert "### Elena Park — *bearish*" in md
+    # Engagement footer line.
+    assert "❤" in md
+
+
+def test_render_markdown_includes_outcome_and_quality(populated_sim_dir, populated_summary):
+    from app.services.transcript import build_transcript_data, render_markdown
+
+    md = render_markdown(build_transcript_data(populated_summary, str(populated_sim_dir)))
+    assert "Verified outcome" in md
+    assert "Aave halted withdrawals" in md
+    assert "https://example.com/aave-halted" in md
+    assert "**Quality.**" in md
+    assert "92% participation" in md
+
+
+def test_render_markdown_handles_no_rounds(tmp_path):
+    """READY simulation with no snapshots — the document must still be
+    coherent (header + consensus block) rather than an empty file."""
+    from app.services.transcript import build_transcript_data, render_markdown
+
+    summary = {
+        "simulation_id": "sim_pending",
+        "scenario": "Pending",
+        "is_public": True,
+        "profiles_count": 5,
+        "total_rounds": 10,
+        "belief": {"final": {"bullish": 50.0, "neutral": 25.0, "bearish": 25.0}},
+    }
+    md = render_markdown(build_transcript_data(summary, str(tmp_path)))
+    assert "MiroShark Simulation Transcript" in md
+    assert "## Consensus" in md
+    assert "No round snapshots recorded yet" in md
+
+
+def test_render_markdown_truncates_oversized_runs(tmp_path):
+    """200-round runs must elide the middle but keep the first 20 +
+    last 20 + a "skipped N rounds" annotation. Final round must
+    always be visible so the resting consensus reads."""
+    from app.services.transcript import (
+        MAX_MD_ROUNDS,
+        build_transcript_data,
+        render_markdown,
+    )
+
+    snaps = [
+        {
+            "round_num": i,
+            "belief_positions": {"1": {"t": 0.0}},
+            "viral_posts": [
+                {"post_id": i, "user_id": 1, "content": f"round {i} note", "num_likes": 0, "num_dislikes": 0},
+            ],
+        }
+        for i in range(1, 201)
+    ]
+    (tmp_path / "trajectory.json").write_text(json.dumps({"snapshots": snaps}), encoding="utf-8")
+    (tmp_path / "reddit_profiles.json").write_text(json.dumps([
+        {"user_id": 1, "name": "Solo"},
+    ]), encoding="utf-8")
+
+    summary = {
+        "simulation_id": "sim_huge",
+        "scenario": "Long run",
+        "is_public": True,
+        "profiles_count": 1,
+        "total_rounds": 200,
+        "belief": {"final": {"bullish": 0.0, "neutral": 100.0, "bearish": 0.0}},
+    }
+    data = build_transcript_data(summary, str(tmp_path))
+    # JSON form keeps every round.
+    assert data["rounds_recorded"] == 200
+    assert len(data["rounds"]) == 200
+
+    md = render_markdown(data)
+    headings = re.findall(r"^## Round (\d+)", md, flags=re.MULTILINE)
+    nums = [int(h) for h in headings]
+    # Markdown must keep first + last and clip the middle.
+    assert 1 in nums
+    assert 200 in nums
+    assert len(nums) <= MAX_MD_ROUNDS
+    assert "middle rounds omitted" in md
+
+
+# ── JSON renderer ──────────────────────────────────────────────────────────
+
+
+def test_render_json_bytes_is_pretty_utf8(populated_sim_dir, populated_summary):
+    from app.services.transcript import build_transcript_data, render_json_bytes
+
+    data = build_transcript_data(populated_summary, str(populated_sim_dir))
+    raw = render_json_bytes(data)
+    assert isinstance(raw, bytes)
+    text = raw.decode("utf-8")
+    parsed = json.loads(text)
+    # Round trip preserves the structured payload.
+    assert parsed["sim_id"] == data["sim_id"]
+    assert parsed["rounds"][0]["posts"][0]["agent_name"] == "Sarah Chen"
+    # Pretty-printed (indent=2) — first-level keys land on their own line.
+    assert "\n  " in text
+
+
+# ── Endpoint shape (decorator presence guard) ─────────────────────────────
+
+
+def test_route_decorators_registered():
+    """Static check that both transcript endpoints exist in the Flask
+    blueprint file. The OpenAPI drift test will validate the spec ↔
+    route equality, but this guards against an accidental decorator
+    removal that the spec test wouldn't catch in isolation (e.g. the
+    decorator is removed AND the spec is updated to drop the path)."""
+    sim_api = (
+        _BACKEND / "app" / "api" / "simulation.py"
+    ).read_text(encoding="utf-8")
+    assert "@simulation_bp.route('/<simulation_id>/transcript.md'" in sim_api
+    assert "@simulation_bp.route('/<simulation_id>/transcript.json'" in sim_api
+    assert "transcript.build_transcript_data" in sim_api or "build_transcript_data" in sim_api

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -116,6 +116,17 @@ Same canvas as the share card (1200×630), but one frame per round — bullish /
 
 The Embed dialog renders a paused thumbnail with a tap-to-play affordance (so opening the dialog doesn't pull the GIF for every viewer) and exposes a copyable URL plus a Download GIF button beneath the share-card row.
 
+## Simulation Transcript Export
+
+The text companion to the share card (preview) and replay GIF (motion) — the same simulation as a citable per-round agent transcript so research papers, Substack posts, and Discord threads can quote what agents actually said without screenshotting.
+
+Two endpoints, same payload, different encoding:
+
+- `GET /api/simulation/<id>/transcript.md` — Markdown with a YAML front-matter block (`sim_id`, `scenario`, `agent_count`, `total_rounds`, `consensus_label`, `quality_health`, `outcome_label`). Notion, Obsidian, Bear, and Substack pick it up as page metadata; the body is one `## Round N` section per recorded round with each agent post as a block quote tagged with the agent's stance. Trajectories longer than ~80 rounds elide the middle rounds in the rendered Markdown view (with a note pointing to the JSON form for the full series) so the document stays readable.
+- `GET /api/simulation/<id>/transcript.json` — same payload as a structured JSON document, pretty-printed (`indent=2`) so a `curl` to a file is immediately readable. Intended for SDK consumers and downstream pipelines (LLM-as-judge eval frameworks, Python client SDK, etc.).
+
+Both endpoints share the share-card publish gate (`is_public=true`). Per-agent stance labels use the same ±0.2 threshold as every other surface — a "bullish" agent on the gallery is the same agent's tag in the transcript. The Embed dialog exposes a "Download .md" + "Download .json" pair beneath the replay-GIF row.
+
 ## Article Generation
 
 After a simulation finishes, click **Write Article** and MiroShark asks the Smart model to produce a 400–600-word Substack-style write-up grounded in what actually happened — key findings, market dynamics, belief shifts, and implications. The article is cached at `generated_article.json` so it doesn't re-spend tokens on reopen; pass `force_regenerate=true` to refresh.

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -440,6 +440,39 @@ export const getReplayGifUrl = (simulationId, origin) => {
 }
 
 /**
+ * Build the absolute URL of the Markdown transcript export for a
+ * simulation. The transcript is the text companion to the share card
+ * (preview) and replay GIF (motion) — per-round agent posts + stances
+ * + final consensus, with YAML front matter so Notion / Obsidian /
+ * Bear pick it up as page metadata.
+ *
+ * Same publish gate as the share card. Returns the absolute URL only —
+ * callers drop it into a download `<a href>` or copy it for manual use.
+ *
+ * @param {string} simulationId
+ * @param {string} [origin]
+ * @returns {string}
+ */
+export const getTranscriptMarkdownUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/api/simulation/${simulationId}/transcript.md`
+}
+
+/**
+ * Build the absolute URL of the JSON transcript export — same payload
+ * as the Markdown form but in a structured shape for SDKs / downstream
+ * pipelines (LLM-as-judge evals, Python client SDK consumers, etc.).
+ *
+ * @param {string} simulationId
+ * @param {string} [origin]
+ * @returns {string}
+ */
+export const getTranscriptJsonUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/api/simulation/${simulationId}/transcript.json`
+}
+
+/**
  * Build the absolute URL of the public share landing page for a
  * simulation. The page exposes Open Graph + Twitter Card meta tags so
  * pasting the URL into Twitter/X / Discord / Slack / LinkedIn unfurls

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -227,6 +227,61 @@
               </div>
             </div>
 
+            <!-- Text transcript — pairs with the share card (preview)
+                 and replay GIF (motion) as the third quote-friendly
+                 share format. The Markdown form has YAML front matter
+                 so Notion / Obsidian / Bear / Substack pick it up as
+                 page metadata; the JSON form is for SDK consumers. -->
+            <div class="transcript-section">
+              <div class="transcript-head">
+                <span class="transcript-icon">📄</span>
+                <div class="transcript-head-body">
+                  <div class="transcript-title">Export transcript</div>
+                  <div class="transcript-sub">
+                    Per-round agent posts + stance labels + final
+                    consensus. Cite the simulation in a research paper
+                    or a Substack post without screenshotting.
+                  </div>
+                </div>
+              </div>
+
+              <div class="transcript-actions">
+                <a
+                  v-if="isPublic && transcriptMarkdownUrl"
+                  class="transcript-download-btn"
+                  :href="transcriptMarkdownUrl"
+                  :download="`miroshark-${simulationId.slice(0, 12)}-transcript.md`"
+                >
+                  ↓ Download .md
+                </a>
+                <a
+                  v-if="isPublic && transcriptJsonUrl"
+                  class="transcript-download-btn transcript-download-btn-secondary"
+                  :href="transcriptJsonUrl"
+                  :download="`miroshark-${simulationId.slice(0, 12)}-transcript.json`"
+                >
+                  ↓ Download .json
+                </a>
+                <span v-if="!isPublic" class="transcript-empty">
+                  Publish the simulation to enable the transcript export.
+                </span>
+              </div>
+
+              <div class="snippet-block transcript-snippet">
+                <div class="snippet-head">
+                  <span class="snippet-label">Markdown URL (Notion / Obsidian "Import from URL")</span>
+                  <button
+                    class="snippet-copy-btn"
+                    @click="copy('transcriptMd')"
+                    :disabled="!isPublic"
+                  >
+                    {{ copied === 'transcriptMd' ? '✓ Copied' : 'Copy URL' }}
+                  </button>
+                </div>
+                <pre class="snippet-code"><code>{{ transcriptMarkdownUrl || '—' }}</code></pre>
+              </div>
+            </div>
+
             <!-- Verified-prediction annotation — lets operators turn a
                  published simulation into a "called it" record on the
                  /verified gallery page. Only meaningful once the run is
@@ -372,6 +427,8 @@ import {
   getShareCardUrl,
   getReplayGifUrl,
   getShareLandingUrl,
+  getTranscriptMarkdownUrl,
+  getTranscriptJsonUrl,
   getSimulationOutcome,
   submitSimulationOutcome,
 } from '../api/simulation'
@@ -467,6 +524,16 @@ const replayGifUrl = computed(() => {
     : base
 })
 
+const transcriptMarkdownUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  return getTranscriptMarkdownUrl(props.simulationId, origin.value)
+})
+
+const transcriptJsonUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  return getTranscriptJsonUrl(props.simulationId, origin.value)
+})
+
 const replayLoaded = ref(false)
 const replayPlay = ref(false)
 const onReplayLoad = () => {
@@ -515,6 +582,7 @@ const copy = async (which) => {
   else if (which === 'share') text = shareLandingUrl.value
   else if (which === 'card') text = shareCardUrl.value
   else if (which === 'replay') text = replayGifUrl.value
+  else if (which === 'transcriptMd') text = transcriptMarkdownUrl.value
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)
@@ -1162,6 +1230,94 @@ watch(isPublic, () => {
 
 .replay-section .snippet-copy-btn {
   background: #ea580c;
+}
+
+.transcript-section {
+  margin-top: 18px;
+  padding: 14px 16px;
+  background: #fafafa;
+  border: 1px solid rgba(10, 10, 10, 0.08);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.transcript-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.transcript-icon {
+  font-size: 18px;
+  line-height: 1;
+  padding-top: 2px;
+}
+
+.transcript-head-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.transcript-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0a0a0a;
+  margin-bottom: 4px;
+}
+
+.transcript-sub {
+  font-size: 12px;
+  line-height: 1.5;
+  color: #4a4a4a;
+}
+
+.transcript-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.transcript-download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: #0a0a0a;
+  color: #ffffff;
+  text-decoration: none;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.transcript-download-btn:hover { background: #2a2a2a; }
+
+.transcript-download-btn-secondary {
+  background: #fff;
+  color: #0a0a0a;
+  border: 1px solid rgba(10, 10, 10, 0.18);
+}
+
+.transcript-download-btn-secondary:hover {
+  background: rgba(10, 10, 10, 0.04);
+}
+
+.transcript-empty {
+  font-size: 12px;
+  color: #6b6b6b;
+  font-style: italic;
+}
+
+.transcript-snippet {
+  margin: 0;
 }
 
 .outcome-section {


### PR DESCRIPTION
## What

Adds two new endpoints — `GET /api/simulation/<id>/transcript.md` and `GET /api/simulation/<id>/transcript.json` — that serve a citable, per-round agent transcript as Markdown (with YAML front matter for Notion / Obsidian / Bear / Substack) or as a structured JSON document for SDK consumers.

Per-round payload: scenario header + run summary + final consensus + outcome + per-round agent posts each tagged with the agent's stance (bullish / neutral / bearish, ±0.2 threshold matching every other surface).

## Why

The Apr 26 repo-actions batch flagged transcript export as the missing third quote-friendly share format:

- **share-card.png** covers preview (Twitter / Discord / Slack OG image).
- **replay.gif** covers motion (Discord / Slack auto-play).
- Until this PR there was nothing covering **text** — the actual agent reasoning per round.

PR #52 (Apr 28) cleaned the agent conversation history (`prune_tool_calls_from_memory=True` + bounded research context), so the transcript is now *readable* — not a wall of tool-call boilerplate. This makes simulation outputs quotable in research papers, Substack posts, and Discord threads without screenshotting.

The Markdown form lands directly in Notion / Obsidian via "Import from URL" with the YAML front matter populating page metadata (`sim_id`, `scenario`, `agent_count`, `total_rounds`, `consensus_label`, `quality_health`, `outcome_label`). The JSON form is shaped for downstream pipelines — LLM-as-judge eval frameworks, the Python client SDK landing on top of the OpenAPI spec, etc.

## Changes

- **`backend/app/services/transcript.py`** *(new)* — pure-stdlib renderer reading `trajectory.json` + `reddit_profiles.json` + `polymarket_profiles.json` + `quality.json` + `resolution.json` + `outcome.json`. ±0.2 stance bucketing matches `_build_embed_summary_payload` so agent stance labels stay consistent across the gallery, share card, replay GIF, webhook, and transcript. Defense-in-depth strip on `outcome_url` so a corrupt `javascript:` URL never lands on the transcript. 400-char per-post excerpt with word-boundary trim. 80-round Markdown cap with first-20 + last-20 preservation + "skipped N rounds" annotation; the JSON form keeps every round.
- **`backend/app/api/simulation.py`** — `GET /api/simulation/<id>/transcript.md` + `transcript.json`. Same `is_public` publish gate as the share card. 60s `Cache-Control` matching the embed-summary cadence. Inline `Content-Disposition` so a click renders in-tab; the frontend uses an explicit `download` attribute on its anchor when it wants save-as. Both routes share a single `_serve_transcript(simulation_id, fmt)` body so the assembly path is one source of truth — the route handlers exist as the surface the OpenAPI drift test scans for.
- **`backend/openapi.yaml`** — both routes under the `Publish & Embed` tag + new `SimulationTranscript` schema with the full per-round shape. Drift-detection test (`test_documented_paths_exist_in_flask` / `test_flask_routes_are_documented_or_allowlisted`) passes.
- **`frontend/src/components/EmbedDialog.vue`** — new "Export transcript" section beneath the replay-GIF row: `↓ Download .md` + `↓ Download .json` buttons (publish-gated), copyable Markdown URL with the standard "Copy URL" snippet block, dashed empty state when not yet published.
- **`frontend/src/api/simulation.js`** — `getTranscriptMarkdownUrl()` and `getTranscriptJsonUrl()` URL builders matching the existing `getShareCardUrl` / `getReplayGifUrl` shape.
- **`backend/tests/test_unit_transcript.py`** *(new, 18 tests)* — pure offline. Cover ±0.2 stance threshold parity (`STANCE_THRESHOLD == 0.2`), profile-name resolution across reddit + polymarket sources, corrupt-JSON / missing-file graceful degradation, long-post excerpting at the configured cap, YAML front-matter integrity (quote + newline escaping so Notion / Obsidian / Substack don't error on import), per-round section emission, oversized-trajectory Markdown truncation with head + tail preservation + the "skipped N rounds" annotation, JSON pretty-print round trip, and a route-decorator presence guard distinct from the OpenAPI drift test.
- **`docs/FEATURES.md`** + **`README.md`** — feature row + "Simulation Transcript Export" section under Sharing.

---
*Built autonomously by Aeon*