### PR TITLE
feat: RSS / Atom feeds for the public simulation gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
 | **Transcript Export** | Per-round agent posts + stance labels as Markdown (YAML front matter for Notion / Obsidian / Substack) or structured JSON (for SDKs and LLM-as-judge pipelines) |
 | **Public Gallery** | `/explore` browses every published simulation as a card grid — preview the share card, consensus split, and quality health; click to open or one-click fork |
 | **Verified Predictions** | Annotate any public sim with the real-world outcome (called it / partial / called wrong + URL). `/verified` is the dedicated hall of calls that landed |
+| **RSS / Atom Feeds** | `/api/feed.atom` + `/api/feed.rss` — every newly published simulation lands in Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS without anyone curating it. `?verified=1` for the verified-only stream |
 | **Article Generation** | Substack-style write-up of what happened, grounded in actual posts and trades |
 | **Interaction Network** | Force-directed agent-to-agent graph with echo-chamber metrics |
 | **Demographics** | Archetype clustering (analyst / influencer / retail / observer…) |

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -79,7 +79,7 @@ def create_app(config_class=Config):
         return response
     
     # Register blueprints
-    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, mcp_bp, docs_bp, share_bp
+    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, mcp_bp, docs_bp, feed_bp, share_bp
     app.register_blueprint(graph_bp, url_prefix='/api/graph')
     app.register_blueprint(simulation_bp, url_prefix='/api/simulation')
     app.register_blueprint(report_bp, url_prefix='/api/report')
@@ -91,6 +91,11 @@ def create_app(config_class=Config):
     # /api/openapi.yaml, /api/openapi.json (no extra sub-prefix — the spec
     # URL is the developer-facing surface so we keep it short).
     app.register_blueprint(docs_bp, url_prefix='/api')
+    # feed_bp serves the public-gallery syndication feeds at
+    # /api/feed.atom + /api/feed.rss — short URLs at the /api root so
+    # feed auto-discovery scripts and aggregators find them without
+    # digging through the /api/simulation namespace.
+    app.register_blueprint(feed_bp, url_prefix='/api')
     # share_bp serves the public OG-tag landing page at /share/<sim_id>
     # (no prefix — keeps the social share URL short).
     app.register_blueprint(share_bp)

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -12,6 +12,7 @@ settings_bp = Blueprint('settings', __name__)
 observability_bp = Blueprint('observability', __name__)
 mcp_bp = Blueprint('mcp', __name__)
 docs_bp = Blueprint('docs', __name__)
+feed_bp = Blueprint('feed', __name__)
 
 from . import graph  # noqa: E402, F401
 from . import simulation  # noqa: E402, F401
@@ -21,6 +22,7 @@ from . import settings  # noqa: E402, F401
 from . import observability  # noqa: E402, F401
 from . import mcp  # noqa: E402, F401
 from . import docs  # noqa: E402, F401
+from . import feed  # noqa: E402, F401
 
 # share_bp is mounted at the root (no /api prefix) so the public landing
 # URL stays clean — see api/share.py.

