### PR TITLE
feat(wonderwall): per-slot endpoint override + cloud preset refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,112 +1,115 @@
 # =============================================================
 # MiroShark Configuration
 # =============================================================
-# Copy this file to .env and adjust values for your setup.
+# Copy this file to .env and paste your OpenRouter key into the
+# blank API_KEY slots below.
 #
-# Three modes: Local (Ollama), Cloud Cheap, or Cloud Best.
-# The defaults below are for local Ollama.
-# For cloud presets, see the OpenRouter sections below.
+# Default = Cloud (OpenRouter, Mimo V2 Flash + Grok-4.1 Fast).
+# To run fully locally with Ollama, see the "Alternatives" block
+# further down.
 # =============================================================
 
-# ===== LLM Configuration =====
-# LLM_PROVIDER: "openai" (default, any OpenAI-compatible API) or "claude-code" (local CLI)
+# ===== LLM Configuration (Cloud — OpenRouter) =====
+# LLM_PROVIDER: "openai" (any OpenAI-compatible API) or "claude-code" (local CLI)
 LLM_PROVIDER=openai
+LLM_API_KEY=                          # ← paste your OpenRouter key (sk-or-v1-...)
+LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_MODEL_NAME=xiaomi/mimo-v2-flash
 
-# --- Local mode (Ollama) ---
-# Points to local Ollama server. Any non-empty value for API key works.
-# For Docker: use service name "ollama" instead of "localhost"
-LLM_API_KEY=ollama
-LLM_BASE_URL=http://localhost:11434/v1
-LLM_MODEL_NAME=qwen2.5:32b
-# Lighter model for development (less VRAM):
-# LLM_MODEL_NAME=qwen2.5:14b
+# ===== Smart Model (reports, ontology, graph reasoning — #1 quality lever) =====
+# Only ~19 calls per run, so investing here is the cheapest quality upgrade.
+SMART_PROVIDER=openai
+SMART_API_KEY=                        # ← same OpenRouter key
+SMART_BASE_URL=https://openrouter.ai/api/v1
+SMART_MODEL_NAME=x-ai/grok-4.1-fast
 
-# --- Claude Code mode ---
-# Set LLM_PROVIDER=claude-code to route all LLM calls through the local Claude Code CLI.
-# Requires `claude` installed and logged in. No API key needed (uses your subscription).
-# Optional: override model (default uses your Claude Code default)
+# ===== NER Model (entity extraction — needs reliable JSON, no hidden CoT) =====
+NER_API_KEY=                          # ← same OpenRouter key
+NER_BASE_URL=https://openrouter.ai/api/v1
+NER_MODEL_NAME=x-ai/grok-4.1-fast
+
+# ===== Wonderwall Model (agent simulation loop — #1 cost driver) =====
+# 850+ calls, 7M+ tokens per run. Verbosity matters more than $/M token.
+WONDERWALL_MODEL_NAME=xiaomi/mimo-v2-flash
+#
+# Optional: route Wonderwall to a custom OpenAI-compatible endpoint
+# (self-hosted vLLM, Modal, fine-tuned model, Ollama on a different host…)
+# without affecting the Default/Smart/NER slots. Either field can be
+# omitted — a blank base URL inherits LLM_BASE_URL, a blank key inherits
+# LLM_API_KEY. See docs/MODELS.md for the full pattern.
+#
+# WONDERWALL_BASE_URL=https://your-endpoint.example.com/v1
+# WONDERWALL_API_KEY=not-checked
+
+# ===== Wonderwall / CAMEL-AI Configuration =====
+# CAMEL-AI reads OPENAI_API_KEY and OPENAI_API_BASE_URL when
+# WONDERWALL_BASE_URL is unset. Same OpenRouter key is fine.
+OPENAI_API_KEY=                       # ← same OpenRouter key
+OPENAI_API_BASE_URL=https://openrouter.ai/api/v1
+
+# ===== Embedding Configuration =====
+# EMBEDDING_PROVIDER: "openai" (uses /v1/embeddings) or "ollama" (uses /api/embed)
+# "openai" mode works with OpenRouter, OpenAI, Azure, or any compatible API.
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=openai/text-embedding-3-large
+EMBEDDING_BASE_URL=https://openrouter.ai/api
+EMBEDDING_API_KEY=                    # ← same OpenRouter key
+EMBEDDING_DIMENSIONS=768
+
+# ===== Web Search Model =====
+# Dedicated model for web enrichment (persona research for public figures).
+# Append ":online" to any OpenRouter model for Exa-powered web results.
+WEB_SEARCH_MODEL=x-ai/grok-4.1-fast:online
+
+# ===== Disable chain-of-thought on reasoning-capable OpenRouter models =====
+# ~3x lower latency on Qwen3-Flash / Grok-4.1-Fast / Mimo-V2-Flash. Flip to
+# false per-deployment if a slot benefits from CoT (rare for MiroShark's
+# short, structured prompts).
+LLM_DISABLE_REASONING=true
+
+# =============================================================
+# Alternatives — comment out the Cloud block above and paste one
+# of these in if you'd rather run locally or via Claude Code.
+# =============================================================
+#
+# ─── Local mode (Ollama) ───
+# Fully self-hosted on your GPU. Requires Ollama + a 7B+ model.
+#   ollama pull qwen2.5:32b
+#   ollama pull nomic-embed-text
+# Then replace the active LLM/Smart/NER/Wonderwall/OPENAI/EMBEDDING
+# blocks with:
+#
+# LLM_API_KEY=ollama
+# LLM_BASE_URL=http://localhost:11434/v1
+# LLM_MODEL_NAME=qwen2.5:32b
+# # Lighter (less VRAM): qwen2.5:14b
+# SMART_PROVIDER=
+# SMART_API_KEY=
+# SMART_BASE_URL=
+# SMART_MODEL_NAME=
+# NER_API_KEY=
+# NER_BASE_URL=
+# NER_MODEL_NAME=
+# WONDERWALL_MODEL_NAME=
+# OPENAI_API_KEY=ollama
+# OPENAI_API_BASE_URL=http://localhost:11434/v1
+# EMBEDDING_PROVIDER=ollama
+# EMBEDDING_MODEL=nomic-embed-text
+# EMBEDDING_BASE_URL=http://localhost:11434
+# EMBEDDING_API_KEY=
+#
+# For Docker: replace "localhost" with the service name "ollama".
+#
+# ─── Claude Code mode ───
+# Route LLM calls through your local Claude CLI subscription. No API key.
+# LLM_PROVIDER=claude-code
 # CLAUDE_CODE_MODEL=claude-sonnet-4-20250514
-
-# =============================================================
-# OPENROUTER CLOUD PRESETS
-# =============================================================
-# Benchmarked across 10+ model combos. See models.md for full data.
-#
-# Pick ONE preset below, uncomment it, and set your API key.
-# Each slot controls a different quality axis:
-#   Default  → persona richness + sim density
-#   Smart    → report quality (#1 lever)
-#   NER      → extraction reliability
-#   Wonderwall    → cost (biggest token consumer, 850+ calls/run)
-#
-# ┌─────────────────────────────────────────────────────────────┐
-# │  CHEAP MODE — ~$1/run, ~10 min                             │
-# │  Qwen3.5 Flash + DeepSeek V3.2 + Grok-4.1 Fast.            │
-# │  Reasoning disabled on every slot for ~3x lower latency.   │
-# ├─────────────────────────────────────────────────────────────┤
-# │  LLM_API_KEY=sk-or-v1-your-key                             │
-# │  LLM_BASE_URL=https://openrouter.ai/api/v1                 │
-# │  LLM_MODEL_NAME=qwen/qwen3.5-flash-02-23                   │
-# │  SMART_PROVIDER=openai                                     │
-# │  SMART_API_KEY=sk-or-v1-your-key                           │
-# │  SMART_BASE_URL=https://openrouter.ai/api/v1               │
-# │  SMART_MODEL_NAME=deepseek/deepseek-v3.2                   │
-# │  NER_MODEL_NAME=x-ai/grok-4.1-fast                         │
-# │  NER_BASE_URL=https://openrouter.ai/api/v1                 │
-# │  NER_API_KEY=sk-or-v1-your-key                             │
-# │  WONDERWALL_MODEL_NAME=qwen/qwen3.5-flash-02-23            │
-# │  OPENAI_API_KEY=sk-or-v1-your-key                          │
-# │  OPENAI_API_BASE_URL=https://openrouter.ai/api/v1          │
-# │  EMBEDDING_PROVIDER=openai                                 │
-# │  EMBEDDING_MODEL=openai/text-embedding-3-large             │
-# │  EMBEDDING_BASE_URL=https://openrouter.ai/api              │
-# │  EMBEDDING_API_KEY=sk-or-v1-your-key                       │
-# │  EMBEDDING_DIMENSIONS=768                                  │
-# │  WEB_SEARCH_MODEL=x-ai/grok-4.1-fast:online                │
-# │  LLM_DISABLE_REASONING=true                                │
-# └─────────────────────────────────────────────────────────────┘
-#
-# ┌─────────────────────────────────────────────────────────────┐
-# │  BEST MODE — ~$3.50/run, ~25 min                           │
-# │  Claude reports, Haiku personas, cheap Wonderwall.               │
-# │  Report quality: 9/10 | Persona richness: 8/10             │
-# ├─────────────────────────────────────────────────────────────┤
-# │  LLM_API_KEY=sk-or-v1-your-key                             │
-# │  LLM_BASE_URL=https://openrouter.ai/api/v1                 │
-# │  LLM_MODEL_NAME=anthropic/claude-haiku-4.5                 │
-# │  SMART_PROVIDER=openai                                     │
-# │  SMART_API_KEY=sk-or-v1-your-key                           │
-# │  SMART_BASE_URL=https://openrouter.ai/api/v1               │
-# │  SMART_MODEL_NAME=anthropic/claude-sonnet-4.6              │
-# │  NER_MODEL_NAME=google/gemini-2.0-flash-001                │
-# │  NER_BASE_URL=https://openrouter.ai/api/v1                 │
-# │  NER_API_KEY=sk-or-v1-your-key                             │
-# │  WONDERWALL_MODEL_NAME=google/gemini-2.0-flash-lite-001         │
-# │  OPENAI_API_KEY=sk-or-v1-your-key                          │
-# │  OPENAI_API_BASE_URL=https://openrouter.ai/api/v1          │
-# │  EMBEDDING_PROVIDER=openai                                 │
-# │  EMBEDDING_MODEL=openai/text-embedding-3-small             │
-# │  EMBEDDING_BASE_URL=https://openrouter.ai/api              │
-# │  EMBEDDING_API_KEY=sk-or-v1-your-key                       │
-# │  EMBEDDING_DIMENSIONS=768                                  │
-# │  WEB_SEARCH_MODEL=google/gemini-2.0-flash-001:online       │
-# └─────────────────────────────────────────────────────────────┘
 
 # ===== Neo4j Configuration =====
 # For Docker: use service name "neo4j" instead of "localhost"
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=miroshark
-
-# ===== Embedding Configuration =====
-# EMBEDDING_PROVIDER: "ollama" (uses /api/embed) or "openai" (uses /v1/embeddings)
-# "openai" mode works with OpenRouter, OpenAI, Azure, or any compatible API.
-EMBEDDING_PROVIDER=ollama
-EMBEDDING_MODEL=nomic-embed-text
-EMBEDDING_BASE_URL=http://localhost:11434
-EMBEDDING_API_KEY=
-EMBEDDING_DIMENSIONS=768
-# For Docker: EMBEDDING_BASE_URL=http://ollama:11434
 
 # ===== Reranker Configuration =====
 # Cross-encoder reranking over hybrid search results. Runs locally via
@@ -182,54 +185,6 @@ LLM_PROMPT_CACHING_ENABLED=true
 # How many texts per embedding HTTP request. Higher is faster for graph
 # build; drop to 32 if your provider 413s you.
 EMBEDDING_BATCH_SIZE=128
-
-# ===== Smart Model (optional) =====
-# Stronger model for report generation, ontology extraction, graph reasoning.
-# When not set, these workflows use the default LLM config above.
-#
-# Benchmark: Smart model is the #1 quality lever.
-#   Claude Sonnet → 9/10 reports | Gemini 2.5 Flash → 5/10 | DeepSeek → 2/10
-#   Only ~19 calls per run (~$1.50 for Sonnet, ~$0.06 for Gemini).
-#
-# SMART_PROVIDER=openai
-# SMART_API_KEY=sk-or-v1-your-key
-# SMART_BASE_URL=https://openrouter.ai/api/v1
-# SMART_MODEL_NAME=anthropic/claude-sonnet-4.6
-
-# ===== Wonderwall Model (optional) =====
-# Model for the Wonderwall/CAMEL simulation loop (agent decisions).
-# When not set, uses LLM_MODEL_NAME.
-#
-# Benchmark: Wonderwall is the #1 cost driver (850+ calls, 7M+ tokens/run).
-# Model verbosity matters more than per-token price:
-#   flash-lite:         7.3M tok, $0.56   ← sweet spot
-#   gpt-oss-120b:      19.5M tok, $2.29   (2.7x more verbose)
-#   gemini-3.1-fl-lite: 31.2M tok, $4.86   (4.3x more verbose)
-# Wonderwall model does NOT drive report quality — Smart model does.
-#
-# WONDERWALL_MODEL_NAME=google/gemini-2.0-flash-lite-001
-
-# ===== Wonderwall / CAMEL-AI Configuration =====
-# CAMEL-AI reads OPENAI_API_KEY and OPENAI_API_BASE_URL
-# Points to same local Ollama server
-OPENAI_API_KEY=ollama
-OPENAI_API_BASE_URL=http://localhost:11434/v1
-
-# ===== NER Model (optional) =====
-# Faster model for entity extraction (high-volume, mechanical task).
-# When not set, NER uses the default LLM config above.
-#
-# Benchmark: Use gemini-2.0-flash, NOT flash-lite.
-# Flash-lite caused 3x retry bloat (267 vs 85 calls) due to invalid JSON.
-#
-# NER_MODEL_NAME=google/gemini-2.0-flash-001
-# NER_BASE_URL=https://openrouter.ai/api/v1
-# NER_API_KEY=sk-or-v1-your-key
-
-# ===== Web Search Model (optional) =====
-# Dedicated model for web enrichment (persona research for public figures).
-# Append ":online" to any OpenRouter model for Exa-powered web results.
-# WEB_SEARCH_MODEL=google/gemini-2.0-flash-001:online
 
 # ===== Trending Topics (optional) =====
 # Comma-separated RSS/Atom feed URLs powering the "What's Trending" panel

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## Quick start
 