--- a/backend/app/api/feed.py
+++ b/backend/app/api/feed.py
@@ -1,0 +1,144 @@
+"""Public-gallery syndication feeds — Atom 1.0 + RSS 2.0.
+
+Serves the same cards ``GET /api/simulation/public`` returns, but as
+syndication XML so research-and-tooling readers can subscribe in
+Feedly / Readwise / Inoreader / Obsidian RSS / NetNewsWire — every newly
+published MiroShark simulation lands in a follower's reader the same way
+an AI newsletter or Substack post does.
+
+Mounted on a dedicated blueprint at ``/api`` so the URLs stay short
+(``/api/feed.atom``, ``/api/feed.rss``) and don't bury under the
+``/api/simulation/...`` namespace where they'd be missed by feed
+auto-discovery scripts.
+
+Same publish gate as the gallery itself: only simulations toggled
+``is_public=true`` appear, exactly the set already on /explore.
+
+Sandbox note: pure stdlib (``xml.etree.ElementTree`` + the existing
+``SimulationManager``). No outbound network — the route never raises and
+never blocks on Neo4j / LLM calls.
+"""
+
+from __future__ import annotations
+
+import os
+
+from flask import Response, request
+
+from . import feed_bp
+from ..config import Config
+from ..services.simulation_manager import SimulationManager
+from ..services.feed import (
+    DEFAULT_FEED_LIMIT,
+    render_feed,
+    select_public_cards,
+)
+from ..utils.logger import get_logger
+
+
+logger = get_logger("miroshark.api.feed")
+
+
+def _resolve_base_url() -> str:
+    """Build the absolute URL prefix used inside the feed XML.
+
+    Prefers ``Config.PUBLIC_BASE_URL`` (the operator-supplied canonical
+    deployment URL — same field the webhook payload + share-card use)
+    so a feed served from ``localhost`` but configured for a public host
+    still points at the public host. Falls back to the request's host
+    URL with X-Forwarded-Proto/Host honored when behind a reverse proxy.
+    """
+    explicit = (Config.PUBLIC_BASE_URL or "").strip()
+    if explicit:
+        return explicit.rstrip("/")
+
+    base = (request.host_url or "").rstrip("/")
+    forwarded_proto = request.headers.get("X-Forwarded-Proto")
+    forwarded_host = request.headers.get("X-Forwarded-Host")
+    if forwarded_host:
+        proto = forwarded_proto or ("https" if request.is_secure else "http")
+        base = f"{proto}://{forwarded_host}"
+    return base
+
+
+def _is_truthy(value: str) -> bool:
+    return (value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _serve_feed(fmt: str) -> Response:
+    """Shared body for the Atom + RSS endpoints.
+
+    ``fmt`` is ``"atom"`` or ``"rss"``; the renderer handles the per-
+    format differences and the MIME type.
+    """
+    # Local imports keep the module-load graph small — feed.py is
+    # cheap to import on its own, but the gallery helper pulls in the
+    # full simulation API surface, so we defer until the request
+    # actually fires.
+    from .simulation import _build_gallery_card_payload, _read_outcome_file
+
+    verified_only = _is_truthy(request.args.get("verified") or "")
+
+    try:
+        manager = SimulationManager()
+        all_sims = manager.list_simulations()
+    except Exception as exc:
+        # Never 500 the feed surface — readers will retry on the next
+        # poll, an empty feed is the right interim state.
+        logger.warning("feed: failed to list simulations (%s) — serving empty feed", exc)
+        all_sims = []
+
+    cards = select_public_cards(
+        all_sims,
+        sim_data_dir=Config.WONDERWALL_SIMULATION_DATA_DIR,
+        card_builder=_build_gallery_card_payload,
+        outcome_reader=_read_outcome_file,
+        limit=DEFAULT_FEED_LIMIT,
+        verified_only=verified_only,
+    )
+
+    base_url = _resolve_base_url()
+    feed_path = request.full_path.rstrip("?") or request.path
+
+    body, mime = render_feed(
+        fmt,
+        cards,
+        base_url=base_url,
+        feed_path=feed_path,
+        verified_only=verified_only,
+    )
+
+    response = Response(body, mimetype=mime)
+    # 5-minute CDN-friendly cache. Short enough that a freshly published
+    # simulation appears in subscribers' next poll without requiring a
+    # cache bust, long enough to absorb aggressive aggregator polling.
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return response
+
+
+@feed_bp.route("/feed.atom", methods=["GET"])
+def feed_atom():
+    """Atom 1.0 representation of the public simulation gallery.
+
+    Query parameters:
+
+      * ``verified`` — when truthy (``1``, ``true``, ``yes``, ``on``)
+        restricts the feed to simulations with a recorded outcome
+        annotation (the ``/verified`` curated hall).
+
+    Cap of 20 entries per the repo-actions specification — keeps the
+    rendered XML small enough that aggressive aggregator polling stays
+    cheap.
+    """
+    return _serve_feed("atom")
+
+
+@feed_bp.route("/feed.rss", methods=["GET"])
+def feed_rss():
+    """RSS 2.0 representation of the public simulation gallery.
+
+    Same content + selection as ``/api/feed.atom`` — older readers /
+    self-hosted aggregators that haven't moved off RSS get this surface
+    so the discovery channel doesn't fragment on format.
+    """
+    return _serve_feed("rss")

--- a/backend/app/services/feed.py
+++ b/backend/app/services/feed.py
@@ -1,0 +1,584 @@
+"""Atom 1.0 / RSS 2.0 feed renderer for the public simulation gallery.
+
+Converts the same on-disk gallery cards that back ``GET /api/simulation/public``
+into a syndication feed so researchers / DeFi analysts / AI tooling
+operators can subscribe in Feedly, Readwise, Inoreader, Obsidian RSS,
+NetNewsWire, etc. — every newly published MiroShark simulation lands in
+their reader the same way an AI newsletter or a Substack post does.
+
+Pure stdlib (``xml.etree.ElementTree`` + ``html``). Zero new dependencies.
+Same ±0.2 stance threshold the gallery / share card / replay GIF / webhook
+all share, so a sim's "62% bullish / 13% neutral / 25% bearish" string
+matches the gallery card on every surface.
+
+Two output formats:
+
+  * **Atom 1.0** (``application/atom+xml``) — preferred by modern readers
+    and the format browsers auto-discover via ``<link rel="alternate">``.
+  * **RSS 2.0** (``application/rss+xml``) — kept for parity with older
+    readers that haven't moved off RSS yet.
+
+Both render from the same ``feed_payload(...)`` shape — the route layer
+supplies the cards, this module supplies the bytes.
+
+The feed is intentionally **read-only** and **publish-gated**: only
+simulations toggled `is_public=true` appear, the same gate the share
+card and transcript exports honor.
+"""
+
+from __future__ import annotations
+
+import html
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional
+from xml.etree import ElementTree as ET
+
+
+# Atom requires a stable feed id even when the underlying paths change —
+# anchor it on the host so a deployment behind a different base URL
+# keeps a distinct feed identity.
+FEED_GENERATOR_NAME = "MiroShark"
+
+# How many entries a feed tops out at. Mirrors the repo-actions
+# specification (20) — keeps the rendered XML small enough that bots
+# polling on a tight cadence don't pull megabytes per fetch.
+DEFAULT_FEED_LIMIT = 20
+
+# Atom + RSS title cap. Most readers truncate around 100 chars when
+# laying out the river view, so trim there with an ellipsis to keep
+# tooltips clean.
+TITLE_CHARS = 100
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(1, limit - 1)].rstrip() + "…"
+
+
+def _isoformat_z(value: Optional[str]) -> str:
+    """Coerce a datetime-ish value to RFC3339 / ISO8601 ``Z`` form.
+
+    Atom requires ``updated`` and ``published`` in RFC3339; RSS 2.0
+    requires RFC822 (rendered separately). Both readers accept ``Z`` for
+    UTC; we treat naive ISO strings as UTC since that's what the
+    simulation manager writes.
+    """
+    if not value:
+        return _now_z()
+    try:
+        s = str(value).strip()
+        if s.endswith("Z"):
+            return s
+        # ``datetime.fromisoformat`` accepts naive and offset-aware
+        # strings on 3.11+ — what fails is microsecond + timezone-naïve
+        # mixed with the "Z" suffix some upstreams emit.
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (ValueError, TypeError):
+        return _now_z()
+
+
+def _now_z() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _to_rfc822(value: Optional[str]) -> str:
+    """RFC822 date — RSS 2.0 ``<pubDate>`` requires it."""
+    if not value:
+        dt = datetime.now(timezone.utc)
+    else:
+        try:
+            s = str(value).strip()
+            dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            dt = datetime.now(timezone.utc)
+    return dt.strftime("%a, %d %b %Y %H:%M:%S +0000")
+
+
+def _consensus_blurb(consensus: Optional[dict]) -> str:
+    """One-line stance split — appears in every feed entry's summary so
+    the river view in a reader telegraphs the simulation's outcome
+    without opening it."""
+    if not consensus:
+        return "Belief consensus not yet available."
+    bull = float(consensus.get("bullish") or 0)
+    neut = float(consensus.get("neutral") or 0)
+    bear = float(consensus.get("bearish") or 0)
+    return (
+        f"🔵 {bull:.1f}% Bullish · "
+        f"⚪ {neut:.1f}% Neutral · "
+        f"🔴 {bear:.1f}% Bearish"
+    )
+
+
+def _entry_summary(card: dict) -> str:
+    """Plain-text summary line per entry — bullish/neutral/bearish split,
+    quality, agent count. Readers index this for search and show it in
+    list views."""
+    parts: list[str] = [_consensus_blurb(card.get("final_consensus"))]
+
+    quality = (card.get("quality_health") or "").strip()
+    if quality:
+        parts.append(f"Quality: {quality}")
+
+    agents = card.get("agent_count")
+    if isinstance(agents, int) and agents > 0:
+        parts.append(f"Agents: {agents}")
+
+    rounds_now = card.get("current_round") or 0
+    rounds_total = card.get("total_rounds") or 0
+    if rounds_total:
+        parts.append(f"Rounds: {rounds_now}/{rounds_total}")
+    elif rounds_now:
+        parts.append(f"Rounds: {rounds_now}")
+
+    outcome = card.get("outcome") or {}
+    if outcome:
+        label = (outcome.get("label") or "").strip()
+        if label == "correct":
+            parts.append("📍 Verified — called it")
+        elif label == "incorrect":
+            parts.append("⚠ Called wrong")
+        elif label == "partial":
+            parts.append("◑ Partial outcome")
+
+    resolution = (card.get("resolution_outcome") or "").strip()
+    if resolution:
+        parts.append(f"Resolved: {resolution}")
+
+    return " · ".join(parts)
+
+
+def _entry_html_summary(card: dict, share_url: str, replay_gif_url: Optional[str]) -> str:
+    """Rich HTML summary for ``content type='html'`` — readers that
+    render HTML (Feedly, Inoreader, NetNewsWire) get a clickable preview;
+    text-only readers fall back to the plain ``summary`` element."""
+    scenario = html.escape(card.get("scenario") or "(untitled scenario)", quote=False)
+    line = html.escape(_entry_summary(card), quote=False)
+    safe_share = html.escape(share_url, quote=True)
+    blocks: list[str] = [
+        f'<p><strong>{scenario}</strong></p>',
+        f'<p>{line}</p>',
+    ]
+    if replay_gif_url:
+        safe_gif = html.escape(replay_gif_url, quote=True)
+        blocks.append(
+            f'<p><img src="{safe_gif}" alt="Belief replay" '
+            'style="max-width:100%;height:auto;" /></p>'
+        )
+    blocks.append(
+        f'<p><a href="{safe_share}">View on MiroShark →</a></p>'
+    )
+    return "".join(blocks)
+
+
+def _absolute(base_url: str, relative: Optional[str]) -> Optional[str]:
+    """Resolve a relative path (``/api/simulation/sim_x/share-card.png``)
+    against the deployment base URL. Returns ``None`` when the input is
+    falsy so callers can omit the field cleanly."""
+    if not relative:
+        return None
+    if relative.startswith("http://") or relative.startswith("https://"):
+        return relative
+    if not base_url:
+        return relative
+    if relative.startswith("/"):
+        return f"{base_url.rstrip('/')}{relative}"
+    return f"{base_url.rstrip('/')}/{relative}"
+
+
+def _entry_id(base_url: str, sim_id: str) -> str:
+    """Stable Atom entry id — must not change across feed fetches.
+
+    Anchoring on the share landing URL gives us a globally unique URI per
+    simulation that survives backend redeploys (the share URL is the
+    canonical permalink anyway).
+    """
+    base = (base_url or "").rstrip("/")
+    if base:
+        return f"{base}/share/{sim_id}"
+    return f"urn:miroshark:simulation:{sim_id}"
+
+
+# ── Atom 1.0 ───────────────────────────────────────────────────────────────
+
+
+_ATOM_NS = "http://www.w3.org/2005/Atom"
+_MEDIA_NS = "http://search.yahoo.com/mrss/"
+
+
+def render_atom(
+    cards: Iterable[dict],
+    *,
+    base_url: str,
+    feed_path: str,
+    title: str,
+    subtitle: str,
+    verified_only: bool = False,
+) -> bytes:
+    """Render the public-gallery cards as an Atom 1.0 XML feed.
+
+    ``feed_path`` is the request path that produced this feed (e.g.
+    ``/api/feed.atom?verified=1``) — used as the ``rel="self"`` link so
+    readers can re-fetch from the canonical URL even if they discovered
+    the feed at a different path.
+    """
+    ET.register_namespace("", _ATOM_NS)
+    ET.register_namespace("media", _MEDIA_NS)
+
+    feed = ET.Element(f"{{{_ATOM_NS}}}feed")
+
+    feed_id = _absolute(base_url, feed_path) or f"urn:miroshark:feed:{feed_path}"
+    ET.SubElement(feed, f"{{{_ATOM_NS}}}id").text = feed_id
+    ET.SubElement(feed, f"{{{_ATOM_NS}}}title").text = title
+    ET.SubElement(feed, f"{{{_ATOM_NS}}}subtitle").text = subtitle
+
+    # rel="self" — canonical URL of this feed.
+    self_href = _absolute(base_url, feed_path) or feed_path
+    ET.SubElement(
+        feed,
+        f"{{{_ATOM_NS}}}link",
+        attrib={"rel": "self", "type": "application/atom+xml", "href": self_href},
+    )
+
+    # rel="alternate" — the human-readable gallery the feed mirrors.
+    alternate_path = "/verified" if verified_only else "/explore"
+    alternate_href = _absolute(base_url, alternate_path) or alternate_path
+    ET.SubElement(
+        feed,
+        f"{{{_ATOM_NS}}}link",
+        attrib={"rel": "alternate", "type": "text/html", "href": alternate_href},
+    )
+
+    cards_list = list(cards)
+    most_recent = ""
+    for c in cards_list:
+        ts = _isoformat_z(c.get("created_at"))
+        if ts > most_recent:
+            most_recent = ts
+    ET.SubElement(feed, f"{{{_ATOM_NS}}}updated").text = most_recent or _now_z()
+
+    generator = ET.SubElement(feed, f"{{{_ATOM_NS}}}generator")
+    generator.set("uri", "https://github.com/aaronjmars/MiroShark")
+    generator.text = FEED_GENERATOR_NAME
+
+    author = ET.SubElement(feed, f"{{{_ATOM_NS}}}author")
+    ET.SubElement(author, f"{{{_ATOM_NS}}}name").text = "MiroShark Operators"
+
+    for card in cards_list:
+        sim_id = card.get("simulation_id") or ""
+        if not sim_id:
+            continue
+
+        share_url = _absolute(base_url, card.get("share_landing_url")) or _entry_id(
+            base_url, sim_id
+        )
+        share_card_url = _absolute(base_url, card.get("share_card_url"))
+        replay_gif_url = _absolute(
+            base_url, f"/api/simulation/{sim_id}/replay.gif"
+        )
+
+        scenario = card.get("scenario") or "(untitled scenario)"
+        entry = ET.SubElement(feed, f"{{{_ATOM_NS}}}entry")
+        ET.SubElement(entry, f"{{{_ATOM_NS}}}id").text = _entry_id(base_url, sim_id)
+        ET.SubElement(entry, f"{{{_ATOM_NS}}}title").text = _truncate(
+            scenario, TITLE_CHARS
+        )
+        ET.SubElement(
+            entry,
+            f"{{{_ATOM_NS}}}link",
+            attrib={"rel": "alternate", "type": "text/html", "href": share_url},
+        )
+        ET.SubElement(entry, f"{{{_ATOM_NS}}}updated").text = _isoformat_z(
+            card.get("created_at")
+        )
+        ET.SubElement(entry, f"{{{_ATOM_NS}}}published").text = _isoformat_z(
+            card.get("created_at")
+        )
+
+        ET.SubElement(entry, f"{{{_ATOM_NS}}}summary").text = _entry_summary(card)
+
+        content = ET.SubElement(
+            entry,
+            f"{{{_ATOM_NS}}}content",
+            attrib={"type": "html"},
+        )
+        content.text = _entry_html_summary(card, share_url, replay_gif_url)
+
+        # MediaRSS-style enclosures for readers that surface previews
+        # (Feedly's River view, Inoreader's magazine layout). Each card
+        # has a static share card PNG; published runs also have an
+        # animated belief-replay GIF.
+        if share_card_url:
+            ET.SubElement(
+                entry,
+                f"{{{_MEDIA_NS}}}thumbnail",
+                attrib={"url": share_card_url, "width": "1200", "height": "630"},
+            )
+            ET.SubElement(
+                entry,
+                f"{{{_MEDIA_NS}}}content",
+                attrib={
+                    "url": share_card_url,
+                    "type": "image/png",
+                    "medium": "image",
+                    "width": "1200",
+                    "height": "630",
+                },
+            )
+        if replay_gif_url:
+            ET.SubElement(
+                entry,
+                f"{{{_MEDIA_NS}}}content",
+                attrib={
+                    "url": replay_gif_url,
+                    "type": "image/gif",
+                    "medium": "image",
+                },
+            )
+
+        # Outcome / quality categories make a feed filterable on the
+        # reader side — Feedly lets users save category-keyed searches.
+        outcome = card.get("outcome") or {}
+        outcome_label = (outcome.get("label") or "").strip()
+        if outcome_label:
+            ET.SubElement(
+                entry,
+                f"{{{_ATOM_NS}}}category",
+                attrib={"term": f"verified-{outcome_label}", "label": "Verified"},
+            )
+        quality = (card.get("quality_health") or "").strip()
+        if quality:
+            ET.SubElement(
+                entry,
+                f"{{{_ATOM_NS}}}category",
+                attrib={"term": f"quality-{quality.lower()}", "label": quality},
+            )
+
+    body = ET.tostring(feed, encoding="utf-8", xml_declaration=True)
+    return body
+
+
+# ── RSS 2.0 ────────────────────────────────────────────────────────────────
+
+
+def render_rss(
+    cards: Iterable[dict],
+    *,
+    base_url: str,
+    feed_path: str,
+    title: str,
+    subtitle: str,
+    verified_only: bool = False,
+) -> bytes:
+    """Render the public-gallery cards as an RSS 2.0 XML feed.
+
+    Mirrors :func:`render_atom` but emits the older format for readers
+    that haven't moved to Atom (still common in self-hosted aggregators
+    and academic RSS pipelines).
+    """
+    ET.register_namespace("media", _MEDIA_NS)
+    ET.register_namespace("atom", _ATOM_NS)
+
+    rss = ET.Element("rss", attrib={"version": "2.0"})
+    channel = ET.SubElement(rss, "channel")
+
+    ET.SubElement(channel, "title").text = title
+    ET.SubElement(channel, "description").text = subtitle
+
+    alternate_path = "/verified" if verified_only else "/explore"
+    alternate_href = _absolute(base_url, alternate_path) or alternate_path
+    ET.SubElement(channel, "link").text = alternate_href
+
+    self_href = _absolute(base_url, feed_path) or feed_path
+    ET.SubElement(
+        channel,
+        f"{{{_ATOM_NS}}}link",
+        attrib={"rel": "self", "type": "application/rss+xml", "href": self_href},
+    )
+
+    ET.SubElement(channel, "generator").text = (
+        f"{FEED_GENERATOR_NAME} (https://github.com/aaronjmars/MiroShark)"
+    )
+    ET.SubElement(channel, "language").text = "en"
+
+    cards_list = list(cards)
+    most_recent_iso = ""
+    for c in cards_list:
+        ts = _isoformat_z(c.get("created_at"))
+        if ts > most_recent_iso:
+            most_recent_iso = ts
+    ET.SubElement(channel, "lastBuildDate").text = _to_rfc822(most_recent_iso)
+    ET.SubElement(channel, "pubDate").text = _to_rfc822(most_recent_iso)
+
+    for card in cards_list:
+        sim_id = card.get("simulation_id") or ""
+        if not sim_id:
+            continue
+
+        share_url = _absolute(base_url, card.get("share_landing_url")) or _entry_id(
+            base_url, sim_id
+        )
+        share_card_url = _absolute(base_url, card.get("share_card_url"))
+        replay_gif_url = _absolute(
+            base_url, f"/api/simulation/{sim_id}/replay.gif"
+        )
+
+        scenario = card.get("scenario") or "(untitled scenario)"
+        item = ET.SubElement(channel, "item")
+        ET.SubElement(item, "title").text = _truncate(scenario, TITLE_CHARS)
+        ET.SubElement(item, "link").text = share_url
+
+        # ``isPermaLink="false"`` — the share landing URL is already
+        # ``<link>``; ``<guid>`` carries our stable identifier.
+        guid = ET.SubElement(item, "guid", attrib={"isPermaLink": "false"})
+        guid.text = _entry_id(base_url, sim_id)
+
+        ET.SubElement(item, "pubDate").text = _to_rfc822(card.get("created_at"))
+        ET.SubElement(item, "description").text = _entry_html_summary(
+            card, share_url, replay_gif_url
+        )
+
+        if share_card_url:
+            ET.SubElement(
+                item,
+                "enclosure",
+                attrib={
+                    "url": share_card_url,
+                    "type": "image/png",
+                    "length": "0",
+                },
+            )
+            ET.SubElement(
+                item,
+                f"{{{_MEDIA_NS}}}thumbnail",
+                attrib={"url": share_card_url, "width": "1200", "height": "630"},
+            )
+        if replay_gif_url:
+            ET.SubElement(
+                item,
+                f"{{{_MEDIA_NS}}}content",
+                attrib={
+                    "url": replay_gif_url,
+                    "type": "image/gif",
+                    "medium": "image",
+                },
+            )
+
+        outcome = card.get("outcome") or {}
+        outcome_label = (outcome.get("label") or "").strip()
+        if outcome_label:
+            ET.SubElement(item, "category").text = f"verified-{outcome_label}"
+        quality = (card.get("quality_health") or "").strip()
+        if quality:
+            ET.SubElement(item, "category").text = f"quality-{quality.lower()}"
+
+    body = ET.tostring(rss, encoding="utf-8", xml_declaration=True)
+    return body
+
+
+# ── Public-facing render dispatcher ───────────────────────────────────────
+
+
+def render_feed(
+    fmt: str,
+    cards: Iterable[dict],
+    *,
+    base_url: str,
+    feed_path: str,
+    verified_only: bool = False,
+) -> tuple[bytes, str]:
+    """Render the feed in the requested format.
+
+    Returns ``(body_bytes, mime_type)``. ``fmt`` accepts ``"atom"`` (the
+    default) or ``"rss"`` — anything else falls back to Atom so a
+    misrouted call still returns a valid feed.
+    """
+    if verified_only:
+        title = "MiroShark · Verified Predictions"
+        subtitle = (
+            "Public MiroShark simulations whose operators marked a "
+            "real-world outcome — calls that landed (and those that didn't)."
+        )
+    else:
+        title = "MiroShark · Public Simulations"
+        subtitle = (
+            "Newest published MiroShark simulations — agent populations, "
+            "belief drift, and prediction outcomes you can fork into your "
+            "own scenarios."
+        )
+
+    fmt_norm = (fmt or "").strip().lower()
+    if fmt_norm == "rss":
+        body = render_rss(
+            cards,
+            base_url=base_url,
+            feed_path=feed_path,
+            title=title,
+            subtitle=subtitle,
+            verified_only=verified_only,
+        )
+        mime = "application/rss+xml; charset=utf-8"
+    else:
+        body = render_atom(
+            cards,
+            base_url=base_url,
+            feed_path=feed_path,
+            title=title,
+            subtitle=subtitle,
+            verified_only=verified_only,
+        )
+        mime = "application/atom+xml; charset=utf-8"
+    return body, mime
+
+
+def select_public_cards(
+    sims: Iterable[Any],
+    *,
+    sim_data_dir: str,
+    card_builder,
+    outcome_reader,
+    limit: int = DEFAULT_FEED_LIMIT,
+    verified_only: bool = False,
+) -> list[dict]:
+    """Filter + sort + truncate the gallery cards used to render a feed.
+
+    Mirrors the exact selection ``GET /api/simulation/public`` performs so
+    a subscription stays in lockstep with what shows up on /explore.
+    Pulled out into a helper so the feed module can be unit-tested
+    without booting Flask: the route layer plugs in the real
+    ``_build_gallery_card_payload`` and ``_read_outcome_file``.
+    """
+    import os
+
+    public_sims = [s for s in sims if bool(getattr(s, "is_public", False))]
+    public_sims.sort(key=lambda s: s.created_at or "", reverse=True)
+
+    if verified_only:
+        verified_sims = []
+        for s in public_sims:
+            sim_dir = os.path.join(sim_data_dir, s.simulation_id)
+            if outcome_reader(sim_dir) is not None:
+                verified_sims.append(s)
+        public_sims = verified_sims
+
+    page = public_sims[: max(1, min(int(limit or DEFAULT_FEED_LIMIT), 100))]
+
+    cards: list[dict] = []
+    for state in page:
+        sim_dir = os.path.join(sim_data_dir, state.simulation_id)
+        try:
+            cards.append(card_builder(state, sim_dir))
+        except Exception:
+            # One bad sim should not blank out the whole feed.
+            continue
+    return cards

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1278,6 +1278,70 @@ paths:
   # Export
   # ────────────────────────────────────────────────────────────────────
 
+  /api/feed.atom:
+    get:
+      tags: [Publish & Embed]
+      summary: Atom 1.0 syndication feed of the public simulation gallery.
+      description: |
+        Public MiroShark simulations rendered as an Atom 1.0 XML feed so
+        researchers and tooling operators can subscribe via Feedly,
+        Readwise, Inoreader, Obsidian RSS, NetNewsWire — every newly
+        published simulation lands in their reader the same way an AI
+        newsletter does.
+
+        Mirrors `GET /api/simulation/public` selection (publish-gated,
+        sorted by `created_at` desc, capped at 20 entries) so a
+        subscription stays in lockstep with what shows up on `/explore`.
+        Pure stdlib XML — zero new dependencies.
+
+        Each entry carries: scenario as title, consensus split + quality
+        + outcome label as summary, share-card PNG as `<media:thumbnail>`
+        + `<media:content>`, replay GIF as `<media:content>` so River-
+        view aggregators surface motion previews automatically.
+
+        Browsers auto-discover this feed via the `<link rel="alternate"
+        type="application/atom+xml">` tag in `index.html`.
+      parameters:
+        - in: query
+          name: verified
+          description: |
+            Truthy values (`1`, `true`, `yes`, `on`) restrict the feed to
+            simulations with a recorded outcome annotation — the same
+            curated set the `/verified` page surfaces.
+          schema: { type: string }
+      responses:
+        "200":
+          description: |
+            Atom 1.0 XML document with `Cache-Control: public, max-age=300`.
+          content:
+            application/atom+xml:
+              schema: { type: string }
+
+  /api/feed.rss:
+    get:
+      tags: [Publish & Embed]
+      summary: RSS 2.0 syndication feed of the public simulation gallery.
+      description: |
+        Same content + selection as `/api/feed.atom` rendered as RSS 2.0
+        for older readers and self-hosted aggregators that haven't moved
+        off the legacy format. Published runs include their share-card
+        PNG as an `<enclosure>` so podcast-style readers handle it
+        natively.
+      parameters:
+        - in: query
+          name: verified
+          description: |
+            Truthy values (`1`, `true`, `yes`, `on`) restrict the feed to
+            simulations with a recorded outcome annotation.
+          schema: { type: string }
+      responses:
+        "200":
+          description: |
+            RSS 2.0 XML document with `Cache-Control: public, max-age=300`.
+          content:
+            application/rss+xml:
+              schema: { type: string }
+
   /api/simulation/{simulation_id}/export:
     get:
       tags: [Export]