-The recommended path: **one [OpenRouter](https://openrouter.ai/) key + the `./miroshark` launcher.** First simulation in ~10 min, ~$1 (Cheap preset) to ~$3.50 (Best preset).
+The recommended path: **one [OpenRouter](https://openrouter.ai/) key + the `./miroshark` launcher.** First simulation in ~10 min, ~$1.
 
 **Prereqs** — Python 3.11+, Node 18+, Neo4j, and an [OpenRouter key](https://openrouter.ai/).
 
@@ -47,7 +47,9 @@ Then:
 ```bash
 git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
 cp .env.example .env
-# Open .env and paste your OpenRouter key into the Best or Cheap preset block
+# Paste your OpenRouter key into the LLM_API_KEY / SMART_API_KEY /
+# NER_API_KEY / OPENAI_API_KEY / EMBEDDING_API_KEY slots (same key,
+# 5 places). Default lineup is Mimo V2 Flash + Grok-4.1 Fast.
 ./miroshark
 ```
 
@@ -71,6 +73,7 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
 | **Preset Templates** | 6 benchmarked scenarios: crypto launch, corporate crisis, political debate, product announcement, campus controversy, historical what-if |
 | **Live Oracle Data** | Opt-in grounded seeds from the [FeedOracle](https://mcp.feedoracle.io/mcp) MCP (484 tools) |
 | **Per-Agent MCP Tools** | Personas can invoke real MCP tools (web search, APIs) during simulation |
+| **Custom Wonderwall Endpoint** | Point the simulation loop at any OpenAI-compatible endpoint (self-hosted vLLM, Modal, fine-tunes…) without affecting Default/Smart/NER. Set `WONDERWALL_BASE_URL` + `WONDERWALL_API_KEY` |
 | **Embed & Publish** | Public/private toggle + embed URLs for sharing finished runs |
 | **Social Share Card** | 1200×630 PNG that auto-unfurls scenario, status, quality, and belief split on Twitter/X, Discord, Slack, LinkedIn |
 | **Animated Belief Replay** | 1200×630 GIF — one frame per round, belief bars sliding to each round's distribution. Discord and Slack auto-play GIFs from the direct URL |
@@ -123,7 +126,7 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 |---|---|
 | [Install](docs/INSTALL.md) | Every deployment path: cloud, Docker, Ollama, Claude Code |
 | [Configuration](docs/CONFIGURATION.md) | Env vars, model routing, feature flags |
-| [Models](docs/MODELS.md) | Cheap vs Best presets, local Ollama models, benchmark findings |
+| [Models](docs/MODELS.md) | Cloud preset, local Ollama models, benchmark findings |
 | [Architecture](docs/ARCHITECTURE.md) | Simulation engine, memory pipeline, graph retrieval |
 | [Features](docs/FEATURES.md) | Deep dive on every feature in the table above |
 | [HTTP API](docs/API.md) | Every endpoint, grouped by concern — plus interactive Swagger UI at `/api/docs` and a spec at `/api/openapi.yaml` |

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -29,47 +29,27 @@ def _mask_key(key: str) -> str:
     return '****' + key[-4:] if len(key) > 4 else '****'
 
 
-# Preset blueprints mirror the .env.example Cheap / Best / Local blocks.
+# Preset blueprints mirror the .env.example Cloud / Local blocks.
 # The `key_slots` list names the fields the preset's API key should be
 # copied into when the caller supplies `preset_api_key`.
 _PRESETS = {
     'cheap': {
-        'label': 'Cheap — ~$1/run (Qwen3.5 Flash + DeepSeek V3.2 + Grok-4.1 Fast)',
+        'label': 'Cloud — ~$1/run (Mimo V2 Flash + Grok-4.1 Fast)',
         'fields': {
             'LLM_PROVIDER': 'openai',
             'LLM_BASE_URL': 'https://openrouter.ai/api/v1',
-            'LLM_MODEL_NAME': 'qwen/qwen3.5-flash-02-23',
+            'LLM_MODEL_NAME': 'xiaomi/mimo-v2-flash',
             'SMART_PROVIDER': 'openai',
             'SMART_BASE_URL': 'https://openrouter.ai/api/v1',
-            'SMART_MODEL_NAME': 'deepseek/deepseek-v3.2',
+            'SMART_MODEL_NAME': 'x-ai/grok-4.1-fast',
             'NER_BASE_URL': 'https://openrouter.ai/api/v1',
             'NER_MODEL_NAME': 'x-ai/grok-4.1-fast',
-            'WONDERWALL_MODEL_NAME': 'qwen/qwen3.5-flash-02-23',
+            'WONDERWALL_MODEL_NAME': 'xiaomi/mimo-v2-flash',
             'EMBEDDING_PROVIDER': 'openai',
             'EMBEDDING_BASE_URL': 'https://openrouter.ai/api',
             'EMBEDDING_MODEL': 'openai/text-embedding-3-large',
             'EMBEDDING_DIMENSIONS': 768,
             'WEB_SEARCH_MODEL': 'x-ai/grok-4.1-fast:online',
-        },
-        'key_slots': ['LLM_API_KEY', 'SMART_API_KEY', 'NER_API_KEY', 'EMBEDDING_API_KEY'],
-    },
-    'best': {
-        'label': 'Best — ~$3.50/run (Claude reports, Haiku personas)',
-        'fields': {
-            'LLM_PROVIDER': 'openai',
-            'LLM_BASE_URL': 'https://openrouter.ai/api/v1',
-            'LLM_MODEL_NAME': 'anthropic/claude-haiku-4.5',
-            'SMART_PROVIDER': 'openai',
-            'SMART_BASE_URL': 'https://openrouter.ai/api/v1',
-            'SMART_MODEL_NAME': 'anthropic/claude-sonnet-4.6',
-            'NER_BASE_URL': 'https://openrouter.ai/api/v1',
-            'NER_MODEL_NAME': 'google/gemini-2.0-flash-001',
-            'WONDERWALL_MODEL_NAME': 'google/gemini-2.0-flash-lite-001',
-            'EMBEDDING_PROVIDER': 'openai',
-            'EMBEDDING_BASE_URL': 'https://openrouter.ai/api',
-            'EMBEDDING_MODEL': 'openai/text-embedding-3-small',
-            'EMBEDDING_DIMENSIONS': 768,
-            'WEB_SEARCH_MODEL': 'google/gemini-2.0-flash-001:online',
         },
         'key_slots': ['LLM_API_KEY', 'SMART_API_KEY', 'NER_API_KEY', 'EMBEDDING_API_KEY'],
     },
@@ -125,6 +105,9 @@ def _current_snapshot() -> dict:
         },
         'wonderwall': {
             'model_name': Config.WONDERWALL_MODEL_NAME,
+            'base_url': Config.WONDERWALL_BASE_URL,
+            'api_key_masked': _mask_key(Config.WONDERWALL_API_KEY or ''),
+            'has_api_key': bool(Config.WONDERWALL_API_KEY),
         },
         'embedding': {
             'provider': Config.EMBEDDING_PROVIDER,
@@ -174,12 +157,12 @@ def update_settings():
     Update configuration at runtime. All fields optional.
 
     Body fields:
-      preset: "cheap" | "best" | "local"                    — apply a full preset
+      preset: "cheap" | "local"                              — apply a full preset
       preset_api_key: str                                    — key filled into every preset slot
       llm: { provider, base_url, model_name, api_key }
       smart: { provider, base_url, model_name, api_key }
       ner:   { base_url, model_name, api_key }
-      wonderwall: { model_name }
+      wonderwall: { base_url, model_name, api_key }
       embedding: { provider, base_url, model_name, api_key, dimensions }
       web_search_model: str
       neo4j: { uri, user, password }
@@ -215,6 +198,10 @@ def update_settings():
     wonderwall = body.get('wonderwall') or {}
     if wonderwall.get('model_name') is not None:
         Config.WONDERWALL_MODEL_NAME = wonderwall['model_name']
+    if wonderwall.get('base_url') is not None:
+        Config.WONDERWALL_BASE_URL = wonderwall['base_url']
+    if wonderwall.get('api_key'):
+        Config.WONDERWALL_API_KEY = wonderwall['api_key']
 
     embedding = body.get('embedding') or {}
     if embedding.get('provider') is not None: Config.EMBEDDING_PROVIDER = embedding['provider']

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,18 +30,16 @@ class Config:
     # LLM configuration (unified OpenAI format)
     # LLM_PROVIDER: "openai" (default, any OpenAI-compatible API) or "claude-code" (local CLI)
     # Default model is used for profile generation, sim config, memory compaction.
-    # Cheap preset: qwen/qwen3.5-flash-02-23 (with LLM_DISABLE_REASONING=true)
-    # Best preset:  anthropic/claude-haiku-4.5 (rich personas, dense sim configs)
+    # Cloud preset: xiaomi/mimo-v2-flash (cheap personas + sim configs)
     LLM_PROVIDER = os.environ.get('LLM_PROVIDER', 'openai')
     LLM_API_KEY = os.environ.get('LLM_API_KEY')
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'https://api.openai.com/v1')
-    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'qwen/qwen3.5-flash-02-23')
+    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'xiaomi/mimo-v2-flash')
 
     # Smart model — stronger model for intelligence-sensitive workflows
     # (report generation, ontology extraction, graph reasoning).
     # When not set, these workflows use the default LLM config above.
-    # Cheap preset: deepseek/deepseek-v3.2 (non-reasoning, stable JSON)
-    # Best preset:  anthropic/claude-sonnet-4.6 (9/10 report quality)
+    # Cloud preset: x-ai/grok-4.1-fast (stable JSON, fast reports)
     SMART_PROVIDER = os.environ.get('SMART_PROVIDER', '')   # "openai", "claude-code", or empty (inherit)
     SMART_API_KEY = os.environ.get('SMART_API_KEY', '')
     SMART_BASE_URL = os.environ.get('SMART_BASE_URL', '')
@@ -146,13 +144,19 @@ class Config:
 
     # Wonderwall model — model for Wonderwall/CAMEL agent simulation loop.
     # When not set, uses LLM_MODEL_NAME.
-    # Cheap preset: qwen/qwen3.5-flash-02-23 (same as default to reuse quota)
+    # Cloud preset: xiaomi/mimo-v2-flash (same as default to reuse quota)
     # Wonderwall is the #1 cost driver — 850+ calls per run. Keep it cheap.
     WONDERWALL_MODEL_NAME = os.environ.get('WONDERWALL_MODEL_NAME', '')
+    # Optional per-slot endpoint override — point Wonderwall at a different
+    # OpenAI-compatible API (e.g. a self-hosted Modal/vLLM endpoint) without
+    # affecting the Default/Smart/NER slots. When unset, the simulation
+    # subprocess falls back to LLM_API_KEY / LLM_BASE_URL.
+    WONDERWALL_API_KEY = os.environ.get('WONDERWALL_API_KEY', '')
+    WONDERWALL_BASE_URL = os.environ.get('WONDERWALL_BASE_URL', '')
 
     # NER model — faster model for entity extraction (high-volume, mechanical task)
     # When not set, NER uses the default LLM config above.
-    # Cheap preset: x-ai/grok-4.1-fast (stable JSON with reasoning disabled)
+    # Cloud preset: x-ai/grok-4.1-fast (stable JSON with reasoning disabled)
     NER_MODEL_NAME = os.environ.get('NER_MODEL_NAME', '')
     NER_BASE_URL = os.environ.get('NER_BASE_URL', '')
     NER_API_KEY = os.environ.get('NER_API_KEY', '')

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -489,6 +489,16 @@ class SimulationRunner:
             env['PYTHONIOENCODING'] = 'utf-8'  # Ensure stdout/stderr use UTF-8
             env['MIROSHARK_SIM_DIR'] = sim_dir  # Observability: tell agents where to write events.jsonl
             env['MIROSHARK_SIMULATION_ID'] = simulation_id  # Observability: tag Wonderwall events with sim ID
+
+            # Forward runtime Wonderwall slot overrides (Settings UI mutates
+            # Config but not os.environ). Each script prefers WONDERWALL_*
+            # over LLM_* and falls back when empty, so passing through only
+            # non-empty values keeps existing setups untouched.
+            from ..config import Config as _Cfg
+            for _attr in ('WONDERWALL_API_KEY', 'WONDERWALL_BASE_URL', 'WONDERWALL_MODEL_NAME'):
+                _val = getattr(_Cfg, _attr, '') or ''
+                if _val:
+                    env[_attr] = _val
             # Forward run_id (when the orchestrator has set one) so the
             # subprocess's Langfuse `metadata.run_id` / `tags` line up with
             # the orchestrator-side calls — both ends end up under the same

--- a/backend/app/utils/run_summary.py
+++ b/backend/app/utils/run_summary.py
@@ -24,11 +24,12 @@ logger = get_logger('miroshark.run_summary')
 # OpenRouter pricing ($/1M tokens) — update as needed
 # ---------------------------------------------------------------------------
 MODEL_PRICING = {
-    # Current Cheap preset (update as OpenRouter prices drift)
+    # Current Cloud preset (update as OpenRouter prices drift)
+    "xiaomi/mimo-v2-flash":              {"input": 0.10, "output": 0.40},
+    "x-ai/grok-4.1-fast":                {"input": 0.20, "output": 0.50},
+    # Tracked for mixed / legacy setups
     "qwen/qwen3.5-flash-02-23":          {"input": 0.065, "output": 0.26},
     "deepseek/deepseek-v3.2":            {"input": 0.252, "output": 0.378},
-    "x-ai/grok-4.1-fast":                {"input": 0.20, "output": 0.50},
-    # Gemini (still tracked for mixed / legacy setups)
     "google/gemini-2.0-flash-001":       {"input": 0.10, "output": 0.40},
     "google/gemini-2.0-flash-lite-001":  {"input": 0.075, "output": 0.30},
     "google/gemini-2.5-flash":           {"input": 0.15, "output": 0.60},

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -1074,10 +1074,12 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
         llm_model = boost_model or os.environ.get("LLM_MODEL_NAME", "")
         config_label = "[Boost LLM]"
     else:
-        # Use general configuration
-        llm_api_key = os.environ.get("LLM_API_KEY", "")
-        llm_base_url = os.environ.get("LLM_BASE_URL", "")
-        # WONDERWALL_MODEL_NAME overrides LLM_MODEL_NAME for the simulation loop
+        # Use general configuration. WONDERWALL_* overrides LLM_* per-slot,
+        # so the simulation loop can target a different OpenAI-compatible
+        # endpoint (e.g. a self-hosted vLLM / Modal deployment) without
+        # touching the Default/Smart/NER slots.
+        llm_api_key = os.environ.get("WONDERWALL_API_KEY", "") or os.environ.get("LLM_API_KEY", "")
+        llm_base_url = os.environ.get("WONDERWALL_BASE_URL", "") or os.environ.get("LLM_BASE_URL", "")
         llm_model = os.environ.get("WONDERWALL_MODEL_NAME", "") or os.environ.get("LLM_MODEL_NAME", "")
         config_label = "[General LLM]"
     

--- a/backend/scripts/run_reddit_simulation.py
+++ b/backend/scripts/run_reddit_simulation.py
@@ -450,15 +450,18 @@ class RedditSimulationRunner:
         """
         Create LLM model
 
-        Uses configuration from the project root .env file (highest priority):
-        - LLM_API_KEY: API key
-        - LLM_BASE_URL: API base URL
-        - LLM_MODEL_NAME: Model name
+        Uses configuration from the project root .env file (highest priority).
+        WONDERWALL_* overrides LLM_* per-slot, so the simulation loop can
+        target a different OpenAI-compatible endpoint without touching the
+        Default/Smart/NER slots.
+        - WONDERWALL_API_KEY / LLM_API_KEY: API key
+        - WONDERWALL_BASE_URL / LLM_BASE_URL: API base URL
+        - WONDERWALL_MODEL_NAME / LLM_MODEL_NAME: Model name
         """
         # Read configuration from .env first
-        llm_api_key = os.environ.get("LLM_API_KEY", "")
-        llm_base_url = os.environ.get("LLM_BASE_URL", "")
-        llm_model = os.environ.get("LLM_MODEL_NAME", "")
+        llm_api_key = os.environ.get("WONDERWALL_API_KEY", "") or os.environ.get("LLM_API_KEY", "")
+        llm_base_url = os.environ.get("WONDERWALL_BASE_URL", "") or os.environ.get("LLM_BASE_URL", "")
+        llm_model = os.environ.get("WONDERWALL_MODEL_NAME", "") or os.environ.get("LLM_MODEL_NAME", "")
         
         # If not in .env, use config as fallback
         if not llm_model:

--- a/backend/scripts/run_twitter_simulation.py
+++ b/backend/scripts/run_twitter_simulation.py
@@ -428,15 +428,18 @@ class TwitterSimulationRunner:
         """
         Create LLM model
 
-        Uses configuration from the project root .env file (highest priority):
-        - LLM_API_KEY: API key
-        - LLM_BASE_URL: API base URL
-        - LLM_MODEL_NAME: Model name
+        Uses configuration from the project root .env file (highest priority).
+        WONDERWALL_* overrides LLM_* per-slot, so the simulation loop can
+        target a different OpenAI-compatible endpoint without touching the
+        Default/Smart/NER slots.
+        - WONDERWALL_API_KEY / LLM_API_KEY: API key
+        - WONDERWALL_BASE_URL / LLM_BASE_URL: API base URL
+        - WONDERWALL_MODEL_NAME / LLM_MODEL_NAME: Model name
         """
         # Read configuration from .env first
-        llm_api_key = os.environ.get("LLM_API_KEY", "")
-        llm_base_url = os.environ.get("LLM_BASE_URL", "")
-        llm_model = os.environ.get("LLM_MODEL_NAME", "")
+        llm_api_key = os.environ.get("WONDERWALL_API_KEY", "") or os.environ.get("LLM_API_KEY", "")
+        llm_base_url = os.environ.get("WONDERWALL_BASE_URL", "") or os.environ.get("LLM_BASE_URL", "")
+        llm_model = os.environ.get("WONDERWALL_MODEL_NAME", "") or os.environ.get("LLM_MODEL_NAME", "")
         
         # If not in .env, use config as fallback
         if not llm_model:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -8,7 +8,7 @@ All settings live in `.env` (copy from `.env.example`). The full reference below
 # LLM
 LLM_API_KEY=your-api-key
 LLM_BASE_URL=https://openrouter.ai/api/v1     # or http://localhost:11434/v1 for Ollama
-LLM_MODEL_NAME=qwen/qwen3.5-flash-02-23
+LLM_MODEL_NAME=xiaomi/mimo-v2-flash
 
 # Neo4j
 NEO4J_URI=bolt://localhost:7687
@@ -33,7 +33,7 @@ MiroShark routes different workflows to different models. Four independent slots
 | **NER** | `NER_MODEL_NAME` | Entity extraction (structured JSON) | ~85–250 calls |
 | **Wonderwall** | `WONDERWALL_MODEL_NAME` | Agent decisions in simulation loop | ~850–1650 calls |
 
-When a slot is not set it falls back to the Default model. If only `SMART_MODEL_NAME` is set (without `SMART_PROVIDER`/`SMART_BASE_URL`/`SMART_API_KEY`), the smart model inherits the default provider settings.
+When a slot is not set it falls back to the Default model. If only `SMART_MODEL_NAME` is set (without `SMART_PROVIDER`/`SMART_BASE_URL`/`SMART_API_KEY`), the smart model inherits the default provider settings. The same applies to `WONDERWALL_MODEL_NAME` — set `WONDERWALL_BASE_URL` and/or `WONDERWALL_API_KEY` to point Wonderwall at a different OpenAI-compatible endpoint (e.g. a self-hosted vLLM/Modal deployment) without touching the other slots.
 
 See [Models](MODELS.md) for benchmarked recommendations per slot.
 
@@ -48,11 +48,15 @@ LLM_MODEL_NAME=qwen2.5:32b
 
 # ─── Smart model (reports, ontology, graph reasoning — #1 quality lever) ───
 # SMART_PROVIDER=openai
-# SMART_MODEL_NAME=deepseek/deepseek-v3.2      # Cheap preset
-# SMART_MODEL_NAME=anthropic/claude-sonnet-4.6 # Best preset (far stronger reports)
+# SMART_MODEL_NAME=x-ai/grok-4.1-fast          # Cloud preset
 
 # ─── Wonderwall (agent sim loop — #1 cost driver, use cheapest viable) ───
-# WONDERWALL_MODEL_NAME=qwen/qwen3.5-flash-02-23
+# WONDERWALL_MODEL_NAME=xiaomi/mimo-v2-flash
+# Optional: route Wonderwall to a custom OpenAI-compatible endpoint
+# (self-hosted vLLM, Modal, custom fine-tune…). Both fields are
+# optional — leaving either blank inherits LLM_BASE_URL / LLM_API_KEY.
+# WONDERWALL_BASE_URL=https://your-endpoint.example.com/v1
+# WONDERWALL_API_KEY=not-checked
 
 # ─── NER (entity extraction — needs reliable JSON, no hidden CoT) ───
 # NER_MODEL_NAME=x-ai/grok-4.1-fast

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -81,6 +81,25 @@ Each round the runner:
 
 Failed calls become `{"_error": "..."}` payloads rather than exceptions — agent prompts stay well-formed. The bridge has a 30-second per-call timeout (`MCP_CALL_TIMEOUT_SEC`) and tears down subprocesses on simulation end (or `atexit` on abnormal exit).
 
+## Custom Wonderwall Endpoint
+
+The simulation loop is the heaviest model consumer in MiroShark — 850–1650 calls per run, 7M+ tokens, all going through CAMEL-AI's per-agent action loop. The Wonderwall slot has its own `WONDERWALL_BASE_URL` + `WONDERWALL_API_KEY` env vars (and matching inputs in **Settings → Advanced → Wonderwall**) so you can route those volume hits to any OpenAI-compatible endpoint without touching the Default/Smart/NER slots — keep graph build, reports, and entity extraction on OpenRouter/Anthropic while the agents talk to a self-hosted vLLM, a Modal/Replicate deployment, an Ollama instance on a separate GPU, or a custom fine-tune of your own.
+
+Both fields are independently optional. A blank `WONDERWALL_BASE_URL` inherits `LLM_BASE_URL`; a blank `WONDERWALL_API_KEY` inherits `LLM_API_KEY`. Open endpoints (no auth) work by passing any non-empty placeholder like `not-checked`.
+
+```bash
+WONDERWALL_BASE_URL=https://your-endpoint.example.com/v1
+WONDERWALL_API_KEY=not-checked
+WONDERWALL_MODEL_NAME=your-model-id
+```
+
+Wiring lives in three places. (1) `backend/scripts/run_parallel_simulation.py` (and the twitter / reddit variants) prefer `WONDERWALL_*` over `LLM_*` when reading env at subprocess start. (2) `backend/app/services/simulation_runner.py` forwards `Config.WONDERWALL_*` into the subprocess `env` at spawn time, so Settings UI updates apply on the next run without a Flask restart. (3) The Settings API (`POST /api/settings`) and the corresponding section of `SettingsPanel.vue` accept all three fields.
+
+Useful when:
+- The Wonderwall character/persona prompts work better with a fine-tune you've trained yourself.
+- You want to bound cost to a fixed-rate self-hosted GPU rather than per-token billing.
+- You want to compare a custom small model's belief drift / coherence against a hosted baseline by running matched simulations with everything but the Wonderwall slot held constant.
+
 ## Publishing for Embed
 
 `EmbedDialog` has a `Public / Private` toggle backed by `is_public` on the simulation state. Embed URLs return `403` on unpublished simulations — flip the toggle (or `POST /api/simulation/<id>/publish`) to make them publicly embeddable. Defaults to private so existing sims are unaffected.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -91,34 +91,7 @@ git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
 cp .env.example .env
 ```
 
-Edit `.env` and paste your OpenRouter key into all five slots (Cheap preset shown — for Best, swap `LLM_MODEL_NAME` to `anthropic/claude-haiku-4.5` and `SMART_MODEL_NAME` to `anthropic/claude-sonnet-4.6`):
-
-```bash
-LLM_API_KEY=sk-or-v1-YOUR_KEY
-LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_MODEL_NAME=qwen/qwen3.5-flash-02-23
-
-SMART_PROVIDER=openai
-SMART_API_KEY=sk-or-v1-YOUR_KEY
-SMART_BASE_URL=https://openrouter.ai/api/v1
-SMART_MODEL_NAME=deepseek/deepseek-v3.2
-
-NER_MODEL_NAME=x-ai/grok-4.1-fast
-NER_BASE_URL=https://openrouter.ai/api/v1
-NER_API_KEY=sk-or-v1-YOUR_KEY
-
-WONDERWALL_MODEL_NAME=qwen/qwen3.5-flash-02-23
-WEB_SEARCH_MODEL=x-ai/grok-4.1-fast:online
-
-OPENAI_API_KEY=sk-or-v1-YOUR_KEY
-OPENAI_API_BASE_URL=https://openrouter.ai/api/v1
-
-EMBEDDING_PROVIDER=openai
-EMBEDDING_MODEL=openai/text-embedding-3-large
-EMBEDDING_BASE_URL=https://openrouter.ai/api
-EMBEDDING_API_KEY=sk-or-v1-YOUR_KEY
-EMBEDDING_DIMENSIONS=768
-```
+`.env.example` ships with the Cloud preset (Mimo V2 Flash + Grok-4.1 Fast) as the active default. Open `.env` and paste your OpenRouter key into the five blank `*_API_KEY=` lines (`LLM_`, `SMART_`, `NER_`, `OPENAI_`, `EMBEDDING_` — same key in all of them). No model edits needed unless you want a different lineup.
 
 Then launch:
 
@@ -135,7 +108,7 @@ What the launcher does:
 5. Launches Vite dev server (`:3000`) and Flask API (`:5001`)
 6. Ctrl+C to stop everything
 
-Open `http://localhost:3000`. First simulation in ~10 min, ~$1 (Cheap) to ~$3.50 (Best). See [Models](MODELS.md) for the full preset breakdown.
+Open `http://localhost:3000`. First simulation in ~10 min, ~$1. See [Models](MODELS.md) for the full preset breakdown.
 
 > Prefer to run everything local? Skip to [Option B (Docker + Ollama)](#option-b-docker--local-ollama) or [Option C (manual Ollama)](#option-c-manual--local-ollama) below.
 
@@ -158,18 +131,18 @@ One key covers every slot, including embeddings. Easiest to set up and the path 
 ```bash
 LLM_API_KEY=sk-or-v1-YOUR_KEY
 LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_MODEL_NAME=qwen/qwen3.5-flash-02-23
+LLM_MODEL_NAME=xiaomi/mimo-v2-flash
 
 SMART_PROVIDER=openai
 SMART_API_KEY=sk-or-v1-YOUR_KEY
 SMART_BASE_URL=https://openrouter.ai/api/v1
-SMART_MODEL_NAME=deepseek/deepseek-v3.2
+SMART_MODEL_NAME=x-ai/grok-4.1-fast
 
 NER_MODEL_NAME=x-ai/grok-4.1-fast
 NER_BASE_URL=https://openrouter.ai/api/v1
 NER_API_KEY=sk-or-v1-YOUR_KEY
 
-WONDERWALL_MODEL_NAME=qwen/qwen3.5-flash-02-23
+WONDERWALL_MODEL_NAME=xiaomi/mimo-v2-flash
 WEB_SEARCH_MODEL=x-ai/grok-4.1-fast:online
 
 OPENAI_API_KEY=sk-or-v1-YOUR_KEY
@@ -184,7 +157,7 @@ EMBEDDING_DIMENSIONS=768
 
 ### Option A.2: OpenAI
 
-Use your OpenAI Platform key directly. Costs are roughly in line with the Best preset.
+Use your OpenAI Platform key directly.
 
 ```bash
 LLM_API_KEY=sk-proj-YOUR_KEY
@@ -243,6 +216,20 @@ EMBEDDING_DIMENSIONS=768
 ```
 
 > Prompt caching (`LLM_PROMPT_CACHING_ENABLED=true`) hits its sweet spot here — the ReACT report loop reuses the same system prompt across iterations, so caching meaningfully reduces the Sonnet bill.
+
+### Option A.4: Custom endpoint for Wonderwall
+
+The Wonderwall slot (the per-agent simulation loop, ~850–1650 calls/run) accepts an independent endpoint override so you can route the volume hits to a self-hosted vLLM, Modal/Replicate deployment, fine-tuned model, or Ollama on a different host — while keeping graph build, reports, and NER on a hosted provider.
+
+Add to any of the configurations above:
+
+```bash
+WONDERWALL_BASE_URL=https://your-endpoint.example.com/v1
+WONDERWALL_API_KEY=not-checked            # any string for open endpoints
+WONDERWALL_MODEL_NAME=your-model-id
+```
+
+Either field can be left blank. A blank `WONDERWALL_BASE_URL` reuses `LLM_BASE_URL`, a blank `WONDERWALL_API_KEY` reuses `LLM_API_KEY`. Settings → Advanced → Wonderwall in the UI exposes the same three fields and updates take effect on the next simulation start (no Flask restart). See [docs/MODELS.md#custom-endpoint-for-wonderwall](MODELS.md#custom-endpoint-for-wonderwall) for the full pattern.
 
 ---
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -2,46 +2,45 @@
 
 Four independent model slots (see [Configuration](CONFIGURATION.md#model-slots) for the env vars). This doc covers which models to put in which slot.
 
-## Cloud presets (OpenRouter)
+## Cloud preset (OpenRouter)
 
-Two benchmarked presets ship in `.env.example`. Copy one and set your API key.
+One benchmarked preset ships in `.env.example`. Copy it and set your API key.
 
 Each slot controls a different quality axis:
 
 | Slot | Controls | Key finding |
 |---|---|---|
-| **Default** | Persona richness, sim density | Haiku produces distinct 348-char voices; cheaper models produce generic 170-char copy |
-| **Smart** | Report quality (#1 lever) | Claude Sonnet 9/10, cheaper alternatives 2–5/10 on prior benchmark runs |
+| **Default** | Persona richness, sim density | Mimo V2 Flash gives distinct voices at flash-tier price |
+| **Smart** | Report quality (#1 lever) | Grok-4.1 Fast holds up on ReACT report loops with reasoning disabled |
 | **NER** | Extraction reliability | Needs deterministic JSON — pick a model that doesn't silently emit CoT |
 | **Wonderwall** | Cost (biggest consumer) | 850+ calls, 7M+ tokens. Verbosity matters more than $/M |
 
-### Cheap mode — ~$1/run, ~10 min
+### Cloud mode — ~$1/run, ~10 min
 
-Qwen3.5 Flash + DeepSeek V3.2 + Grok-4.1 Fast. Reasoning is disabled on every slot (`LLM_DISABLE_REASONING=true` sends `reasoning: {enabled: false}` in `extra_body`), which is the difference between a ~45s scenario-suggest call and a ~3s one.
+Mimo V2 Flash personas + Grok-4.1 Fast smart/NER. Reasoning is disabled on every slot (`LLM_DISABLE_REASONING=true` sends `reasoning: {enabled: false}` in `extra_body`), which is the difference between a ~45s scenario-suggest call and a ~3s one.
 
-| Slot | Model | $/M (in/out) | Observed avg latency |
-|---|---|---|---|
-| Default | `qwen/qwen3.5-flash-02-23` | $0.065 / $0.26 | 8.5s (Wonderwall-heavy prompts) |
-| Smart | `deepseek/deepseek-v3.2` | $0.252 / $0.378 | 12.5s (report ReACT loops) |
-| NER | `x-ai/grok-4.1-fast` | $0.20 / $0.50 | 2.0s |
-| Wonderwall | `qwen/qwen3.5-flash-02-23` | $0.065 / $0.26 | 7.6s (per agent action) |
+| Slot | Model | Notes |
+|---|---|---|
+| Default | `xiaomi/mimo-v2-flash` | Persona generation, sim config, memory compaction |
+| Smart | `x-ai/grok-4.1-fast` | Report ReACT loop — only ~19 calls/run |
+| NER | `x-ai/grok-4.1-fast` | Stable JSON with reasoning off |
+| Wonderwall | `xiaomi/mimo-v2-flash` | 850+ agent-action calls/run; keep verbosity low |
 
-Observed on a 359-call end-to-end run (2.99M tokens, ~67 min wall clock): **~$0.50 total** including Grok-`:online` web enrichment. Docs without public figures typically come in under $0.30.
+Embeddings use `openai/text-embedding-3-large` (truncated to 768 dims via Matryoshka). Web enrichment uses `x-ai/grok-4.1-fast:online`.
 
-### Best mode — ~$3.50/run, ~25 min
-
-Claude reports, Haiku personas, cheap Wonderwall. Best report quality at reasonable cost.
-
-| Slot | Model | $/M | Why |
-|---|---|---|---|
-| Default | `anthropic/claude-haiku-4.5` | $0.80/$4.00 | Rich personas, dense sim configs |
-| Smart | `anthropic/claude-sonnet-4.6` | $3.00/$15.00 | 9/10 report quality, only ~19 calls |
-| NER | `x-ai/grok-4.1-fast` | ~$0.20 | Stable JSON with reasoning off |
-| Wonderwall | `qwen/qwen3.5-flash-02-23` | ~$0.10 | Wonderwall doesn't drive quality — Smart does |
-
-> Cheap preset uses `openai/text-embedding-3-large` (truncated to 768 dims via Matryoshka) and `x-ai/grok-4.1-fast:online` for web research. Best preset inherits the same embedding + web-search defaults.
->
 > **Latency note** — every OpenRouter call goes through `LLMClient`, which injects `reasoning: {enabled: false}` into `extra_body` by default. Turn it off with `LLM_DISABLE_REASONING=false` only if a specific slot benefits from chain-of-thought (rare for MiroShark's structured prompts).
+
+### Custom endpoint for Wonderwall
+
+The Wonderwall slot accepts a per-slot endpoint override so you can run a self-hosted or fine-tuned model alongside the OpenRouter-backed Default/Smart/NER slots:
+
+```bash
+WONDERWALL_BASE_URL=https://your-endpoint.example.com/v1
+WONDERWALL_API_KEY=not-checked          # any string for open endpoints
+WONDERWALL_MODEL_NAME=your-model-id
+```
+
+Either field can be omitted — a blank `WONDERWALL_BASE_URL` reuses `LLM_BASE_URL`, a blank `WONDERWALL_API_KEY` reuses `LLM_API_KEY`. Useful for routing the 850+ agent-action calls per run to a vLLM / Modal / Ollama-on-a-server deployment while keeping the report and graph-build slots on a hosted provider.
 
 ## Local mode (Ollama)
 

--- a/frontend/src/api/settings.js
+++ b/frontend/src/api/settings.js
@@ -13,12 +13,12 @@ export const getSettings = () => {
  * Update settings at runtime. Every field is optional.
  *
  * @param {Object} data
- *   - preset:             "cheap" | "best" | "local"   (apply full preset)
+ *   - preset:             "cheap" | "local"             (apply full preset)
  *   - preset_api_key:     string                        (filled into every preset key slot)
  *   - llm:                { provider, base_url, model_name, api_key }
  *   - smart:              { provider, base_url, model_name, api_key }
  *   - ner:                { base_url, model_name, api_key }
- *   - wonderwall:         { model_name }
+ *   - wonderwall:         { base_url, model_name, api_key }
  *   - embedding:          { provider, base_url, model_name, api_key, dimensions }
  *   - web_search_model:   string
  *   - neo4j:              { uri, user, password }

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -239,7 +239,7 @@
                   v-model="form.smart.model_name"
                   class="field-input"
                   type="text"
-                  placeholder="e.g. anthropic/claude-sonnet-4.6"
+                  placeholder="e.g. x-ai/grok-4.1-fast"
                 />
               </div>
             </div>
@@ -253,7 +253,7 @@
                   v-model="form.ner.model_name"
                   class="field-input"
                   type="text"
-                  placeholder="e.g. google/gemini-2.0-flash-001"
+                  placeholder="e.g. x-ai/grok-4.1-fast"
                 />
               </div>
             </div>
@@ -267,7 +267,25 @@
                   v-model="form.wonderwall.model_name"
                   class="field-input"
                   type="text"
-                  placeholder="e.g. google/gemini-2.0-flash-lite-001"
+                  placeholder="e.g. xiaomi/mimo-v2-flash"
+                />
+              </div>
+              <div class="field-row">
+                <label class="field-label">Base URL</label>
+                <input
+                  v-model="form.wonderwall.base_url"
+                  class="field-input"
+                  type="text"
+                  placeholder="Inherits LLM base URL when blank"
+                />
+              </div>
+              <div class="field-row">
+                <label class="field-label">API Key</label>
+                <input
+                  v-model="form.wonderwall.api_key"
+                  class="field-input"
+                  type="password"
+                  :placeholder="currentSettings.wonderwall?.has_api_key ? `Saved: ${currentSettings.wonderwall.api_key_masked}` : 'Inherits LLM key when blank'"
                 />
               </div>
             </div>
@@ -573,7 +591,7 @@ const form = reactive({
   },
   smart: { model_name: '' },
   ner: { model_name: '' },
-  wonderwall: { model_name: '' },
+  wonderwall: { model_name: '', base_url: '', api_key: '' },
   embedding: { provider: 'ollama', model_name: '' },
   web_search_model: '',
   neo4j: {
@@ -644,6 +662,8 @@ const loadCurrentSettings = async () => {
       form.smart.model_name = d.smart?.model_name || ''
       form.ner.model_name = d.ner?.model_name || ''
       form.wonderwall.model_name = d.wonderwall?.model_name || ''
+      form.wonderwall.base_url = d.wonderwall?.base_url || ''
+      form.wonderwall.api_key = '' // never pre-fill
       form.embedding.provider = d.embedding?.provider || 'ollama'
       form.embedding.model_name = d.embedding?.model_name || ''
       form.web_search_model = d.web_search_model || ''
@@ -663,9 +683,9 @@ const loadCurrentSettings = async () => {
 
 const presetOptions = computed(() => currentSettings.value.available_presets || [])
 
-// `local` preset doesn't need an API key — the others do.
+// `local` preset doesn't need an API key — the cloud preset does.
 const presetNeedsKey = computed(() =>
-  form.preset === 'cheap' || form.preset === 'best'
+  form.preset === 'cheap'
 )
 
 // Whether current base URL is OpenRouter
@@ -867,7 +887,11 @@ const saveSettings = async () => {
 
     payload.smart = { model_name: form.smart.model_name }
     payload.ner = { model_name: form.ner.model_name }
-    payload.wonderwall = { model_name: form.wonderwall.model_name }
+    payload.wonderwall = {
+      model_name: form.wonderwall.model_name,
+      base_url: form.wonderwall.base_url,
+    }
+    if (form.wonderwall.api_key) payload.wonderwall.api_key = form.wonderwall.api_key
     payload.embedding = {
       provider: form.embedding.provider,
       model_name: form.embedding.model_name,

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -77,7 +77,7 @@
           
           <h2 class="section-title">Ready</h2>
           <p class="section-desc">
-            First simulation in ~10 min, ~$1 on the Cheap preset. Drop in a doc or pick a trending headline to start.
+            First simulation in ~10 min, ~$1 on the cloud preset. Drop in a doc or pick a trending headline to start.
           </p>
 
 


### PR DESCRIPTION
## Summary

- **Per-slot Wonderwall endpoint override** — new `WONDERWALL_BASE_URL` + `WONDERWALL_API_KEY` env vars (and matching Settings UI inputs) let the simulation loop target any OpenAI-compatible endpoint without affecting the Default/Smart/NER slots. Both fields fall back to `LLM_*` when blank. Tested live against a Modal-hosted vLLM endpoint.
- **Cloud preset refresh** — Mimo V2 Flash (Default + Wonderwall) and Grok-4.1 Fast (Smart + NER + web search) replace the previous Qwen + DeepSeek mix. Now the active default in `.env.example` so a fresh clone runs cloud-first; users only fill in the OpenRouter key.
- **Best preset dropped** — same `~$1/run` budget as the new Cloud preset and the Claude tier was redundant for most users.

## How the override flows

1. `Config.WONDERWALL_API_KEY` / `Config.WONDERWALL_BASE_URL` (new) read from env at startup, settable at runtime via `POST /api/settings { wonderwall: { base_url, api_key, model_name } }`.
2. `simulation_runner.py` forwards those Config values into the subprocess `env` at spawn time, so Settings UI updates apply on the **next simulation run** with no Flask restart.
3. The three CAMEL-AI subprocess scripts (`run_parallel`, `run_twitter`, `run_reddit`) prefer `WONDERWALL_*` over `LLM_*` when constructing the model — open endpoints work by passing any non-empty `WONDERWALL_API_KEY` placeholder like `not-checked`.
4. `SettingsPanel.vue` exposes Model + Base URL + API Key fields under Advanced → Wonderwall; the API-key input never round-trips the masked saved value (cleared on each settings load).

## Documentation surfaces

- `README.md` — new feature-table row + Quick Start updated for cloud-default
- `docs/INSTALL.md` — new **Option A.4: Custom endpoint for Wonderwall** subsection + cloud-as-default phrasing throughout Option A.1
- `docs/MODELS.md` — **Custom endpoint for Wonderwall** subsection with the bash example
- `docs/CONFIGURATION.md` — slot-fallback paragraph mentions the override + commented example in the full `.env` reference
- `docs/FEATURES.md` — full prose section in the existing per-feature style with three "useful when" cases

## Test plan

- [x] `pytest backend/tests/` — 196 pass / 17 skipped (integration-only) / 0 new failures
- [x] Live simulation with `WONDERWALL_BASE_URL` pointing at a Modal-hosted custom OpenAI-compatible endpoint, other slots on OpenRouter — agents talked to the custom endpoint, graph build / report stayed on the OpenRouter slots
- [x] Settings UI: change `wonderwall.base_url`/`api_key` in the modal, save, kick off a new sim — subprocess picks up the new endpoint without a Flask restart
- [x] Backward-compat: blank `WONDERWALL_BASE_URL` + `WONDERWALL_API_KEY` reuse `LLM_*` (existing setups untouched)
- [ ] CI green