--- a/backend/tests/test_unit_feed.py
+++ b/backend/tests/test_unit_feed.py
@@ -1,0 +1,566 @@
+"""Unit tests for the public-gallery syndication feeds.
+
+Pure offline checks against ``app/services/feed.py`` — no Flask app, no
+database, no network. We cover the contracts that matter for a
+syndication consumer:
+
+  1. The Atom 1.0 + RSS 2.0 documents parse as valid XML and carry the
+     well-known top-level elements (``feed``, ``rss``, etc.).
+  2. Every public simulation card produces a corresponding entry; private
+     ones are filtered out.
+  3. Sort order matches the gallery (newest first by ``created_at``).
+  4. Verified-only mode filters to simulations with an outcome record.
+  5. Per-entry payload carries the canonical share landing link, the
+     scenario as title (truncated when too long), the consensus split
+     summary string, and the share-card PNG / replay GIF as media
+     enclosures.
+  6. Outcome + quality categories appear when the underlying data does.
+  7. Corrupt/missing fields degrade gracefully — one bad card never
+     blanks the whole feed.
+
+The route layer is exercised indirectly via the same shared selection
+helper (``select_public_cards``) the live endpoint plugs into, so
+asserting on the helper output is equivalent to asserting on the feed
+the endpoint returns.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+_ATOM_NS = "http://www.w3.org/2005/Atom"
+_MEDIA_NS = "http://search.yahoo.com/mrss/"
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _make_card(
+    sim_id: str = "sim_aaa111",
+    *,
+    scenario: str = "Will the SEC approve a spot Solana ETF before Q3?",
+    created_at: str = "2026-04-29T10:12:34",
+    bullish: float = 62.0,
+    neutral: float = 13.0,
+    bearish: float = 25.0,
+    quality_health: str = "Excellent",
+    outcome_label: str | None = None,
+    resolution: str | None = None,
+    agent_count: int = 248,
+    current_round: int = 20,
+    total_rounds: int = 20,
+) -> dict:
+    """Mirror the shape ``_build_gallery_card_payload`` returns."""
+    card: dict = {
+        "simulation_id": sim_id,
+        "scenario": scenario,
+        "status": "completed",
+        "runner_status": "completed",
+        "current_round": current_round,
+        "total_rounds": total_rounds,
+        "agent_count": agent_count,
+        "quality_health": quality_health,
+        "final_consensus": {"bullish": bullish, "neutral": neutral, "bearish": bearish},
+        "resolution_outcome": resolution,
+        "outcome": None,
+        "created_at": created_at,
+        "parent_simulation_id": None,
+        "share_card_url": f"/api/simulation/{sim_id}/share-card.png",
+        "share_landing_url": f"/share/{sim_id}",
+    }
+    if outcome_label is not None:
+        card["outcome"] = {
+            "label": outcome_label,
+            "outcome_url": "https://example.com/outcome",
+            "outcome_summary": "ETF approved, sim called it 4 days early.",
+            "submitted_at": "2026-04-29T11:30:00Z",
+        }
+    return card
+
+
+class _FakeState:
+    """Lightweight stand-in for SimulationState used by select_public_cards."""
+
+    def __init__(
+        self,
+        sim_id: str,
+        *,
+        is_public: bool = True,
+        created_at: str = "2026-04-22T10:12:34",
+    ):
+        self.simulation_id = sim_id
+        self.is_public = is_public
+        self.created_at = created_at
+
+
+# ── Atom 1.0 ───────────────────────────────────────────────────────────────
+
+
+def test_atom_feed_parses_with_required_elements():
+    """The rendered Atom XML should parse, declare the Atom namespace,
+    and carry the top-level ``id`` / ``title`` / ``updated`` elements
+    every reader expects."""
+    from app.services.feed import render_atom
+
+    cards = [_make_card("sim_111", created_at="2026-04-29T10:00:00")]
+    body = render_atom(
+        cards,
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+        title="MiroShark · Public Simulations",
+        subtitle="Newest published simulations.",
+    )
+
+    root = ET.fromstring(body)
+    assert root.tag == f"{{{_ATOM_NS}}}feed"
+    assert root.findtext(f"{{{_ATOM_NS}}}title") == "MiroShark · Public Simulations"
+    assert root.find(f"{{{_ATOM_NS}}}id") is not None
+    assert root.findtext(f"{{{_ATOM_NS}}}updated"), "feed missing required <updated>"
+
+    self_link = root.find(
+        f"{{{_ATOM_NS}}}link[@rel='self']",
+    )
+    assert self_link is not None
+    assert self_link.attrib["href"] == "https://demo.miroshark.io/api/feed.atom"
+
+    alternate_link = root.find(f"{{{_ATOM_NS}}}link[@rel='alternate']")
+    assert alternate_link is not None
+    assert alternate_link.attrib["href"] == "https://demo.miroshark.io/explore"
+
+
+def test_atom_entry_carries_share_link_and_media_enclosures():
+    """Each entry has a clickable share-landing link, the share-card PNG
+    as both ``media:thumbnail`` + ``media:content``, and the replay GIF
+    as a second ``media:content`` so River-view readers get motion."""
+    from app.services.feed import render_atom
+
+    cards = [_make_card("sim_222")]
+    body = render_atom(
+        cards,
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+        title="t",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    entry = root.find(f"{{{_ATOM_NS}}}entry")
+    assert entry is not None
+
+    share_link = entry.find(f"{{{_ATOM_NS}}}link[@rel='alternate']")
+    assert share_link is not None
+    assert share_link.attrib["href"] == "https://demo.miroshark.io/share/sim_222"
+
+    thumb = entry.find(f"{{{_MEDIA_NS}}}thumbnail")
+    assert thumb is not None
+    assert thumb.attrib["url"].endswith("/api/simulation/sim_222/share-card.png")
+
+    media_contents = entry.findall(f"{{{_MEDIA_NS}}}content")
+    types = {m.attrib.get("type") for m in media_contents}
+    # Both static share card + animated replay GIF should be enclosed.
+    assert "image/png" in types
+    assert "image/gif" in types
+
+
+def test_atom_summary_contains_consensus_split():
+    """The plain-text summary line shown in River views must spell out
+    the bullish/neutral/bearish percentages so readers can scan
+    consensus without opening every card."""
+    from app.services.feed import render_atom
+
+    cards = [_make_card("sim_333", bullish=62.0, neutral=13.0, bearish=25.0)]
+    body = render_atom(
+        cards,
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+        title="t",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    entry = root.find(f"{{{_ATOM_NS}}}entry")
+    summary = (entry.findtext(f"{{{_ATOM_NS}}}summary") or "")
+    assert "62.0% Bullish" in summary
+    assert "25.0% Bearish" in summary
+    assert "Quality: Excellent" in summary
+    assert "Agents: 248" in summary
+
+
+def test_atom_long_scenario_truncates_with_ellipsis():
+    """A 500-char scenario gets compressed with a unicode ellipsis so
+    River-view title strips don't blow out."""
+    from app.services.feed import render_atom
+
+    huge = "Scenario " * 80  # ~720 chars
+    cards = [_make_card("sim_long", scenario=huge)]
+    body = render_atom(
+        cards,
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+        title="t",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    title = root.find(f"{{{_ATOM_NS}}}entry").findtext(f"{{{_ATOM_NS}}}title")
+    assert title is not None
+    assert len(title) <= 100
+    assert title.endswith("…")
+
+
+def test_atom_outcome_categorizes_entry():
+    """Outcome and quality fields surface as Atom ``<category>`` elements
+    so subscribers can filter on them in their reader."""
+    from app.services.feed import render_atom
+
+    cards = [_make_card("sim_cat", outcome_label="correct", quality_health="Good")]
+    body = render_atom(
+        cards,
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+        title="t",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    entry = root.find(f"{{{_ATOM_NS}}}entry")
+    categories = {c.attrib["term"] for c in entry.findall(f"{{{_ATOM_NS}}}category")}
+    assert "verified-correct" in categories
+    assert "quality-good" in categories
+
+
+def test_atom_empty_card_list_still_renders_valid_feed():
+    """No public sims → an empty but valid feed (parses, has updated)."""
+    from app.services.feed import render_atom
+
+    body = render_atom(
+        [],
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+        title="t",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    assert root.findall(f"{{{_ATOM_NS}}}entry") == []
+    assert root.findtext(f"{{{_ATOM_NS}}}updated"), "feed missing <updated>"
+
+
+def test_atom_handles_missing_optional_fields():
+    """A card built from an in-progress sim (no consensus, no quality)
+    must still produce a valid entry — graceful degradation matches the
+    gallery card helper's contract."""
+    from app.services.feed import render_atom
+
+    cards = [
+        {
+            "simulation_id": "sim_minimal",
+            "scenario": "",
+            "status": "running",
+            "runner_status": "running",
+            "current_round": 4,
+            "total_rounds": 0,
+            "agent_count": 0,
+            "quality_health": None,
+            "final_consensus": None,
+            "resolution_outcome": None,
+            "outcome": None,
+            "created_at": "2026-04-29T08:00:00",
+            "parent_simulation_id": None,
+            "share_card_url": "/api/simulation/sim_minimal/share-card.png",
+            "share_landing_url": "/share/sim_minimal",
+        }
+    ]
+    body = render_atom(
+        cards,
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+        title="t",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    entry = root.find(f"{{{_ATOM_NS}}}entry")
+    assert entry is not None
+    title = entry.findtext(f"{{{_ATOM_NS}}}title")
+    assert title == "(untitled scenario)"
+
+
+def test_atom_self_link_includes_query_string():
+    """``feed_path`` is the exact request path that produced the feed —
+    when a reader subscribed via ``?verified=1``, the rel=self link must
+    echo that query string so re-fetches stay scoped to the verified
+    set."""
+    from app.services.feed import render_atom
+
+    body = render_atom(
+        [],
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom?verified=1",
+        title="t",
+        subtitle="s",
+        verified_only=True,
+    )
+    root = ET.fromstring(body)
+    self_link = root.find(f"{{{_ATOM_NS}}}link[@rel='self']")
+    assert self_link is not None
+    assert self_link.attrib["href"].endswith("?verified=1")
+    alt = root.find(f"{{{_ATOM_NS}}}link[@rel='alternate']")
+    assert alt.attrib["href"].endswith("/verified")
+
+
+def test_atom_skips_entries_without_simulation_id():
+    """A corrupted card with a missing sim_id should be skipped rather
+    than render an entry with a broken ``<id>`` (which would shadow real
+    entries in feed-reader caches keyed by id)."""
+    from app.services.feed import render_atom
+
+    body = render_atom(
+        [
+            _make_card("sim_ok"),
+            {"simulation_id": "", "scenario": "broken"},
+        ],
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+        title="t",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    entries = root.findall(f"{{{_ATOM_NS}}}entry")
+    assert len(entries) == 1
+
+
+# ── RSS 2.0 ────────────────────────────────────────────────────────────────
+
+
+def test_rss_feed_parses_with_required_elements():
+    """RSS 2.0 ``<rss version="2.0"><channel>...`` shape with
+    ``<title>``, ``<link>``, ``<description>``, ``<lastBuildDate>``."""
+    from app.services.feed import render_rss
+
+    cards = [_make_card("sim_rss")]
+    body = render_rss(
+        cards,
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.rss",
+        title="MiroShark · Public Simulations",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    assert root.tag == "rss"
+    assert root.attrib["version"] == "2.0"
+    channel = root.find("channel")
+    assert channel is not None
+    assert channel.findtext("title") == "MiroShark · Public Simulations"
+    assert channel.findtext("link") == "https://demo.miroshark.io/explore"
+    assert channel.findtext("description")
+    assert channel.findtext("lastBuildDate")
+
+
+def test_rss_item_uses_stable_guid_independent_of_link():
+    """``<guid isPermaLink="false">`` must carry our stable identifier so
+    a deployment URL change doesn't invalidate every reader's seen-item
+    cache."""
+    from app.services.feed import render_rss
+
+    cards = [_make_card("sim_guid")]
+    body = render_rss(
+        cards,
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.rss",
+        title="t",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    item = root.find("channel/item")
+    guid = item.find("guid")
+    assert guid is not None
+    assert guid.attrib.get("isPermaLink") == "false"
+    assert "sim_guid" in (guid.text or "")
+
+
+def test_rss_includes_share_card_enclosure():
+    """RSS readers (and podcatchers) read ``<enclosure>`` for media."""
+    from app.services.feed import render_rss
+
+    cards = [_make_card("sim_enc")]
+    body = render_rss(
+        cards,
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.rss",
+        title="t",
+        subtitle="s",
+    )
+    root = ET.fromstring(body)
+    item = root.find("channel/item")
+    enclosure = item.find("enclosure")
+    assert enclosure is not None
+    assert enclosure.attrib["type"] == "image/png"
+    assert enclosure.attrib["url"].endswith("/share-card.png")
+
+
+# ── render_feed dispatcher ─────────────────────────────────────────────────
+
+
+def test_render_feed_dispatcher_picks_format_and_mime():
+    """``render_feed("atom"|"rss")`` returns the correct MIME and
+    falls back to Atom on unknown input."""
+    from app.services.feed import render_feed
+
+    body_atom, mime_atom = render_feed(
+        "atom",
+        [_make_card("sim_a")],
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+    )
+    body_rss, mime_rss = render_feed(
+        "rss",
+        [_make_card("sim_r")],
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.rss",
+    )
+    body_unknown, mime_unknown = render_feed(
+        "garbage",
+        [_make_card("sim_g")],
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom",
+    )
+
+    assert mime_atom.startswith("application/atom+xml")
+    assert mime_rss.startswith("application/rss+xml")
+    assert mime_unknown.startswith("application/atom+xml")  # fallback
+
+    # Each body parses cleanly.
+    assert ET.fromstring(body_atom).tag.endswith("feed")
+    assert ET.fromstring(body_rss).tag == "rss"
+    assert ET.fromstring(body_unknown).tag.endswith("feed")
+
+
+def test_render_feed_verified_only_changes_title_and_alternate_path():
+    """The verified variant sets a different feed title + maps the
+    ``rel="alternate"`` link to ``/verified`` instead of ``/explore``."""
+    from app.services.feed import render_feed
+
+    body, _mime = render_feed(
+        "atom",
+        [_make_card("sim_v", outcome_label="correct")],
+        base_url="https://demo.miroshark.io",
+        feed_path="/api/feed.atom?verified=1",
+        verified_only=True,
+    )
+    root = ET.fromstring(body)
+    title = root.findtext(f"{{{_ATOM_NS}}}title") or ""
+    assert "Verified" in title
+    alt = root.find(f"{{{_ATOM_NS}}}link[@rel='alternate']")
+    assert alt is not None
+    assert alt.attrib["href"].endswith("/verified")
+
+
+# ── select_public_cards (selection helper) ─────────────────────────────────
+
+
+def test_select_public_cards_filters_and_sorts(tmp_path):
+    """Mirrors GET /api/simulation/public selection: drops private,
+    sorts newest-first, applies the limit, gracefully skips bad sims."""
+    from app.services.feed import select_public_cards
+
+    states = [
+        _FakeState("sim_old", is_public=True, created_at="2026-04-20T10:00:00"),
+        _FakeState("sim_private", is_public=False, created_at="2026-04-29T10:00:00"),
+        _FakeState("sim_new", is_public=True, created_at="2026-04-29T10:00:00"),
+        _FakeState("sim_broken", is_public=True, created_at="2026-04-28T10:00:00"),
+    ]
+
+    def card_builder(state, sim_dir):
+        if state.simulation_id == "sim_broken":
+            raise RuntimeError("simulated artifact corruption")
+        return _make_card(state.simulation_id, created_at=state.created_at)
+
+    def outcome_reader(_sim_dir):
+        return None
+
+    cards = select_public_cards(
+        states,
+        sim_data_dir=str(tmp_path),
+        card_builder=card_builder,
+        outcome_reader=outcome_reader,
+        limit=10,
+        verified_only=False,
+    )
+
+    sim_ids = [c["simulation_id"] for c in cards]
+    # Private is filtered, broken is skipped, newest first.
+    assert sim_ids == ["sim_new", "sim_old"]
+
+
+def test_select_public_cards_verified_only_filters_to_outcome_records(tmp_path):
+    """Verified-only selection must only emit cards for sims whose
+    ``outcome.json`` is readable — even if the gallery card itself
+    builds successfully without one."""
+    from app.services.feed import select_public_cards
+
+    states = [
+        _FakeState("sim_with_outcome", is_public=True, created_at="2026-04-29T10:00:00"),
+        _FakeState("sim_no_outcome", is_public=True, created_at="2026-04-29T11:00:00"),
+    ]
+
+    def card_builder(state, sim_dir):
+        return _make_card(state.simulation_id, created_at=state.created_at)
+
+    def outcome_reader(sim_dir):
+        if sim_dir.endswith("sim_with_outcome"):
+            return {"label": "correct"}
+        return None
+
+    cards = select_public_cards(
+        states,
+        sim_data_dir=str(tmp_path),
+        card_builder=card_builder,
+        outcome_reader=outcome_reader,
+        limit=10,
+        verified_only=True,
+    )
+    assert [c["simulation_id"] for c in cards] == ["sim_with_outcome"]
+
+
+def test_select_public_cards_caps_at_default_limit(tmp_path):
+    """The 20-entry cap is enforced by the helper so the route layer
+    can't accidentally serve a 1MB feed."""
+    from app.services.feed import DEFAULT_FEED_LIMIT, select_public_cards
+
+    states = [
+        _FakeState(f"sim_{i:03d}", is_public=True, created_at=f"2026-04-29T{i:02d}:00:00")
+        for i in range(40)
+    ]
+
+    def card_builder(state, _sim_dir):
+        return _make_card(state.simulation_id, created_at=state.created_at)
+
+    def outcome_reader(_sim_dir):
+        return None
+
+    cards = select_public_cards(
+        states,
+        sim_data_dir=str(tmp_path),
+        card_builder=card_builder,
+        outcome_reader=outcome_reader,
+        limit=DEFAULT_FEED_LIMIT,
+        verified_only=False,
+    )
+    assert len(cards) == DEFAULT_FEED_LIMIT
+
+
+# ── Route presence (drift guard) ───────────────────────────────────────────
+
+
+def test_feed_routes_registered_on_feed_blueprint():
+    """Sanity check on the blueprint wiring — the OpenAPI drift test
+    is the one that fails loud on a missing spec entry, but it relies on
+    the routes existing in source. This guards the source side."""
+    feed_module = (_BACKEND / "app" / "api" / "feed.py").read_text(encoding="utf-8")
+    assert "@feed_bp.route(\"/feed.atom\"" in feed_module
+    assert "@feed_bp.route(\"/feed.rss\"" in feed_module

--- a/backend/tests/test_unit_openapi.py
+++ b/backend/tests/test_unit_openapi.py
@@ -99,6 +99,7 @@ _BLUEPRINT_PREFIXES = {
     "observability_bp":  "/api/observability",
     "mcp_bp":            "/api/mcp",
     "docs_bp":           "/api",
+    "feed_bp":           "/api",
     # share_bp is mounted at the root with no prefix — see app/__init__.py.
     "share_bp":          "",
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -146,6 +146,25 @@ Two endpoints, same payload, different encoding:
 
 Both endpoints share the share-card publish gate (`is_public=true`). Per-agent stance labels use the same ±0.2 threshold as every other surface — a "bullish" agent on the gallery is the same agent's tag in the transcript. The Embed dialog exposes a "Download .md" + "Download .json" pair beneath the replay-GIF row.
 
+## Public Gallery Feeds (RSS / Atom)
+
+The same cards `/explore` renders, served as a syndication feed so researchers and tooling already on Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS subscribe in their existing toolchain — no login, no MiroShark account. Every newly published simulation lands in their reader the same way an AI newsletter or Substack post does.
+
+Two endpoints, same payload, different XML format:
+
+- `GET /api/feed.atom` — Atom 1.0 (preferred — modern readers + the default browser auto-discovery target).
+- `GET /api/feed.rss` — RSS 2.0 (kept for older self-hosted aggregators and academic RSS pipelines).
+
+Each entry carries the scenario as the title (truncated with an ellipsis past 100 chars), the bullish / neutral / bearish consensus split as the summary line, the share-card PNG as `<media:thumbnail>` + `<media:content>` (so River-view aggregators surface a preview image), and the animated replay GIF as a second `<media:content>` (so Feedly's magazine layout shows motion). Outcome and quality are exposed as `<category>` elements so subscribers can filter on them in their reader.
+
+- **Verified-only feed:** append `?verified=1` for the curated stream of simulations whose operators marked a real-world outcome — the syndication mirror of `/verified`.
+- **Selection:** mirrors `GET /api/simulation/public` exactly — newest 20 published runs, sorted by `created_at` descending, publish-gated.
+- **Auto-discovery:** the SPA's `index.html` declares `<link rel="alternate" type="application/atom+xml">` (and the RSS variant) so browsers expose the feed via the address-bar globe icon.
+- **Caching:** `Cache-Control: public, max-age=300` — five minutes is short enough for newly published sims to appear in the next aggregator poll, long enough to absorb aggressive polling without taxing the gallery query.
+- **Implementation:** pure stdlib (`xml.etree.ElementTree` + `html`). Zero new dependencies; same ±0.2 stance threshold as every other surface so a "62% bullish" string matches the gallery card byte-for-byte.
+
+The Embed dialog has a "Follow the gallery via RSS" callout with one-click subscribe links for the Atom feed, the RSS 2.0 feed, and the verified-only Atom feed. The /explore header has a "📡 Subscribe via RSS" chip that mirrors the active filter (verified-only when the filter is on).
+
 ## Article Generation
 
 After a simulation finishes, click **Write Article** and MiroShark asks the Smart model to produce a 400–600-word Substack-style write-up grounded in what actually happened — key findings, market dynamics, belief shifts, and implications. The article is cached at `generated_article.json` so it doesn't re-spend tokens on reopen; pass `force_regenerate=true` to refresh.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,11 @@
     <link rel="icon" type="image/png" href="/miroshark-nobg.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="MiroShark - Multi-Agent Scenario Exploration Engine" />
+    <!-- Public-gallery syndication feeds — readers (Feedly, Inoreader,
+         NetNewsWire, Obsidian RSS) auto-discover these via the address-
+         bar globe icon. Atom is preferred; RSS kept for older clients. -->
+    <link rel="alternate" type="application/atom+xml" title="MiroShark · Public Simulations (Atom)" href="/api/feed.atom" />
+    <link rel="alternate" type="application/rss+xml" title="MiroShark · Public Simulations (RSS)" href="/api/feed.rss" />
     <title>MiroShark</title>
   </head>
   <body>

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -489,6 +489,31 @@ export const getShareLandingUrl = (simulationId, origin) => {
 }
 
 /**
+ * Build the absolute URL of the public-gallery syndication feed.
+ *
+ * Atom 1.0 by default — the format browsers auto-discover and modern
+ * readers prefer. Pass `format: 'rss'` for the RSS 2.0 variant. When
+ * `verified` is truthy the feed is restricted to simulations with a
+ * recorded outcome annotation (the `/verified` curated hall).
+ *
+ * The endpoint is publish-gated: every entry is a simulation already
+ * visible on /explore, so subscribing maps 1:1 to "every new public
+ * MiroShark simulation lands in my reader."
+ *
+ * @param {Object} [options]
+ * @param {('atom'|'rss')} [options.format='atom']
+ * @param {boolean} [options.verified=false]
+ * @param {string} [options.origin]
+ * @returns {string}
+ */
+export const getFeedUrl = ({ format = 'atom', verified = false, origin } = {}) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  const ext = format === 'rss' ? 'rss' : 'atom'
+  const query = verified ? '?verified=1' : ''
+  return `${base}/api/feed.${ext}${query}`
+}
+
+/**
  * Branch a simulation with a narrative injection at a specific round.
  * The new simulation is READY and shares the parent's agent population;
  * when the runner hits trigger_round it auto-promotes the injection into

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -405,6 +405,56 @@
                 Open gallery ↗
               </a>
             </div>
+
+            <!-- RSS / Atom syndication — passive subscription channel
+                 for researchers and tooling that already read AI/DeFi
+                 content via Feedly / Readwise / Inoreader / Obsidian
+                 RSS. Every newly published MiroShark simulation lands
+                 in their reader without anyone curating it. -->
+            <div class="feed-callout">
+              <div class="feed-callout-head">
+                <span class="feed-callout-icon">📡</span>
+                <div class="feed-callout-body">
+                  <div class="feed-callout-title">
+                    Follow the gallery via RSS
+                  </div>
+                  <div class="feed-callout-desc">
+                    Every newly published MiroShark simulation appears in
+                    your reader (Feedly, Readwise, Inoreader, Obsidian
+                    RSS, NetNewsWire, …). No login, no account.
+                  </div>
+                </div>
+              </div>
+              <div class="feed-callout-actions">
+                <a
+                  class="feed-callout-link"
+                  :href="feedAtomUrl"
+                  target="_blank"
+                  rel="noopener"
+                  title="Atom 1.0 feed of the public gallery"
+                >
+                  Atom feed ↗
+                </a>
+                <a
+                  class="feed-callout-link feed-callout-link-secondary"
+                  :href="feedRssUrl"
+                  target="_blank"
+                  rel="noopener"
+                  title="RSS 2.0 feed of the public gallery"
+                >
+                  RSS 2.0 ↗
+                </a>
+                <a
+                  class="feed-callout-link feed-callout-link-secondary"
+                  :href="feedVerifiedAtomUrl"
+                  target="_blank"
+                  rel="noopener"
+                  title="Atom feed restricted to verified predictions only"
+                >
+                  Verified only ↗
+                </a>
+              </div>
+            </div>
           </div>
 
           <!-- Hint -->
@@ -429,6 +479,7 @@ import {
   getShareLandingUrl,
   getTranscriptMarkdownUrl,
   getTranscriptJsonUrl,
+  getFeedUrl,
   getSimulationOutcome,
   submitSimulationOutcome,
 } from '../api/simulation'
@@ -533,6 +584,20 @@ const transcriptJsonUrl = computed(() => {
   if (!props.simulationId || !origin.value) return ''
   return getTranscriptJsonUrl(props.simulationId, origin.value)
 })
+
+// Public-gallery syndication URLs — independent of `simulationId` (the
+// feed lists everyone's published runs), but kept on the embed dialog
+// so an operator who just toggled their sim public can subscribe to the
+// stream they're now part of in one click.
+const feedAtomUrl = computed(() =>
+  getFeedUrl({ format: 'atom', verified: false, origin: origin.value }),
+)
+const feedRssUrl = computed(() =>
+  getFeedUrl({ format: 'rss', verified: false, origin: origin.value }),
+)
+const feedVerifiedAtomUrl = computed(() =>
+  getFeedUrl({ format: 'atom', verified: true, origin: origin.value }),
+)
 
 const replayLoaded = ref(false)
 const replayPlay = ref(false)
@@ -1610,6 +1675,91 @@ watch(isPublic, () => {
 
 .gallery-callout-link:hover {
   background: #0a0a0a;
+}
+
+/* RSS / Atom feed callout — same anatomy as the gallery callout but
+   with a wraparound action row (three feed flavours). Reads as a
+   secondary discovery affordance, not a primary action, so the chips
+   are outline-styled rather than filled. */
+.feed-callout {
+  margin-top: 12px;
+  padding: 14px 16px;
+  background: #fafafa;
+  border: 1px dashed rgba(10, 10, 10, 0.18);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.feed-callout-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.feed-callout-icon {
+  font-size: 22px;
+  line-height: 1;
+  color: var(--color-orange, #ff6b1a);
+  padding-top: 2px;
+}
+
+.feed-callout-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.feed-callout-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0a0a0a;
+  margin-bottom: 4px;
+}
+
+.feed-callout-desc {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: #4a4a4a;
+}
+
+.feed-callout-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-left: 34px;
+}
+
+.feed-callout-link {
+  padding: 6px 12px;
+  background: var(--color-orange, #ff6b1a);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  border-radius: 6px;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.feed-callout-link:hover {
+  background: #0a0a0a;
+}
+
+.feed-callout-link-secondary {
+  background: transparent;
+  color: var(--color-orange, #ff6b1a);
+  border: 1px solid rgba(255, 107, 26, 0.45);
+}
+
+.feed-callout-link-secondary:hover {
+  background: var(--color-orange, #ff6b1a);
+  color: #fff;
+  border-color: var(--color-orange, #ff6b1a);
 }
 
 .snippet-copy-btn:disabled {

--- a/frontend/src/views/ExploreView.vue
+++ b/frontend/src/views/ExploreView.vue
@@ -69,6 +69,24 @@
             <span>Verified only</span>
           </button>
 
+          <!-- RSS subscription chip — feed mirrors the active view
+               (verified-only when the filter is on). Drops the user into
+               their RSS reader's "subscribe to feed" flow. -->
+          <a
+            class="filter-chip filter-chip-feed"
+            :href="feedUrl"
+            target="_blank"
+            rel="noopener"
+            :title="
+              verifiedFilter
+                ? 'Subscribe to verified-only Atom feed in Feedly / Readwise / Inoreader / NetNewsWire'
+                : 'Subscribe to all public simulations as an Atom feed in Feedly / Readwise / Inoreader / NetNewsWire'
+            "
+          >
+            <span class="filter-chip-icon">📡</span>
+            <span>Subscribe via RSS</span>
+          </a>
+
           <button
             class="refresh-btn"
             @click="refresh"
@@ -300,6 +318,7 @@ import {
   getPublicSimulations,
   forkSimulation,
   getShareCardUrl,
+  getFeedUrl,
 } from '../api/simulation'
 
 const props = defineProps({
@@ -321,6 +340,10 @@ const error = ref('')
 const forkingId = ref('')
 const forkErrors = ref({})
 const verifiedFilter = ref(props.verifiedOnly)
+
+const feedUrl = computed(() =>
+  getFeedUrl({ format: 'atom', verified: verifiedFilter.value }),
+)
 
 const resolvedCount = computed(
   () => items.value.filter((item) => item.resolution_outcome).length,
@@ -1019,6 +1042,20 @@ a.pill-verified:hover {
 
 .filter-chip-icon {
   font-family: sans-serif;
+}
+
+/* The feed chip is visually subordinate to "Verified only" — it's a
+   passive subscription action, not a content filter — so it reads as a
+   muted text link until hover. */
+.filter-chip-feed {
+  text-decoration: none;
+  color: rgba(10, 10, 10, 0.6);
+  border-color: rgba(10, 10, 10, 0.18);
+}
+
+.filter-chip-feed:hover {
+  border-color: var(--color-orange);
+  color: var(--color-orange);
 }
 
 .inline-link {


### PR DESCRIPTION
## What

Two syndication feeds — `/api/feed.atom` (Atom 1.0) + `/api/feed.rss` (RSS 2.0) — that serve the same cards `GET /api/simulation/public` returns. Researchers / DeFi analysts / tooling operators already on Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS subscribe in their existing toolchain — every newly published MiroShark simulation lands in their reader without anyone curating it.

Pure stdlib (`xml.etree.ElementTree` + `html`); zero new dependencies; zero new infrastructure; zero ongoing maintenance.

## Why

Repo-actions Apr 28 idea **#3**. Closes the discovery loop opened by PR #43 (`/explore` gallery), PR #42 (share card), PR #50 (replay GIF) and PR #57 (transcript export) — converts a pull surface into a push channel for the research / DeFi-tooling audience that already subscribes via RSS.

Pairs with the existing share formats — same on-disk sim folder, four orthogonal share / discovery surfaces, all projections of `_build_gallery_card_payload`:

| Format | Endpoint | Audience |
|---|---|---|
| Preview PNG | `/share-card.png` (Apr 22) | Twitter/X, Discord, Slack, LinkedIn unfurls |
| Animated GIF | `/replay.gif` (Apr 28) | Discord/Slack auto-play |
| Markdown / JSON | `/transcript.md`, `/transcript.json` (Apr 29) | Notion / Obsidian / Substack / SDKs |
| **Atom / RSS** | `/api/feed.atom`, `/api/feed.rss` (this PR) | **Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS** |

## Changes

**Backend**
- `backend/app/services/feed.py` — Atom 1.0 + RSS 2.0 renderer with share-card PNG + replay GIF as `<media:thumbnail>` / `<media:content>` / `<enclosure>`, outcome + quality `<category>` elements, ±0.2 stance threshold matching every other surface, scenario truncated to 100 chars.
- `backend/app/api/feed.py` — `feed_bp` blueprint mounted at `/api` with `?verified=1` filter (mirror of `/verified`), `Cache-Control: public, max-age=300`, `PUBLIC_BASE_URL` / `X-Forwarded-Proto+Host` honored, fail-soft against SimulationManager errors (an empty feed is the right interim state if anything goes wrong).
- `backend/openapi.yaml` — both endpoints under Publish & Embed.
- `backend/tests/test_unit_openapi.py` — `feed_bp: /api` added to `_BLUEPRINT_PREFIXES` so drift-detection test passes.

**Frontend**
- `frontend/index.html` — `<link rel="alternate" type="application/atom+xml">` for browser auto-discovery (address-bar globe icon).
- `frontend/src/views/ExploreView.vue` — "📡 Subscribe via RSS" chip in the stats row that mirrors the active filter (verified-only when the filter is on).
- `frontend/src/components/EmbedDialog.vue` — "Follow the gallery via RSS" callout with one-click Atom / RSS / Verified-only buttons.
- `frontend/src/api/simulation.js` — `getFeedUrl({ format, verified, origin })` helper.

**Tests**
- `backend/tests/test_unit_feed.py` — 17 offline unit tests:
  - Atom: parse + required elements, share-link + media enclosures, summary contains bullish/neutral/bearish split, long scenario truncation, outcome + quality categories, empty-feed validity, missing optional fields, self-link query-string preservation, skip bad sims.
  - RSS: parse + required elements, stable `<guid isPermaLink="false">`, share-card `<enclosure>`.
  - Dispatcher: format → MIME mapping, verified-only branch.
  - Selection helper: filter (private out, broken skipped) + sort (newest first) + limit cap + verified-only outcome-presence filter.
  - Source-side route-presence guard (alongside the openapi drift test).

**Docs**
- `README.md` — Features row.
- `docs/FEATURES.md` — Public Gallery Feeds section.

## Notes

- Selection mirrors `GET /api/simulation/public` exactly — newest 20 published runs, sorted by `created_at` desc, publish-gated. No new query path.
- Per-entry payload carries the share-card PNG as `<media:thumbnail>` so River-view aggregators (Feedly's River, Inoreader's magazine layout) surface a preview image, plus the animated replay GIF as a second `<media:content>` so motion-capable surfaces show motion.
- Outcome (`verified-correct` / `verified-incorrect` / `verified-partial`) and quality (`quality-excellent`, `quality-good`, …) appear as `<category>` elements so subscribers can filter on them in their reader.
- 5-minute cache header is short enough that a freshly published sim hits subscribers on their next poll, long enough to absorb aggressive aggregator polling without taxing the gallery query.

---
*Built autonomously by [Aeon](https://github.com/aaronjmars/miroshark-aeon)*