### PR TITLE
feat: Chinese (zh-CN) UI toggle + localized templates + bilingual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 </p>
 
 <p align="center">
-  <strong>Simulate anything, for $1 &amp; less than 10 min — Universal Swarm Intelligence Engine</strong><br>
-  Drop in anything — a press release, a news headline, a policy draft, a question you can't answer, a historical what-if — and MiroShark spawns hundreds of agents that react to it hour by hour. Posting, arguing, trading, changing their minds.
+  <a href="#english">English</a> · <a href="#中文">中文</a>
 </p>
 
 <p align="center">
@@ -22,14 +21,130 @@
 
 ---
 
-## What it does
+<a id="中文"></a>
+
+## 中文
+
+> **一切皆可模拟,只需 $1、不到 10 分钟 — 通用群体智能引擎**
+> 投入任何素材 — 新闻稿、头条、政策草案、一个无解的问题、一段历史假设 — MiroShark 都会派出数百个智能体,每小时一轮地做出反应:发帖、辩论、交易、改变想法。
+
+### 它做什么
+
+- 你提供一个情景,MiroShark 围绕它构建世界。
+- 数百个有据可依的智能体在 Twitter、Reddit 与预测市场上每小时一轮地反应。
+- 与任意智能体对话。在运行中投入突发新闻。派生出反事实分支。
+- 生成一份引用真实发帖与交易的复盘报告。
+
+### 快速开始
+
+推荐路径:**一个 [OpenRouter](https://openrouter.ai/) 密钥 + `./miroshark` 启动器**。首次模拟约 10 分钟、约 $1。
+
+**前置条件** — Python 3.11+、Node 18+、Neo4j,以及 [OpenRouter 密钥](https://openrouter.ai/)。
+
+安装 Neo4j(启动器会自动启动它):
+
+- **macOS** — `brew install neo4j`
+- **Linux** — `sudo apt install neo4j` *(或所在发行版对应的命令)*
+- **Windows** — 安装 [Neo4j Desktop](https://neo4j.com/download/) *(原生 GUI,先在其中启动数据库,然后通过 WSL2 或 Git Bash 运行启动器)*,或在 [WSL2](https://learn.microsoft.com/windows/wsl/install) 内运行整套环境并按 Linux 步骤操作
+- **零安装** — 创建免费的 [Neo4j Aura](https://neo4j.com/cloud/aura-free/) 云实例,在 `.env` 中将 `NEO4J_URI` / `NEO4J_PASSWORD` 指向它
+
+然后:
+
+```bash
+git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
+cp .env.example .env
+# 将你的 OpenRouter 密钥粘贴到 LLM_API_KEY / SMART_API_KEY /
+# NER_API_KEY / OPENAI_API_KEY / EMBEDDING_API_KEY 五个字段
+# (同一个密钥,粘 5 处)。默认组合是 Mimo V2 Flash + Grok-4.1 Fast。
+./miroshark
+```
+
+启动器会检查依赖、启动 Neo4j、安装前后端,并在 `:3000` + `:5001` 提供服务。Ctrl+C 停止。打开 `http://localhost:3000` 投入文档即可。
+
+**界面语言** — 启动后,在导航栏右上角点击「中 / EN」按钮即可切换中英文。语言选择会保存在浏览器中,下次访问时自动应用。模板画廊与公开模拟列表的卡片标题/描述也会随之切换。
+
+**其他部署路径** — [一键 Railway / Render](docs/INSTALL.md#one-click-cloud)、[Docker + Ollama](docs/INSTALL.md#option-b-docker--local-ollama)、[手动 Ollama](docs/INSTALL.md#option-c-manual--local-ollama)、[Claude Code CLI](docs/INSTALL.md#option-d-claude-code-no-api-key) — 详见 **[docs/INSTALL.md](docs/INSTALL.md)**。
+
+### 主要功能
+
+| 功能 | 说明 |
+|---|---|
+| **智能配置** | 投入文档 → 约 2 秒生成三套自动情景(看涨/看跌/中立) |
+| **热门追踪** | 从 RSS 中挑选实时新闻,一键预填情景 |
+| **直接提问** | 不用文档,直接打字提问 — MiroShark 自行调研并撰写种子简报 |
+| **反事实分支** | 在运行中的模拟里派生分支并注入事件(「如果 24 轮时 CEO 辞职会怎样?」) |
+| **导演模式** | 在当前时间线中投入突发新闻,无需派生分支 |
+| **预设模板** | 6 套基准情景:加密代币发布、企业危机、政治辩论、产品发布、校园风波、历史假设 |
+| **现实预言机** | 可选地从 [FeedOracle](https://mcp.feedoracle.io/mcp) MCP 中拉取实时数据(484 个工具) |
+| **每个智能体的 MCP 工具** | 人设可在模拟过程中调用真实 MCP 工具(网页搜索、API 等) |
+| **自定义 Wonderwall 端点** | 将模拟主循环指向任意 OpenAI 兼容端点(自部署 vLLM、Modal、微调模型……),不影响 Default/Smart/NER。设置 `WONDERWALL_BASE_URL` + `WONDERWALL_API_KEY` |
+| **嵌入与发布** | 公开/私有切换 + 嵌入 URL,便于分享已完成的运行 |
+| **社交分享卡片** | 1200×630 PNG,自动展开情景、状态、质量与信念分布,适配 Twitter/X、Discord、Slack、LinkedIn |
+| **信念回放动图** | 1200×630 GIF,每轮一帧,信念条动态滑向各轮分布。Discord 与 Slack 在直接 URL 上自动播放 |
+| **转录导出** | 每轮智能体发帖与立场标签,导出为 Markdown(YAML 头,适配 Notion / Obsidian / Substack)或结构化 JSON(适配 SDK 与 LLM 评审管线) |
+| **公开图库** | `/explore` 以卡片网格浏览所有公开模拟 — 预览分享卡、共识分布与质量指标;一键打开或派生 |
+| **已验证预言** | 为公开模拟标注真实结果(命中 / 部分 / 失误 + 链接)。`/verified` 是命中预言专属展厅 |
+| **RSS / Atom 订阅源** | `/api/feed.atom` + `/api/feed.rss` — 每个新发布的模拟无需任何整理就会进入 Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS。`?verified=1` 只看已验证内容 |
+| **文章生成** | Substack 风格的复盘文章,基于真实发帖与交易数据 |
+| **互动网络** | 力导向智能体关系图,带回声室指标 |
+| **人口分布** | 原型聚类(分析师 / 影响者 / 散户 / 旁观者……) |
+| **质量诊断** | 单次运行的健康评分 — 参与度、连贯性、多样性、方差 |
+| **历史数据库** | 搜索、克隆、导出或删除任一过往模拟 |
+| **轨迹访谈** | 查看智能体回复背后的完整推理链,而不止是回复本身 |
+| **推送通知** | 长耗时图谱 / 模拟 / 报告任务完成时的浏览器推送提醒 |
+| **完成 Webhook** | 模拟一结束即 POST 一份 JSON 摘要 — 一个 URL 字段即可连通 Slack、Discord、Zapier、Make、n8n 或任意自定义端点 |
+
+每项功能详见 **[docs/FEATURES.md](docs/FEATURES.md)**。
+
+### 应用场景
+
+- **公关危机演练** — 在新闻稿发布前模拟舆论反应
+- **市场反应** — 喂入财经新闻,观察模拟交易者与投资者情绪
+- **广告测试** — 在投放前用模拟受众检验文案、标题或卖点
+- **政策分析** — 用模拟公众检验法规草案
+- **人生抉择** — 把个人决定(换工作、搬家、上线时机)作为情景,看多元人设辩论
+- **历史假设** — 改写一段历史事件,看一群人设如何重写后续叙事
+- **创意实验** — 喂入失去结尾的小说,智能体续写出叙事自洽的结局
+
+### 文档
+
+| | |
+|---|---|
+| [安装](docs/INSTALL.md) | 全部部署路径:云端、Docker、Ollama、Claude Code |
+| [配置](docs/CONFIGURATION.md) | 环境变量、模型路由、特性开关 |
+| [模型](docs/MODELS.md) | 云端预设、本地 Ollama 模型、基准发现 |
+| [架构](docs/ARCHITECTURE.md) | 模拟引擎、记忆管线、图谱检索 |
+| [功能](docs/FEATURES.md) | 上述功能表的深入解析 |
+| [HTTP API](docs/API.md) | 全部端点,按关注点分组 — 含 `/api/docs` 交互式 Swagger UI 与 `/api/openapi.yaml` 规范 |
+| [CLI](docs/CLI.md) | `miroshark-cli` 参考 |
+| [MCP](docs/MCP.md) | Claude Desktop / Cursor / Windsurf / Continue 集成 + 报告智能体工具(可在「设置 → AI 集成」中获取自动生成的片段) |
+| [Webhook](docs/WEBHOOKS.md) | 完成 Webhook 载荷、头部、投递语义、Slack/Discord/Zapier/n8n 食谱 |
+| [可观测性](docs/OBSERVABILITY.md) | 调试面板、事件流、日志 |
+| [贡献](CONTRIBUTING.md) | 测试与开发 |
+
+### 许可证
+
+AGPL-3.0,详见 [LICENSE](./LICENSE)。
+
+支持本项目:`0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3`
+
+---
+
+<a id="english"></a>
+
+## English
+
+> **Simulate anything, for $1 & less than 10 min — Universal Swarm Intelligence Engine**
+> Drop in anything — a press release, a news headline, a policy draft, a question you can't answer, a historical what-if — and MiroShark spawns hundreds of agents that react to it hour by hour. Posting, arguing, trading, changing their minds.
+
+### What it does
 
 - You bring a scenario. MiroShark builds the world around it.
 - Hundreds of grounded agents. Twitter, Reddit, and a prediction market. Hour by hour.
 - Chat with any of them. Drop breaking news mid-run. Fork the timeline.
 - Get a report on what happened, citing actual posts and trades.
 
-## Quick start
+### Quick start
 
 The recommended path: **one [OpenRouter](https://openrouter.ai/) key + the `./miroshark` launcher.** First simulation in ~10 min, ~$1.
 
@@ -61,7 +176,11 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
   <img src="./docs/images/miroshark-overview.jpg" alt="MiroShark Overview" />
 </p>
 
-## Features
+### Interface language
+
+After launching, click the **中 / EN** toggle in the top-right of the navbar to switch between English and Chinese. Your choice is persisted in the browser, and the public gallery card titles + descriptions follow the active locale.
+
+### Features
 
 | Feature | What it does |
 |---|---|
@@ -92,7 +211,7 @@ The launcher checks dependencies, starts Neo4j, installs frontend + backend, and
 
 Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 
-## Use cases
+### Use cases
 
 - **PR crisis testing** — simulate public reaction to a press release before publishing
 - **Market reaction** — feed financial news and observe simulated trader + investor sentiment
@@ -102,7 +221,7 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 - **What-if history** — rewrite a historical event and see how a population of personas re-narrates the aftermath
 - **Creative experiments** — feed a novel with a lost ending; agents write a narratively consistent conclusion
 
-## Screenshots
+### Screenshots
 
 <div align="center">
 <table>
@@ -121,7 +240,7 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 </table>
 </div>
 
-## Documentation
+### Documentation
 
 | | |
 |---|---|
@@ -137,12 +256,12 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 | [Observability](docs/OBSERVABILITY.md) | Debug panel, event stream, logging |
 | [Contributing](CONTRIBUTING.md) | Tests and development |
 
-## License
+### License
 
 AGPL-3.0. See [LICENSE](./LICENSE).
 
 Support the project: `0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3`
 
-## Star History
+### Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=aaronjmars/miroshark&type=Date)](https://www.star-history.com/#aaronjmars/miroshark&Date)

--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -8,6 +8,7 @@ from flask import jsonify, request
 
 from . import templates_bp
 from ..utils.logger import get_logger
+from ..utils.i18n import get_locale, apply_i18n, t as _t
 from ..services.oracle_seed import resolve_oracle_tools
 
 logger = get_logger('miroshark.api.templates')
@@ -62,22 +63,24 @@ def list_templates():
     """
     try:
         templates = _load_templates()
+        locale = get_locale(request)
 
         summaries = []
-        for t in templates:
-            branches = t.get("counterfactual_branches", []) or []
-            oracle_tools = t.get("oracle_tools", []) or []
+        for tpl in templates:
+            localized = apply_i18n(tpl, locale)
+            branches = localized.get("counterfactual_branches", []) or []
+            oracle_tools = localized.get("oracle_tools", []) or []
             summaries.append({
-                "id": t["id"],
-                "name": t["name"],
-                "category": t.get("category", ""),
-                "description": t.get("description", ""),
-                "icon": t.get("icon", ""),
-                "difficulty": t.get("difficulty", "medium"),
-                "estimated_agents": t.get("estimated_agents", 0),
-                "estimated_rounds": t.get("estimated_rounds", 0),
-                "platforms": t.get("platforms", []),
-                "tags": t.get("tags", []),
+                "id": localized["id"],
+                "name": localized["name"],
+                "category": localized.get("category", ""),
+                "description": localized.get("description", ""),
+                "icon": localized.get("icon", ""),
+                "difficulty": localized.get("difficulty", "medium"),
+                "estimated_agents": localized.get("estimated_agents", 0),
+                "estimated_rounds": localized.get("estimated_rounds", 0),
+                "platforms": localized.get("platforms", []),
+                "tags": localized.get("tags", []),
                 "has_counterfactuals": len(branches) > 0,
                 "counterfactual_count": len(branches),
                 "has_oracle_tools": len(oracle_tools) > 0,
@@ -105,16 +108,17 @@ def get_template(template_id: str):
     simulation_requirement for use in the creation flow.
     """
     try:
+        locale = get_locale(request)
         filepath = os.path.realpath(os.path.join(TEMPLATES_DIR, f"{template_id}.json"))
         if not filepath.startswith(os.path.realpath(TEMPLATES_DIR)):
             return jsonify({
                 "success": False,
-                "error": "Invalid template ID"
+                "error": _t("Invalid template ID", "无效的模板 ID", locale)
             }), 400
         if not os.path.exists(filepath):
             return jsonify({
                 "success": False,
-                "error": f"Template not found: {template_id}"
+                "error": _t(f"Template not found: {template_id}", f"未找到模板:{template_id}", locale)
             }), 404
 
         with open(filepath, 'r', encoding='utf-8') as f:
@@ -132,6 +136,8 @@ def get_template(template_id: str):
                     template['oracle_enriched'] = True
             except Exception as exc:
                 logger.warning(f"oracle enrichment failed for {template_id}: {exc}")
+
+        template = apply_i18n(template, locale)
 
         return jsonify({
             "success": True,

--- a/backend/app/preset_templates/campus_controversy.json
+++ b/backend/app/preset_templates/campus_controversy.json
@@ -15,5 +15,13 @@
     "enable_twitter": true,
     "enable_reddit": true,
     "enable_polymarket": false
+  },
+  "i18n": {
+    "zh-CN": {
+      "name": "校园风波",
+      "category": "教育",
+      "description": "模拟一场大学政策争议在社交媒体上掀起的风暴。观察学生、教职工、校友、记者与活动人士如何组成阵营并推动舆论走向。",
+      "tags": ["大学", "学生", "政策", "行动主义"]
+    }
   }
 }

--- a/backend/app/preset_templates/corporate_crisis.json
+++ b/backend/app/preset_templates/corporate_crisis.json
@@ -47,5 +47,36 @@
       "trigger_round": 48,
       "injection": "CloudLocker Inc. (a direct competitor) has just disclosed a 40M-user breach — 3x the size of DataVault's. The news cycle is pivoting."
     }
-  ]
+  ],
+  "i18n": {
+    "zh-CN": {
+      "name": "企业危机",
+      "category": "商业",
+      "description": "模拟一家大企业在社交媒体上爆发的公关危机。观察客户、员工、记者与维权人士如何塑造叙事、施压公司作出回应。",
+      "tags": ["企业", "公关危机", "品牌声誉", "抵制"],
+      "counterfactual_branches": [
+        {
+          "id": "ceo_resigns",
+          "label": "CEO 在第 2 天辞职",
+          "description": "事件曝光 24 小时后 CEO 辞职,由临时 CEO 接替。",
+          "trigger_round": 24,
+          "injection": "DataVault Inc. CEO 刚刚宣布辞职。董事会已任命 CTO 为临时 CEO。卸任 CEO 表示:「我对延迟披露承担全部责任。」"
+        },
+        {
+          "id": "class_action",
+          "label": "提起集体诉讼",
+          "description": "在第 36 轮前,一家大型律所提起 10 亿美元集体诉讼。",
+          "trigger_round": 36,
+          "injection": "Cohen Milstein 代表 1200 万受影响用户提起 10 亿美元集体诉讼,指控公司故意隐瞒泄露事件。"
+        },
+        {
+          "id": "competitor_breach",
+          "label": "竞争对手出现更大泄露事件",
+          "description": "一家直接竞争对手披露 4000 万用户数据泄露,转移注意力。",
+          "trigger_round": 48,
+          "injection": "CloudLocker Inc.(直接竞争对手)刚刚披露 4000 万用户数据泄露 — 是 DataVault 的 3 倍。新闻焦点正在转移。"
+        }
+      ]
+    }
+  }
 }

--- a/backend/app/preset_templates/crypto_launch.json
+++ b/backend/app/preset_templates/crypto_launch.json
@@ -42,5 +42,36 @@
       "trigger_round": 24,
       "injection": "The SEC has just sent NeuralCoin a Wells notice stating the token may qualify as an unregistered security. The team has 30 days to respond."
     }
-  ]
+  ],
+  "i18n": {
+    "zh-CN": {
+      "name": "加密代币发布",
+      "category": "加密货币与金融",
+      "description": "模拟一款新加密代币发布时的社交媒体狂热。观察交易员、KOL、怀疑者与散户如何制造炒作循环、传播 FUD,以及推动市场情绪。",
+      "tags": ["加密货币", "交易", "炒作", "市场情绪"],
+      "counterfactual_branches": [
+        {
+          "id": "rug_pull",
+          "label": "团队钱包抽干流动性",
+          "description": "团队在第 12 小时左右撤走流动性 — Rug Pull。",
+          "trigger_round": 12,
+          "injection": "链上监控检测到一笔异常的多签交易,正在抽走 180 万美元的 $NRAL 流动性。团队的钱包地址全部沉默。"
+        },
+        {
+          "id": "cex_listing",
+          "label": "一线 CEX 确认上线",
+          "description": "在第 18 轮,一家前 5 中心化交易所宣布上线 $NRAL。",
+          "trigger_round": 18,
+          "injection": "币安正式宣布 $NRAL/USDT 永续合约将在 6 小时后上线。受此消息影响,代币上涨 70%。"
+        },
+        {
+          "id": "sec_notice",
+          "label": "SEC 发出 Wells 通知",
+          "description": "SEC 向 $NRAL 发出 Wells 通知,将其定性为未注册证券。",
+          "trigger_round": 24,
+          "injection": "SEC 刚刚向 NeuralCoin 发出 Wells 通知,称该代币可能构成未注册证券。团队需在 30 天内作出回应。"
+        }
+      ]
+    }
+  }
 }

--- a/backend/app/preset_templates/historical_whatif.json
+++ b/backend/app/preset_templates/historical_whatif.json
@@ -24,5 +24,13 @@
     "enable_twitter": true,
     "enable_reddit": true,
     "enable_polymarket": true
+  },
+  "i18n": {
+    "zh-CN": {
+      "name": "历史假设",
+      "category": "历史",
+      "description": "模拟一段反事实的历史情景 — 如果关键事件走向不同会怎样?观察学者、爱好者、记者与大众如何讨论这条平行时间线及其影响。",
+      "tags": ["历史", "反事实", "假设", "太空竞赛"]
+    }
   }
 }

--- a/backend/app/preset_templates/political_debate.json
+++ b/backend/app/preset_templates/political_debate.json
@@ -24,5 +24,13 @@
     "enable_twitter": true,
     "enable_reddit": true,
     "enable_polymarket": true
+  },
+  "i18n": {
+    "zh-CN": {
+      "name": "政治辩论",
+      "category": "政治",
+      "description": "模拟一场激烈政治辩论后的舆论动态。观察不同选民群体、媒体人物与政治评论员如何反应、结盟,并在 48 小时内调整立场。",
+      "tags": ["政治", "舆论", "辩论", "极化"]
+    }
   }
 }

--- a/backend/app/preset_templates/product_announcement.json
+++ b/backend/app/preset_templates/product_announcement.json
@@ -24,5 +24,13 @@
     "enable_twitter": true,
     "enable_reddit": true,
     "enable_polymarket": true
+  },
+  "i18n": {
+    "zh-CN": {
+      "name": "产品发布",
+      "category": "科技",
+      "description": "模拟互联网对一款重磅科技产品发布的反应。看开发者、爱好者、分析师与普通用户如何争论功能、定价以及是否对得起宣传声量。",
+      "tags": ["科技", "产品发布", "消费", "炒作"]
+    }
   }
 }

--- a/backend/app/utils/i18n.py
+++ b/backend/app/utils/i18n.py
@@ -1,0 +1,122 @@
+"""Lightweight locale helper for backend responses.
+
+The frontend forwards the user's chosen locale on every request via the
+``X-MiroShark-Locale`` header (preferred) and ``Accept-Language`` (fallback).
+A ``?lang=`` query parameter wins over both for share-card / feed URLs that
+need to be locale-pinned in their canonical form.
+
+Only ``en`` (default) and ``zh-CN`` are recognised — anything else falls
+back to ``en`` so callers can pass ``Accept-Language`` straight through.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+SUPPORTED = ("en", "zh-CN")
+DEFAULT = "en"
+
+
+def normalize_locale(raw: Optional[str]) -> str:
+    """Normalise a free-form locale string to one of ``SUPPORTED``."""
+    if not raw:
+        return DEFAULT
+    s = str(raw).strip()
+    if not s:
+        return DEFAULT
+    # Accept-Language can be ``zh-CN,zh;q=0.9,en;q=0.8`` — only look at the
+    # first tag.
+    head = s.split(",", 1)[0].strip()
+    head_lc = head.lower()
+    if head_lc.startswith("zh"):
+        return "zh-CN"
+    if head_lc.startswith("en"):
+        return "en"
+    return DEFAULT
+
+
+def get_locale(request) -> str:
+    """Resolve the active locale from the Flask request object.
+
+    Order of precedence: ``?lang=`` query param → ``X-MiroShark-Locale``
+    header → ``Accept-Language`` → default.
+    """
+    if request is None:
+        return DEFAULT
+    try:
+        q = request.args.get("lang")
+        if q:
+            return normalize_locale(q)
+    except Exception:
+        pass
+    try:
+        h = request.headers.get("X-MiroShark-Locale")
+        if h:
+            return normalize_locale(h)
+    except Exception:
+        pass
+    try:
+        h = request.headers.get("Accept-Language")
+        if h:
+            return normalize_locale(h)
+    except Exception:
+        pass
+    return DEFAULT
+
+
+def t(en: str, zh: str, locale: str = DEFAULT) -> str:
+    """Pick a translation given a locale.
+
+    Falls back to the English source if no Chinese is provided.
+    """
+    if locale == "zh-CN" and zh:
+        return zh
+    return en
+
+
+def apply_i18n(payload: Any, locale: str) -> Any:
+    """Recursively merge embedded ``i18n[locale]`` blocks into a JSON payload.
+
+    Looks for an ``i18n`` mapping on each dict node — when present and the
+    requested locale is a key, the keys inside that block override the
+    sibling keys at the same level.
+
+    Example::
+
+        {"name": "Crypto Token Launch",
+         "i18n": {"zh-CN": {"name": "加密代币发布"}}}
+
+    With ``locale='zh-CN'`` this becomes ``{"name": "加密代币发布"}``.
+
+    The ``i18n`` block itself is dropped from the returned structure so
+    clients never see the source overrides.
+    """
+    if locale == DEFAULT or not isinstance(payload, (dict, list)):
+        # Still strip i18n blocks so the response shape is identical
+        # regardless of locale.
+        return _strip_i18n(payload)
+
+    if isinstance(payload, list):
+        return [apply_i18n(item, locale) for item in payload]
+
+    if isinstance(payload, dict):
+        out = dict(payload)
+        overrides = out.pop("i18n", None)
+        if isinstance(overrides, Mapping):
+            block = overrides.get(locale)
+            if isinstance(block, Mapping):
+                for k, v in block.items():
+                    out[k] = v
+        # Recurse into nested values
+        return {k: apply_i18n(v, locale) for k, v in out.items()}
+
+    return payload
+
+
+def _strip_i18n(payload: Any) -> Any:
+    """Drop ``i18n`` keys recursively without applying overrides."""
+    if isinstance(payload, list):
+        return [_strip_i18n(item) for item in payload]
+    if isinstance(payload, dict):
+        return {k: _strip_i18n(v) for k, v in payload.items() if k != "i18n"}
+    return payload

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { locale } from '../i18n'
 
 // Create axios instance
 const service = axios.create({
@@ -9,9 +10,15 @@ const service = axios.create({
   }
 })
 
-// Request interceptor
+// Request interceptor — forwards the active UI locale so the backend can
+// localise template metadata, error messages, and feed copy.
 service.interceptors.request.use(
   config => {
+    if (locale && locale.value) {
+      config.headers = config.headers || {}
+      config.headers['X-MiroShark-Locale'] = locale.value
+      config.headers['Accept-Language'] = locale.value
+    }
     return config
   },
   error => {

--- a/frontend/src/components/BeliefDriftChart.vue
+++ b/frontend/src/components/BeliefDriftChart.vue
@@ -4,39 +4,39 @@
     <div class="bd-header">
       <div class="bd-title">
         <span class="bd-icon">◎</span>
-        <span class="bd-label">DRIFT</span>
+        <span class="bd-label">{{ $tr('DRIFT', '漂移') }}</span>
       </div>
       <div class="bd-header-actions">
         <button
           class="bd-export-btn"
           :disabled="!hasData || exporting || !copySupported"
-          :title="copySupported ? 'Copy chart as PNG (with MiroShark watermark)' : 'Image copy not supported in this browser'"
+          :title="copySupported ? $tr('Copy chart as PNG (with MiroShark watermark)', '复制图表为 PNG(含 MiroShark 水印)') : $tr('Image copy not supported in this browser', '此浏览器不支持图像复制')"
           @click="copyChart"
         >
-          {{ copiedFlash ? 'Copied' : 'Copy' }}
+          {{ copiedFlash ? $tr('Copied', '已复制') : $tr('Copy', '复制') }}
         </button>
         <button
           class="bd-export-btn"
           :disabled="!hasData || exporting"
           @click="downloadChart"
-          title="Download chart as PNG (with MiroShark watermark)"
+          :title="$tr('Download chart as PNG (with MiroShark watermark)', '下载图表为 PNG(含 MiroShark 水印)')"
         >
-          Download ↓
+          {{ $tr('Download ↓', '下载 ↓') }}
         </button>
       </div>
     </div>
 
     <!-- Legend -->
     <div class="bd-legend">
-      <span class="legend-item"><span class="legend-dot bullish-dot"></span>Bullish (&gt;+0.2)</span>
-      <span class="legend-item"><span class="legend-dot neutral-dot"></span>Neutral</span>
-      <span class="legend-item"><span class="legend-dot bearish-dot"></span>Bearish (&lt;-0.2)</span>
+      <span class="legend-item"><span class="legend-dot bullish-dot"></span>{{ $tr('Bullish', '看涨') }} (&gt;+0.2)</span>
+      <span class="legend-item"><span class="legend-dot neutral-dot"></span>{{ $tr('Neutral', '中立') }}</span>
+      <span class="legend-item"><span class="legend-dot bearish-dot"></span>{{ $tr('Bearish', '看跌') }} (&lt;-0.2)</span>
     </div>
 
     <!-- Loading -->
     <div v-if="loading" class="bd-state">
       <div class="pulse-ring"></div>
-      <span>Computing belief drift...</span>
+      <span>{{ $tr('Computing belief drift...', '计算信念漂移中...') }}</span>
     </div>
 
     <!-- Error -->
@@ -44,8 +44,8 @@
 
     <!-- No trajectory data -->
     <div v-else-if="!hasData" class="bd-state">
-      <span>No belief trajectory data available.</span>
-      <span class="bd-hint">Run a simulation with belief tracking enabled.</span>
+      <span>{{ $tr('No belief trajectory data available.', '暂无信念轨迹数据。') }}</span>
+      <span class="bd-hint">{{ $tr('Run a simulation with belief tracking enabled.', '请启用信念追踪运行模拟。') }}</span>
     </div>
 
     <!-- Chart -->
@@ -107,7 +107,7 @@
           v-if="driftData.consensus_round != null"
           :x="xS(driftData.consensus_round) + 4" :y="MT + 12"
           fill="rgba(10,10,10,0.5)" font-size="9" font-family="monospace"
-        >consensus r{{ driftData.consensus_round }}</text>
+        >{{ $tr('consensus r', '共识 r') }}{{ driftData.consensus_round }}</text>
 
         <!-- Director event injection markers -->
         <g v-for="(evt, idx) in eventMarkers" :key="'evt' + idx">
@@ -138,7 +138,7 @@
           :x="ML + (W - ML - MR) / 2" :y="H - 2"
           fill="rgba(10,10,10,0.3)" font-size="9"
           font-family="monospace" text-anchor="middle"
-        >Round</text>
+        >{{ $tr('Round', '轮次') }}</text>
       </svg>
     </div>
 
@@ -149,7 +149,7 @@
 
     <!-- Topics footer -->
     <div v-if="driftData?.topics?.length" class="bd-topics">
-      Topics: {{ driftData.topics.join(' · ') }}
+      {{ $tr('Topics:', '话题:') }} {{ driftData.topics.join(' · ') }}
     </div>
   </div>
 </template>
@@ -164,6 +164,7 @@ import {
   canCopyImageToClipboard,
   buildTitledHeader,
 } from '../utils/chartExport'
+import { tr } from '../i18n'
 
 const props = defineProps({
   simulationId: { type: String, required: true },
@@ -262,10 +263,10 @@ const load = async () => {
     } else if (res.success && !res.data) {
       driftData.value = null
     } else {
-      error.value = res.error || 'Failed to load belief drift data.'
+      error.value = res.error || tr('Failed to load belief drift data.', '加载信念漂移数据失败。')
     }
   } catch (err) {
-    error.value = err.message || 'Failed to load belief drift.'
+    error.value = err.message || tr('Failed to load belief drift.', '加载信念漂移失败。')
   } finally {
     loading.value = false
   }
@@ -279,11 +280,11 @@ const _buildExportCanvas = () => {
   const bullish = d.bullish || []
   const bearish = d.bearish || []
   const parts = []
-  if (bullish.length) parts.push(`${bullish[bullish.length - 1]}% bullish`)
-  if (bearish.length) parts.push(`${bearish[bearish.length - 1]}% bearish`)
+  if (bullish.length) parts.push(`${bullish[bullish.length - 1]}% ${tr('bullish', '看涨')}`)
+  if (bearish.length) parts.push(`${bearish[bearish.length - 1]}% ${tr('bearish', '看跌')}`)
   const { drawHeader, headerHeight } = buildTitledHeader({
-    title: 'Belief drift — bullish / neutral / bearish',
-    subtitle: parts.length ? `Final: ${parts.join(' · ')}` : null,
+    title: tr('Belief drift — bullish / neutral / bearish', '信念漂移 — 看涨 / 中立 / 看跌'),
+    subtitle: parts.length ? `${tr('Final:', '最终:')} ${parts.join(' · ')}` : null,
     width: W,
   })
   return renderSvgToCanvas(svgRef.value, {

--- a/frontend/src/components/CounterfactualBranchPanel.vue
+++ b/frontend/src/components/CounterfactualBranchPanel.vue
@@ -3,24 +3,22 @@
     <div class="cf-header">
       <div class="cf-title">
         <span class="cf-icon">⤷</span>
-        <span class="cf-label">COUNTERFACTUAL BRANCH</span>
+        <span class="cf-label">{{ $tr('COUNTERFACTUAL BRANCH', '反事实分支') }}</span>
       </div>
       <span class="cf-hint">
-        Fork this simulation from round N with a narrative injection.
-        Preserves the agent population; the runner promotes your injection into
-        a director event when round {{ triggerRound || 'N' }} arrives.
+        {{ $tr('Fork this simulation from round N with a narrative injection. Preserves the agent population; the runner promotes your injection into a director event when round', '从第 N 轮派生此模拟,并注入一段叙事。保留智能体人群;当达到第') }} {{ triggerRound || 'N' }} {{ $tr('arrives.', '轮时,运行器会将你的注入提升为导演事件。') }}
       </span>
     </div>
 
     <!-- Preset-branch dropdown (when the source template declared them) -->
     <div v-if="presetBranches.length" class="cf-preset-row">
-      <label class="cf-preset-label">Preset</label>
+      <label class="cf-preset-label">{{ $tr('Preset', '预设') }}</label>
       <select
         class="cf-preset-select"
         :value="selectedPresetId"
         @change="applyPreset($event.target.value)"
       >
-        <option value="">— custom —</option>
+        <option value="">{{ $tr('— custom —', '— 自定义 —') }}</option>
         <option
           v-for="b in presetBranches"
           :key="b.id"
@@ -31,7 +29,7 @@
 
     <!-- Trigger round picker -->
     <div class="cf-form-row">
-      <label class="cf-form-label">Trigger round</label>
+      <label class="cf-form-label">{{ $tr('Trigger round', '触发轮次') }}</label>
       <input
         type="number"
         class="cf-form-input cf-form-input--narrow"
@@ -41,31 +39,31 @@
         :disabled="busy"
       />
       <span class="cf-form-meta">
-        of {{ totalRounds || '?' }} · currently at round {{ currentRound }}
+        {{ $tr('of', '共') }} {{ totalRounds || '?' }} · {{ $tr('currently at round', '当前在第') }} {{ currentRound }}
       </span>
     </div>
 
     <!-- Short label -->
     <div class="cf-form-row">
-      <label class="cf-form-label">Label</label>
+      <label class="cf-form-label">{{ $tr('Label', '标签') }}</label>
       <input
         type="text"
         class="cf-form-input"
         v-model="label"
         maxlength="80"
-        placeholder="e.g. CEO resigns"
+        :placeholder="$tr('e.g. CEO resigns', '例如 CEO 辞职')"
         :disabled="busy"
       />
     </div>
 
     <!-- Injection text -->
     <div class="cf-form-row cf-form-row--stack">
-      <label class="cf-form-label">Injection (breaking-news style)</label>
+      <label class="cf-form-label">{{ $tr('Injection (breaking-news style)', '注入内容(突发新闻风格)') }}</label>
       <textarea
         class="cf-form-textarea"
         v-model="injectionText"
         maxlength="2000"
-        placeholder="The board has just announced the CEO's resignation, effective immediately. The CFO steps in as interim lead."
+        :placeholder="$tr(`The board has just announced the CEO's resignation, effective immediately. The CFO steps in as interim lead.`, '董事会刚刚宣布 CEO 立即辞职,CFO 作为临时负责人接任。')"
         rows="4"
         :disabled="busy"
       ></textarea>
@@ -76,11 +74,11 @@
 
     <div v-if="error" class="cf-error">{{ error }}</div>
     <div v-if="result" class="cf-result">
-      Branch created: <code>{{ result.simulation_id }}</code>
+      {{ $tr('Branch created:', '分支已创建:') }} <code>{{ result.simulation_id }}</code>
       <span v-if="result.config_diff?.counterfactual?.label">
         · "{{ result.config_diff.counterfactual.label }}"
       </span>
-      <button class="cf-open-btn" @click="openBranch">Open →</button>
+      <button class="cf-open-btn" @click="openBranch">{{ $tr('Open →', '打开 →') }}</button>
     </div>
 
     <div class="cf-actions">
@@ -88,14 +86,14 @@
         class="cf-cancel"
         @click="$emit('close')"
         :disabled="busy"
-      >Cancel</button>
+      >{{ $tr('Cancel', '取消') }}</button>
       <button
         class="cf-submit"
         :disabled="!canSubmit || busy"
         @click="submit"
       >
         <span v-if="busy" class="cf-spinner"></span>
-        {{ busy ? 'Forking…' : 'Fork branch →' }}
+        {{ busy ? $tr('Forking…', '派生中…') : $tr('Fork branch →', '派生分支 →') }}
       </button>
     </div>
   </div>
@@ -105,6 +103,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { branchCounterfactual } from '../api/simulation'
+import { tr } from '../i18n'
 
 const props = defineProps({
   simulationId: { type: String, required: true },
@@ -158,12 +157,12 @@ const submit = async () => {
       branchId: selectedPresetId.value || undefined,
     })
     if (!res.success) {
-      error.value = res.error || 'Branch failed.'
+      error.value = res.error || tr('Branch failed.', '分支创建失败。')
       return
     }
     result.value = res.data
   } catch (err) {
-    error.value = err?.response?.data?.error || err?.message || 'Branch failed.'
+    error.value = err?.response?.data?.error || err?.message || tr('Branch failed.', '分支创建失败。')
   } finally {
     busy.value = false
   }

--- a/frontend/src/components/DebugPanel.vue
+++ b/frontend/src/components/DebugPanel.vue
@@ -4,16 +4,16 @@
     <div class="debug-header" @click="isCollapsed = !isCollapsed">
       <div class="debug-header__left">
         <span class="debug-header__icon">&#9881;</span>
-        <span class="debug-header__title">OBSERVABILITY</span>
-        <span v-if="connected" class="debug-header__status debug-header__status--live">LIVE</span>
-        <span v-else class="debug-header__status debug-header__status--off">OFF</span>
-        <span v-if="stats.llm_calls" class="debug-header__stat">{{ stats.llm_calls }} calls</span>
-        <span v-if="stats.tokens_total" class="debug-header__stat">{{ formatTokens(stats.tokens_total) }} tok</span>
+        <span class="debug-header__title">{{ $tr('OBSERVABILITY', '可观测性') }}</span>
+        <span v-if="connected" class="debug-header__status debug-header__status--live">{{ $tr('LIVE', '实时') }}</span>
+        <span v-else class="debug-header__status debug-header__status--off">{{ $tr('OFF', '离线') }}</span>
+        <span v-if="stats.llm_calls" class="debug-header__stat">{{ stats.llm_calls }} {{ $tr('calls', '次调用') }}</span>
+        <span v-if="stats.tokens_total" class="debug-header__stat">{{ formatTokens(stats.tokens_total) }} {{ $tr('tok', 'token') }}</span>
       </div>
       <div class="debug-header__right">
-        <button class="debug-btn debug-btn--icon" :class="{ 'debug-btn--copied': justCopied }" @click.stop="copyAll" :title="justCopied ? 'Copied!' : 'Copy all events'">{{ justCopied ? '&#10003;' : '&#9112;' }}</button>
-        <button class="debug-btn debug-btn--icon" @click.stop="clearEvents" title="Clear">&#10005;</button>
-        <button class="debug-btn debug-btn--icon" @click.stop="isVisible = false" title="Close (Ctrl+Shift+D)">&#9866;</button>
+        <button class="debug-btn debug-btn--icon" :class="{ 'debug-btn--copied': justCopied }" @click.stop="copyAll" :title="justCopied ? $tr('Copied!', '已复制!') : $tr('Copy all events', '复制所有事件')">{{ justCopied ? '&#10003;' : '&#9112;' }}</button>
+        <button class="debug-btn debug-btn--icon" @click.stop="clearEvents" :title="$tr('Clear', '清除')">&#10005;</button>
+        <button class="debug-btn debug-btn--icon" @click.stop="isVisible = false" :title="$tr('Close (Ctrl+Shift+D)', '关闭 (Ctrl+Shift+D)')">&#9866;</button>
       </div>
     </div>
 
@@ -28,7 +28,7 @@
           :class="{ 'debug-tab--active': activeTab === tab.key }"
           @click="activeTab = tab.key"
         >
-          {{ tab.label }}
+          {{ translateTabLabel(tab.label) }}
           <span v-if="tab.key === 'errors' && errorCount > 0" class="debug-tab__badge">{{ errorCount }}</span>
         </button>
       </div>
@@ -36,7 +36,7 @@
       <!-- Filters -->
       <div class="debug-filters">
         <select v-model="filterPlatform" class="debug-select">
-          <option value="">All platforms</option>
+          <option value="">{{ $tr('All platforms', '所有平台') }}</option>
           <option value="twitter">Twitter</option>
           <option value="reddit">Reddit</option>
           <option value="polymarket">Polymarket</option>
@@ -44,11 +44,11 @@
         <input
           v-model="filterText"
           class="debug-input"
-          placeholder="Filter..."
+          :placeholder="$tr('Filter...', '筛选...')"
         />
         <label class="debug-checkbox">
           <input type="checkbox" v-model="autoScroll" />
-          Auto-scroll
+          {{ $tr('Auto-scroll', '自动滚动') }}
         </label>
       </div>
 
@@ -58,7 +58,7 @@
         <!-- Live Feed -->
         <div v-if="activeTab === 'feed'" class="debug-feed">
           <div v-if="filteredEvents.length === 0" class="debug-empty">
-            No events yet. Waiting for activity...
+            {{ $tr('No events yet. Waiting for activity...', '暂无事件。等待活动中...') }}
           </div>
           <div
             v-for="event in filteredEvents"
@@ -87,28 +87,28 @@
           <div class="debug-llm__summary">
             <div class="debug-stat-card">
               <div class="debug-stat-card__value">{{ stats.llm_calls }}</div>
-              <div class="debug-stat-card__label">Total Calls</div>
+              <div class="debug-stat-card__label">{{ $tr('Total Calls', '调用总数') }}</div>
             </div>
             <div class="debug-stat-card">
               <div class="debug-stat-card__value">{{ formatTokens(stats.tokens_total) }}</div>
-              <div class="debug-stat-card__label">Total Tokens</div>
+              <div class="debug-stat-card__label">{{ $tr('Total Tokens', '总 Token') }}</div>
             </div>
             <div class="debug-stat-card">
               <div class="debug-stat-card__value">{{ stats.avg_latency_ms }}ms</div>
-              <div class="debug-stat-card__label">Avg Latency</div>
+              <div class="debug-stat-card__label">{{ $tr('Avg Latency', '平均延迟') }}</div>
             </div>
             <div class="debug-stat-card">
               <div class="debug-stat-card__value">{{ stats.errors }}</div>
-              <div class="debug-stat-card__label">Errors</div>
+              <div class="debug-stat-card__label">{{ $tr('Errors', '错误') }}</div>
             </div>
           </div>
           <div class="debug-llm__table">
             <div class="debug-table-header">
-              <span class="debug-col--time">Time</span>
-              <span class="debug-col--caller">Caller</span>
-              <span class="debug-col--model">Model</span>
-              <span class="debug-col--tokens">In/Out</span>
-              <span class="debug-col--latency">Latency</span>
+              <span class="debug-col--time">{{ $tr('Time', '时间') }}</span>
+              <span class="debug-col--caller">{{ $tr('Caller', '调用方') }}</span>
+              <span class="debug-col--model">{{ $tr('Model', '模型') }}</span>
+              <span class="debug-col--tokens">{{ $tr('In/Out', '输入/输出') }}</span>
+              <span class="debug-col--latency">{{ $tr('Latency', '延迟') }}</span>
             </div>
             <div
               v-for="event in llmEvents"
@@ -127,19 +127,19 @@
               </span>
               <div v-if="expandedIds.has(event.event_id)" class="debug-table-row__detail">
                 <div v-if="event.data?.response_preview" class="debug-detail-section">
-                  <strong>Response preview:</strong>
+                  <strong>{{ $tr('Response preview:', '响应预览:') }}</strong>
                   <pre>{{ event.data.response_preview }}</pre>
                 </div>
                 <div v-if="event.data?.messages" class="debug-detail-section">
-                  <strong>Messages:</strong>
+                  <strong>{{ $tr('Messages:', '消息:') }}</strong>
                   <pre>{{ JSON.stringify(event.data.messages, null, 2) }}</pre>
                 </div>
                 <div v-if="event.data?.response" class="debug-detail-section">
-                  <strong>Full response:</strong>
+                  <strong>{{ $tr('Full response:', '完整响应:') }}</strong>
                   <pre>{{ event.data.response }}</pre>
                 </div>
                 <div v-if="event.data?.error" class="debug-detail-section debug-detail-section--error">
-                  <strong>Error:</strong> {{ event.data.error }}
+                  <strong>{{ $tr('Error:', '错误:') }}</strong> {{ event.data.error }}
                 </div>
               </div>
             </div>
@@ -149,7 +149,7 @@
         <!-- Agent Trace -->
         <div v-if="activeTab === 'agents'" class="debug-agents">
           <div v-if="agentDecisions.length === 0" class="debug-empty">
-            No agent decisions recorded yet.
+            {{ $tr('No agent decisions recorded yet.', '尚未记录智能体决策。') }}
           </div>
           <div
             v-for="event in agentDecisions"
@@ -160,29 +160,29 @@
             <div class="debug-agent-card__header">
               <span class="debug-event__time">{{ formatTime(event.timestamp) }}</span>
               <span v-if="event.round_num" class="debug-agent-card__round">R{{ event.round_num }}</span>
-              <span class="debug-agent-card__name">{{ event.agent_name || `Agent #${event.agent_id}` }}</span>
+              <span class="debug-agent-card__name">{{ event.agent_name || `${$tr('Agent', '智能体')} #${event.agent_id}` }}</span>
               <span
                 class="debug-agent-card__action"
                 :class="event.data?.success ? 'debug-agent-card__action--ok' : 'debug-agent-card__action--fail'"
               >
-                {{ event.data?.parsed_action?.action_type || 'unknown' }}
+                {{ event.data?.parsed_action?.action_type || $tr('unknown', '未知') }}
               </span>
             </div>
             <div v-if="expandedIds.has(event.event_id)" class="debug-agent-card__detail">
               <div v-if="event.data?.env_prompt_preview" class="debug-detail-section">
-                <strong>Environment observation:</strong>
+                <strong>{{ $tr('Environment observation:', '环境观察:') }}</strong>
                 <pre>{{ event.data.env_prompt || event.data.env_prompt_preview }}</pre>
               </div>
               <div v-if="event.data?.llm_response_preview" class="debug-detail-section">
-                <strong>LLM response:</strong>
+                <strong>{{ $tr('LLM response:', 'LLM 响应:') }}</strong>
                 <pre>{{ event.data.llm_response || event.data.llm_response_preview }}</pre>
               </div>
               <div v-if="event.data?.tool_calls?.length" class="debug-detail-section">
-                <strong>Tool calls:</strong>
+                <strong>{{ $tr('Tool calls:', '工具调用:') }}</strong>
                 <pre>{{ JSON.stringify(event.data.tool_calls, null, 2) }}</pre>
               </div>
               <div v-if="event.data?.error" class="debug-detail-section debug-detail-section--error">
-                <strong>Error:</strong> {{ event.data.error }}
+                <strong>{{ $tr('Error:', '错误:') }}</strong> {{ event.data.error }}
               </div>
             </div>
           </div>
@@ -191,7 +191,7 @@
         <!-- Errors -->
         <div v-if="activeTab === 'errors'" class="debug-errors">
           <div v-if="errorEvents.length === 0" class="debug-empty">
-            No errors recorded.
+            {{ $tr('No errors recorded.', '未记录错误。') }}
           </div>
           <div
             v-for="event in errorEvents"
@@ -202,11 +202,11 @@
             <div class="debug-error-card__header">
               <span class="debug-event__time">{{ formatTime(event.timestamp) }}</span>
               <span class="debug-error-card__class">{{ event.data?.error_class || event.event_type }}</span>
-              <span class="debug-error-card__msg">{{ event.data?.message || event.data?.error || 'Unknown error' }}</span>
+              <span class="debug-error-card__msg">{{ event.data?.message || event.data?.error || $tr('Unknown error', '未知错误') }}</span>
             </div>
             <div v-if="expandedIds.has(event.event_id)" class="debug-error-card__detail">
               <div v-if="event.data?.context" class="debug-detail-section">
-                <strong>Context:</strong> {{ event.data.context }}
+                <strong>{{ $tr('Context:', '上下文:') }}</strong> {{ event.data.context }}
               </div>
               <pre v-if="event.data?.traceback" class="debug-traceback">{{ event.data.traceback }}</pre>
             </div>
@@ -221,6 +221,17 @@
 import { ref, computed, onMounted, onUnmounted, watch, nextTick, reactive } from 'vue'
 import { useRoute } from 'vue-router'
 import { streamEvents, getObservabilityStats } from '../api/observability'
+import { tr } from '../i18n'
+
+const translateTabLabel = (label) => {
+  const map = {
+    'Live Feed': tr('Live Feed', '实时事件'),
+    'LLM Calls': tr('LLM Calls', 'LLM 调用'),
+    'Agent Trace': tr('Agent Trace', '智能体追踪'),
+    'Errors': tr('Errors', '错误'),
+  }
+  return map[label] || label
+}
 
 const route = useRoute()
 

--- a/frontend/src/components/DemographicBreakdown.vue
+++ b/frontend/src/components/DemographicBreakdown.vue
@@ -4,19 +4,19 @@
     <div class="demo-header">
       <div class="demo-title">
         <span class="demo-icon">◇</span>
-        <span class="demo-label">DEMOGRAPHIC BREAKDOWN</span>
+        <span class="demo-label">{{ $tr('DEMOGRAPHIC BREAKDOWN', '人口分布') }}</span>
       </div>
       <div class="demo-header-actions">
         <span v-if="meta" class="demo-meta">
-          {{ meta.agents_with_stance }}/{{ meta.total_agents }} agents with belief data
+          {{ meta.agents_with_stance }}/{{ meta.total_agents }} {{ $tr('agents with belief data', '个智能体含信念数据') }}
         </span>
         <button
           class="demo-export-btn"
           :disabled="!hasData"
           @click="refresh"
-          title="Refresh demographic breakdown"
+          :title="$tr('Refresh demographic breakdown', '刷新人口分布')"
         >
-          ↻ Refresh
+          ↻ {{ $tr('Refresh', '刷新') }}
         </button>
       </div>
     </div>
@@ -30,7 +30,7 @@
         :class="{ active: activeTab === tab.key }"
         @click="activeTab = tab.key"
       >
-        {{ tab.label }}
+        {{ translateTabLabel(tab.label) }}
         <span class="demo-tab-count">{{ tabSegmentCount(tab.key) }}</span>
       </button>
     </div>
@@ -38,7 +38,7 @@
     <!-- Loading -->
     <div v-if="loading" class="demo-state">
       <div class="pulse-ring"></div>
-      <span>Computing demographic breakdown...</span>
+      <span>{{ $tr('Computing demographic breakdown...', '正在计算人口分布...') }}</span>
     </div>
 
     <!-- Error -->
@@ -46,32 +46,31 @@
 
     <!-- No data -->
     <div v-else-if="!hasData" class="demo-state">
-      <span>No demographic data available.</span>
-      <span class="demo-hint">Run a simulation to generate agent profiles.</span>
+      <span>{{ $tr('No demographic data available.', '暂无人口数据。') }}</span>
+      <span class="demo-hint">{{ $tr('Run a simulation to generate agent profiles.', '运行一次模拟以生成智能体画像。') }}</span>
     </div>
 
     <!-- Main content -->
     <div v-else class="demo-content">
       <!-- Top divergence callout -->
       <div v-if="topDivergence" class="demo-highlight">
-        <span class="demo-highlight-label">KEY SUBGROUP DYNAMIC</span>
+        <span class="demo-highlight-label">{{ $tr('KEY SUBGROUP DYNAMIC', '关键子群体动态') }}</span>
         <span class="demo-highlight-text">{{ topDivergence.headline }}</span>
       </div>
       <div v-else-if="meta && !meta.has_trajectory" class="demo-highlight demo-highlight-muted">
-        <span class="demo-highlight-label">NOTICE</span>
+        <span class="demo-highlight-label">{{ $tr('NOTICE', '提示') }}</span>
         <span class="demo-highlight-text">
-          This simulation has no belief trajectory — stance comparisons will be
-          unavailable, but counts and influence remain accurate.
+          {{ $tr('This simulation has no belief trajectory — stance comparisons will be unavailable, but counts and influence remain accurate.', '此模拟没有信念轨迹 — 立场对比将不可用,但数量和影响力数据仍然准确。') }}
         </span>
       </div>
 
       <!-- Legend -->
       <div class="demo-legend">
-        <span class="legend-item"><span class="legend-dot bullish-dot"></span>Bullish</span>
-        <span class="legend-item"><span class="legend-dot neutral-dot"></span>Neutral</span>
-        <span class="legend-item"><span class="legend-dot bearish-dot"></span>Bearish</span>
+        <span class="legend-item"><span class="legend-dot bullish-dot"></span>{{ $tr('Bullish', '看涨') }}</span>
+        <span class="legend-item"><span class="legend-dot neutral-dot"></span>{{ $tr('Neutral', '中立') }}</span>
+        <span class="legend-item"><span class="legend-dot bearish-dot"></span>{{ $tr('Bearish', '看跌') }}</span>
         <span class="legend-sep">·</span>
-        <span class="legend-item">Stance mean: -1 ↔ +1</span>
+        <span class="legend-item">{{ $tr('Stance mean: -1 ↔ +1', '立场均值: -1 ↔ +1') }}</span>
       </div>
 
       <!-- Segment list for active tab -->
@@ -83,7 +82,7 @@
         >
           <div class="demo-row-head">
             <span class="demo-row-label">{{ formatSegmentLabel(segment.label) }}</span>
-            <span class="demo-row-count">{{ segment.count }} agent{{ segment.count === 1 ? '' : 's' }}</span>
+            <span class="demo-row-count">{{ segment.count }} {{ $tr(segment.count === 1 ? 'agent' : 'agents', '个智能体') }}</span>
           </div>
 
           <!-- Stance distribution bar -->
@@ -91,17 +90,17 @@
             <div
               class="stance-seg stance-bullish"
               :style="{ width: segment.bullish_pct + '%' }"
-              :title="`Bullish: ${segment.bullish_pct}%`"
+              :title="$tr('Bullish:', '看涨:') + ` ${segment.bullish_pct}%`"
             ></div>
             <div
               class="stance-seg stance-neutral"
               :style="{ width: segment.neutral_pct + '%' }"
-              :title="`Neutral: ${segment.neutral_pct}%`"
+              :title="$tr('Neutral:', '中立:') + ` ${segment.neutral_pct}%`"
             ></div>
             <div
               class="stance-seg stance-bearish"
               :style="{ width: segment.bearish_pct + '%' }"
-              :title="`Bearish: ${segment.bearish_pct}%`"
+              :title="$tr('Bearish:', '看跌:') + ` ${segment.bearish_pct}%`"
             ></div>
           </div>
           <div v-else class="stance-bar stance-empty"></div>
@@ -109,7 +108,7 @@
           <!-- Metrics row -->
           <div class="demo-metrics">
             <span class="metric">
-              <span class="metric-label">mean</span>
+              <span class="metric-label">{{ $tr('mean', '均值') }}</span>
               <span class="metric-value" :class="stanceClass(segment.final_stance_mean)">
                 {{ formatStance(segment.final_stance_mean) }}
               </span>
@@ -119,11 +118,11 @@
               <span class="metric-value">{{ formatNumber(segment.final_stance_std) }}</span>
             </span>
             <span class="metric">
-              <span class="metric-label">volatility</span>
+              <span class="metric-label">{{ $tr('volatility', '波动率') }}</span>
               <span class="metric-value">{{ formatNumber(segment.stance_volatility) }}</span>
             </span>
             <span class="metric">
-              <span class="metric-label">influence</span>
+              <span class="metric-label">{{ $tr('influence', '影响力') }}</span>
               <span class="metric-value">{{ formatInfluence(segment.influence_mean) }}</span>
             </span>
           </div>
@@ -132,9 +131,7 @@
 
       <!-- Footer hint -->
       <div class="demo-footer-hint">
-        Stance values average each agent's final belief across tracked topics
-        (-1 bearish → +1 bullish). Volatility is the mean absolute change from
-        round 0 to the final round.
+        {{ $tr(`Stance values average each agent's final belief across tracked topics (-1 bearish → +1 bullish). Volatility is the mean absolute change from round 0 to the final round.`, '立场值为每个智能体在跟踪话题上的最终信念均值(-1 看跌 → +1 看涨)。波动率为从第 0 轮到最终轮的绝对变化均值。') }}
       </div>
     </div>
   </div>
@@ -143,6 +140,7 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
 import { getDemographicBreakdown } from '../api/simulation'
+import { tr } from '../i18n'
 
 const props = defineProps({
   simulationId: { type: String, required: true },
@@ -190,20 +188,31 @@ const hasStanceData = (segment) =>
   (segment.bullish_pct + segment.neutral_pct + segment.bearish_pct) > 0
 
 const formatSegmentLabel = (raw) => {
-  if (!raw) return 'unknown'
+  if (!raw) return tr('unknown', '未知')
   const map = {
-    unknown: 'Unknown',
-    individual: 'Individual',
-    institutional: 'Institutional',
-    inactive: 'Inactive',
-    male: 'Male',
-    female: 'Female',
-    other: 'Other',
+    unknown: tr('Unknown', '未知'),
+    individual: tr('Individual', '个人'),
+    institutional: tr('Institutional', '机构'),
+    inactive: tr('Inactive', '不活跃'),
+    male: tr('Male', '男性'),
+    female: tr('Female', '女性'),
+    other: tr('Other', '其他'),
     twitter: 'X / Twitter',
     reddit: 'Reddit',
     polymarket: 'Polymarket',
   }
   return map[raw] || raw
+}
+
+const translateTabLabel = (label) => {
+  const map = {
+    'Age': tr('Age', '年龄'),
+    'Gender': tr('Gender', '性别'),
+    'Country': tr('Country', '国家'),
+    'Actor type': tr('Actor type', '主体类型'),
+    'Platform': tr('Platform', '平台'),
+  }
+  return map[label] || label
 }
 
 const formatStance = (v) => {
@@ -244,10 +253,10 @@ const load = async (opts = {}) => {
     } else if (res.success && !res.data) {
       payload.value = null
     } else {
-      error.value = res.error || 'Failed to load demographic breakdown.'
+      error.value = res.error || tr('Failed to load demographic breakdown.', '加载人口分布失败。')
     }
   } catch (err) {
-    error.value = err.message || 'Failed to load demographic breakdown.'
+    error.value = err.message || tr('Failed to load demographic breakdown.', '加载人口分布失败。')
   } finally {
     loading.value = false
   }

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -7,7 +7,7 @@
           <div class="embed-dialog-header">
             <div class="embed-dialog-title">
               <span class="title-icon">⌘</span>
-              <span>Embed simulation</span>
+              <span>{{ $tr('Embed simulation', '嵌入模拟') }}</span>
               <span class="title-sub">{{ formatSimulationId(simulationId) }}</span>
             </div>
             <button class="embed-dialog-close" @click="$emit('close')">×</button>
@@ -15,8 +15,7 @@
 
           <!-- Description -->
           <p class="embed-dialog-desc">
-            Paste the iframe below into Notion, Substack, Medium, a GitHub README, or any HTML page.
-            The widget loads live from this MiroShark instance and updates automatically as the simulation changes.
+            {{ $tr('Paste the iframe below into Notion, Substack, Medium, a GitHub README, or any HTML page. The widget loads live from this MiroShark instance and updates automatically as the simulation changes.', '将下面的 iframe 粘贴到 Notion、Substack、Medium、GitHub README 或任何 HTML 页面中。组件从当前 MiroShark 实例实时加载,并随模拟变化自动更新。') }}
           </p>
 
           <!-- Public toggle -->
@@ -24,7 +23,7 @@
             <label class="embed-public-toggle">
               <input type="checkbox" :checked="isPublic" @change="togglePublic" :disabled="publishing" />
               <span class="embed-public-label">
-                {{ isPublic ? 'Public — embeddable by anyone with the URL' : 'Private — embed URL returns 403' }}
+                {{ isPublic ? $tr('Public — embeddable by anyone with the URL', '公开 — 任何获得 URL 的人都可嵌入') : $tr('Private — embed URL returns 403', '私有 — 嵌入 URL 返回 403') }}
               </span>
             </label>
             <span v-if="publishError" class="embed-public-error">{{ publishError }}</span>
@@ -32,7 +31,7 @@
 
           <!-- Size presets -->
           <div class="embed-size-row">
-            <span class="embed-size-label">Size</span>
+            <span class="embed-size-label">{{ $tr('Size', '尺寸') }}</span>
             <div class="embed-size-buttons">
               <button
                 v-for="preset in sizePresets"
@@ -41,15 +40,15 @@
                 :class="{ active: activePreset === preset.name }"
                 @click="activePreset = preset.name"
               >
-                {{ preset.name }}
+                {{ translatePresetName(preset.name) }}
                 <span class="embed-size-dim">{{ preset.width }}×{{ preset.height }}</span>
               </button>
             </div>
             <label class="embed-theme-toggle">
-              <span>Theme</span>
+              <span>{{ $tr('Theme', '主题') }}</span>
               <select v-model="theme" class="embed-theme-select">
-                <option value="light">Light</option>
-                <option value="dark">Dark</option>
+                <option value="light">{{ $tr('Light', '浅色') }}</option>
+                <option value="dark">{{ $tr('Dark', '深色') }}</option>
               </select>
             </label>
           </div>
@@ -72,9 +71,9 @@
           <div class="embed-snippets">
             <div class="snippet-block">
               <div class="snippet-head">
-                <span class="snippet-label">HTML iframe</span>
+                <span class="snippet-label">{{ $tr('HTML iframe', 'HTML iframe') }}</span>
                 <button class="snippet-copy-btn" @click="copy('iframe')">
-                  {{ copied === 'iframe' ? '✓ Copied' : 'Copy' }}
+                  {{ copied === 'iframe' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy', '复制') }}
                 </button>
               </div>
               <pre class="snippet-code"><code>{{ iframeSnippet }}</code></pre>
@@ -82,9 +81,9 @@
 
             <div class="snippet-block">
               <div class="snippet-head">
-                <span class="snippet-label">Markdown (Notion / Substack auto-embed)</span>
+                <span class="snippet-label">{{ $tr('Markdown (Notion / Substack auto-embed)', 'Markdown(Notion / Substack 自动嵌入)') }}</span>
                 <button class="snippet-copy-btn" @click="copy('markdown')">
-                  {{ copied === 'markdown' ? '✓ Copied' : 'Copy' }}
+                  {{ copied === 'markdown' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy', '复制') }}
                 </button>
               </div>
               <pre class="snippet-code"><code>{{ markdownSnippet }}</code></pre>
@@ -92,9 +91,9 @@
 
             <div class="snippet-block">
               <div class="snippet-head">
-                <span class="snippet-label">Direct URL</span>
+                <span class="snippet-label">{{ $tr('Direct URL', '直接 URL') }}</span>
                 <button class="snippet-copy-btn" @click="copy('url')">
-                  {{ copied === 'url' ? '✓ Copied' : 'Copy' }}
+                  {{ copied === 'url' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy', '复制') }}
                 </button>
               </div>
               <pre class="snippet-code"><code>{{ embedUrl }}</code></pre>
@@ -105,15 +104,12 @@
           <div class="share-card-section">
             <div class="share-card-divider">
               <span class="divider-line"></span>
-              <span class="divider-text">Social card</span>
+              <span class="divider-text">{{ $tr('Social card', '社交卡片') }}</span>
               <span class="divider-line"></span>
             </div>
 
             <p class="share-card-desc">
-              A 1200×630 PNG with the scenario headline, status, quality, and
-              belief split — the same image Twitter/X, Discord, Slack, and
-              LinkedIn unfurl automatically when someone pastes the share
-              link.
+              {{ $tr('A 1200×630 PNG with the scenario headline, status, quality, and belief split — the same image Twitter/X, Discord, Slack, and LinkedIn unfurl automatically when someone pastes the share link.', '一张 1200×630 的 PNG,包含情景标题、状态、质量和信念分布 — Twitter/X、Discord、Slack 和 LinkedIn 在有人粘贴分享链接时会自动展开此图。') }}
             </p>
 
             <div class="share-card-preview-wrap">
@@ -126,16 +122,16 @@
                 @error="onShareCardError"
               />
               <div v-else class="share-card-empty">
-                {{ isPublic ? 'Loading preview…' : 'Publish the simulation to enable the share card.' }}
+                {{ isPublic ? $tr('Loading preview…', '加载预览中…') : $tr('Publish the simulation to enable the share card.', '发布模拟以启用分享卡片。') }}
               </div>
             </div>
 
             <div class="share-card-actions">
               <div class="snippet-block share-snippet">
                 <div class="snippet-head">
-                  <span class="snippet-label">Share link (auto-unfurls with card)</span>
+                  <span class="snippet-label">{{ $tr('Share link (auto-unfurls with card)', '分享链接(随卡片自动展开)') }}</span>
                   <button class="snippet-copy-btn" @click="copy('share')" :disabled="!isPublic">
-                    {{ copied === 'share' ? '✓ Copied' : 'Copy link' }}
+                    {{ copied === 'share' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy link', '复制链接') }}
                   </button>
                 </div>
                 <pre class="snippet-code"><code>{{ shareLandingUrl || '—' }}</code></pre>
@@ -143,9 +139,9 @@
 
               <div class="snippet-block share-snippet">
                 <div class="snippet-head">
-                  <span class="snippet-label">Card image URL (for manual paste)</span>
+                  <span class="snippet-label">{{ $tr('Card image URL (for manual paste)', '卡片图片 URL(供手动粘贴)') }}</span>
                   <button class="snippet-copy-btn" @click="copy('card')" :disabled="!isPublic">
-                    {{ copied === 'card' ? '✓ Copied' : 'Copy URL' }}
+                    {{ copied === 'card' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy URL', '复制 URL') }}
                   </button>
                 </div>
                 <pre class="snippet-code"><code>{{ shareCardUrl || '—' }}</code></pre>
@@ -157,7 +153,7 @@
                 :href="shareCardUrl"
                 :download="`miroshark-${simulationId.slice(0, 12)}.png`"
               >
-                ↓ Download PNG
+                ↓ {{ $tr('Download PNG', '下载 PNG') }}
               </a>
             </div>
 
@@ -168,11 +164,9 @@
               <div class="replay-head">
                 <span class="replay-icon">▶</span>
                 <div class="replay-head-body">
-                  <div class="replay-title">Belief replay (animated)</div>
+                  <div class="replay-title">{{ $tr('Belief replay (animated)', '信念回放(动画)') }}</div>
                   <div class="replay-sub">
-                    Same canvas as the share card, one frame per round.
-                    Discord and Slack auto-play GIFs from the direct URL —
-                    drop the link in a channel and it plays inline.
+                    {{ $tr('Same canvas as the share card, one frame per round. Discord and Slack auto-play GIFs from the direct URL — drop the link in a channel and it plays inline.', '与分享卡片相同的画布,每轮一帧。Discord 和 Slack 会从直接 URL 自动播放 GIF — 在频道里贴上链接即可内联播放。') }}
                   </div>
                 </div>
               </div>
@@ -194,23 +188,23 @@
                 />
                 <div v-if="!replayPlay" class="replay-overlay">
                   <span class="replay-overlay-icon">▶</span>
-                  <span class="replay-overlay-text">Tap to play</span>
+                  <span class="replay-overlay-text">{{ $tr('Tap to play', '点击播放') }}</span>
                 </div>
               </div>
               <div v-else class="replay-empty">
-                Publish the simulation to enable the belief replay GIF.
+                {{ $tr('Publish the simulation to enable the belief replay GIF.', '发布模拟以启用信念回放 GIF。') }}
               </div>
 
               <div class="replay-actions">
                 <div class="snippet-block share-snippet">
                   <div class="snippet-head">
-                    <span class="snippet-label">Replay GIF URL (auto-plays in Discord / Slack)</span>
+                    <span class="snippet-label">{{ $tr('Replay GIF URL (auto-plays in Discord / Slack)', '回放 GIF URL(在 Discord / Slack 中自动播放)') }}</span>
                     <button
                       class="snippet-copy-btn"
                       @click="copy('replay')"
                       :disabled="!isPublic"
                     >
-                      {{ copied === 'replay' ? '✓ Copied' : 'Copy URL' }}
+                      {{ copied === 'replay' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy URL', '复制 URL') }}
                     </button>
                   </div>
                   <pre class="snippet-code"><code>{{ replayGifUrl || '—' }}</code></pre>
@@ -222,7 +216,7 @@
                   :href="replayGifUrl"
                   :download="`miroshark-${simulationId.slice(0, 12)}-replay.gif`"
                 >
-                  ↓ Download GIF
+                  ↓ {{ $tr('Download GIF', '下载 GIF') }}
                 </a>
               </div>
             </div>
@@ -236,11 +230,9 @@
               <div class="transcript-head">
                 <span class="transcript-icon">📄</span>
                 <div class="transcript-head-body">
-                  <div class="transcript-title">Export transcript</div>
+                  <div class="transcript-title">{{ $tr('Export transcript', '导出对话记录') }}</div>
                   <div class="transcript-sub">
-                    Per-round agent posts + stance labels + final
-                    consensus. Cite the simulation in a research paper
-                    or a Substack post without screenshotting.
+                    {{ $tr('Per-round agent posts + stance labels + final consensus. Cite the simulation in a research paper or a Substack post without screenshotting.', '逐轮智能体帖子 + 立场标签 + 最终共识。在研究论文或 Substack 文章中引用该模拟,无需截屏。') }}
                   </div>
                 </div>
               </div>
@@ -252,7 +244,7 @@
                   :href="transcriptMarkdownUrl"
                   :download="`miroshark-${simulationId.slice(0, 12)}-transcript.md`"
                 >
-                  ↓ Download .md
+                  ↓ {{ $tr('Download .md', '下载 .md') }}
                 </a>
                 <a
                   v-if="isPublic && transcriptJsonUrl"
@@ -260,22 +252,22 @@
                   :href="transcriptJsonUrl"
                   :download="`miroshark-${simulationId.slice(0, 12)}-transcript.json`"
                 >
-                  ↓ Download .json
+                  ↓ {{ $tr('Download .json', '下载 .json') }}
                 </a>
                 <span v-if="!isPublic" class="transcript-empty">
-                  Publish the simulation to enable the transcript export.
+                  {{ $tr('Publish the simulation to enable the transcript export.', '发布模拟以启用对话记录导出。') }}
                 </span>
               </div>
 
               <div class="snippet-block transcript-snippet">
                 <div class="snippet-head">
-                  <span class="snippet-label">Markdown URL (Notion / Obsidian "Import from URL")</span>
+                  <span class="snippet-label">{{ $tr(`Markdown URL (Notion / Obsidian "Import from URL")`, 'Markdown URL(Notion / Obsidian「从 URL 导入」)') }}</span>
                   <button
                     class="snippet-copy-btn"
                     @click="copy('transcriptMd')"
                     :disabled="!isPublic"
                   >
-                    {{ copied === 'transcriptMd' ? '✓ Copied' : 'Copy URL' }}
+                    {{ copied === 'transcriptMd' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy URL', '复制 URL') }}
                   </button>
                 </div>
                 <pre class="snippet-code"><code>{{ transcriptMarkdownUrl || '—' }}</code></pre>
@@ -291,16 +283,15 @@
                 <span class="outcome-icon">📍</span>
                 <div class="outcome-head-body">
                   <div class="outcome-title">
-                    Mark outcome
+                    {{ $tr('Mark outcome', '标记结果') }}
                     <span v-if="outcome && outcome.label" class="outcome-saved-tag">
                       ✓ {{ outcomeLabelText(outcome.label) }}
                     </span>
                   </div>
                   <div class="outcome-sub">
-                    Did this simulation predict a real event? Annotate it and
-                    your run lands on
+                    {{ $tr('Did this simulation predict a real event? Annotate it and your run lands on', '此模拟预测到了真实事件吗?为它做标注,你的运行将出现在') }}
                     <a href="/verified" target="_blank" rel="noopener">/verified</a>
-                    — the public hall of calls that landed.
+                    {{ $tr('— the public hall of calls that landed.', ' — 已落地预测的公开展示厅。') }}
                   </div>
                 </div>
               </div>
@@ -326,14 +317,14 @@
                 <input
                   v-model="outcomeForm.outcome_url"
                   type="url"
-                  placeholder="Outcome URL (article, tweet, dashboard) — optional"
+                  :placeholder="$tr('Outcome URL (article, tweet, dashboard) — optional', '结果 URL(文章、推文、仪表板)— 可选')"
                   class="outcome-input"
                   :disabled="!isPublic"
                   maxlength="500"
                 />
                 <textarea
                   v-model="outcomeForm.outcome_summary"
-                  placeholder="What happened, in one or two sentences (max 280 chars)"
+                  :placeholder="$tr('What happened, in one or two sentences (max 280 chars)', '用一两句话描述发生了什么(最多 280 字符)')"
                   class="outcome-textarea"
                   :disabled="!isPublic"
                   maxlength="280"
@@ -349,9 +340,9 @@
                     @click="submitOutcome"
                     :disabled="!isPublic || !outcomeForm.label || outcomeSubmitting"
                   >
-                    <span v-if="outcomeSubmitting">Saving…</span>
-                    <span v-else-if="outcome">Update outcome</span>
-                    <span v-else>Save outcome</span>
+                    <span v-if="outcomeSubmitting">{{ $tr('Saving…', '保存中…') }}</span>
+                    <span v-else-if="outcome">{{ $tr('Update outcome', '更新结果') }}</span>
+                    <span v-else>{{ $tr('Save outcome', '保存结果') }}</span>
                   </button>
                   <a
                     v-if="outcome"
@@ -360,7 +351,7 @@
                     rel="noopener"
                     class="outcome-link"
                   >
-                    View on /verified ↗
+                    {{ $tr('View on /verified ↗', '在 /verified 查看 ↗') }}
                   </a>
                 </div>
 
@@ -377,21 +368,18 @@
               <div class="gallery-callout-icon">◎</div>
               <div class="gallery-callout-body">
                 <div class="gallery-callout-title">
-                  {{ isPublic ? 'Live on the public gallery' : 'Submit to the public gallery' }}
+                  {{ isPublic ? $tr('Live on the public gallery', '已发布到公开画廊') : $tr('Submit to the public gallery', '提交到公开画廊') }}
                 </div>
                 <div class="gallery-callout-desc">
                   <template v-if="isPublic">
-                    This simulation is now visible on
+                    {{ $tr('This simulation is now visible on', '此模拟现可在以下页面查看') }}
                     <a href="/explore" target="_blank" rel="noopener">/explore</a> —
-                    the public gallery where anyone can browse published runs
-                    and fork them into their own simulations.
+                    {{ $tr('the public gallery where anyone can browse published runs and fork them into their own simulations.', '公开画廊,任何人都可浏览已发布运行并派生为自己的模拟。') }}
                   </template>
                   <template v-else>
-                    Toggle "Public" above and this run joins the community
-                    gallery at
+                    {{ $tr(`Toggle "Public" above and this run joins the community gallery at`, '将上方切换为「公开」,该运行将加入社区画廊') }}
                     <a href="/explore" target="_blank" rel="noopener">/explore</a>.
-                    Others can browse it, view the full belief drift, and
-                    fork your agents into their own scenarios.
+                    {{ $tr('Others can browse it, view the full belief drift, and fork your agents into their own scenarios.', '其他人可以浏览、查看完整的信念漂移,并将你的智能体派生到他们自己的情景中。') }}
                   </template>
                 </div>
               </div>
@@ -402,7 +390,7 @@
                 rel="noopener"
                 class="gallery-callout-link"
               >
-                Open gallery ↗
+                {{ $tr('Open gallery ↗', '打开画廊 ↗') }}
               </a>
             </div>
 
@@ -416,12 +404,10 @@
                 <span class="feed-callout-icon">📡</span>
                 <div class="feed-callout-body">
                   <div class="feed-callout-title">
-                    Follow the gallery via RSS
+                    {{ $tr('Follow the gallery via RSS', '通过 RSS 关注画廊') }}
                   </div>
                   <div class="feed-callout-desc">
-                    Every newly published MiroShark simulation appears in
-                    your reader (Feedly, Readwise, Inoreader, Obsidian
-                    RSS, NetNewsWire, …). No login, no account.
+                    {{ $tr('Every newly published MiroShark simulation appears in your reader (Feedly, Readwise, Inoreader, Obsidian RSS, NetNewsWire, …). No login, no account.', '每个新发布的 MiroShark 模拟都会出现在你的阅读器中(Feedly、Readwise、Inoreader、Obsidian RSS、NetNewsWire 等)。无需登录,无需账户。') }}
                   </div>
                 </div>
               </div>
@@ -431,16 +417,16 @@
                   :href="feedAtomUrl"
                   target="_blank"
                   rel="noopener"
-                  title="Atom 1.0 feed of the public gallery"
+                  :title="$tr('Atom 1.0 feed of the public gallery', '公开画廊的 Atom 1.0 源')"
                 >
-                  Atom feed ↗
+                  {{ $tr('Atom feed ↗', 'Atom 源 ↗') }}
                 </a>
                 <a
                   class="feed-callout-link feed-callout-link-secondary"
                   :href="feedRssUrl"
                   target="_blank"
                   rel="noopener"
-                  title="RSS 2.0 feed of the public gallery"
+                  :title="$tr('RSS 2.0 feed of the public gallery', '公开画廊的 RSS 2.0 源')"
                 >
                   RSS 2.0 ↗
                 </a>
@@ -449,9 +435,9 @@
                   :href="feedVerifiedAtomUrl"
                   target="_blank"
                   rel="noopener"
-                  title="Atom feed restricted to verified predictions only"
+                  :title="$tr('Atom feed restricted to verified predictions only', '仅限已验证预测的 Atom 源')"
                 >
-                  Verified only ↗
+                  {{ $tr('Verified only ↗', '仅已验证 ↗') }}
                 </a>
               </div>
             </div>
@@ -460,8 +446,8 @@
           <!-- Hint -->
           <div class="embed-dialog-hint">
             <span class="hint-icon">ⓘ</span>
-            The widget reads from this instance's API, so viewers must be able to reach
-            <code>{{ origin }}</code>. For public embeds, deploy MiroShark somewhere reachable from the internet.
+            {{ $tr(`The widget reads from this instance's API, so viewers must be able to reach`, '组件读取自当前实例的 API,因此查看者必须能访问') }}
+            <code>{{ origin }}</code>. {{ $tr('For public embeds, deploy MiroShark somewhere reachable from the internet.', '若要进行公开嵌入,请将 MiroShark 部署到互联网可访问的位置。') }}
           </div>
         </div>
       </div>
@@ -483,6 +469,16 @@ import {
   getSimulationOutcome,
   submitSimulationOutcome,
 } from '../api/simulation'
+import { tr } from '../i18n'
+
+const translatePresetName = (name) => {
+  const map = {
+    'Compact': tr('Compact', '紧凑'),
+    'Standard': tr('Standard', '标准'),
+    'Wide': tr('Wide', '宽屏'),
+  }
+  return map[name] || name
+}
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -504,7 +500,7 @@ const togglePublic = async () => {
     const res = await publishSimulation(props.simulationId, next)
     isPublic.value = res?.data?.is_public ?? next
   } catch (err) {
-    publishError.value = err?.response?.data?.error || err?.message || 'Publish failed'
+    publishError.value = err?.response?.data?.error || err?.message || tr('Publish failed', '发布失败')
   } finally {
     publishing.value = false
   }
@@ -513,7 +509,7 @@ const togglePublic = async () => {
 const sizePresets = [
   { name: 'Compact', width: 480, height: 260 },
   { name: 'Standard', width: 640, height: 340 },
-  { name: 'Wide', width: 800, height: 420 }
+  { name: 'Wide', width: 800, height: 420 },
 ]
 
 const activePreset = ref('Standard')
@@ -672,9 +668,9 @@ const copy = async (which) => {
 
 // ── Verified-prediction outcome submission ─────────────────────────────
 const outcomeOptions = [
-  { value: 'correct', label: 'Called it', icon: '📍' },
-  { value: 'partial', label: 'Partial', icon: '◑' },
-  { value: 'incorrect', label: 'Called wrong', icon: '⚠' },
+  { value: 'correct', label: tr('Called it', '命中'), icon: '📍' },
+  { value: 'partial', label: tr('Partial', '部分命中'), icon: '◑' },
+  { value: 'incorrect', label: tr('Called wrong', '判断错误'), icon: '⚠' },
 ]
 
 const outcomeForm = reactive({
@@ -734,15 +730,15 @@ const submitOutcome = async () => {
     if (res?.success && res.data) {
       _applyOutcomeToForm(res.data)
       outcomeMessage.value =
-        'Outcome saved — your simulation is visible in the Verified filter.'
+        tr('Outcome saved — your simulation is visible in the Verified filter.', '结果已保存 — 你的模拟现在「已验证」筛选中可见。')
       outcomeMessageClass.value = 'outcome-message-success'
     } else {
-      outcomeMessage.value = res?.error || 'Could not save outcome.'
+      outcomeMessage.value = res?.error || tr('Could not save outcome.', '无法保存结果。')
       outcomeMessageClass.value = 'outcome-message-error'
     }
   } catch (err) {
     outcomeMessage.value =
-      err?.response?.data?.error || err?.message || 'Could not save outcome.'
+      err?.response?.data?.error || err?.message || tr('Could not save outcome.', '无法保存结果。')
     outcomeMessageClass.value = 'outcome-message-error'
   } finally {
     outcomeSubmitting.value = false

--- a/frontend/src/components/GraphPanel.vue
+++ b/frontend/src/components/GraphPanel.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="graph-panel">
     <div class="panel-header">
-      <span class="panel-title">Graph Overview</span>
+      <span class="panel-title">{{ $tr('Graph Overview', '图谱概览') }}</span>
       <!-- Top Toolbar (Internal Top Right) -->
       <div class="header-tools">
-        <button class="tool-btn" @click="$emit('refresh')" :disabled="loading" title="Refresh Graph">
+        <button class="tool-btn" @click="$emit('refresh')" :disabled="loading" :title="$tr('Refresh Graph', '刷新图谱')">
           <span class="icon-refresh" :class="{ 'spinning': loading }">↻</span>
-          <span class="btn-text">Refresh</span>
+          <span class="btn-text">{{ $tr('Refresh', '刷新') }}</span>
         </button>
-        <button class="tool-btn" @click="$emit('toggle-maximize')" title="Maximize/Restore">
+        <button class="tool-btn" @click="$emit('toggle-maximize')" :title="$tr('Maximize/Restore', '最大化/还原')">
           <span class="icon-maximize">⛶</span>
         </button>
       </div>
@@ -27,56 +27,56 @@
               <path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96.44 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-4.44-4.04z" />
             </svg>
           </div>
-          Updating in real time...
+          {{ $tr('Updating in real time...', '实时更新中...') }}
           <span class="hint-close" @click="hideUpdateHint = true">&times;</span>
         </div>
-        
-        
+
+
         <!-- Node/Edge Detail Panel -->
         <div v-if="selectedItem" class="detail-panel">
           <div class="detail-panel-header">
-            <span class="detail-title">{{ selectedItem.type === 'node' ? 'Agent Details' : 'Relationship' }}</span>
+            <span class="detail-title">{{ selectedItem.type === 'node' ? $tr('Agent Details', '智能体详情') : $tr('Relationship', '关系') }}</span>
             <span v-if="selectedItem.type === 'node'" class="detail-type-badge" :style="{ background: selectedItem.color, color: '#fff' }">
               {{ selectedItem.entityType }}
             </span>
             <button class="detail-close" @click="closeDetailPanel">×</button>
           </div>
-          
+
           <!-- Node Details -->
           <div v-if="selectedItem.type === 'node'" class="detail-content">
             <div class="detail-row">
-              <span class="detail-label">Name:</span>
+              <span class="detail-label">{{ $tr('Name:', '名称:') }}</span>
               <span class="detail-value">{{ selectedItem.data.name }}</span>
             </div>
             <div class="detail-row">
-              <span class="detail-label">UUID:</span>
+              <span class="detail-label">{{ $tr('UUID:', 'UUID:') }}</span>
               <span class="detail-value uuid-text copyable" @click="copyText(selectedItem.data.uuid)">{{ selectedItem.data.uuid }}</span>
             </div>
             <div class="detail-row" v-if="selectedItem.data.created_at">
-              <span class="detail-label">Created:</span>
+              <span class="detail-label">{{ $tr('Created:', '创建时间:') }}</span>
               <span class="detail-value">{{ formatDateTime(selectedItem.data.created_at) }}</span>
             </div>
-            
+
             <!-- Properties -->
             <div class="detail-section" v-if="selectedItem.data.attributes && Object.keys(selectedItem.data.attributes).length > 0">
-              <div class="section-title">Properties:</div>
+              <div class="section-title">{{ $tr('Properties:', '属性:') }}</div>
               <div class="properties-list">
                 <div v-for="(value, key) in selectedItem.data.attributes" :key="key" class="property-item">
                   <span class="property-key">{{ key }}:</span>
-                  <span class="property-value">{{ value || 'None' }}</span>
+                  <span class="property-value">{{ value || $tr('None', '无') }}</span>
                 </div>
               </div>
             </div>
-            
+
             <!-- Summary -->
             <div class="detail-section" v-if="selectedItem.data.summary">
-              <div class="section-title">Summary:</div>
+              <div class="section-title">{{ $tr('Summary:', '摘要:') }}</div>
               <div class="summary-text">{{ selectedItem.data.summary }}</div>
             </div>
-            
+
             <!-- Labels -->
             <div class="detail-section" v-if="selectedItem.data.labels && selectedItem.data.labels.length > 0">
-              <div class="section-title">Labels:</div>
+              <div class="section-title">{{ $tr('Labels:', '标签:') }}</div>
               <div class="labels-list">
                 <span v-for="label in selectedItem.data.labels" :key="label" class="label-tag">
                   {{ label }}
@@ -88,8 +88,8 @@
             <div class="detail-section" v-if="simulationId">
               <div class="section-title actions-title" @click="actionsExpanded = !actionsExpanded" style="cursor: pointer;">
                 <span class="actions-toggle">{{ actionsExpanded ? '▼' : '▶' }}</span>
-                Agent Actions
-                <span v-if="agentActionsLoading" class="actions-loading">loading...</span>
+                {{ $tr('Agent Actions', '智能体动作') }}
+                <span v-if="agentActionsLoading" class="actions-loading">{{ $tr('loading...', '加载中...') }}</span>
                 <span v-else-if="agentActions.length > 0" class="actions-count">{{ agentActions.length }}</span>
               </div>
               <div v-show="actionsExpanded">
@@ -112,65 +112,65 @@
                     <!-- Expanded details -->
                     <div v-show="expandedActions.has(idx)" class="action-details">
                       <div class="action-detail-row" v-if="action.timestamp">
-                        <span class="action-detail-label">Time</span>
+                        <span class="action-detail-label">{{ $tr('Time', '时间') }}</span>
                         <span class="action-detail-value">{{ action.timestamp }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.agent_name">
-                        <span class="action-detail-label">Agent</span>
+                        <span class="action-detail-label">{{ $tr('Agent', '智能体') }}</span>
                         <span class="action-detail-value">{{ action.agent_name }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.agent_id != null">
-                        <span class="action-detail-label">Agent ID</span>
+                        <span class="action-detail-label">{{ $tr('Agent ID', '智能体 ID') }}</span>
                         <span class="action-detail-value mono">{{ action.agent_id }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.action_args?.post_id != null">
-                        <span class="action-detail-label">Post ID</span>
+                        <span class="action-detail-label">{{ $tr('Post ID', '帖子 ID') }}</span>
                         <span class="action-detail-value mono">#{{ action.action_args.post_id }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.action_args?.comment_id != null">
-                        <span class="action-detail-label">Comment ID</span>
+                        <span class="action-detail-label">{{ $tr('Comment ID', '评论 ID') }}</span>
                         <span class="action-detail-value mono">#{{ action.action_args.comment_id }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.action_args?.target_post_id != null">
-                        <span class="action-detail-label">Target Post</span>
+                        <span class="action-detail-label">{{ $tr('Target Post', '目标帖子') }}</span>
                         <span class="action-detail-value mono">#{{ action.action_args.target_post_id }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.action_args?.market_id != null">
-                        <span class="action-detail-label">Market</span>
+                        <span class="action-detail-label">{{ $tr('Market', '市场') }}</span>
                         <span class="action-detail-value mono">#{{ action.action_args.market_id }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.action_args?.outcome">
-                        <span class="action-detail-label">Position</span>
+                        <span class="action-detail-label">{{ $tr('Position', '仓位') }}</span>
                         <span class="action-detail-value" :class="action.action_args.outcome === 'YES' ? 'text-green' : 'text-orange'">{{ action.action_args.outcome }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.action_args?.cost != null">
-                        <span class="action-detail-label">Cost</span>
+                        <span class="action-detail-label">{{ $tr('Cost', '成本') }}</span>
                         <span class="action-detail-value">${{ action.action_args.cost.toFixed(2) }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.action_args?.shares != null">
-                        <span class="action-detail-label">Shares</span>
+                        <span class="action-detail-label">{{ $tr('Shares', '份额') }}</span>
                         <span class="action-detail-value">{{ action.action_args.shares.toFixed(2) }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.action_args?.price != null">
-                        <span class="action-detail-label">Price</span>
+                        <span class="action-detail-label">{{ $tr('Price', '价格') }}</span>
                         <span class="action-detail-value">${{ action.action_args.price.toFixed(4) }}</span>
                       </div>
                       <div class="action-detail-row" v-else-if="action.action_args?.usd_received != null && action.action_args?.shares">
-                        <span class="action-detail-label">Price</span>
+                        <span class="action-detail-label">{{ $tr('Price', '价格') }}</span>
                         <span class="action-detail-value">${{ (action.action_args.usd_received / action.action_args.shares).toFixed(4) }}</span>
                       </div>
                       <div class="action-detail-row" v-if="action.action_args?.usd_received != null">
-                        <span class="action-detail-label">Received</span>
+                        <span class="action-detail-label">{{ $tr('Received', '已收到') }}</span>
                         <span class="action-detail-value text-green">${{ action.action_args.usd_received.toFixed(2) }}</span>
                       </div>
                       <div class="action-detail-row">
-                        <span class="action-detail-label">Success</span>
-                        <span class="action-detail-value" :class="action.success ? 'text-green' : 'text-orange'">{{ action.success ? 'YES' : 'NO' }}</span>
+                        <span class="action-detail-label">{{ $tr('Success', '成功') }}</span>
+                        <span class="action-detail-value" :class="action.success ? 'text-green' : 'text-orange'">{{ action.success ? $tr('YES', '是') : $tr('NO', '否') }}</span>
                       </div>
                     </div>
                   </div>
                 </div>
-                <div v-else-if="!agentActionsLoading" class="actions-empty">No actions recorded yet</div>
+                <div v-else-if="!agentActionsLoading" class="actions-empty">{{ $tr('No actions recorded yet', '尚未记录任何动作') }}</div>
               </div>
             </div>
           </div>
@@ -180,18 +180,18 @@
             <!-- Self-loop Group Details -->
             <template v-if="selectedItem.data.isSelfLoopGroup">
               <div class="edge-relation-header self-loop-header">
-                {{ selectedItem.data.source_name }} - Self Relations
-                <span class="self-loop-count">{{ selectedItem.data.selfLoopCount }} items</span>
+                {{ selectedItem.data.source_name }} - {{ $tr('Self Relations', '自我关系') }}
+                <span class="self-loop-count">{{ selectedItem.data.selfLoopCount }} {{ $tr('items', '项') }}</span>
               </div>
-              
+
               <div class="self-loop-list">
-                <div 
-                  v-for="(loop, idx) in selectedItem.data.selfLoopEdges" 
-                  :key="loop.uuid || idx" 
+                <div
+                  v-for="(loop, idx) in selectedItem.data.selfLoopEdges"
+                  :key="loop.uuid || idx"
                   class="self-loop-item"
                   :class="{ expanded: expandedSelfLoops.has(loop.uuid || idx) }"
                 >
-                  <div 
+                  <div
                     class="self-loop-item-header"
                     @click="toggleSelfLoop(loop.uuid || idx)"
                   >
@@ -199,26 +199,26 @@
                     <span class="self-loop-name">{{ loop.name || loop.fact_type || 'RELATED' }}</span>
                     <span class="self-loop-toggle">{{ expandedSelfLoops.has(loop.uuid || idx) ? '−' : '+' }}</span>
                   </div>
-                  
+
                   <div class="self-loop-item-content" v-show="expandedSelfLoops.has(loop.uuid || idx)">
                     <div class="detail-row" v-if="loop.uuid">
-                      <span class="detail-label">UUID:</span>
+                      <span class="detail-label">{{ $tr('UUID:', 'UUID:') }}</span>
                       <span class="detail-value uuid-text copyable" @click="copyText(loop.uuid)">{{ loop.uuid }}</span>
                     </div>
                     <div class="detail-row" v-if="loop.fact">
-                      <span class="detail-label">Fact:</span>
+                      <span class="detail-label">{{ $tr('Fact:', '事实:') }}</span>
                       <span class="detail-value fact-text">{{ loop.fact }}</span>
                     </div>
                     <div class="detail-row" v-if="loop.fact_type">
-                      <span class="detail-label">Type:</span>
+                      <span class="detail-label">{{ $tr('Type:', '类型:') }}</span>
                       <span class="detail-value">{{ loop.fact_type }}</span>
                     </div>
                     <div class="detail-row" v-if="loop.created_at">
-                      <span class="detail-label">Created:</span>
+                      <span class="detail-label">{{ $tr('Created:', '创建时间:') }}</span>
                       <span class="detail-value">{{ formatDateTime(loop.created_at) }}</span>
                     </div>
                     <div v-if="loop.episodes && loop.episodes.length > 0" class="self-loop-episodes">
-                      <span class="detail-label">Episodes:</span>
+                      <span class="detail-label">{{ $tr('Episodes:', '片段:') }}</span>
                       <div class="episodes-list compact">
                         <span v-for="ep in loop.episodes" :key="ep" class="episode-tag small">{{ ep }}</span>
                       </div>
@@ -227,69 +227,69 @@
                 </div>
               </div>
             </template>
-            
+
             <!-- Normal Edge Details -->
             <template v-else>
               <div class="edge-relation-header">
                 {{ selectedItem.data.source_name }} → {{ selectedItem.data.name || 'RELATED_TO' }} → {{ selectedItem.data.target_name }}
               </div>
-              
+
               <div class="detail-row">
-                <span class="detail-label">UUID:</span>
+                <span class="detail-label">{{ $tr('UUID:', 'UUID:') }}</span>
                 <span class="detail-value uuid-text copyable" @click="copyText(selectedItem.data.uuid)">{{ selectedItem.data.uuid }}</span>
               </div>
               <div class="detail-row">
-                <span class="detail-label">Label:</span>
+                <span class="detail-label">{{ $tr('Label:', '标签:') }}</span>
                 <span class="detail-value">{{ selectedItem.data.name || 'RELATED_TO' }}</span>
               </div>
               <div class="detail-row">
-                <span class="detail-label">Type:</span>
-                <span class="detail-value">{{ selectedItem.data.fact_type || 'Unknown' }}</span>
+                <span class="detail-label">{{ $tr('Type:', '类型:') }}</span>
+                <span class="detail-value">{{ selectedItem.data.fact_type || $tr('Unknown', '未知') }}</span>
               </div>
               <div class="detail-row" v-if="selectedItem.data.fact">
-                <span class="detail-label">Fact:</span>
+                <span class="detail-label">{{ $tr('Fact:', '事实:') }}</span>
                 <span class="detail-value fact-text">{{ selectedItem.data.fact }}</span>
               </div>
-              
+
               <!-- Episodes -->
               <div class="detail-section" v-if="selectedItem.data.episodes && selectedItem.data.episodes.length > 0">
-                <div class="section-title">Episodes:</div>
+                <div class="section-title">{{ $tr('Episodes:', '片段:') }}</div>
                 <div class="episodes-list">
                   <span v-for="ep in selectedItem.data.episodes" :key="ep" class="episode-tag">
                     {{ ep }}
                   </span>
                 </div>
               </div>
-              
+
               <div class="detail-row" v-if="selectedItem.data.created_at">
-                <span class="detail-label">Created:</span>
+                <span class="detail-label">{{ $tr('Created:', '创建时间:') }}</span>
                 <span class="detail-value">{{ formatDateTime(selectedItem.data.created_at) }}</span>
               </div>
               <div class="detail-row" v-if="selectedItem.data.valid_at">
-                <span class="detail-label">Valid From:</span>
+                <span class="detail-label">{{ $tr('Valid From:', '生效时间:') }}</span>
                 <span class="detail-value">{{ formatDateTime(selectedItem.data.valid_at) }}</span>
               </div>
             </template>
           </div>
         </div>
       </div>
-      
+
       <!-- Loading State -->
       <div v-else-if="loading" class="graph-state">
         <div class="loading-spinner"></div>
-        <p>Loading graph data...</p>
+        <p>{{ $tr('Loading graph data...', '加载图谱数据中...') }}</p>
       </div>
-      
+
       <!-- Waiting/Empty State -->
       <div v-else class="graph-state">
         <div class="empty-icon">❖</div>
-        <p class="empty-text">Waiting for ontology generation...</p>
+        <p class="empty-text">{{ $tr('Waiting for ontology generation...', '等待本体生成...') }}</p>
       </div>
     </div>
 
     <!-- Bottom Legend (Bottom Left) -->
     <div v-if="graphData && entityTypes.length" class="graph-legend">
-      <span class="legend-title">Entity Types</span>
+      <span class="legend-title">{{ $tr('Entity Types', '实体类型') }}</span>
       <div class="legend-items">
         <div
           class="legend-item"
@@ -303,7 +303,7 @@
         </div>
       </div>
     </div>
-    
+
     <!-- Edge Labels Toggle -->
     <div v-if="graphData" class="graph-toggles">
       <div class="toggle-row">
@@ -311,14 +311,14 @@
           <input type="checkbox" v-model="showLinks" />
           <span class="slider"></span>
         </label>
-        <span class="toggle-label">Show Links</span>
+        <span class="toggle-label">{{ $tr('Show Links', '显示连接') }}</span>
       </div>
       <div class="toggle-row">
         <label class="toggle-switch">
           <input type="checkbox" v-model="showEdgeLabels" />
           <span class="slider"></span>
         </label>
-        <span class="toggle-label">Show Edge Labels</span>
+        <span class="toggle-label">{{ $tr('Show Edge Labels', '显示边标签') }}</span>
       </div>
     </div>
   </div>

--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -12,25 +12,25 @@
 
     <!-- Track Record Summary (shown when any simulation has been resolved) -->
     <div v-if="trackRecord" class="track-record-bar">
-      <span class="track-record-label">Track Record</span>
-      <span class="track-record-stat">{{ trackRecord.total }} resolved</span>
+      <span class="track-record-label">{{ $tr('Track Record', '战绩记录') }}</span>
+      <span class="track-record-stat">{{ trackRecord.total }} {{ $tr('resolved', '已结算') }}</span>
       <span v-if="trackRecord.overallAccuracy !== null" class="track-record-accuracy" :class="trackRecord.overallAccuracy >= 60 ? 'good' : 'poor'">
-        {{ trackRecord.overallAccuracy }}% accurate
+        {{ trackRecord.overallAccuracy }}% {{ $tr('accurate', '准确') }}
       </span>
-      <span v-if="trackRecord.correct > 0" class="track-record-correct">{{ trackRecord.correct }} correct</span>
+      <span v-if="trackRecord.correct > 0" class="track-record-correct">{{ trackRecord.correct }} {{ $tr('correct', '正确') }}</span>
     </div>
 
     <!-- Title Area -->
     <div class="section-header">
       <div class="section-line"></div>
-      <span class="section-title">Simulation Records</span>
+      <span class="section-title">{{ $tr('Simulation Records', '模拟记录') }}</span>
       <div class="section-line"></div>
       <button
         v-if="projects.length >= 2"
         class="compare-mode-btn"
         :class="{ active: compareMode }"
         @click="toggleCompareMode"
-      >{{ compareMode ? (compareSelections.length === 2 ? 'Compare →' : `${compareSelections.length}/2 selected`) : '⇄ Compare' }}</button>
+      >{{ compareMode ? (compareSelections.length === 2 ? $tr('Compare →', '对比 →') : `${compareSelections.length}/2 ${$tr('selected', '已选')}`) : $tr('⇄ Compare', '⇄ 对比') }}</button>
     </div>
 
     <!-- Search & Filter Bar -->
@@ -39,33 +39,33 @@
         <input
           v-model="searchQuery"
           class="search-input"
-          placeholder="Search scenarios..."
+          :placeholder="$tr('Search scenarios...', '搜索情景...')"
           type="text"
         />
         <span v-if="searchQuery" class="search-clear" @click="searchQuery = ''">×</span>
       </div>
       <div class="filter-controls">
         <select v-model="statusFilter" class="filter-select">
-          <option value="all">All Status</option>
-          <option value="completed">Completed</option>
-          <option value="in-progress">In Progress</option>
-          <option value="not-started">Not Started</option>
+          <option value="all">{{ $tr('All Status', '全部状态') }}</option>
+          <option value="completed">{{ $tr('Completed', '已完成') }}</option>
+          <option value="in-progress">{{ $tr('In Progress', '进行中') }}</option>
+          <option value="not-started">{{ $tr('Not Started', '未开始') }}</option>
         </select>
         <select v-model="dateFilter" class="filter-select">
-          <option value="all">All Time</option>
-          <option value="today">Today</option>
-          <option value="week">This Week</option>
-          <option value="month">This Month</option>
+          <option value="all">{{ $tr('All Time', '全部时间') }}</option>
+          <option value="today">{{ $tr('Today', '今天') }}</option>
+          <option value="week">{{ $tr('This Week', '本周') }}</option>
+          <option value="month">{{ $tr('This Month', '本月') }}</option>
         </select>
         <select v-model="sortOrder" class="filter-select">
-          <option value="newest">Newest First</option>
-          <option value="oldest">Oldest First</option>
-          <option value="most-agents">Most Agents</option>
-          <option value="most-rounds">Most Rounds</option>
+          <option value="newest">{{ $tr('Newest First', '最新优先') }}</option>
+          <option value="oldest">{{ $tr('Oldest First', '最早优先') }}</option>
+          <option value="most-agents">{{ $tr('Most Agents', '智能体最多') }}</option>
+          <option value="most-rounds">{{ $tr('Most Rounds', '轮次最多') }}</option>
         </select>
         <label class="forks-only-label">
           <input type="checkbox" v-model="forksOnly" class="forks-only-check" />
-          Forks Only
+          {{ $tr('Forks Only', '仅派生') }}
         </label>
       </div>
       <span
@@ -93,7 +93,7 @@
             <span
               v-if="project.parent_simulation_id"
               class="fork-badge"
-              :title="`Forked from ${formatSimulationId(project.parent_simulation_id)}`"
+              :title="$tr('Forked from', '派生自') + ' ' + formatSimulationId(project.parent_simulation_id)"
             >⑂</span>
             <span
               v-if="project.resolution"
@@ -104,7 +104,7 @@
             <span
               v-else-if="project.status === 'completed'"
               class="resolution-badge pending"
-              title="Awaiting outcome resolution"
+              :title="$tr('Awaiting outcome resolution', '等待结果结算')"
             >⏳</span>
             <span
               v-if="project.quality && project.quality.health"
@@ -115,16 +115,16 @@
             <span
               class="status-icon"
               :class="{ available: project.project_id, unavailable: !project.project_id }"
-              title="Graph Build"
+              :title="$tr('Graph Build', '图谱构建')"
             >◇</span>
             <span
               class="status-icon available"
-              title="Agent Setup"
+              :title="$tr('Agent Setup', '智能体配置')"
             >◈</span>
             <span
               class="status-icon"
               :class="{ available: project.report_id, unavailable: !project.report_id }"
-              title="Analysis Report"
+              :title="$tr('Analysis Report', '分析报告')"
             >◆</span>
           </div>
         </div>
@@ -146,13 +146,13 @@
             </div>
             <!-- Show hint if more files exist -->
             <div v-if="project.files.length > 3" class="files-more">
-              +{{ project.files.length - 3 }} files
+              +{{ project.files.length - 3 }} {{ $tr('files', '个文件') }}
             </div>
           </div>
           <!-- Placeholder when no files -->
           <div class="files-empty" v-else>
             <span class="empty-file-icon">◇</span>
-            <span class="empty-file-text">No files</span>
+            <span class="empty-file-text">{{ $tr('No files', '无文件') }}</span>
           </div>
         </div>
 
@@ -189,14 +189,14 @@
     <!-- No results state (projects exist but filters hide them all) -->
     <div v-else-if="projects.length > 0 && !loading" class="no-results-state">
       <span class="no-results-icon">◇</span>
-      <span class="no-results-text">No simulations match your filters</span>
-      <button class="clear-filters-btn" @click="clearFilters">Clear Filters</button>
+      <span class="no-results-text">{{ $tr('No simulations match your filters', '没有匹配筛选条件的模拟') }}</span>
+      <button class="clear-filters-btn" @click="clearFilters">{{ $tr('Clear Filters', '清除筛选') }}</button>
     </div>
 
     <!-- Loading State -->
     <div v-if="loading" class="loading-state">
       <span class="loading-spinner"></span>
-      <span class="loading-text">Loading...</span>
+      <span class="loading-text">{{ $tr('Loading...', '加载中...') }}</span>
     </div>
 
     <!-- History Replay Detail Modal -->
@@ -220,13 +220,13 @@
             <div class="modal-body">
               <!-- Simulation Requirement -->
               <div class="modal-section">
-                <div class="modal-label">Simulation Requirement</div>
-                <div class="modal-requirement">{{ selectedProject.simulation_requirement || 'None' }}</div>
+                <div class="modal-label">{{ $tr('Simulation Requirement', '模拟需求') }}</div>
+                <div class="modal-requirement">{{ selectedProject.simulation_requirement || $tr('None', '无') }}</div>
               </div>
 
               <!-- File List -->
               <div class="modal-section">
-                <div class="modal-label">Associated Files</div>
+                <div class="modal-label">{{ $tr('Associated Files', '关联文件') }}</div>
                 <div class="modal-files" v-if="selectedProject.files && selectedProject.files.length > 0">
                   <component
                     :is="fileLinkFor(file, selectedProject) ? 'a' : 'div'"
@@ -243,14 +243,14 @@
                     <span class="modal-file-name">{{ file.filename }}</span>
                   </component>
                 </div>
-                <div class="modal-empty" v-else>No associated files</div>
+                <div class="modal-empty" v-else>{{ $tr('No associated files', '无关联文件') }}</div>
               </div>
             </div>
 
             <!-- Simulation Replay Divider -->
             <div class="modal-divider">
               <span class="divider-line"></span>
-              <span class="divider-text">Simulation Replay</span>
+              <span class="divider-text">{{ $tr('Simulation Replay', '模拟回放') }}</span>
               <span class="divider-line"></span>
             </div>
 
@@ -261,25 +261,25 @@
                 @click="goToProject"
                 :disabled="!selectedProject.project_id"
               >
-                <span class="btn-step">Step1</span>
+                <span class="btn-step">{{ $tr('Step1', '第1步') }}</span>
                 <span class="btn-icon">◇</span>
-                <span class="btn-text">Graph Build</span>
+                <span class="btn-text">{{ $tr('Graph Build', '图谱构建') }}</span>
               </button>
               <button
                 class="modal-btn btn-simulation"
                 @click="goToSimulation"
               >
-                <span class="btn-step">Step2</span>
+                <span class="btn-step">{{ $tr('Step2', '第2步') }}</span>
                 <span class="btn-icon">◈</span>
-                <span class="btn-text">Agent Setup</span>
+                <span class="btn-text">{{ $tr('Agent Setup', '智能体配置') }}</span>
               </button>
               <button
                 class="modal-btn btn-simrun"
                 @click="goToSimulationRun"
               >
-                <span class="btn-step">Step3</span>
+                <span class="btn-step">{{ $tr('Step3', '第3步') }}</span>
                 <span class="btn-icon">◆</span>
-                <span class="btn-text">Simulation Run</span>
+                <span class="btn-text">{{ $tr('Simulation Run', '模拟运行') }}</span>
               </button>
               <button
                 class="modal-btn btn-replay"
@@ -288,86 +288,86 @@
               >
                 <span class="btn-step">▶</span>
                 <span class="btn-icon">◈</span>
-                <span class="btn-text">Replay</span>
+                <span class="btn-text">{{ $tr('Replay', '回放') }}</span>
               </button>
               <button
                 class="modal-btn btn-report"
                 @click="goToReport"
                 :disabled="!selectedProject.report_id"
               >
-                <span class="btn-step">Step4</span>
+                <span class="btn-step">{{ $tr('Step4', '第4步') }}</span>
                 <span class="btn-icon">◆</span>
-                <span class="btn-text">Analysis Report</span>
+                <span class="btn-text">{{ $tr('Analysis Report', '分析报告') }}</span>
               </button>
               <button
                 class="modal-btn btn-interaction"
                 @click="goToInteraction"
                 :disabled="!selectedProject.report_id"
               >
-                <span class="btn-step">Step5</span>
+                <span class="btn-step">{{ $tr('Step5', '第5步') }}</span>
                 <span class="btn-icon">◈</span>
-                <span class="btn-text">Deep Interaction</span>
+                <span class="btn-text">{{ $tr('Deep Interaction', '深度互动') }}</span>
               </button>
             </div>
             <!-- Non-replayable Hint -->
             <div class="modal-playback-hint">
-              <span class="hint-text">Select a step to replay from the simulation history</span>
+              <span class="hint-text">{{ $tr('Select a step to replay from the simulation history', '从模拟历史中选择一个步骤进行回放') }}</span>
             </div>
 
             <!-- Resolve Prediction Section (completed simulations only) -->
             <div v-if="selectedProject.status === 'completed' || selectedProject.current_round > 0" class="modal-resolve-section">
               <div class="modal-divider">
                 <span class="divider-line"></span>
-                <span class="divider-text">Prediction Outcome</span>
+                <span class="divider-text">{{ $tr('Prediction Outcome', '预测结果') }}</span>
                 <span class="divider-line"></span>
               </div>
 
               <!-- Already resolved: show result -->
               <div v-if="selectedProject.resolution && !showResolvePanel" class="resolve-result">
                 <div class="resolve-result-row">
-                  <span class="resolve-label">Actual Outcome</span>
+                  <span class="resolve-label">{{ $tr('Actual Outcome', '实际结果') }}</span>
                   <span class="resolve-value outcome-badge" :class="selectedProject.resolution.actual_outcome === 'YES' ? 'yes' : 'no'">
                     {{ selectedProject.resolution.actual_outcome }}
                   </span>
                 </div>
                 <div v-if="selectedProject.resolution.predicted_consensus" class="resolve-result-row">
-                  <span class="resolve-label">Agent Consensus</span>
+                  <span class="resolve-label">{{ $tr('Agent Consensus', '智能体共识') }}</span>
                   <span class="resolve-value outcome-badge" :class="selectedProject.resolution.predicted_consensus === 'YES' ? 'yes' : 'no'">
                     {{ selectedProject.resolution.predicted_consensus }}
                     <span class="resolve-confidence">{{ Math.round(selectedProject.resolution.predicted_confidence * 100) }}%</span>
                   </span>
                 </div>
                 <div v-if="selectedProject.resolution.accuracy_score !== null" class="resolve-result-row">
-                  <span class="resolve-label">Accuracy</span>
+                  <span class="resolve-label">{{ $tr('Accuracy', '准确率') }}</span>
                   <span class="resolve-value accuracy-value"
                     :class="selectedProject.resolution.accuracy_score >= 1.0 ? 'correct' : (selectedProject.resolution.accuracy_score <= 0.0 && selectedProject.resolution.accuracy_score !== null) ? 'wrong' : 'split'">
-                    {{ selectedProject.resolution.accuracy_score >= 1.0 ? '✓ Correct' : (selectedProject.resolution.accuracy_score <= 0.0 && selectedProject.resolution.accuracy_score !== null) ? '✗ Incorrect' : '~ Split' }}
+                    {{ selectedProject.resolution.accuracy_score >= 1.0 ? $tr('✓ Correct', '✓ 正确') : (selectedProject.resolution.accuracy_score <= 0.0 && selectedProject.resolution.accuracy_score !== null) ? $tr('✗ Incorrect', '✗ 错误') : $tr('~ Split', '~ 分歧') }}
                   </span>
                 </div>
                 <div v-if="selectedProject.resolution.notes" class="resolve-notes">{{ selectedProject.resolution.notes }}</div>
-                <button class="resolve-reopen-btn" @click="openResolvePanel">Re-resolve</button>
+                <button class="resolve-reopen-btn" @click="openResolvePanel">{{ $tr('Re-resolve', '重新结算') }}</button>
               </div>
 
               <!-- Not yet resolved or re-resolving -->
               <div v-else-if="!showResolvePanel" class="resolve-intro">
-                <p class="resolve-desc">Did the simulation correctly predict what happened? Record the real-world outcome to build your accuracy track record.</p>
-                <button class="resolve-trigger-btn" @click="openResolvePanel">⌘ Record Outcome</button>
+                <p class="resolve-desc">{{ $tr('Did the simulation correctly predict what happened? Record the real-world outcome to build your accuracy track record.', '模拟是否正确预测了实际发生的事情?记录真实结果以建立你的准确率战绩。') }}</p>
+                <button class="resolve-trigger-btn" @click="openResolvePanel">⌘ {{ $tr('Record Outcome', '记录结果') }}</button>
               </div>
 
               <div v-if="showResolvePanel" class="resolve-form">
-                <p class="resolve-form-label">What actually happened?</p>
+                <p class="resolve-form-label">{{ $tr('What actually happened?', '实际发生了什么?') }}</p>
                 <div v-if="resolveError" class="resolve-error">{{ resolveError }}</div>
                 <div class="resolve-buttons">
                   <button class="resolve-outcome-btn yes" :disabled="resolving" @click="executeResolve('YES')">
                     <span v-if="resolving" class="loading-spinner-small"></span>
-                    YES — It happened
+                    {{ $tr('YES — It happened', 'YES — 发生了') }}
                   </button>
                   <button class="resolve-outcome-btn no" :disabled="resolving" @click="executeResolve('NO')">
                     <span v-if="resolving" class="loading-spinner-small"></span>
-                    NO — It didn't happen
+                    {{ $tr(`NO — It didn't happen`, 'NO — 没有发生') }}
                   </button>
                 </div>
-                <button class="resolve-cancel-btn" @click="closeResolvePanel" :disabled="resolving">Cancel</button>
+                <button class="resolve-cancel-btn" @click="closeResolvePanel" :disabled="resolving">{{ $tr('Cancel', '取消') }}</button>
               </div>
             </div>
 
@@ -375,45 +375,45 @@
             <div v-if="selectedQuality" class="modal-quality-section">
               <div class="modal-divider">
                 <span class="divider-line"></span>
-                <span class="divider-text">Simulation Quality</span>
+                <span class="divider-text">{{ $tr('Simulation Quality', '模拟质量') }}</span>
                 <span class="divider-line"></span>
               </div>
 
               <div class="quality-overview">
                 <div class="quality-health-badge" :class="selectedQuality.health.toLowerCase()">
-                  {{ selectedQuality.health }}
+                  {{ translateHealth(selectedQuality.health) }}
                 </div>
                 <div class="quality-metrics">
                   <div class="quality-metric">
-                    <span class="metric-label">Participation</span>
+                    <span class="metric-label">{{ $tr('Participation', '参与度') }}</span>
                     <div class="metric-bar-wrap">
                       <div class="metric-bar" :class="selectedQuality.participation_rate >= 0.8 ? 'bar-good' : selectedQuality.participation_rate >= 0.6 ? 'bar-ok' : 'bar-low'" :style="{ width: Math.round(selectedQuality.participation_rate * 100) + '%' }"></div>
                     </div>
                     <span class="metric-value">{{ Math.round(selectedQuality.participation_rate * 100) }}%</span>
                   </div>
                   <div class="quality-metric" v-if="selectedQuality.stance_entropy !== null">
-                    <span class="metric-label">Stance Diversity</span>
+                    <span class="metric-label">{{ $tr('Stance Diversity', '立场多样性') }}</span>
                     <div class="metric-bar-wrap">
                       <div class="metric-bar" :class="selectedQuality.stance_entropy >= 0.5 ? 'bar-good' : selectedQuality.stance_entropy >= 0.3 ? 'bar-ok' : 'bar-low'" :style="{ width: Math.round(selectedQuality.stance_entropy * 100) + '%' }"></div>
                     </div>
                     <span class="metric-value">{{ Math.round(selectedQuality.stance_entropy * 100) }}%</span>
                   </div>
                   <div class="quality-metric">
-                    <span class="metric-label">Cross-Platform</span>
+                    <span class="metric-label">{{ $tr('Cross-Platform', '跨平台') }}</span>
                     <div class="metric-bar-wrap">
                       <div class="metric-bar" :class="selectedQuality.cross_platform_rate >= 0.2 ? 'bar-good' : selectedQuality.cross_platform_rate >= 0.1 ? 'bar-ok' : 'bar-low'" :style="{ width: Math.min(Math.round(selectedQuality.cross_platform_rate * 100), 100) + '%' }"></div>
                     </div>
                     <span class="metric-value">{{ Math.round(selectedQuality.cross_platform_rate * 100) }}%</span>
                   </div>
                   <div class="quality-metric" v-if="selectedQuality.convergence_round !== null">
-                    <span class="metric-label">Consensus</span>
-                    <span class="metric-value convergence-tag">Round {{ selectedQuality.convergence_round }}</span>
+                    <span class="metric-label">{{ $tr('Consensus', '共识') }}</span>
+                    <span class="metric-value convergence-tag">{{ $isZh() ? `第 ${selectedQuality.convergence_round} 轮` : `Round ${selectedQuality.convergence_round}` }}</span>
                   </div>
                 </div>
               </div>
 
               <div v-if="selectedQuality.suggestions && selectedQuality.suggestions.length" class="quality-suggestions">
-                <div class="suggestions-label">Try for next run:</div>
+                <div class="suggestions-label">{{ $tr('Try for next run:', '下次运行可尝试:') }}</div>
                 <div v-for="(s, i) in selectedQuality.suggestions" :key="i" class="suggestion-chip">{{ s }}</div>
               </div>
             </div>
@@ -422,13 +422,13 @@
             <div class="modal-embed-section">
               <div class="modal-divider">
                 <span class="divider-line"></span>
-                <span class="divider-text">Embed</span>
+                <span class="divider-text">{{ $tr('Embed', '嵌入') }}</span>
                 <span class="divider-line"></span>
               </div>
 
               <div class="embed-intro">
-                <p class="embed-desc">Drop this simulation into a Notion page, blog post, or README as a live widget — updates automatically as the simulation progresses.</p>
-                <button class="embed-trigger-btn" @click="openEmbedDialog">⌘ Get Embed Code</button>
+                <p class="embed-desc">{{ $tr('Drop this simulation into a Notion page, blog post, or README as a live widget — updates automatically as the simulation progresses.', '将此模拟作为实时组件嵌入 Notion 页面、博客文章或 README — 模拟进展时会自动更新。') }}</p>
+                <button class="embed-trigger-btn" @click="openEmbedDialog">⌘ {{ $tr('Get Embed Code', '获取嵌入代码') }}</button>
               </div>
             </div>
 
@@ -436,32 +436,32 @@
             <div class="modal-fork-section">
               <div class="modal-divider">
                 <span class="divider-line"></span>
-                <span class="divider-text">Fork</span>
+                <span class="divider-text">{{ $tr('Fork', '派生') }}</span>
                 <span class="divider-line"></span>
               </div>
 
               <div v-if="!showForkPanel" class="fork-intro">
-                <p class="fork-desc">Clone this simulation with a new scenario — agent profiles are reused instantly.</p>
-                <button class="fork-trigger-btn" @click="openForkPanel">⑂ Fork Simulation</button>
+                <p class="fork-desc">{{ $tr('Clone this simulation with a new scenario — agent profiles are reused instantly.', '使用新情景克隆此模拟 — 智能体画像将立即复用。') }}</p>
+                <button class="fork-trigger-btn" @click="openForkPanel">⑂ {{ $tr('Fork Simulation', '派生模拟') }}</button>
                 <div v-if="selectedProject.parent_simulation_id" class="fork-lineage-badge">
-                  ⑂ Forked from <span class="fork-parent-id">{{ formatSimulationId(selectedProject.parent_simulation_id) }}</span>
+                  ⑂ {{ $tr('Forked from', '派生自') }} <span class="fork-parent-id">{{ formatSimulationId(selectedProject.parent_simulation_id) }}</span>
                 </div>
               </div>
 
               <div v-else class="fork-form">
-                <label class="fork-label">Scenario (edit to explore a variant)</label>
+                <label class="fork-label">{{ $tr('Scenario (edit to explore a variant)', '情景(编辑以探索变体)') }}</label>
                 <textarea
                   v-model="forkRequirement"
                   class="fork-textarea"
-                  placeholder="Describe the scenario you want to simulate..."
+                  :placeholder="$tr('Describe the scenario you want to simulate...', '描述你想要模拟的情景...')"
                   rows="3"
                 ></textarea>
-                <p class="fork-note">Agent profiles will be copied from the parent simulation — no re-preparation needed.</p>
+                <p class="fork-note">{{ $tr('Agent profiles will be copied from the parent simulation — no re-preparation needed.', '智能体画像将从父级模拟复制 — 无需重新准备。') }}</p>
                 <div v-if="forkError" class="fork-error">{{ forkError }}</div>
                 <div class="fork-actions">
-                  <button class="fork-cancel-btn" @click="closeForkPanel" :disabled="forking">Cancel</button>
+                  <button class="fork-cancel-btn" @click="closeForkPanel" :disabled="forking">{{ $tr('Cancel', '取消') }}</button>
                   <button class="fork-submit-btn" @click="executeFork" :disabled="forking">
-                    {{ forking ? 'Forking...' : '⑂ Fork & Open' }}
+                    {{ forking ? $tr('Forking...', '派生中...') : $tr('⑂ Fork & Open', '⑂ 派生并打开') }}
                   </button>
                 </div>
               </div>
@@ -486,6 +486,18 @@ import { useRouter, useRoute } from 'vue-router'
 import { getSimulationHistory, forkSimulation, resolveSimulation, getSimulationQuality } from '../api/simulation'
 import { truncate as truncateText } from '../utils/text'
 import EmbedDialog from './EmbedDialog.vue'
+import { tr } from '../i18n'
+
+const translateHealth = (health) => {
+  if (!health) return ''
+  const map = {
+    'Excellent': tr('Excellent', '优秀'),
+    'Good': tr('Good', '良好'),
+    'Fair': tr('Fair', '一般'),
+    'Poor': tr('Poor', '差'),
+  }
+  return map[health] || health
+}
 
 const router = useRouter()
 const route = useRoute()
@@ -761,7 +773,7 @@ const formatTime = (dateStr) => {
 
 // Generate title from simulation requirement (first 20 chars)
 const getSimulationTitle = (requirement) => {
-  if (!requirement) return 'Untitled Simulation'
+  if (!requirement) return tr('Untitled Simulation', '未命名模拟')
   const title = requirement.slice(0, 20)
   return requirement.length > 20 ? title + '...' : title
 }
@@ -777,8 +789,8 @@ const formatSimulationId = (simulationId) => {
 const formatRounds = (simulation) => {
   const current = simulation.current_round || 0
   const total = simulation.total_rounds || 0
-  if (total === 0) return 'Not Started'
-  return `${current}/${total} rounds`
+  if (total === 0) return tr('Not Started', '未开始')
+  return `${current}/${total} ${tr('rounds', '轮次')}`
 }
 
 // Get file type (for styling)
@@ -799,9 +811,9 @@ const getFileType = (filename) => {
 
 // Get file type label text
 const getFileTypeLabel = (filename) => {
-  if (!filename) return 'FILE'
+  if (!filename) return tr('FILE', '文件')
   const ext = filename.split('.').pop()?.toUpperCase()
-  return ext || 'FILE'
+  return ext || tr('FILE', '文件')
 }
 
 // Build a clickable URL for an associated file:
@@ -819,7 +831,7 @@ const fileLinkFor = (file, project) => {
 
 // Truncate filename (preserve extension)
 const truncateFilename = (filename, maxLength) => {
-  if (!filename) return 'Unknown file'
+  if (!filename) return tr('Unknown file', '未知文件')
   if (filename.length <= maxLength) return filename
 
   const ext = filename.includes('.') ? '.' + filename.split('.').pop() : ''
@@ -950,10 +962,10 @@ const executeFork = async () => {
       await loadHistory()
       router.push({ name: 'SimulationRun', params: { simulationId: newSimId } })
     } else {
-      forkError.value = response.error || 'Fork failed'
+      forkError.value = response.error || tr('Fork failed', '派生失败')
     }
   } catch (err) {
-    forkError.value = err?.response?.data?.error || err.message || 'Fork failed'
+    forkError.value = err?.response?.data?.error || err.message || tr('Fork failed', '派生失败')
   } finally {
     forking.value = false
   }
@@ -979,29 +991,29 @@ const getResolutionLabel = (project) => {
   const r = project.resolution
   if (!r) return null
   if (r.accuracy_score === null || r.accuracy_score === undefined) {
-    return { text: `Resolved: ${r.actual_outcome}`, cls: 'resolved-no-score' }
+    return { text: `${tr('Resolved:', '已结算:')} ${r.actual_outcome}`, cls: 'resolved-no-score' }
   }
   if (r.accuracy_score >= 1.0) {
     const pct = r.predicted_confidence ? Math.round(r.predicted_confidence * 100) : null
-    return { text: `✓ Correct${pct ? ` — ${pct}% confident` : ''}`, cls: 'resolved-correct' }
+    return { text: `${tr('✓ Correct', '✓ 正确')}${pct ? ` — ${pct}% ${tr('confident', '置信度')}` : ''}`, cls: 'resolved-correct' }
   }
   if (r.accuracy_score <= 0.0) {
     const pct = r.predicted_confidence ? Math.round(r.predicted_confidence * 100) : null
-    return { text: `✗ Incorrect${pct ? ` — ${pct}% confident` : ''}`, cls: 'resolved-wrong' }
+    return { text: `${tr('✗ Incorrect', '✗ 错误')}${pct ? ` — ${pct}% ${tr('confident', '置信度')}` : ''}`, cls: 'resolved-wrong' }
   }
-  return { text: '~ Split', cls: 'resolved-split' }
+  return { text: tr('~ Split', '~ 分歧'), cls: 'resolved-split' }
 }
 
 const getQualityTooltip = (q) => {
   if (!q) return ''
-  const parts = [`Simulation Health: ${q.health}`]
-  parts.push(`Participation ${Math.round(q.participation_rate * 100)}%`)
+  const parts = [`${tr('Simulation Health:', '模拟健康度:')} ${translateHealth(q.health)}`]
+  parts.push(`${tr('Participation', '参与度')} ${Math.round(q.participation_rate * 100)}%`)
   if (q.stance_entropy !== null && q.stance_entropy !== undefined) {
-    const level = q.stance_entropy >= 0.7 ? 'high' : q.stance_entropy >= 0.4 ? 'medium' : 'low'
-    parts.push(`Stance diversity: ${level}`)
+    const level = q.stance_entropy >= 0.7 ? tr('high', '高') : q.stance_entropy >= 0.4 ? tr('medium', '中') : tr('low', '低')
+    parts.push(`${tr('Stance diversity:', '立场多样性:')} ${level}`)
   }
   if (q.convergence_round !== null && q.convergence_round !== undefined) {
-    parts.push(`Consensus at round ${q.convergence_round}`)
+    parts.push(tr(`Consensus at round ${q.convergence_round}`, `共识于第 ${q.convergence_round} 轮`))
   }
   return parts.join(' · ')
 }
@@ -1031,10 +1043,10 @@ const executeResolve = async (outcome) => {
       if (idx >= 0) projects.value[idx].resolution = response.data
       showResolvePanel.value = false
     } else {
-      resolveError.value = response.error || 'Resolve failed'
+      resolveError.value = response.error || tr('Resolve failed', '结算失败')
     }
   } catch (err) {
-    resolveError.value = err?.response?.data?.error || err.message || 'Resolve failed'
+    resolveError.value = err?.response?.data?.error || err.message || tr('Resolve failed', '结算失败')
   } finally {
     resolving.value = false
   }

--- a/frontend/src/components/InfluenceLeaderboard.vue
+++ b/frontend/src/components/InfluenceLeaderboard.vue
@@ -4,15 +4,15 @@
     <div class="lb-header">
       <div class="lb-title">
         <span class="lb-icon">◈</span>
-        <span class="lb-label">AGENT INFLUENCE LEADERBOARD</span>
+        <span class="lb-label">{{ $tr('AGENT INFLUENCE LEADERBOARD', '智能体影响力排行榜') }}</span>
       </div>
       <button
         class="export-btn"
         :disabled="!agents.length"
         @click="exportReport"
-        title="Download influence report as JSON"
+        :title="$tr('Download influence report as JSON', '下载影响力报告 JSON')"
       >
-        Export JSON ↓
+        {{ $tr('Export JSON ↓', '导出 JSON ↓') }}
       </button>
     </div>
 
@@ -27,8 +27,8 @@
               <div>
                 <div class="iv-name">{{ interviewAgent.agent_name }}</div>
                 <div class="iv-meta">
-                  Rank #{{ interviewAgent.rank }} · {{ interviewAgent.influence_score }} pts
-                  · {{ interviewAgent.posts_created }} posts
+                  {{ $tr('Rank', '排名') }} #{{ interviewAgent.rank }} · {{ interviewAgent.influence_score }} {{ $tr('pts', '分') }}
+                  · {{ interviewAgent.posts_created }} {{ $tr('posts', '帖子') }}
                 </div>
               </div>
             </div>
@@ -38,8 +38,8 @@
           <!-- Chat thread -->
           <div class="iv-thread" ref="threadEl">
             <div v-if="!interviewHistory.length && !interviewLoading" class="iv-empty">
-              Ask {{ interviewAgent.agent_name }} about their simulation experience.
-              Try: "Why did you post so much in the early rounds?" or "What changed your mind?"
+              {{ $tr('Ask', '询问') }} {{ interviewAgent.agent_name }} {{ $tr('about their simulation experience.', '关于他们的模拟体验。') }}
+              {{ $tr(`Try: "Why did you post so much in the early rounds?" or "What changed your mind?"`, '试试:"你为什么在前几轮发帖这么多?" 或 "什么改变了你的想法?"') }}
             </div>
             <div
               v-for="(qa, i) in interviewHistory"
@@ -47,7 +47,7 @@
               class="iv-qa-pair"
             >
               <div class="iv-question">
-                <span class="iv-role">You</span>
+                <span class="iv-role">{{ $tr('You', '你') }}</span>
                 <span class="iv-text">{{ qa.question }}</span>
               </div>
               <div class="iv-answer">
@@ -57,7 +57,7 @@
             </div>
             <div v-if="interviewLoading" class="iv-thinking">
               <div class="iv-dots"><span></span><span></span><span></span></div>
-              <span>{{ interviewAgent.agent_name }} is thinking...</span>
+              <span>{{ interviewAgent.agent_name }} {{ $tr('is thinking...', '正在思考...') }}</span>
             </div>
           </div>
 
@@ -68,7 +68,7 @@
               v-model="interviewQuestion"
               class="iv-input"
               type="text"
-              placeholder="Ask a question..."
+              :placeholder="$tr('Ask a question...', '提问...')"
               :disabled="interviewLoading"
               @keydown.enter.prevent="submitQuestion"
             />
@@ -77,7 +77,7 @@
               :disabled="interviewLoading || !interviewQuestion.trim()"
               @click="submitQuestion"
             >
-              Ask
+              {{ $tr('Ask', '提问') }}
             </button>
           </div>
 
@@ -89,15 +89,15 @@
 
     <!-- Score legend -->
     <div class="lb-legend">
-      <span class="legend-item"><span class="legend-dot engage"></span>Engagement ×3</span>
-      <span class="legend-item"><span class="legend-dot platform"></span>Platforms ×5</span>
-      <span class="legend-item"><span class="legend-dot post"></span>Posts ×1</span>
+      <span class="legend-item"><span class="legend-dot engage"></span>{{ $tr('Engagement ×3', '互动 ×3') }}</span>
+      <span class="legend-item"><span class="legend-dot platform"></span>{{ $tr('Platforms ×5', '平台 ×5') }}</span>
+      <span class="legend-item"><span class="legend-dot post"></span>{{ $tr('Posts ×1', '帖子 ×1') }}</span>
     </div>
 
     <!-- Loading -->
     <div v-if="loading" class="lb-loading">
       <div class="pulse-ring"></div>
-      <span>Computing influence scores...</span>
+      <span>{{ $tr('Computing influence scores...', '正在计算影响力分数...') }}</span>
     </div>
 
     <!-- Error -->
@@ -105,7 +105,7 @@
 
     <!-- Empty -->
     <div v-else-if="!agents.length" class="lb-empty">
-      No simulation data available yet. Run the simulation first.
+      {{ $tr('No simulation data available yet. Run the simulation first.', '尚无模拟数据。请先运行模拟。') }}
     </div>
 
     <!-- Leaderboard rows -->
@@ -136,12 +136,12 @@
 
         <!-- Score breakdown -->
         <div class="lb-breakdown">
-          <div class="bd-item" title="Engagement received (likes, reposts, quotes)">
-            <span class="bd-label engage">ENG</span>
+          <div class="bd-item" :title="$tr('Engagement received (likes, reposts, quotes)', '收到的互动(点赞、转发、引用)')">
+            <span class="bd-label engage">{{ $tr('ENG', '互动') }}</span>
             <span class="bd-value">{{ agent.engagement_received }}</span>
           </div>
-          <div class="bd-item" title="Original posts created">
-            <span class="bd-label post">PST</span>
+          <div class="bd-item" :title="$tr('Original posts created', '发布的原创帖子')">
+            <span class="bd-label post">{{ $tr('PST', '帖子') }}</span>
             <span class="bd-value">{{ agent.posts_created }}</span>
           </div>
         </div>
@@ -161,16 +161,16 @@
         <button
           class="iv-btn"
           @click.stop="openInterview(agent)"
-          title="Interview this agent about their simulation"
+          :title="$tr('Interview this agent about their simulation', '采访这位智能体关于其模拟的经历')"
         >
-          ▶ Interview
+          ▶ {{ $tr('Interview', '采访') }}
         </button>
       </div>
     </div>
 
     <!-- Footer -->
     <div v-if="totalAgents > agents.length" class="lb-footer">
-      Showing top {{ agents.length }} of {{ totalAgents }} agents
+      {{ $tr('Showing top', '显示前') }} {{ agents.length }} {{ $tr('of', '/共') }} {{ totalAgents }} {{ $tr('agents', '个智能体') }}
     </div>
   </div>
 </template>
@@ -178,6 +178,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, nextTick } from 'vue'
 import { getInfluenceLeaderboard, traceInterviewAgent, getAgentInterview } from '../api/simulation'
+import { tr } from '../i18n'
 
 const props = defineProps({
   simulationId: { type: String, required: true },
@@ -217,10 +218,10 @@ const load = async () => {
       agents.value = res.data.agents || []
       totalAgents.value = res.data.total_agents || 0
     } else {
-      error.value = res.error || 'Failed to load influence data.'
+      error.value = res.error || tr('Failed to load influence data.', '加载影响力数据失败。')
     }
   } catch (err) {
-    error.value = err.message || 'Failed to load influence data.'
+    error.value = err.message || tr('Failed to load influence data.', '加载影响力数据失败。')
   } finally {
     loading.value = false
   }
@@ -300,10 +301,10 @@ const submitQuestion = async () => {
       await nextTick()
       scrollThread()
     } else {
-      interviewError.value = res.error || 'Failed to get a response.'
+      interviewError.value = res.error || tr('Failed to get a response.', '未能获取回复。')
     }
   } catch (err) {
-    interviewError.value = err.message || 'Request failed.'
+    interviewError.value = err.message || tr('Request failed.', '请求失败。')
   } finally {
     interviewLoading.value = false
     await nextTick()

--- a/frontend/src/components/InteractionNetwork.vue
+++ b/frontend/src/components/InteractionNetwork.vue
@@ -4,37 +4,37 @@
     <div class="net-header">
       <div class="net-title">
         <span class="net-icon">⬡</span>
-        <span class="net-label">INTERACTION NETWORK</span>
+        <span class="net-label">{{ $tr('INTERACTION NETWORK', '互动网络') }}</span>
       </div>
       <div class="net-header-actions">
         <button
           class="net-export-btn"
           :disabled="!hasData || exporting || !copySupported"
-          :title="copySupported ? 'Copy graph as PNG (with MiroShark watermark)' : 'Image copy not supported in this browser'"
+          :title="copySupported ? $tr('Copy graph as PNG (with MiroShark watermark)', '复制图为 PNG(含 MiroShark 水印)') : $tr('Image copy not supported in this browser', '此浏览器不支持图像复制')"
           @click="copyChart"
         >
-          {{ copiedFlash ? 'Copied' : 'Copy' }}
+          {{ copiedFlash ? $tr('Copied', '已复制') : $tr('Copy', '复制') }}
         </button>
         <button
           class="net-export-btn"
           :disabled="!hasData || exporting"
           @click="downloadChart"
-          title="Download graph as PNG (with MiroShark watermark)"
+          :title="$tr('Download graph as PNG (with MiroShark watermark)', '下载图为 PNG(含 MiroShark 水印)')"
         >
-          Download ↓
+          {{ $tr('Download ↓', '下载 ↓') }}
         </button>
       </div>
     </div>
 
     <!-- Legend -->
     <div class="net-legend">
-      <span class="legend-item"><span class="legend-dot bullish-dot"></span>Bullish</span>
-      <span class="legend-item"><span class="legend-dot neutral-dot"></span>Neutral</span>
-      <span class="legend-item"><span class="legend-dot bearish-dot"></span>Bearish</span>
+      <span class="legend-item"><span class="legend-dot bullish-dot"></span>{{ $tr('Bullish', '看涨') }}</span>
+      <span class="legend-item"><span class="legend-dot neutral-dot"></span>{{ $tr('Neutral', '中立') }}</span>
+      <span class="legend-item"><span class="legend-dot bearish-dot"></span>{{ $tr('Bearish', '看跌') }}</span>
       <span class="legend-sep">|</span>
       <span class="legend-item"><span class="legend-line twitter-line"></span>Twitter</span>
       <span class="legend-item"><span class="legend-line reddit-line"></span>Reddit</span>
-      <span class="legend-item"><span class="legend-line cross-line"></span>Cross-platform</span>
+      <span class="legend-item"><span class="legend-line cross-line"></span>{{ $tr('Cross-platform', '跨平台') }}</span>
     </div>
 
     <!-- Platform filter -->
@@ -48,7 +48,7 @@
     <!-- Loading -->
     <div v-if="loading" class="net-state">
       <div class="pulse-ring"></div>
-      <span>Computing interaction network...</span>
+      <span>{{ $tr('Computing interaction network...', '正在计算互动网络...') }}</span>
     </div>
 
     <!-- Error -->
@@ -56,8 +56,8 @@
 
     <!-- No data -->
     <div v-else-if="!hasData" class="net-state">
-      <span>No interaction data available.</span>
-      <span class="net-hint">Run a simulation to generate agent interactions.</span>
+      <span>{{ $tr('No interaction data available.', '暂无互动数据。') }}</span>
+      <span class="net-hint">{{ $tr('Run a simulation to generate agent interactions.', '运行一次模拟以生成智能体互动。') }}</span>
     </div>
 
     <!-- Graph -->
@@ -136,20 +136,20 @@
             {{ hoveredNodeData?.name }}
           </text>
           <text x="0" y="13" font-size="9" font-family="monospace" fill="rgba(10,10,10,0.5)">
-            {{ hoveredNodeData?.stance }} · {{ hoveredNodeData?.platforms?.join(', ') }}
+            {{ translateStance(hoveredNodeData?.stance) }} · {{ hoveredNodeData?.platforms?.join(', ') }}
           </text>
           <text x="0" y="26" font-size="9" font-family="monospace" fill="rgba(10,10,10,0.5)">
-            In: {{ hoveredNodeData?.in_degree }} · Out: {{ hoveredNodeData?.out_degree }} · Rank #{{ hoveredNodeData?.rank }}
+            {{ $tr('In:', '入度:') }} {{ hoveredNodeData?.in_degree }} · {{ $tr('Out:', '出度:') }} {{ hoveredNodeData?.out_degree }} · {{ $tr('Rank', '排名') }} #{{ hoveredNodeData?.rank }}
           </text>
           <text x="0" y="34" font-size="0" fill="transparent">pad</text>
         </g>
       </svg>
 
       <!-- Zoom controls -->
-      <div class="net-zoom-controls" aria-label="Zoom controls">
-        <button class="zoom-btn" @click="zoomBy(1.25)" title="Zoom in">+</button>
-        <button class="zoom-btn" @click="zoomBy(0.8)" title="Zoom out">−</button>
-        <button class="zoom-btn zoom-reset" @click="resetView" title="Reset view (double-click graph)">⤢</button>
+      <div class="net-zoom-controls" :aria-label="$tr('Zoom controls', '缩放控制')">
+        <button class="zoom-btn" @click="zoomBy(1.25)" :title="$tr('Zoom in', '放大')">+</button>
+        <button class="zoom-btn" @click="zoomBy(0.8)" :title="$tr('Zoom out', '缩小')">−</button>
+        <button class="zoom-btn zoom-reset" @click="resetView" :title="$tr('Reset view (double-click graph)', '重置视图(双击图)')">⤢</button>
         <span class="zoom-level">{{ Math.round(zoom * 100) }}%</span>
       </div>
     </div>
@@ -157,20 +157,20 @@
     <!-- Insights Panel -->
     <div v-if="hasData && networkData?.insights" class="net-insights">
       <div v-if="networkData.insights.top_hub" class="insight-card">
-        <span class="insight-label">Top Hub</span>
+        <span class="insight-label">{{ $tr('Top Hub', '顶级中心') }}</span>
         <span class="insight-text">{{ networkData.insights.top_hub.description }}</span>
       </div>
       <div v-if="networkData.insights.top_bridge" class="insight-card">
-        <span class="insight-label">Top Bridge</span>
+        <span class="insight-label">{{ $tr('Top Bridge', '顶级桥梁') }}</span>
         <span class="insight-text">{{ networkData.insights.top_bridge.description }}</span>
       </div>
       <div v-if="networkData.insights.echo_chamber" class="insight-card">
-        <span class="insight-label">Echo Chamber</span>
+        <span class="insight-label">{{ $tr('Echo Chamber', '回音室') }}</span>
         <span class="insight-text">{{ networkData.insights.echo_chamber.description }}</span>
       </div>
       <div class="insight-card stats-row">
-        <span class="insight-stat">{{ networkData.insights.total_nodes }} agents</span>
-        <span class="insight-stat">{{ networkData.insights.total_edges }} interactions</span>
+        <span class="insight-stat">{{ networkData.insights.total_nodes }} {{ $tr('agents', '智能体') }}</span>
+        <span class="insight-stat">{{ networkData.insights.total_edges }} {{ $tr('interactions', '互动') }}</span>
       </div>
     </div>
   </div>
@@ -186,6 +186,14 @@ import {
   canCopyImageToClipboard,
   buildTitledHeader,
 } from '../utils/chartExport'
+import { tr } from '../i18n'
+
+const translateStance = (stance) => {
+  if (stance === 'bullish') return tr('bullish', '看涨')
+  if (stance === 'bearish') return tr('bearish', '看跌')
+  if (stance === 'neutral') return tr('neutral', '中立')
+  return stance
+}
 
 const props = defineProps({
   simulationId: { type: String, required: true },
@@ -522,10 +530,10 @@ const load = async () => {
     } else if (res.success && !res.data) {
       networkData.value = null
     } else {
-      error.value = res.error || 'Failed to load interaction network.'
+      error.value = res.error || tr('Failed to load interaction network.', '加载互动网络失败。')
     }
   } catch (err) {
-    error.value = err.message || 'Failed to load interaction network.'
+    error.value = err.message || tr('Failed to load interaction network.', '加载互动网络失败。')
   } finally {
     loading.value = false
   }
@@ -538,8 +546,8 @@ const _buildExportCanvas = () => {
   const nodeCount = (networkData.value?.nodes || []).length
   const edgeCount = (networkData.value?.edges || []).length
   const { drawHeader, headerHeight } = buildTitledHeader({
-    title: 'Interaction Network',
-    subtitle: `${nodeCount} agents · ${edgeCount} edges`,
+    title: tr('Interaction Network', '互动网络'),
+    subtitle: `${nodeCount} ${tr('agents', '智能体')} · ${edgeCount} ${tr('edges', '条边')}`,
     width: W,
   })
   return renderSvgToCanvas(svgRef.value, {

--- a/frontend/src/components/LocaleToggle.vue
+++ b/frontend/src/components/LocaleToggle.vue
@@ -1,0 +1,63 @@
+<template>
+  <button
+    class="locale-toggle"
+    :class="{ active: locale === 'zh-CN' }"
+    type="button"
+    :title="locale === 'zh-CN' ? 'Switch to English' : '切换到中文'"
+    :aria-label="locale === 'zh-CN' ? 'Switch to English' : 'Switch to Chinese'"
+    @click="toggleLocale"
+  >
+    <span class="locale-toggle-flag" aria-hidden="true">{{ locale === 'zh-CN' ? '中' : 'EN' }}</span>
+    <span class="locale-toggle-text">{{ locale === 'zh-CN' ? 'EN' : '中' }}</span>
+  </button>
+</template>
+
+<script setup>
+import { useI18n } from '../i18n'
+
+const { locale, toggleLocale } = useI18n()
+</script>
+
+<style scoped>
+.locale-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-family: 'JetBrains Mono', 'Courier New', monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  user-select: none;
+}
+
+.locale-toggle:hover {
+  color: #ff7a3d;
+  border-color: rgba(255, 122, 61, 0.4);
+  background: rgba(255, 122, 61, 0.08);
+}
+
+.locale-toggle.active {
+  color: #ff7a3d;
+  border-color: rgba(255, 122, 61, 0.5);
+}
+
+.locale-toggle-flag {
+  display: inline-block;
+  padding: 1px 5px;
+  background: rgba(255, 122, 61, 0.18);
+  border-radius: 2px;
+  color: #ff7a3d;
+  font-size: 10px;
+}
+
+.locale-toggle-text {
+  opacity: 0.65;
+}
+</style>

--- a/frontend/src/components/NetworkPanel.vue
+++ b/frontend/src/components/NetworkPanel.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="network-panel">
     <div class="panel-header">
-      <span class="panel-title">Agent Network</span>
+      <span class="panel-title">{{ $tr('Agent Network', '智能体网络') }}</span>
       <div class="header-tools">
-        <span class="node-count" v-if="networkStats.nodes">{{ networkStats.nodes }} agents · {{ networkStats.edges }} links</span>
-        <button class="tool-btn" @click="resetView" title="Reset View">
+        <span class="node-count" v-if="networkStats.nodes">{{ networkStats.nodes }} {{ $tr('agents', '智能体') }} · {{ networkStats.edges }} {{ $tr('links', '连接') }}</span>
+        <button class="tool-btn" @click="resetView" :title="$tr('Reset View', '重置视图')">
           <span class="icon-refresh">↻</span>
-          <span class="btn-text">Reset</span>
+          <span class="btn-text">{{ $tr('Reset', '重置') }}</span>
         </button>
       </div>
     </div>
@@ -26,7 +26,7 @@
           @input="onRoundChange"
         />
         <span class="round-label">
-          <template v-if="currentRound === 0">ALL</template>
+          <template v-if="currentRound === 0">{{ $tr('ALL', '全部') }}</template>
           <template v-else>R{{ currentRound }}/{{ maxRound }}</template>
         </span>
       </div>
@@ -42,7 +42,7 @@
           <div class="agent-avatar" :style="{ background: selectedAgent.color }">{{ selectedAgent.name[0] }}</div>
           <div class="agent-meta">
             <span class="agent-name">{{ selectedAgent.name }}</span>
-            <span class="agent-stats-line">{{ selectedAgent.actionCount }} actions · {{ selectedAgent.connections }} connections</span>
+            <span class="agent-stats-line">{{ selectedAgent.actionCount }} {{ $tr('actions', '动作') }} · {{ selectedAgent.connections }} {{ $tr('connections', '连接') }}</span>
           </div>
           <button class="detail-close" @click="selectedAgent = null">×</button>
         </div>
@@ -65,19 +65,19 @@
       <!-- Empty State -->
       <div v-if="!hasData" class="empty-state">
         <div class="pulse-ring"></div>
-        <span>Waiting for agent interactions...</span>
+        <span>{{ $tr('Waiting for agent interactions...', '等待智能体互动...') }}</span>
       </div>
     </div>
 
     <!-- Legend -->
     <div class="network-legend" v-if="hasData">
-      <span class="legend-title">Platforms</span>
+      <span class="legend-title">{{ $tr('Platforms', '平台') }}</span>
       <div class="legend-items">
         <div class="legend-item"><span class="legend-dot" style="background: #0A0A0A"></span><span>X</span></div>
         <div class="legend-item"><span class="legend-dot" style="background: #FF6B1A"></span><span>Reddit</span></div>
         <div class="legend-item"><span class="legend-dot" style="background: #43C165"></span><span>Polymarket</span></div>
       </div>
-      <div class="legend-hint">Node size = activity · Edge thickness = interactions</div>
+      <div class="legend-hint">{{ $tr('Node size = activity · Edge thickness = interactions', '节点大小 = 活跃度 · 边粗细 = 互动次数') }}</div>
     </div>
   </div>
 </template>

--- a/frontend/src/components/PolymarketChart.vue
+++ b/frontend/src/components/PolymarketChart.vue
@@ -4,25 +4,25 @@
     <div class="pm-header">
       <div class="pm-header-left">
         <img src="/pm.png" alt="Polymarket" class="pm-logo" />
-        <span class="pm-header-title">Prediction Markets</span>
-        <span v-if="live" class="pm-live-dot"><span class="pm-live-pulse"></span>LIVE</span>
+        <span class="pm-header-title">{{ $tr('Prediction Markets', '预测市场') }}</span>
+        <span v-if="live" class="pm-live-dot"><span class="pm-live-pulse"></span>{{ $tr('LIVE', '实时') }}</span>
       </div>
       <div v-if="selected" class="pm-header-actions">
         <button
           class="pm-export-btn"
           :disabled="exporting || !copySupported"
-          :title="copySupported ? 'Copy chart as PNG (with MiroShark watermark)' : 'Image copy not supported in this browser'"
+          :title="copySupported ? $tr('Copy chart as PNG (with MiroShark watermark)', '复制图表为 PNG(含 MiroShark 水印)') : $tr('Image copy not supported in this browser', '此浏览器不支持图像复制')"
           @click="copyChart"
         >
-          {{ copiedFlash ? 'Copied' : 'Copy' }}
+          {{ copiedFlash ? $tr('Copied', '已复制') : $tr('Copy', '复制') }}
         </button>
         <button
           class="pm-export-btn"
           :disabled="exporting"
-          title="Download chart as PNG (with MiroShark watermark)"
+          :title="$tr('Download chart as PNG (with MiroShark watermark)', '下载图表为 PNG(含 MiroShark 水印)')"
           @click="downloadChart"
         >
-          Download ↓
+          {{ $tr('Download ↓', '下载 ↓') }}
         </button>
       </div>
     </div>
@@ -31,11 +31,11 @@
       <div class="pm-body">
         <!-- Market list -->
         <aside class="pm-market-list">
-          <div v-if="marketsLoading && !markets.length" class="pm-empty">Loading markets...</div>
+          <div v-if="marketsLoading && !markets.length" class="pm-empty">{{ $tr('Loading markets...', '加载市场中...') }}</div>
           <div v-else-if="marketsError" class="pm-empty pm-error">{{ marketsError }}</div>
           <div v-else-if="!markets.length" class="pm-empty">
-            <div class="pm-empty-title">No markets yet</div>
-            <div class="pm-empty-hint">Markets appear as agents create them during the simulation.</div>
+            <div class="pm-empty-title">{{ $tr('No markets yet', '暂无市场') }}</div>
+            <div class="pm-empty-hint">{{ $tr('Markets appear as agents create them during the simulation.', '智能体在模拟过程中创建市场后,将显示在此处。') }}</div>
           </div>
           <button
             v-for="m in markets"
@@ -44,13 +44,13 @@
             :class="{ 'pm-market-row-active': selectedId === m.market_id }"
             @click="selectMarket(m.market_id)"
           >
-            <div class="pm-market-q">{{ m.question || `Market #${m.market_id}` }}</div>
+            <div class="pm-market-q">{{ m.question || `${$tr('Market', '市场')} #${m.market_id}` }}</div>
             <div class="pm-market-meta">
               <span class="pm-market-price" :class="priceClass(m.price_yes)">
                 {{ formatPct(m.price_yes) }}
               </span>
-              <span class="pm-market-trades">{{ m.trade_count }} trades</span>
-              <span v-if="m.resolved" class="pm-market-resolved">{{ m.winning_outcome || 'RESOLVED' }}</span>
+              <span class="pm-market-trades">{{ m.trade_count }} {{ $tr('trades', '笔交易') }}</span>
+              <span v-if="m.resolved" class="pm-market-resolved">{{ m.winning_outcome || $tr('RESOLVED', '已结算') }}</span>
             </div>
           </button>
         </aside>
@@ -59,26 +59,26 @@
         <section class="pm-chart-section">
           <div v-if="!selected" class="pm-placeholder">
             <div class="pm-placeholder-icon">◎</div>
-            <div class="pm-placeholder-text">Select a market to view its price history</div>
+            <div class="pm-placeholder-text">{{ $tr('Select a market to view its price history', '选择一个市场以查看其价格历史') }}</div>
           </div>
           <template v-else>
             <!-- Question + price header -->
             <div class="pm-chart-header">
-              <div class="pm-chart-q">{{ selected.market.question || `Market #${selected.market.market_id}` }}</div>
+              <div class="pm-chart-q">{{ selected.market.question || `${$tr('Market', '市场')} #${selected.market.market_id}` }}</div>
               <div class="pm-chart-price-row">
                 <div class="pm-chart-price" :class="priceClass(latestPrice)">
                   {{ formatPct(latestPrice) }}
-                  <span class="pm-chart-outcome-label">chance {{ selected.market.outcome_a || 'YES' }}</span>
+                  <span class="pm-chart-outcome-label">{{ $tr('chance', '概率') }} {{ selected.market.outcome_a || 'YES' }}</span>
                 </div>
                 <div v-if="priceDelta !== null" class="pm-chart-delta" :class="deltaClass(priceDelta)">
                   {{ priceDelta >= 0 ? '▲' : '▼' }} {{ formatPct(Math.abs(priceDelta)) }}
                 </div>
               </div>
               <div class="pm-chart-stats">
-                <span class="pm-stat"><span class="pm-stat-k">TRADES</span><span class="pm-stat-v">{{ selected.points.length - 1 }}</span></span>
-                <span class="pm-stat"><span class="pm-stat-k">VOLUME</span><span class="pm-stat-v">{{ tradeVolume.toFixed(1) }}</span></span>
-                <span class="pm-stat"><span class="pm-stat-k">OUTCOMES</span><span class="pm-stat-v">{{ selected.market.outcome_a }}/{{ selected.market.outcome_b }}</span></span>
-                <span v-if="selected.market.resolved" class="pm-stat pm-stat-resolved">RESOLVED: {{ selected.market.winning_outcome }}</span>
+                <span class="pm-stat"><span class="pm-stat-k">{{ $tr('TRADES', '交易') }}</span><span class="pm-stat-v">{{ selected.points.length - 1 }}</span></span>
+                <span class="pm-stat"><span class="pm-stat-k">{{ $tr('VOLUME', '成交量') }}</span><span class="pm-stat-v">{{ tradeVolume.toFixed(1) }}</span></span>
+                <span class="pm-stat"><span class="pm-stat-k">{{ $tr('OUTCOMES', '结果') }}</span><span class="pm-stat-v">{{ selected.market.outcome_a }}/{{ selected.market.outcome_b }}</span></span>
+                <span v-if="selected.market.resolved" class="pm-stat pm-stat-resolved">{{ $tr('RESOLVED:', '已结算:') }} {{ selected.market.winning_outcome }}</span>
               </div>
             </div>
 
@@ -173,7 +173,7 @@
                   {{ selected.points[hoverPoint].outcome }}
                   · {{ selected.points[hoverPoint].shares?.toFixed(1) }} shares
                 </div>
-                <div v-else class="pm-tooltip-trade">Origin (no trades yet)</div>
+                <div v-else class="pm-tooltip-trade">{{ $tr('Origin (no trades yet)', '初始(尚无交易)') }}</div>
                 <div class="pm-tooltip-time">{{ formatTime(selected.points[hoverPoint].t) }}</div>
               </div>
             </div>
@@ -193,6 +193,7 @@ import {
   canCopyImageToClipboard,
   wrapText,
 } from '../utils/chartExport'
+import { tr } from '../i18n'
 
 const props = defineProps({
   simulationId: { type: String, required: true },
@@ -311,7 +312,7 @@ async function fetchMarkets({ autoSelect = false } = {}) {
       selectedId.value = topMarket.market_id
     }
   } catch (err) {
-    marketsError.value = err?.response?.data?.error || err?.message || 'Failed to load markets'
+    marketsError.value = err?.response?.data?.error || err?.message || tr('Failed to load markets', '加载市场失败')
   } finally {
     marketsLoading.value = false
   }
@@ -327,7 +328,7 @@ async function fetchSelected() {
       selectedError.value = ''
     }
   } catch (err) {
-    selectedError.value = err?.response?.data?.error || err?.message || 'Failed to load prices'
+    selectedError.value = err?.response?.data?.error || err?.message || tr('Failed to load prices', '加载价格失败')
   }
 }
 

--- a/frontend/src/components/ScenarioSuggestions.vue
+++ b/frontend/src/components/ScenarioSuggestions.vue
@@ -3,21 +3,21 @@
     <div v-if="shouldShow" class="ss-wrap">
       <div class="ss-head">
         <span class="ss-label">
-          <span class="ss-dot">◈</span> Smart Setup
+          <span class="ss-dot">◈</span> {{ $tr('Smart Setup', '智能设置') }}
           <span class="ss-sub">{{ statusLine }}</span>
         </span>
         <button
           v-if="!loading"
           class="ss-close"
           type="button"
-          title="Dismiss suggestions"
+          :title="$tr('Dismiss suggestions', '关闭建议')"
           @click="dismiss"
         >×</button>
       </div>
 
       <div v-if="loading" class="ss-loading">
         <span class="ss-spinner"></span>
-        Drafting three scenarios from your document…
+        {{ $tr('Drafting three scenarios from your document…', '正在根据你的文档起草三个情景…') }}
       </div>
 
       <div v-else-if="suggestions.length > 0" class="ss-cards">
@@ -28,8 +28,8 @@
           :class="cardClass(s.label)"
         >
           <div class="ss-card-head">
-            <span class="ss-badge" :class="badgeClass(s.label)">{{ s.label }}</span>
-            <span class="ss-range">Initial YES {{ s.expected_yes_range[0] }}–{{ s.expected_yes_range[1] }}%</span>
+            <span class="ss-badge" :class="badgeClass(s.label)">{{ s.label === 'Bull' ? $tr('Bull', '看涨') : s.label === 'Bear' ? $tr('Bear', '看跌') : s.label === 'Neutral' ? $tr('Neutral', '中立') : s.label }}</span>
+            <span class="ss-range">{{ $tr('Initial YES', '初始 YES') }} {{ s.expected_yes_range[0] }}–{{ s.expected_yes_range[1] }}%</span>
           </div>
           <div class="ss-question">{{ s.question }}</div>
           <div v-if="s.rationale" class="ss-rationale">{{ s.rationale }}</div>
@@ -37,7 +37,7 @@
             class="ss-use"
             type="button"
             @click="useSuggestion(s, idx)"
-          >Use this →</button>
+          >{{ $tr('Use this →', '使用 →') }}</button>
         </div>
       </div>
 
@@ -65,6 +65,7 @@
 
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import { suggestScenarios } from '../api/simulation'
+import { tr } from '../i18n'
 
 const props = defineProps({
   textPreview: { type: String, default: '' },
@@ -93,8 +94,8 @@ const shouldShow = computed(() => {
 })
 
 const statusLine = computed(() => {
-  if (loading.value) return '// generating…'
-  if (suggestions.value.length > 0) return '// pick one or refine your own'
+  if (loading.value) return tr('// generating…', '// 生成中…')
+  if (suggestions.value.length > 0) return tr('// pick one or refine your own', '// 选择一个或自行完善')
   return ''
 })
 

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -5,17 +5,28 @@
         <!-- Header -->
         <div class="modal-header">
           <div class="modal-title">
-            <span class="title-label">⚙ Settings</span>
+            <span class="title-label">⚙ {{ $tr('Settings', '设置') }}</span>
           </div>
           <button class="close-btn" @click="$emit('close')">✕</button>
         </div>
 
         <div class="warning-stripe"></div>
 
+        <!-- Language Toggle -->
+        <section class="settings-section">
+          <div class="section-header">
+            <span class="section-label">{{ $tr('Language / 语言', '语言 / Language') }}</span>
+          </div>
+          <div class="field-row" style="display:flex;align-items:center;gap:12px;">
+            <label class="field-label">{{ $tr('Interface language', '界面语言') }}</label>
+            <LocaleToggle />
+          </div>
+        </section>
+
         <!-- Current Setup Summary -->
         <section class="settings-section">
           <div class="section-header">
-            <span class="section-label">Current Setup</span>
+            <span class="section-label">{{ $tr('Current Setup', '当前配置') }}</span>
             <div class="status-badge" :class="testStatus">
               <span class="badge-dot"></span>
               {{ testStatusText }}
@@ -24,38 +35,38 @@
 
           <div class="setup-grid">
             <div class="setup-row">
-              <span class="setup-key">Default model</span>
+              <span class="setup-key">{{ $tr('Default model', '默认模型') }}</span>
               <span class="setup-val">{{ currentSettings.llm?.model_name || '—' }}</span>
             </div>
             <div class="setup-row">
-              <span class="setup-key">Smart (reports)</span>
+              <span class="setup-key">{{ $tr('Smart (reports)', '智能(报告)') }}</span>
               <span class="setup-val">{{ currentSettings.smart?.model_name || inheritMarker }}</span>
             </div>
             <div class="setup-row">
-              <span class="setup-key">NER (extraction)</span>
+              <span class="setup-key">{{ $tr('NER (extraction)', 'NER(实体抽取)') }}</span>
               <span class="setup-val">{{ currentSettings.ner?.model_name || inheritMarker }}</span>
             </div>
             <div class="setup-row">
-              <span class="setup-key">Wonderwall (sim loop)</span>
+              <span class="setup-key">{{ $tr('Wonderwall (sim loop)', 'Wonderwall(模拟循环)') }}</span>
               <span class="setup-val">{{ currentSettings.wonderwall?.model_name || inheritMarker }}</span>
             </div>
             <div class="setup-row">
-              <span class="setup-key">Embeddings</span>
+              <span class="setup-key">{{ $tr('Embeddings', '嵌入') }}</span>
               <span class="setup-val">
                 {{ currentSettings.embedding?.model_name || '—' }}
               </span>
             </div>
             <div class="setup-row">
-              <span class="setup-key">Web search</span>
+              <span class="setup-key">{{ $tr('Web search', '网页搜索') }}</span>
               <span class="setup-val">{{ currentSettings.web_search_model || inheritMarker }}</span>
             </div>
             <div class="setup-row">
-              <span class="setup-key">API key</span>
+              <span class="setup-key">{{ $tr('API key', 'API 密钥') }}</span>
               <span class="setup-val">
                 <span v-if="currentSettings.llm?.has_api_key">
                   {{ currentSettings.llm.api_key_masked }}
                 </span>
-                <span v-else class="setup-missing">not set</span>
+                <span v-else class="setup-missing">{{ $tr('not set', '未设置') }}</span>
               </span>
             </div>
           </div>
@@ -64,14 +75,14 @@
         <!-- Preset Picker -->
         <section class="settings-section">
           <div class="section-header">
-            <span class="section-label">Preset</span>
+            <span class="section-label">{{ $tr('Preset', '预设') }}</span>
           </div>
 
           <div class="field-row">
-            <label class="field-label">Config template</label>
+            <label class="field-label">{{ $tr('Config template', '配置模板') }}</label>
             <div class="select-wrapper">
               <select v-model="form.preset" class="field-select">
-                <option value="">Custom — leave fields as they are</option>
+                <option value="">{{ $tr('Custom — leave fields as they are', '自定义 — 保留当前字段') }}</option>
                 <option
                   v-for="p in presetOptions"
                   :key="p.id"
@@ -80,15 +91,15 @@
               </select>
             </div>
             <div class="field-hint">
-              Applies the full set of model slots on save. See
+              {{ $tr('Applies the full set of model slots on save. See', '保存时将应用完整的模型槽配置。请参考') }}
               <a href="https://github.com/aaronjmars/MiroShark/blob/main/.env.example"
                  target="_blank" rel="noopener">.env.example</a>
-              for the exact values each preset uses.
+              {{ $tr('for the exact values each preset uses.', '了解各预设使用的精确值。') }}
             </div>
           </div>
 
           <div v-if="presetNeedsKey" class="field-row">
-            <label class="field-label">OpenRouter API key</label>
+            <label class="field-label">{{ $tr('OpenRouter API key', 'OpenRouter API 密钥') }}</label>
             <div class="key-input-group">
               <input
                 v-model="form.presetApiKey"
@@ -101,8 +112,7 @@
               </button>
             </div>
             <div class="field-hint">
-              Filled into every slot the preset needs (default, smart, NER, embedding).
-              Leave blank to keep your existing keys.
+              {{ $tr('Filled into every slot the preset needs (default, smart, NER, embedding). Leave blank to keep your existing keys.', '将填入预设所需的每个槽(default、smart、NER、embedding)。留空则保留现有密钥。') }}
             </div>
           </div>
         </section>
@@ -110,23 +120,23 @@
         <!-- LLM Configuration -->
         <section class="settings-section">
           <div class="section-header">
-            <span class="section-label">LLM Configuration</span>
+            <span class="section-label">{{ $tr('LLM Configuration', 'LLM 配置') }}</span>
           </div>
 
           <!-- Provider -->
           <div class="field-row">
-            <label class="field-label">Provider</label>
+            <label class="field-label">{{ $tr('Provider', '提供商') }}</label>
             <div class="select-wrapper">
               <select v-model="form.llm.provider" class="field-select">
-                <option value="openai">OpenAI-compatible (OpenRouter, Ollama, etc.)</option>
-                <option value="claude-code">Claude Code (local CLI)</option>
+                <option value="openai">{{ $tr('OpenAI-compatible (OpenRouter, Ollama, etc.)', 'OpenAI 兼容(OpenRouter、Ollama 等)') }}</option>
+                <option value="claude-code">{{ $tr('Claude Code (local CLI)', 'Claude Code(本地 CLI)') }}</option>
               </select>
             </div>
           </div>
 
           <!-- Base URL -->
           <div v-if="form.llm.provider !== 'claude-code'" class="field-row">
-            <label class="field-label">Base URL</label>
+            <label class="field-label">{{ $tr('Base URL', '基础 URL') }}</label>
             <input
               v-model="form.llm.base_url"
               class="field-input"
@@ -137,7 +147,7 @@
 
           <!-- Model -->
           <div v-if="form.llm.provider !== 'claude-code'" class="field-row">
-            <label class="field-label">Model</label>
+            <label class="field-label">{{ $tr('Model', '模型') }}</label>
             <div class="model-input-group">
               <div class="select-wrapper model-select-wrapper">
                 <select
@@ -162,14 +172,14 @@
                   v-model="form.llm.model_name"
                   class="field-input"
                   type="text"
-                  placeholder="e.g. openai/gpt-4o-mini"
+                  :placeholder="$tr('e.g. openai/gpt-4o-mini', '例如 openai/gpt-4o-mini')"
                 />
               </div>
               <button
                 class="load-models-btn"
                 :disabled="loadingModels || !isOpenRouter"
                 @click="loadOpenRouterModels"
-                :title="isOpenRouter ? 'Load available models from OpenRouter' : 'Only available for OpenRouter base URL'"
+                :title="isOpenRouter ? $tr('Load available models from OpenRouter', '从 OpenRouter 加载可用模型') : $tr('Only available for OpenRouter base URL', '仅在 OpenRouter 基础 URL 下可用')"
               >
                 <span v-if="loadingModels">...</span>
                 <span v-else>↻</span>
@@ -180,7 +190,7 @@
 
           <!-- API Key -->
           <div v-if="form.llm.provider !== 'claude-code'" class="field-row">
-            <label class="field-label">API Key</label>
+            <label class="field-label">{{ $tr('API Key', 'API 密钥') }}</label>
             <div class="key-input-group">
               <input
                 v-model="form.llm.api_key"
@@ -193,7 +203,7 @@
               </button>
             </div>
             <div v-if="currentSettings.llm?.has_api_key && !form.llm.api_key" class="field-hint">
-              Current key: {{ currentSettings.llm.api_key_masked }} — leave blank to keep unchanged
+              {{ $tr('Current key:', '当前密钥:') }} {{ currentSettings.llm.api_key_masked }} {{ $tr('— leave blank to keep unchanged', ' — 留空则保持不变') }}
             </div>
           </div>
 
@@ -204,8 +214,8 @@
               :disabled="testing"
               @click="testConnection"
             >
-              <span v-if="testing">Testing...</span>
-              <span v-else>Test Connection</span>
+              <span v-if="testing">{{ $tr('Testing...', '测试中...') }}</span>
+              <span v-else>{{ $tr('Test Connection', '测试连接') }}</span>
             </button>
             <div v-if="testResult" class="test-result" :class="testResult.success ? 'ok' : 'fail'">
               <span v-if="testResult.success">
@@ -220,109 +230,109 @@
         <section class="settings-section">
           <button class="advanced-toggle" @click="advancedOpen = !advancedOpen">
             <span class="section-label">
-              Advanced slot overrides
+              {{ $tr('Advanced slot overrides', '高级槽位覆盖') }}
             </span>
             <span class="chevron">{{ advancedOpen ? '−' : '+' }}</span>
           </button>
 
           <div v-if="advancedOpen" class="advanced-body">
             <div class="advanced-hint">
-              Each slot falls back to the default LLM config when left empty.
+              {{ $tr('Each slot falls back to the default LLM config when left empty.', '每个槽位为空时将回退到默认 LLM 配置。') }}
             </div>
 
             <!-- Smart -->
             <div class="advanced-group">
-              <div class="advanced-group-title">Smart — report generation</div>
+              <div class="advanced-group-title">{{ $tr('Smart — report generation', '智能 — 报告生成') }}</div>
               <div class="field-row">
-                <label class="field-label">Model</label>
+                <label class="field-label">{{ $tr('Model', '模型') }}</label>
                 <input
                   v-model="form.smart.model_name"
                   class="field-input"
                   type="text"
-                  placeholder="e.g. x-ai/grok-4.1-fast"
+                  :placeholder="$tr('e.g. x-ai/grok-4.1-fast', '例如 x-ai/grok-4.1-fast')"
                 />
               </div>
             </div>
 
             <!-- NER -->
             <div class="advanced-group">
-              <div class="advanced-group-title">NER — entity extraction</div>
+              <div class="advanced-group-title">{{ $tr('NER — entity extraction', 'NER — 实体抽取') }}</div>
               <div class="field-row">
-                <label class="field-label">Model</label>
+                <label class="field-label">{{ $tr('Model', '模型') }}</label>
                 <input
                   v-model="form.ner.model_name"
                   class="field-input"
                   type="text"
-                  placeholder="e.g. x-ai/grok-4.1-fast"
+                  :placeholder="$tr('e.g. x-ai/grok-4.1-fast', '例如 x-ai/grok-4.1-fast')"
                 />
               </div>
             </div>
 
             <!-- Wonderwall -->
             <div class="advanced-group">
-              <div class="advanced-group-title">Wonderwall — simulation loop</div>
+              <div class="advanced-group-title">{{ $tr('Wonderwall — simulation loop', 'Wonderwall — 模拟循环') }}</div>
               <div class="field-row">
-                <label class="field-label">Model</label>
+                <label class="field-label">{{ $tr('Model', '模型') }}</label>
                 <input
                   v-model="form.wonderwall.model_name"
                   class="field-input"
                   type="text"
-                  placeholder="e.g. xiaomi/mimo-v2-flash"
+                  :placeholder="$tr('e.g. xiaomi/mimo-v2-flash', '例如 xiaomi/mimo-v2-flash')"
                 />
               </div>
               <div class="field-row">
-                <label class="field-label">Base URL</label>
+                <label class="field-label">{{ $tr('Base URL', '基础 URL') }}</label>
                 <input
                   v-model="form.wonderwall.base_url"
                   class="field-input"
                   type="text"
-                  placeholder="Inherits LLM base URL when blank"
+                  :placeholder="$tr('Inherits LLM base URL when blank', '留空时继承 LLM 基础 URL')"
                 />
               </div>
               <div class="field-row">
-                <label class="field-label">API Key</label>
+                <label class="field-label">{{ $tr('API Key', 'API 密钥') }}</label>
                 <input
                   v-model="form.wonderwall.api_key"
                   class="field-input"
                   type="password"
-                  :placeholder="currentSettings.wonderwall?.has_api_key ? `Saved: ${currentSettings.wonderwall.api_key_masked}` : 'Inherits LLM key when blank'"
+                  :placeholder="currentSettings.wonderwall?.has_api_key ? `${$tr('Saved:', '已保存:')} ${currentSettings.wonderwall.api_key_masked}` : $tr('Inherits LLM key when blank', '留空时继承 LLM 密钥')"
                 />
               </div>
             </div>
 
             <!-- Embedding -->
             <div class="advanced-group">
-              <div class="advanced-group-title">Embeddings</div>
+              <div class="advanced-group-title">{{ $tr('Embeddings', '嵌入') }}</div>
               <div class="field-row">
-                <label class="field-label">Provider</label>
+                <label class="field-label">{{ $tr('Provider', '提供商') }}</label>
                 <div class="select-wrapper">
                   <select v-model="form.embedding.provider" class="field-select">
-                    <option value="ollama">Ollama (local)</option>
-                    <option value="openai">OpenAI-compatible</option>
+                    <option value="ollama">{{ $tr('Ollama (local)', 'Ollama(本地)') }}</option>
+                    <option value="openai">{{ $tr('OpenAI-compatible', 'OpenAI 兼容') }}</option>
                   </select>
                 </div>
               </div>
               <div class="field-row">
-                <label class="field-label">Model</label>
+                <label class="field-label">{{ $tr('Model', '模型') }}</label>
                 <input
                   v-model="form.embedding.model_name"
                   class="field-input"
                   type="text"
-                  placeholder="e.g. openai/text-embedding-3-small"
+                  :placeholder="$tr('e.g. openai/text-embedding-3-small', '例如 openai/text-embedding-3-small')"
                 />
               </div>
             </div>
 
             <!-- Web Search -->
             <div class="advanced-group">
-              <div class="advanced-group-title">Web search (URL import + enrichment)</div>
+              <div class="advanced-group-title">{{ $tr('Web search (URL import + enrichment)', '网页搜索(URL 导入 + 丰富)') }}</div>
               <div class="field-row">
-                <label class="field-label">Model</label>
+                <label class="field-label">{{ $tr('Model', '模型') }}</label>
                 <input
                   v-model="form.web_search_model"
                   class="field-input"
                   type="text"
-                  placeholder="e.g. google/gemini-2.0-flash-001:online"
+                  :placeholder="$tr('e.g. google/gemini-2.0-flash-001:online', '例如 google/gemini-2.0-flash-001:online')"
                 />
               </div>
             </div>
@@ -332,11 +342,11 @@
         <!-- Neo4j Configuration -->
         <section class="settings-section">
           <div class="section-header">
-            <span class="section-label">Graph Database (Neo4j)</span>
+            <span class="section-label">{{ $tr('Graph Database (Neo4j)', '图数据库 (Neo4j)') }}</span>
           </div>
 
           <div class="field-row">
-            <label class="field-label">URI</label>
+            <label class="field-label">{{ $tr('URI', '地址') }}</label>
             <input
               v-model="form.neo4j.uri"
               class="field-input"
@@ -346,7 +356,7 @@
           </div>
 
           <div class="field-row">
-            <label class="field-label">User</label>
+            <label class="field-label">{{ $tr('User', '用户') }}</label>
             <input
               v-model="form.neo4j.user"
               class="field-input"
@@ -356,12 +366,12 @@
           </div>
 
           <div class="field-row">
-            <label class="field-label">Password</label>
+            <label class="field-label">{{ $tr('Password', '密码') }}</label>
             <input
               v-model="form.neo4j.password"
               class="field-input"
               type="password"
-              placeholder="Leave blank to keep unchanged"
+              :placeholder="$tr('Leave blank to keep unchanged', '留空保持不变')"
             />
           </div>
         </section>
@@ -369,7 +379,7 @@
         <!-- Outbound webhook · Slack / Discord / Zapier / n8n / custom -->
         <section class="settings-section ai-section">
           <div class="section-header">
-            <span class="section-label">Integrations · Webhook</span>
+            <span class="section-label">{{ $tr('Integrations · Webhook', '集成 · Webhook') }}</span>
             <div class="status-badge" :class="webhookSavedClass">
               <span class="badge-dot"></span>
               {{ webhookSavedText }}
@@ -377,14 +387,11 @@
           </div>
 
           <div class="ai-intro">
-            POST a JSON summary to your URL the moment a simulation finishes —
-            wires Slack, Discord, Zapier, Make, n8n, IFTTT, or any custom listener.
-            Empty to disable. Payload includes scenario, final consensus, quality,
-            and the share-card URL so links auto-unfurl.
+            {{ $tr('POST a JSON summary to your URL the moment a simulation finishes — wires Slack, Discord, Zapier, Make, n8n, IFTTT, or any custom listener. Empty to disable. Payload includes scenario, final consensus, quality, and the share-card URL so links auto-unfurl.', '模拟结束时立即向你的 URL POST 一份 JSON 摘要 — 可对接 Slack、Discord、Zapier、Make、n8n、IFTTT 或任何自定义监听器。留空以禁用。负载包括情景、最终共识、质量,以及分享卡 URL 以便链接自动展开。') }}
           </div>
 
           <div class="field-row">
-            <label class="field-label">Webhook URL</label>
+            <label class="field-label">{{ $tr('Webhook URL', 'Webhook URL') }}</label>
             <input
               v-model="form.integrations.webhook.url"
               class="field-input"
@@ -394,17 +401,17 @@
               spellcheck="false"
             />
             <div class="field-hint">
-              e.g.
+              {{ $tr('e.g.', '例如') }}
               <code>https://hooks.slack.com/services/T0…/B0…/abc</code>
-              or any URL that accepts a POST.
-              See <a href="https://github.com/aaronjmars/MiroShark/blob/main/docs/WEBHOOKS.md"
-                     target="_blank" rel="noopener">the webhook docs</a>
-              for the payload schema.
+              {{ $tr('or any URL that accepts a POST.', '或任何接受 POST 的 URL。') }}
+              {{ $tr('See', '参见') }} <a href="https://github.com/aaronjmars/MiroShark/blob/main/docs/WEBHOOKS.md"
+                     target="_blank" rel="noopener">{{ $tr('the webhook docs', 'Webhook 文档') }}</a>
+              {{ $tr('for the payload schema.', '了解负载结构。') }}
             </div>
           </div>
 
           <div class="field-row">
-            <label class="field-label">Public base URL <span class="field-label-optional">(optional)</span></label>
+            <label class="field-label">{{ $tr('Public base URL', '公开基础 URL') }} <span class="field-label-optional">{{ $tr('(optional)', '(可选)') }}</span></label>
             <input
               v-model="form.integrations.webhook.public_base_url"
               class="field-input"
@@ -414,9 +421,8 @@
               spellcheck="false"
             />
             <div class="field-hint">
-              When set, the payload includes absolute <code>share_url</code> +
-              <code>share_card_url</code> so Slack &amp; Discord auto-unfurl
-              with the simulation card. Leave blank for relative paths only.
+              {{ $tr('When set, the payload includes absolute', '设置后,负载将包含绝对的') }} <code>share_url</code> +
+              <code>share_card_url</code> {{ $tr('so Slack & Discord auto-unfurl with the simulation card. Leave blank for relative paths only.', '以便 Slack 与 Discord 用模拟卡片自动展开。留空则仅使用相对路径。') }}
             </div>
           </div>
 
@@ -426,14 +432,14 @@
               :disabled="webhookTesting || !webhookCanTest"
               @click="testWebhookFire"
             >
-              {{ webhookTesting ? 'Sending…' : 'Send test event' }}
+              {{ webhookTesting ? $tr('Sending…', '发送中…') : $tr('Send test event', '发送测试事件') }}
             </button>
             <span v-if="webhookTestResult" class="webhook-test-result" :class="webhookTestResult.success ? 'ok' : 'fail'">
               <template v-if="webhookTestResult.success">
-                ✓ Delivered ({{ webhookTestResult.latency_ms }}ms)
+                ✓ {{ $tr('Delivered', '已送达') }} ({{ webhookTestResult.latency_ms }}ms)
               </template>
               <template v-else>
-                ✗ {{ webhookTestResult.error || webhookTestResult.message || 'Failed' }}
+                ✗ {{ webhookTestResult.error || webhookTestResult.message || $tr('Failed', '失败') }}
               </template>
             </span>
           </div>
@@ -442,7 +448,7 @@
         <!-- AI Integration (MCP) -->
         <section class="settings-section ai-section">
           <div class="section-header">
-            <span class="section-label">AI Integration · MCP</span>
+            <span class="section-label">{{ $tr('AI Integration · MCP', 'AI 集成 · MCP') }}</span>
             <div class="status-badge" :class="mcpHealthClass">
               <span class="badge-dot"></span>
               {{ mcpHealthText }}
@@ -450,46 +456,45 @@
           </div>
 
           <div class="ai-intro">
-            Wire MiroShark's knowledge graph into Claude Desktop, Cursor, Windsurf,
-            or Continue. Pick your client, paste the snippet, restart the editor.
+            {{ $tr(`Wire MiroShark's knowledge graph into Claude Desktop, Cursor, Windsurf, or Continue. Pick your client, paste the snippet, restart the editor.`, '将 MiroShark 的知识图谱接入 Claude Desktop、Cursor、Windsurf 或 Continue。选择你的客户端,粘贴代码片段,重启编辑器。') }}
           </div>
 
-          <div v-if="mcpLoading" class="ai-loading">Loading MCP catalog…</div>
+          <div v-if="mcpLoading" class="ai-loading">{{ $tr('Loading MCP catalog…', '加载 MCP 目录…') }}</div>
           <div v-else-if="mcpLoadError" class="ai-error">
             {{ mcpLoadError }}
-            <button class="ai-retry" @click="loadMcpStatus">Retry</button>
+            <button class="ai-retry" @click="loadMcpStatus">{{ $tr('Retry', '重试') }}</button>
           </div>
 
           <div v-else-if="mcpStatus" class="ai-body">
             <!-- Health summary grid -->
             <div class="ai-summary">
               <div class="ai-summary-row">
-                <span class="ai-summary-key">Server file</span>
+                <span class="ai-summary-key">{{ $tr('Server file', '服务文件') }}</span>
                 <span class="ai-summary-val" :class="mcpStatus.paths.mcp_script_exists ? '' : 'setup-missing'">
-                  {{ mcpStatus.paths.mcp_script_exists ? 'present' : 'missing' }}
+                  {{ mcpStatus.paths.mcp_script_exists ? $tr('present', '存在') : $tr('missing', '缺失') }}
                 </span>
               </div>
               <div class="ai-summary-row">
-                <span class="ai-summary-key">Tools exposed</span>
+                <span class="ai-summary-key">{{ $tr('Tools exposed', '已暴露工具') }}</span>
                 <span class="ai-summary-val">{{ mcpStatus.tool_count }}</span>
               </div>
               <div class="ai-summary-row">
                 <span class="ai-summary-key">Neo4j</span>
                 <span class="ai-summary-val" :class="mcpStatus.neo4j.connected ? '' : 'setup-missing'">
-                  {{ mcpStatus.neo4j.connected ? 'connected' : 'unreachable' }}
+                  {{ mcpStatus.neo4j.connected ? $tr('connected', '已连接') : $tr('unreachable', '不可达') }}
                 </span>
               </div>
               <div class="ai-summary-row" v-if="mcpStatus.neo4j.connected">
-                <span class="ai-summary-key">Graphs available</span>
+                <span class="ai-summary-key">{{ $tr('Graphs available', '可用图谱') }}</span>
                 <span class="ai-summary-val">
                   {{ mcpStatus.neo4j.graph_count ?? 0 }}
                   <span class="setup-aux" v-if="mcpStatus.neo4j.entity_count != null">
-                    ({{ mcpStatus.neo4j.entity_count }} entities)
+                    ({{ mcpStatus.neo4j.entity_count }} {{ $tr('entities', '个实体') }})
                   </span>
                 </span>
               </div>
               <div class="ai-summary-row" v-if="mcpStatus.neo4j.error">
-                <span class="ai-summary-key">Error</span>
+                <span class="ai-summary-key">{{ $tr('Error', '错误') }}</span>
                 <span class="ai-summary-val ai-error-text">{{ mcpStatus.neo4j.error }}</span>
               </div>
             </div>
@@ -512,7 +517,7 @@
             <!-- Active client snippet -->
             <div v-if="currentClient" class="ai-client">
               <div class="ai-client-file">
-                <span class="ai-client-file-label">Config file:</span>
+                <span class="ai-client-file-label">{{ $tr('Config file:', '配置文件:') }}</span>
                 <code class="ai-client-file-path">{{ currentClient.file }}</code>
               </div>
               <div class="ai-snippet-wrap">
@@ -532,7 +537,7 @@
 
             <!-- Tool catalog (collapsed by default) -->
             <button class="ai-tools-toggle" @click="toolsOpen = !toolsOpen">
-              <span>{{ toolsOpen ? '▾' : '▸' }} {{ mcpStatus.tool_count }} tools available</span>
+              <span>{{ toolsOpen ? '▾' : '▸' }} {{ mcpStatus.tool_count }} {{ $tr('tools available', '个可用工具') }}</span>
             </button>
             <ul v-if="toolsOpen" class="ai-tools-list">
               <li v-for="t in mcpStatus.tools" :key="t.name" class="ai-tool">
@@ -542,8 +547,8 @@
             </ul>
 
             <div class="ai-docs-link">
-              Need a deeper walkthrough?
-              <a :href="mcpStatus.docs_url" target="_blank" rel="noopener">Read the full MCP guide →</a>
+              {{ $tr('Need a deeper walkthrough?', '需要更深入的指南?') }}
+              <a :href="mcpStatus.docs_url" target="_blank" rel="noopener">{{ $tr('Read the full MCP guide →', '阅读完整的 MCP 指南 →') }}</a>
             </div>
           </div>
         </section>
@@ -551,12 +556,12 @@
         <!-- Footer -->
         <div class="modal-footer">
           <div v-if="saveError" class="save-error">{{ saveError }}</div>
-          <div v-if="saveSuccess" class="save-success">✓ Settings saved (runtime — edit .env to persist across restarts)</div>
+          <div v-if="saveSuccess" class="save-success">✓ {{ $tr('Settings saved (runtime — edit .env to persist across restarts)', '设置已保存(运行时 — 编辑 .env 以在重启后保留)') }}</div>
           <div class="footer-actions">
-            <button class="cancel-btn" @click="$emit('close')">Cancel</button>
+            <button class="cancel-btn" @click="$emit('close')">{{ $tr('Cancel', '取消') }}</button>
             <button class="save-btn" :disabled="saving" @click="saveSettings">
-              <span v-if="saving">Saving...</span>
-              <span v-else>Save Settings →</span>
+              <span v-if="saving">{{ $tr('Saving...', '保存中...') }}</span>
+              <span v-else>{{ $tr('Save Settings →', '保存设置 →') }}</span>
             </button>
           </div>
         </div>
@@ -569,6 +574,8 @@
 import { ref, reactive, computed, watch } from 'vue'
 import { getSettings, updateSettings, testLlmConnection, testWebhook } from '../api/settings'
 import { getMcpStatus } from '../api/mcp'
+import { tr } from '../i18n'
+import LocaleToggle from './LocaleToggle.vue'
 
 const props = defineProps({
   open: { type: Boolean, required: true }
@@ -618,7 +625,7 @@ const modelList = ref([])
 const loadingModels = ref(false)
 const modelLoadError = ref('')
 const advancedOpen = ref(false)
-const inheritMarker = '— inherits default —'
+const inheritMarker = tr('— inherits default —', '— 继承默认值 —')
 
 // Webhook integration state
 const webhookTesting = ref(false)
@@ -727,7 +734,7 @@ const loadOpenRouterModels = async () => {
         })
     }
   } catch (_) {
-    modelLoadError.value = 'Could not load model list — check your network connection.'
+    modelLoadError.value = tr('Could not load model list — check your network connection.', '无法加载模型列表 — 请检查网络连接。')
   } finally {
     loadingModels.value = false
   }
@@ -756,10 +763,10 @@ const loadMcpStatus = async () => {
     if (res?.success && res.data) {
       mcpStatus.value = res.data
     } else {
-      mcpLoadError.value = res?.error || 'MCP status unavailable'
+      mcpLoadError.value = res?.error || tr('MCP status unavailable', 'MCP 状态不可用')
     }
   } catch (e) {
-    mcpLoadError.value = e?.message || 'MCP status request failed'
+    mcpLoadError.value = e?.message || tr('MCP status request failed', 'MCP 状态请求失败')
   } finally {
     mcpLoading.value = false
   }
@@ -777,17 +784,17 @@ const mcpHealthClass = computed(() => {
 })
 
 const mcpHealthText = computed(() => {
-  if (!mcpStatus.value) return 'Loading'
-  if (!mcpStatus.value.paths.mcp_script_exists) return 'Server file missing'
-  return mcpStatus.value.neo4j.connected ? 'Ready' : 'Neo4j down'
+  if (!mcpStatus.value) return tr('Loading', '加载中')
+  if (!mcpStatus.value.paths.mcp_script_exists) return tr('Server file missing', '服务文件缺失')
+  return mcpStatus.value.neo4j.connected ? tr('Ready', '就绪') : tr('Neo4j down', 'Neo4j 不可用')
 })
 
 const formatJson = (obj) => JSON.stringify(obj, null, 2)
 
 const copyButtonLabel = computed(() => {
-  if (copyState.value === 'ok') return '✓ Copied'
-  if (copyState.value === 'fail') return '✗ Copy failed'
-  return 'Copy snippet'
+  if (copyState.value === 'ok') return '✓ ' + tr('Copied', '已复制')
+  if (copyState.value === 'fail') return '✗ ' + tr('Copy failed', '复制失败')
+  return tr('Copy snippet', '复制代码片段')
 })
 
 const copySnippet = async () => {
@@ -822,8 +829,8 @@ const testStatus = computed(() => {
 })
 
 const testStatusText = computed(() => {
-  if (!testResult.value) return 'Not tested'
-  return testResult.value.success ? 'Connected' : 'Failed'
+  if (!testResult.value) return tr('Not tested', '未测试')
+  return testResult.value.success ? tr('Connected', '已连接') : tr('Failed', '失败')
 })
 
 const webhookConfigured = computed(() =>
@@ -832,15 +839,15 @@ const webhookConfigured = computed(() =>
 
 const webhookSavedClass = computed(() => (webhookConfigured.value ? 'ok' : 'idle'))
 const webhookSavedText = computed(() =>
-  webhookConfigured.value ? 'Configured' : 'Not configured'
+  webhookConfigured.value ? tr('Configured', '已配置') : tr('Not configured', '未配置')
 )
 
 const webhookPlaceholder = computed(() => {
   if (webhookConfigured.value) {
     const masked = currentSettings.value.integrations?.webhook?.url_masked
     return masked
-      ? `${masked} — leave blank to keep, type to replace`
-      : 'Leave blank to keep saved URL, type to replace'
+      ? `${masked}${tr(' — leave blank to keep, type to replace', ' — 留空保留,输入以替换')}`
+      : tr('Leave blank to keep saved URL, type to replace', '留空保留已保存的 URL,输入以替换')
   }
   return 'https://hooks.slack.com/services/T0…/B0…/abc'
 })
@@ -859,7 +866,7 @@ const testWebhookFire = async () => {
     const res = await testWebhook(url, baseUrl)
     webhookTestResult.value = res
   } catch (e) {
-    webhookTestResult.value = { success: false, error: e?.message || 'Network error' }
+    webhookTestResult.value = { success: false, error: e?.message || tr('Network error', '网络错误') }
   } finally {
     webhookTesting.value = false
   }
@@ -927,7 +934,7 @@ const saveSettings = async () => {
       form.integrations.webhook.url = ''
       setTimeout(() => { saveSuccess.value = false }, 4000)
     } else {
-      saveError.value = res?.error || 'Save failed'
+      saveError.value = res?.error || tr('Save failed', '保存失败')
     }
   } catch (e) {
     saveError.value = e.message

--- a/frontend/src/components/Step1GraphBuild.vue
+++ b/frontend/src/components/Step1GraphBuild.vue
@@ -6,32 +6,32 @@
         <div class="card-header">
           <div class="step-info">
             <span class="step-num">01</span>
-            <span class="step-title">Ontology Generation</span>
+            <span class="step-title">{{ $tr('Ontology Generation', '本体生成') }}</span>
           </div>
           <div class="step-status">
-            <span v-if="currentPhase > 0" class="badge success">Completed</span>
-            <span v-else-if="currentPhase === 0" class="badge processing">Generating</span>
-            <span v-else class="badge pending">Waiting</span>
+            <span v-if="currentPhase > 0" class="badge success">{{ $tr('Completed', '已完成') }}</span>
+            <span v-else-if="currentPhase === 0" class="badge processing">{{ $tr('Generating', '生成中') }}</span>
+            <span v-else class="badge pending">{{ $tr('Waiting', '等待中') }}</span>
           </div>
         </div>
 
         <div class="card-content">
           <p class="api-note">POST /api/graph/ontology/generate</p>
           <p class="description">
-            LLM analyzes document content and simulation requirements, extracts reality seeds, and automatically generates a suitable ontology structure
+            {{ $tr('LLM analyzes document content and simulation requirements, extracts reality seeds, and automatically generates a suitable ontology structure', 'LLM 分析文档内容与模拟需求,提取现实种子,并自动生成合适的本体结构') }}
           </p>
 
           <!-- Loading / Progress -->
           <div v-if="currentPhase === 0 && ontologyProgress" class="progress-section">
             <div class="spinner-sm"></div>
-            <span>{{ ontologyProgress.message || 'Analyzing documents...' }}</span>
+            <span>{{ ontologyProgress.message || $tr('Analyzing documents...', '分析文档中...') }}</span>
           </div>
 
           <!-- Detail Overlay -->
           <div v-if="selectedOntologyItem" class="ontology-detail-overlay">
             <div class="detail-header">
                <div class="detail-title-group">
-                  <span class="detail-type-badge">{{ selectedOntologyItem.itemType === 'entity' ? 'ENTITY' : 'RELATION' }}</span>
+                  <span class="detail-type-badge">{{ selectedOntologyItem.itemType === 'entity' ? $tr('ENTITY', '实体') : $tr('RELATION', '关系') }}</span>
                   <span class="detail-name">{{ selectedOntologyItem.name }}</span>
                </div>
                <button class="close-btn" @click="selectedOntologyItem = null">×</button>
@@ -41,7 +41,7 @@
 
                <!-- Attributes -->
                <div class="detail-section" v-if="selectedOntologyItem.attributes?.length">
-                  <span class="section-label">ATTRIBUTES</span>
+                  <span class="section-label">{{ $tr('ATTRIBUTES', '属性') }}</span>
                   <div class="attr-list">
                      <div v-for="attr in selectedOntologyItem.attributes" :key="attr.name" class="attr-item">
                         <span class="attr-name">{{ attr.name }}</span>
@@ -53,7 +53,7 @@
 
                <!-- Examples (Entity) -->
                <div class="detail-section" v-if="selectedOntologyItem.examples?.length">
-                  <span class="section-label">EXAMPLES</span>
+                  <span class="section-label">{{ $tr('EXAMPLES', '示例') }}</span>
                   <div class="example-list">
                      <span v-for="ex in selectedOntologyItem.examples" :key="ex" class="example-tag">{{ ex }}</span>
                   </div>
@@ -61,7 +61,7 @@
 
                <!-- Source/Target (Relation) -->
                <div class="detail-section" v-if="selectedOntologyItem.source_targets?.length">
-                  <span class="section-label">CONNECTIONS</span>
+                  <span class="section-label">{{ $tr('CONNECTIONS', '连接') }}</span>
                   <div class="conn-list">
                      <div v-for="(conn, idx) in selectedOntologyItem.source_targets" :key="idx" class="conn-item">
                         <span class="conn-node">{{ conn.source }}</span>
@@ -75,7 +75,7 @@
 
           <!-- Generated Entity Tags -->
           <div v-if="projectData?.ontology?.entity_types" class="tags-container" :class="{ 'dimmed': selectedOntologyItem }">
-            <span class="tag-label">GENERATED ENTITY TYPES</span>
+            <span class="tag-label">{{ $tr('GENERATED ENTITY TYPES', '已生成的实体类型') }}</span>
             <div class="tags-list">
               <span
                 v-for="entity in projectData.ontology.entity_types"
@@ -90,7 +90,7 @@
 
           <!-- Generated Relation Tags -->
           <div v-if="projectData?.ontology?.edge_types" class="tags-container" :class="{ 'dimmed': selectedOntologyItem }">
-            <span class="tag-label">GENERATED RELATION TYPES</span>
+            <span class="tag-label">{{ $tr('GENERATED RELATION TYPES', '已生成的关系类型') }}</span>
             <div class="tags-list">
               <span
                 v-for="rel in projectData.ontology.edge_types"
@@ -110,34 +110,34 @@
         <div class="card-header">
           <div class="step-info">
             <span class="step-num">02</span>
-            <span class="step-title">GraphRAG Build</span>
+            <span class="step-title">{{ $tr('GraphRAG Build', 'GraphRAG 构建') }}</span>
           </div>
           <div class="step-status">
-            <span v-if="currentPhase > 1" class="badge success">Completed</span>
+            <span v-if="currentPhase > 1" class="badge success">{{ $tr('Completed', '已完成') }}</span>
             <span v-else-if="currentPhase === 1" class="badge processing">{{ buildProgress?.progress || 0 }}%</span>
-            <span v-else class="badge pending">Waiting</span>
+            <span v-else class="badge pending">{{ $tr('Waiting', '等待中') }}</span>
           </div>
         </div>
 
         <div class="card-content">
           <p class="api-note">POST /api/graph/build</p>
           <p class="description">
-            Based on the generated ontology, automatically chunks documents and builds a knowledge graph via Neo4j, extracting entities and relationships, forming temporal memory and community summaries
+            {{ $tr('Based on the generated ontology, automatically chunks documents and builds a knowledge graph via Neo4j, extracting entities and relationships, forming temporal memory and community summaries', '基于生成的本体,自动对文档分块,通过 Neo4j 构建知识图谱,提取实体与关系,形成时序记忆与社区摘要') }}
           </p>
 
           <!-- Stats Cards -->
           <div class="stats-grid">
             <div class="stat-card">
               <span class="stat-value">{{ graphStats.nodes }}</span>
-              <span class="stat-label">Entity Nodes</span>
+              <span class="stat-label">{{ $tr('Entity Nodes', '实体节点') }}</span>
             </div>
             <div class="stat-card">
               <span class="stat-value">{{ graphStats.edges }}</span>
-              <span class="stat-label">Relation Edges</span>
+              <span class="stat-label">{{ $tr('Relation Edges', '关系边') }}</span>
             </div>
             <div class="stat-card">
               <span class="stat-value">{{ graphStats.types }}</span>
-              <span class="stat-label">Schema Types</span>
+              <span class="stat-label">{{ $tr('Schema Types', '模式类型') }}</span>
             </div>
           </div>
         </div>
@@ -148,15 +148,15 @@
         <div class="card-header">
           <div class="step-info">
             <span class="step-num">03</span>
-            <span class="step-title">Build Complete</span>
+            <span class="step-title">{{ $tr('Build Complete', '构建完成') }}</span>
           </div>
           <div class="step-status">
-            <span v-if="currentPhase >= 2" class="badge accent">Ready to launch</span>
+            <span v-if="currentPhase >= 2" class="badge accent">{{ $tr('Ready to launch', '可以启动') }}</span>
           </div>
         </div>
 
         <div class="card-content">
-          <p class="description">Graph build is complete. Please proceed to the next step for simulation agent setup.</p>
+          <p class="description">{{ $tr('Graph build is complete. Please proceed to the next step for simulation agent setup.', '图谱构建完成。请进入下一步进行模拟智能体配置。') }}</p>
 
           <!-- Existing simulations -->
           <div v-if="existingSimulations.length > 0" class="existing-sims">
@@ -174,16 +174,16 @@
 
           <div class="sim-settings">
             <label class="sim-setting-row" for="market-count-select">
-              <span class="sim-setting-label">Prediction markets</span>
+              <span class="sim-setting-label">{{ $tr('Prediction markets', '预测市场') }}</span>
               <select
                 id="market-count-select"
                 class="sim-setting-select"
                 v-model.number="marketCount"
                 :disabled="creatingSimulation"
-                title="How many prediction markets to generate for this simulation"
+                :title="$tr('How many prediction markets to generate for this simulation', '为本次模拟生成多少个预测市场')"
               >
                 <option v-for="n in 5" :key="n" :value="n">
-                  {{ n }} {{ n === 1 ? 'market' : 'markets' }}
+                  {{ n }} {{ $tr(n === 1 ? 'market' : 'markets', '个市场') }}
                 </option>
               </select>
             </label>
@@ -195,7 +195,7 @@
             @click="handleEnterEnvSetup"
           >
             <span v-if="creatingSimulation" class="spinner-sm"></span>
-            {{ creatingSimulation ? 'Creating...' : (existingSimulations.length > 0 ? 'New Simulation ➝' : 'Enter Agent Setup ➝') }}
+            {{ creatingSimulation ? $tr('Creating...', '创建中...') : (existingSimulations.length > 0 ? $tr('New Simulation ➝', '新建模拟 ➝') : $tr('Enter Agent Setup ➝', '进入智能体配置 ➝')) }}
           </button>
         </div>
       </div>
@@ -204,8 +204,8 @@
     <!-- Bottom Info / Logs -->
     <div class="system-logs" :class="{ collapsed: dashboardCollapsed }">
       <div class="log-header" @click="dashboardCollapsed = !dashboardCollapsed">
-        <span class="log-title">SYSTEM DASHBOARD <span class="log-toggle">{{ dashboardCollapsed ? '▲' : '▼' }}</span></span>
-        <span class="log-id">{{ projectData?.project_id || 'NO_PROJECT' }}</span>
+        <span class="log-title">{{ $tr('SYSTEM DASHBOARD', '系统面板') }} <span class="log-toggle">{{ dashboardCollapsed ? '▲' : '▼' }}</span></span>
+        <span class="log-id">{{ projectData?.project_id || $tr('NO_PROJECT', '无项目') }}</span>
       </div>
       <div v-show="!dashboardCollapsed" class="log-content" ref="logContent">
         <div class="log-line" v-for="(log, idx) in systemLogs" :key="idx">
@@ -221,6 +221,7 @@
 import { computed, ref, watch, nextTick, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { createSimulation, listSimulations } from '../api/simulation'
+import { tr } from '../i18n'
 
 const router = useRouter()
 
@@ -289,11 +290,11 @@ const handleEnterEnvSetup = async () => {
       })
     } else {
       console.error('Failed to create simulation:', res.error)
-      alert('Failed to create simulation: ' + (res.error || 'Unknown error'))
+      alert(tr('Failed to create simulation: ', '创建模拟失败:') + (res.error || tr('Unknown error', '未知错误')))
     }
   } catch (err) {
     console.error('Simulation creation error:', err)
-    alert('Simulation creation error: ' + err.message)
+    alert(tr('Simulation creation error: ', '创建模拟出错:') + err.message)
   } finally {
     creatingSimulation.value = false
   }

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -6,37 +6,37 @@
         <div class="card-header">
           <div class="step-info">
             <span class="step-num">01</span>
-            <span class="step-title">Simulation Instance Initialization</span>
+            <span class="step-title">{{ $tr('Simulation Instance Initialization', '模拟实例初始化') }}</span>
           </div>
           <div class="step-status">
-            <span v-if="phase > 0" class="badge success"><span class="badge-dot"></span>Completed</span>
-            <span v-else-if="simulationId" class="badge processing"><span class="badge-dot"></span>Initializing</span>
-            <span v-else class="badge pending"><span class="badge-dot"></span>Loading</span>
+            <span v-if="phase > 0" class="badge success"><span class="badge-dot"></span>{{ $tr('Completed', '已完成') }}</span>
+            <span v-else-if="simulationId" class="badge processing"><span class="badge-dot"></span>{{ $tr('Initializing', '初始化中') }}</span>
+            <span v-else class="badge pending"><span class="badge-dot"></span>{{ $tr('Loading', '加载中…') }}</span>
           </div>
         </div>
 
         <div class="card-content">
           <p class="api-note">POST /api/simulation/create</p>
           <p class="description">
-            Create a new simulation instance and fetch simulation world parameter templates
+            {{ $tr('Create a new simulation instance and fetch simulation world parameter templates', '创建一个新的模拟实例并获取模拟世界参数模板') }}
           </p>
 
           <div v-if="simulationId" class="info-card">
             <div class="info-row" @click="copyValue(projectData?.project_id)">
-              <span class="info-label">Project ID</span>
+              <span class="info-label">{{ $tr('Project ID', '项目 ID') }}</span>
               <span class="info-value mono copyable">{{ projectData?.project_id }}</span>
             </div>
             <div class="info-row" @click="copyValue(projectData?.graph_id)">
-              <span class="info-label">Graph ID</span>
+              <span class="info-label">{{ $tr('Graph ID', '图谱 ID') }}</span>
               <span class="info-value mono copyable">{{ projectData?.graph_id }}</span>
             </div>
             <div class="info-row" @click="copyValue(simulationId)">
-              <span class="info-label">Simulation ID</span>
+              <span class="info-label">{{ $tr('Simulation ID', '模拟 ID') }}</span>
               <span class="info-value mono copyable">{{ simulationId }}</span>
             </div>
             <div class="info-row" @click="copyValue(taskId)">
-              <span class="info-label">Task ID</span>
-              <span class="info-value mono copyable">{{ taskId || 'Async task completed' }}</span>
+              <span class="info-label">{{ $tr('Task ID', '任务 ID') }}</span>
+              <span class="info-value mono copyable">{{ taskId || $tr('Async task completed', '异步任务已完成') }}</span>
             </div>
           </div>
         </div>
@@ -47,41 +47,41 @@
         <div class="card-header">
           <div class="step-info">
             <span class="step-num">02</span>
-            <span class="step-title">Generate Agent Profiles</span>
+            <span class="step-title">{{ $tr('Generate Agent Profiles', '生成智能体画像') }}</span>
           </div>
           <div class="step-status">
-            <span v-if="phase > 1" class="badge success"><span class="badge-dot"></span>Completed</span>
+            <span v-if="phase > 1" class="badge success"><span class="badge-dot"></span>{{ $tr('Completed', '已完成') }}</span>
             <span v-else-if="phase === 1" class="badge processing"><span class="badge-dot"></span>{{ prepareProgress }}%</span>
-            <span v-else class="badge pending"><span class="badge-dot"></span>Waiting</span>
+            <span v-else class="badge pending"><span class="badge-dot"></span>{{ $tr('Waiting', '等待中') }}</span>
           </div>
         </div>
 
         <div class="card-content">
           <p class="api-note">POST /api/simulation/prepare</p>
           <p class="description">
-            Combines context to automatically invoke tools, organize entities and relationships from the knowledge graph, initialize simulated individuals, and assign them unique behaviors and memories based on reality seeds
+            {{ $tr('Combines context to automatically invoke tools, organize entities and relationships from the knowledge graph, initialize simulated individuals, and assign them unique behaviors and memories based on reality seeds', '结合上下文自动调用工具,从知识图谱整理实体与关系,初始化模拟个体,并基于现实种子赋予其独特的行为与记忆') }}
           </p>
 
           <!-- Profiles Stats -->
           <div v-if="profiles.length > 0" class="stats-grid">
             <div class="stat-card">
               <span class="stat-value">{{ profiles.length }}</span>
-              <span class="stat-label">Current Agents</span>
+              <span class="stat-label">{{ $tr('Current Agents', '当前智能体') }}</span>
             </div>
             <div class="stat-card">
               <span class="stat-value">{{ expectedTotal || '-' }}</span>
-              <span class="stat-label">Expected Total Agents</span>
+              <span class="stat-label">{{ $tr('Expected Total Agents', '预期智能体总数') }}</span>
             </div>
             <div class="stat-card">
               <span class="stat-value">{{ totalTopicsCount }}</span>
-              <span class="stat-label">Reality Seed Topics</span>
+              <span class="stat-label">{{ $tr('Reality Seed Topics', '现实种子话题') }}</span>
             </div>
           </div>
 
           <!-- Profiles List Preview -->
           <div v-if="profiles.length > 0" class="profiles-preview">
             <div class="preview-header">
-              <span class="preview-title">Generated Agent Profiles</span>
+              <span class="preview-title">{{ $tr('Generated Agent Profiles', '已生成的智能体画像') }}</span>
             </div>
             <div class="profiles-list">
               <div
@@ -91,13 +91,13 @@
                 @click="selectProfile(profile)"
               >
                 <div class="profile-header">
-                  <span class="profile-realname">{{ profile.username || 'Unknown' }}</span>
+                  <span class="profile-realname">{{ profile.username || $tr('Unknown', '未知') }}</span>
                   <span class="profile-username">@{{ profile.name || `agent_${idx}` }}</span>
                 </div>
                 <div class="profile-meta">
-                  <span class="profile-profession">{{ profile.profession || 'Unknown Profession' }}</span>
+                  <span class="profile-profession">{{ profile.profession || $tr('Unknown Profession', '未知职业') }}</span>
                 </div>
-                <p class="profile-bio">{{ profile.bio || 'No bio available' }}</p>
+                <p class="profile-bio">{{ profile.bio || $tr('No bio available', '暂无简介') }}</p>
                 <div v-if="profile.interested_topics?.length" class="profile-topics">
                   <span
                     v-for="topic in profile.interested_topics.slice(0, 3)"
@@ -115,7 +115,7 @@
               class="profiles-toggle"
               @click="profilesExpanded = !profilesExpanded"
             >
-              {{ profilesExpanded ? 'Show less' : `Show all ${profiles.length} agents` }}
+              {{ profilesExpanded ? $tr('Show less', '收起') : $tr('Show all ', '查看全部 ') + profiles.length + $tr(' agents', ' 个智能体') }}
             </button>
           </div>
         </div>
@@ -126,29 +126,29 @@
         <div class="card-header">
           <div class="step-info">
             <span class="step-num">03</span>
-            <span class="step-title">Generate Simulation Config</span>
+            <span class="step-title">{{ $tr('Generate Simulation Config', '生成模拟配置') }}</span>
           </div>
           <div class="step-status">
-            <span v-if="phase > 2" class="badge success"><span class="badge-dot"></span>Completed</span>
-            <span v-else-if="configError" class="badge error"><span class="badge-dot"></span>Failed</span>
-            <span v-else-if="phase === 2" class="badge processing"><span class="badge-dot"></span>Generating</span>
-            <span v-else class="badge pending"><span class="badge-dot"></span>Waiting</span>
+            <span v-if="phase > 2" class="badge success"><span class="badge-dot"></span>{{ $tr('Completed', '已完成') }}</span>
+            <span v-else-if="configError" class="badge error"><span class="badge-dot"></span>{{ $tr('Failed', '失败') }}</span>
+            <span v-else-if="phase === 2" class="badge processing"><span class="badge-dot"></span>{{ $tr('Generating', '生成中') }}</span>
+            <span v-else class="badge pending"><span class="badge-dot"></span>{{ $tr('Waiting', '等待中') }}</span>
           </div>
         </div>
 
         <div class="card-content">
           <p class="api-note">POST /api/simulation/prepare</p>
           <p class="description">
-            LLM intelligently configures world time flow, recommendation algorithms, each individual's active time periods, posting frequency, event triggers, and other parameters based on simulation requirements and reality seeds
+            {{ $tr('LLM intelligently configures world time flow, recommendation algorithms, each individual\'s active time periods, posting frequency, event triggers, and other parameters based on simulation requirements and reality seeds', 'LLM 根据模拟需求与现实种子,智能配置世界时间流速、推荐算法、每个个体的活跃时段、发帖频率、事件触发等参数') }}
           </p>
 
           <!-- Config Error Panel -->
           <div v-if="configError" class="config-error-panel">
-            <div class="config-error-title">Config Generation Failed</div>
+            <div class="config-error-title">{{ $tr('Config Generation Failed', '配置生成失败') }}</div>
             <div class="config-error-msg">{{ configError }}</div>
             <div class="config-error-hint">
-              Common causes: OpenRouter API key invalid or quota exceeded, model name not found, network timeout.
-              Check your <code>.env</code> values for <code>OPENROUTER_API_KEY</code> and <code>OPENROUTER_MODEL</code>.
+              {{ $tr('Common causes: OpenRouter API key invalid or quota exceeded, model name not found, network timeout.', '常见原因:OpenRouter API 密钥无效或额度耗尽、模型名称未找到、网络超时。') }}
+              {{ $tr('Check your', '请检查您的') }} <code>.env</code> {{ $tr('values for', '中的') }} <code>OPENROUTER_API_KEY</code> {{ $tr('and', '与') }} <code>OPENROUTER_MODEL</code>.
             </div>
             <button
               class="retry-config-btn"
@@ -156,7 +156,7 @@
               @click="handleConfigRetry"
             >
               <span v-if="isConfigRetrying" class="loading-spinner-small"></span>
-              {{ isConfigRetrying ? 'Retrying...' : 'Retry Config Generation' }}
+              {{ isConfigRetrying ? $tr('Retrying...', '重试中…') : $tr('Retry Config Generation', '重新生成配置') }}
             </button>
           </div>
 
@@ -166,40 +166,40 @@
             <div class="config-block">
               <div class="config-grid">
                 <div class="config-item">
-                  <span class="config-item-label">Simulation Duration</span>
-                  <span class="config-item-value">{{ simulationConfig.time_config?.total_simulation_hours || '-' }} hours</span>
+                  <span class="config-item-label">{{ $tr('Simulation Duration', '模拟时长') }}</span>
+                  <span class="config-item-value">{{ simulationConfig.time_config?.total_simulation_hours || '-' }} {{ $tr('hours', '小时') }}</span>
                 </div>
                 <div class="config-item">
-                  <span class="config-item-label">Duration Per Round</span>
-                  <span class="config-item-value">{{ simulationConfig.time_config?.minutes_per_round || '-' }} min</span>
+                  <span class="config-item-label">{{ $tr('Duration Per Round', '每轮时长') }}</span>
+                  <span class="config-item-value">{{ simulationConfig.time_config?.minutes_per_round || '-' }} {{ $tr('min', '分钟') }}</span>
                 </div>
                 <div class="config-item">
-                  <span class="config-item-label">Total Rounds</span>
-                  <span class="config-item-value">{{ Math.floor((simulationConfig.time_config?.total_simulation_hours * 60 / simulationConfig.time_config?.minutes_per_round)) || '-' }} rounds</span>
+                  <span class="config-item-label">{{ $tr('Total Rounds', '总轮次') }}</span>
+                  <span class="config-item-value">{{ Math.floor((simulationConfig.time_config?.total_simulation_hours * 60 / simulationConfig.time_config?.minutes_per_round)) || '-' }} {{ $tr('rounds', '轮') }}</span>
                 </div>
                 <div class="config-item">
-                  <span class="config-item-label">Active Per Hour</span>
+                  <span class="config-item-label">{{ $tr('Active Per Hour', '每小时活跃数') }}</span>
                   <span class="config-item-value">{{ simulationConfig.time_config?.agents_per_hour_min }}-{{ simulationConfig.time_config?.agents_per_hour_max }}</span>
                 </div>
               </div>
               <div class="time-periods">
                 <div class="period-item">
-                  <span class="period-label">Peak Hours</span>
+                  <span class="period-label">{{ $tr('Peak Hours', '高峰时段') }}</span>
                   <span class="period-hours">{{ simulationConfig.time_config?.peak_hours?.join(':00, ') }}:00</span>
                   <span class="period-multiplier">×{{ simulationConfig.time_config?.peak_activity_multiplier }}</span>
                 </div>
                 <div class="period-item">
-                  <span class="period-label">Working Hours</span>
+                  <span class="period-label">{{ $tr('Working Hours', '工作时段') }}</span>
                   <span class="period-hours">{{ simulationConfig.time_config?.work_hours?.[0] }}:00-{{ simulationConfig.time_config?.work_hours?.slice(-1)[0] }}:00</span>
                   <span class="period-multiplier">×{{ simulationConfig.time_config?.work_activity_multiplier }}</span>
                 </div>
                 <div class="period-item">
-                  <span class="period-label">Morning Hours</span>
+                  <span class="period-label">{{ $tr('Morning Hours', '清晨时段') }}</span>
                   <span class="period-hours">{{ simulationConfig.time_config?.morning_hours?.[0] }}:00-{{ simulationConfig.time_config?.morning_hours?.slice(-1)[0] }}:00</span>
                   <span class="period-multiplier">×{{ simulationConfig.time_config?.morning_activity_multiplier }}</span>
                 </div>
                 <div class="period-item">
-                  <span class="period-label">Off-Peak Hours</span>
+                  <span class="period-label">{{ $tr('Off-Peak Hours', '低峰时段') }}</span>
                   <span class="period-hours">{{ simulationConfig.time_config?.off_peak_hours?.[0] }}:00-{{ simulationConfig.time_config?.off_peak_hours?.slice(-1)[0] }}:00</span>
                   <span class="period-multiplier">×{{ simulationConfig.time_config?.off_peak_activity_multiplier }}</span>
                 </div>
@@ -209,7 +209,7 @@
             <!-- Agent Configuration -->
             <div class="config-block">
               <div class="config-block-header">
-                <span class="config-block-title">Agent Configuration</span>
+                <span class="config-block-title">{{ $tr('Agent Configuration', '智能体配置') }}</span>
                 <span class="config-block-badge">{{ simulationConfig.agent_configs?.length || 0 }}</span>
               </div>
               <div class="agents-cards">
@@ -221,7 +221,7 @@
                   <!-- Card Header -->
                   <div class="agent-card-header">
                     <div class="agent-identity">
-                      <span class="agent-id">Agent {{ agent.agent_id }}</span>
+                      <span class="agent-id">{{ $tr('Agent', '智能体') }} {{ agent.agent_id }}</span>
                       <span class="agent-name">{{ agent.entity_name }}</span>
                     </div>
                     <div class="agent-tags">
@@ -229,10 +229,10 @@
                       <span class="agent-stance" :class="'stance-' + agent.stance">{{ agent.stance }}</span>
                     </div>
                   </div>
-                  
+
                   <!-- Profile Info (from generated profiles) -->
                   <div v-if="getAgentProfile(agent.agent_id)" class="agent-profile-info">
-                    <span class="profile-profession-tag">{{ getAgentProfile(agent.agent_id).profession || 'Unknown' }}</span>
+                    <span class="profile-profession-tag">{{ getAgentProfile(agent.agent_id).profession || $tr('Unknown', '未知') }}</span>
                     <span v-if="getAgentProfile(agent.agent_id).country" class="profile-country-tag">{{ getAgentProfile(agent.agent_id).country }}</span>
                     <span v-if="getAgentProfile(agent.agent_id).mbti" class="profile-mbti-tag">{{ getAgentProfile(agent.agent_id).mbti }}</span>
                     <p class="profile-bio-snippet">{{ (getAgentProfile(agent.agent_id).bio || '').slice(0, 120) }}{{ (getAgentProfile(agent.agent_id).bio || '').length > 120 ? '...' : '' }}</p>
@@ -240,7 +240,7 @@
 
                   <!-- Active Timeline -->
                   <div class="agent-timeline">
-                    <span class="timeline-label">Active Hours</span>
+                    <span class="timeline-label">{{ $tr('Active Hours', '活跃时段') }}</span>
                     <div class="mini-timeline">
                       <div 
                         v-for="hour in 24" 
@@ -263,34 +263,34 @@
                   <div class="agent-params">
                     <div class="param-group">
                       <div class="param-item">
-                        <span class="param-label">Posts/hr</span>
+                        <span class="param-label">{{ $tr('Posts/hr', '帖子/小时') }}</span>
                         <span class="param-value">{{ agent.posts_per_hour }}</span>
                       </div>
                       <div class="param-item">
-                        <span class="param-label">Comments/hr</span>
+                        <span class="param-label">{{ $tr('Comments/hr', '评论/小时') }}</span>
                         <span class="param-value">{{ agent.comments_per_hour }}</span>
                       </div>
                       <div class="param-item">
-                        <span class="param-label">Response Delay</span>
-                        <span class="param-value">{{ agent.response_delay_min }}-{{ agent.response_delay_max }}min</span>
+                        <span class="param-label">{{ $tr('Response Delay', '响应延迟') }}</span>
+                        <span class="param-value">{{ agent.response_delay_min }}-{{ agent.response_delay_max }}{{ $tr('min', '分钟') }}</span>
                       </div>
                     </div>
                     <div class="param-group">
                       <div class="param-item">
-                        <span class="param-label">Activity Level</span>
+                        <span class="param-label">{{ $tr('Activity Level', '活跃水平') }}</span>
                         <span class="param-value with-bar">
                           <span class="mini-bar" :style="{ width: (agent.activity_level * 100) + '%' }"></span>
                           {{ (agent.activity_level * 100).toFixed(0) }}%
                         </span>
                       </div>
                       <div class="param-item">
-                        <span class="param-label">Sentiment Tendency</span>
+                        <span class="param-label">{{ $tr('Sentiment Tendency', '情绪倾向') }}</span>
                         <span class="param-value" :class="agent.sentiment_bias > 0 ? 'positive' : agent.sentiment_bias < 0 ? 'negative' : 'neutral'">
                           {{ agent.sentiment_bias > 0 ? '+' : '' }}{{ agent.sentiment_bias?.toFixed(1) }}
                         </span>
                       </div>
                       <div class="param-item">
-                        <span class="param-label">Influence</span>
+                        <span class="param-label">{{ $tr('Influence', '影响力') }}</span>
                         <span class="param-value highlight">{{ agent.influence_weight?.toFixed(1) }}</span>
                       </div>
                     </div>
@@ -302,14 +302,14 @@
                 class="profiles-toggle"
                 @click="agentCardsExpanded = !agentCardsExpanded"
               >
-                {{ agentCardsExpanded ? 'Show less' : `Show all ${simulationConfig.agent_configs.length} agents` }}
+                {{ agentCardsExpanded ? $tr('Show less', '收起') : $tr('Show all ', '查看全部 ') + simulationConfig.agent_configs.length + $tr(' agents', ' 个智能体') }}
               </button>
             </div>
 
             <!-- Platform Configuration -->
             <div class="config-block">
               <div class="config-block-header">
-                <span class="config-block-title">Recommendation Algorithm Configuration</span>
+                <span class="config-block-title">{{ $tr('Recommendation Algorithm Configuration', '推荐算法配置') }}</span>
               </div>
               <div class="platforms-grid">
                 <div v-if="simulationConfig.twitter_config" class="platform-card">
@@ -318,23 +318,23 @@
                   </div>
                   <div class="platform-params">
                     <div class="param-row">
-                      <span class="param-label">Timeliness Weight</span>
+                      <span class="param-label">{{ $tr('Timeliness Weight', '时效性权重') }}</span>
                       <span class="param-value">{{ simulationConfig.twitter_config.recency_weight }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Popularity Weight</span>
+                      <span class="param-label">{{ $tr('Popularity Weight', '热度权重') }}</span>
                       <span class="param-value">{{ simulationConfig.twitter_config.popularity_weight }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Relevance Weight</span>
+                      <span class="param-label">{{ $tr('Relevance Weight', '相关性权重') }}</span>
                       <span class="param-value">{{ simulationConfig.twitter_config.relevance_weight }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Viral Threshold</span>
+                      <span class="param-label">{{ $tr('Viral Threshold', '病毒传播阈值') }}</span>
                       <span class="param-value">{{ simulationConfig.twitter_config.viral_threshold }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Echo Chamber Intensity</span>
+                      <span class="param-label">{{ $tr('Echo Chamber Intensity', '回音室强度') }}</span>
                       <span class="param-value">{{ simulationConfig.twitter_config.echo_chamber_strength }}</span>
                     </div>
                   </div>
@@ -345,23 +345,23 @@
                   </div>
                   <div class="platform-params">
                     <div class="param-row">
-                      <span class="param-label">Timeliness Weight</span>
+                      <span class="param-label">{{ $tr('Timeliness Weight', '时效性权重') }}</span>
                       <span class="param-value">{{ simulationConfig.reddit_config.recency_weight }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Popularity Weight</span>
+                      <span class="param-label">{{ $tr('Popularity Weight', '热度权重') }}</span>
                       <span class="param-value">{{ simulationConfig.reddit_config.popularity_weight }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Relevance Weight</span>
+                      <span class="param-label">{{ $tr('Relevance Weight', '相关性权重') }}</span>
                       <span class="param-value">{{ simulationConfig.reddit_config.relevance_weight }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Viral Threshold</span>
+                      <span class="param-label">{{ $tr('Viral Threshold', '病毒传播阈值') }}</span>
                       <span class="param-value">{{ simulationConfig.reddit_config.viral_threshold }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Echo Chamber Intensity</span>
+                      <span class="param-label">{{ $tr('Echo Chamber Intensity', '回音室强度') }}</span>
                       <span class="param-value">{{ simulationConfig.reddit_config.echo_chamber_strength }}</span>
                     </div>
                   </div>
@@ -372,20 +372,20 @@
                   </div>
                   <div class="platform-params">
                     <div class="param-row">
-                      <span class="param-label">Market Maker</span>
-                      <span class="param-value">Constant-Product AMM</span>
+                      <span class="param-label">{{ $tr('Market Maker', '做市商') }}</span>
+                      <span class="param-value">{{ $tr('Constant-Product AMM', '恒定乘积 AMM') }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Initial Liquidity</span>
-                      <span class="param-value">$100 per outcome</span>
+                      <span class="param-label">{{ $tr('Initial Liquidity', '初始流动性') }}</span>
+                      <span class="param-value">{{ $tr('$100 per outcome', '每个结果 $100') }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Trading Actions</span>
-                      <span class="param-value">Buy/Sell YES & NO shares</span>
+                      <span class="param-label">{{ $tr('Trading Actions', '交易操作') }}</span>
+                      <span class="param-value">{{ $tr('Buy/Sell YES & NO shares', '买入/卖出 YES 与 NO 份额') }}</span>
                     </div>
                     <div class="param-row">
-                      <span class="param-label">Market-Media Bridge</span>
-                      <span class="param-value">Enabled (prices feed social media)</span>
+                      <span class="param-label">{{ $tr('Market-Media Bridge', '市场-媒体桥接') }}</span>
+                      <span class="param-value">{{ $tr('Enabled (prices feed social media)', '已启用(价格反馈至社交媒体)') }}</span>
                     </div>
                   </div>
                 </div>
@@ -395,7 +395,7 @@
             <!-- LLM Configuration Reasoning -->
             <div v-if="simulationConfig.generation_reasoning" class="config-block">
               <div class="config-block-header">
-                <span class="config-block-title">LLM Configuration Reasoning</span>
+                <span class="config-block-title">{{ $tr('LLM Configuration Reasoning', 'LLM 配置推理') }}</span>
               </div>
               <div class="reasoning-content">
                 <div 
@@ -416,19 +416,19 @@
         <div class="card-header">
           <div class="step-info">
             <span class="step-num">04</span>
-            <span class="step-title">Initial Activation Orchestration</span>
+            <span class="step-title">{{ $tr('Initial Activation Orchestration', '初始激活编排') }}</span>
           </div>
           <div class="step-status">
-            <span v-if="phase > 3" class="badge success"><span class="badge-dot"></span>Completed</span>
-            <span v-else-if="phase === 3" class="badge processing"><span class="badge-dot"></span>Orchestrating</span>
-            <span v-else class="badge pending"><span class="badge-dot"></span>Waiting</span>
+            <span v-if="phase > 3" class="badge success"><span class="badge-dot"></span>{{ $tr('Completed', '已完成') }}</span>
+            <span v-else-if="phase === 3" class="badge processing"><span class="badge-dot"></span>{{ $tr('Orchestrating', '编排中') }}</span>
+            <span v-else class="badge pending"><span class="badge-dot"></span>{{ $tr('Waiting', '等待中') }}</span>
           </div>
         </div>
 
         <div class="card-content">
           <p class="api-note">POST /api/simulation/prepare</p>
           <p class="description">
-            Based on narrative direction, automatically generate initial activation events and hot topics to guide the initial state of the simulation world
+            {{ $tr('Based on narrative direction, automatically generate initial activation events and hot topics to guide the initial state of the simulation world', '根据叙事方向,自动生成初始激活事件与热门话题,以引导模拟世界的初始状态') }}
           </p>
 
           <div v-if="simulationConfig?.event_config" class="orchestration-content">
@@ -445,14 +445,14 @@
                     </linearGradient>
                   </defs>
                 </svg>
-                Narrative Guidance Direction
+                {{ $tr('Narrative Guidance Direction', '叙事引导方向') }}
               </span>
               <p class="narrative-text">{{ simulationConfig.event_config.narrative_direction }}</p>
             </div>
 
             <!-- Hot Topics -->
             <div class="topics-section">
-              <span class="box-label">Initial Hot Topics</span>
+              <span class="box-label">{{ $tr('Initial Hot Topics', '初始热门话题') }}</span>
               <div class="hot-topics-grid">
                 <span v-for="topic in simulationConfig.event_config.hot_topics" :key="topic" class="hot-topic-tag">
                   # {{ topic }}
@@ -462,7 +462,7 @@
 
             <!-- Initial Posts Stream -->
             <div class="initial-posts-section">
-              <span class="box-label">Initial Activation Sequence ({{ simulationConfig.event_config.initial_posts.length }})</span>
+              <span class="box-label">{{ $tr('Initial Activation Sequence (', '初始激活序列(') }}{{ simulationConfig.event_config.initial_posts.length }}{{ $tr(')', ')') }}</span>
               <div class="posts-timeline">
                 <div v-for="(post, idx) in simulationConfig.event_config.initial_posts" :key="idx" class="timeline-item">
                   <div class="timeline-marker"></div>
@@ -470,7 +470,7 @@
                     <div class="post-header">
                       <span class="post-role">{{ post.poster_type }}</span>
                       <span class="post-agent-info">
-                        <span class="post-id">Agent {{ post.poster_agent_id }}</span>
+                        <span class="post-id">{{ $tr('Agent', '智能体') }} {{ post.poster_agent_id }}</span>
                         <span class="post-username">@{{ getAgentUsername(post.poster_agent_id) }}</span>
                       </span>
                     </div>
@@ -488,29 +488,29 @@
         <div class="card-header">
           <div class="step-info">
             <span class="step-num">05</span>
-            <span class="step-title">Preparation Complete</span>
+            <span class="step-title">{{ $tr('Preparation Complete', '准备完成') }}</span>
           </div>
           <div class="step-status">
-            <span v-if="phase >= 4" class="badge processing"><span class="badge-dot"></span>In Progress</span>
-            <span v-else class="badge pending"><span class="badge-dot"></span>Waiting</span>
+            <span v-if="phase >= 4" class="badge processing"><span class="badge-dot"></span>{{ $tr('In Progress', '进行中') }}</span>
+            <span v-else class="badge pending"><span class="badge-dot"></span>{{ $tr('Waiting', '等待中') }}</span>
           </div>
         </div>
 
         <div class="card-content">
           <p class="api-note">POST /api/simulation/start</p>
-          <p class="description">Simulation environment is ready, you can start running the simulation</p>
-          
+          <p class="description">{{ $tr('Simulation environment is ready, you can start running the simulation', '模拟环境已就绪,您可以开始运行模拟') }}</p>
+
           <!-- Simulation rounds config - only shown after config generation and rounds calculation -->
           <div v-if="simulationConfig && autoGeneratedRounds" class="rounds-config-section">
             <div class="rounds-header">
               <div class="header-left">
-                <span class="section-title">Simulation Round Settings</span>
-                <span class="section-desc">MiroShark automatically plans to simulate <span class="desc-highlight">{{ simulationConfig?.time_config?.total_simulation_hours || '-' }}</span> hours of reality, each round represents <span class="desc-highlight">{{ simulationConfig?.time_config?.minutes_per_round || '-' }}</span> minutes of elapsed time</span>
+                <span class="section-title">{{ $tr('Simulation Round Settings', '模拟轮次设置') }}</span>
+                <span class="section-desc">{{ $tr('MiroShark automatically plans to simulate ', 'MiroShark 已自动规划模拟 ') }}<span class="desc-highlight">{{ simulationConfig?.time_config?.total_simulation_hours || '-' }}</span>{{ $tr(' hours of reality, each round represents ', ' 小时的现实时间,每一轮代表 ') }}<span class="desc-highlight">{{ simulationConfig?.time_config?.minutes_per_round || '-' }}</span>{{ $tr(' minutes of elapsed time', ' 分钟的流逝时间') }}</span>
               </div>
               <label class="switch-control">
                 <input type="checkbox" v-model="useCustomRounds">
                 <span class="switch-track"></span>
-                <span class="switch-label">Custom</span>
+                <span class="switch-label">{{ $tr('Custom', '自定义') }}</span>
               </label>
             </div>
             
@@ -519,10 +519,10 @@
                 <div class="slider-display">
                   <div class="slider-main-value">
                     <span class="val-num">{{ customMaxRounds }}</span>
-                    <span class="val-unit">rounds</span>
+                    <span class="val-unit">{{ $tr('rounds', '轮') }}</span>
                   </div>
                   <div class="slider-meta-info">
-                    <span>Estimated duration ~{{ Math.round(customMaxRounds * (profiles.length || 100) * 0.006) }} min</span>
+                    <span>{{ $tr('Estimated duration ~', '预计时长约 ') }}{{ Math.round(customMaxRounds * (profiles.length || 100) * 0.006) }} {{ $tr('min', '分钟') }}</span>
                   </div>
                 </div>
 
@@ -543,7 +543,7 @@
                       :class="{ active: customMaxRounds === 40 }"
                       @click="customMaxRounds = 40"
                       :style="{ position: 'absolute', left: `calc(${(40 - 10) / (naturalMaxRounds - 10) * 100}% - 30px)` }"
-                    >40 (Recommended)</span>
+                    >40 {{ $tr('(Recommended)', '(推荐)') }}</span>
                     <span>{{ naturalMaxRounds }}</span>
                   </div>
                 </div>
@@ -553,7 +553,7 @@
                 <div class="auto-info-card">
                   <div class="auto-value">
                     <span class="val-num">{{ autoGeneratedRounds }}</span>
-                    <span class="val-unit">rounds</span>
+                    <span class="val-unit">{{ $tr('rounds', '轮') }}</span>
                   </div>
                   <div class="auto-content">
                     <div class="auto-meta-row">
@@ -562,11 +562,11 @@
                           <circle cx="12" cy="12" r="10"></circle>
                           <polyline points="12 6 12 12 16 14"></polyline>
                         </svg>
-                        Estimated duration ~{{ Math.round(autoGeneratedRounds * (profiles.length || 100) * 0.006) }} min
+                        {{ $tr('Estimated duration ~', '预计时长约 ') }}{{ Math.round(autoGeneratedRounds * (profiles.length || 100) * 0.006) }} {{ $tr('min', '分钟') }}
                       </span>
                     </div>
                     <div class="auto-desc">
-                      <p class="highlight-tip" @click="useCustomRounds = true">First time? Switch to ‘Custom Mode’ to reduce rounds for a quick preview ➝</p>
+                      <p class="highlight-tip" @click="useCustomRounds = true">{{ $tr('First time? Switch to ‘Custom Mode’ to reduce rounds for a quick preview ➝', '首次体验?切换至「自定义模式」减少轮次以快速预览 ➝') }}</p>
                     </div>
                   </div>
                 </div>
@@ -575,18 +575,18 @@
           </div>
 
           <div class="action-group dual">
-            <button 
+            <button
               class="action-btn secondary"
               @click="$emit('go-back')"
             >
-              ← Back to Graph
+              {{ $tr('← Back to Graph', '← 返回图谱') }}
             </button>
-            <button 
+            <button
               class="action-btn primary"
               :disabled="phase < 4"
               @click="handleStartSimulation"
             >
-              {{ hasRunBefore ? 'Resume Simulation ➝' : 'Start Simulation ➝' }}
+              {{ hasRunBefore ? $tr('Resume Simulation ➝', '继续模拟 ➝') : $tr('Start Simulation ➝', '开始模拟 ➝') }}
             </button>
           </div>
         </div>
@@ -612,36 +612,36 @@
           <!-- Basic Info -->
           <div class="modal-info-grid">
             <div class="info-item">
-              <span class="info-label">Apparent Age</span>
-              <span class="info-value">{{ selectedProfile.age || '-' }} years old</span>
+              <span class="info-label">{{ $tr('Apparent Age', '表观年龄') }}</span>
+              <span class="info-value">{{ selectedProfile.age || '-' }} {{ $tr('years old', '岁') }}</span>
             </div>
             <div class="info-item">
-              <span class="info-label">Apparent Gender</span>
-              <span class="info-value">{{ { male: 'Male', female: 'Female', other: 'Other' }[selectedProfile.gender] || selectedProfile.gender }}</span>
+              <span class="info-label">{{ $tr('Apparent Gender', '表观性别') }}</span>
+              <span class="info-value">{{ { male: $tr('Male', '男'), female: $tr('Female', '女'), other: $tr('Other', '其他') }[selectedProfile.gender] || selectedProfile.gender }}</span>
             </div>
             <div class="info-item">
-              <span class="info-label">Country/Region</span>
+              <span class="info-label">{{ $tr('Country/Region', '国家/地区') }}</span>
               <span class="info-value">{{ selectedProfile.country || '-' }}</span>
             </div>
             <div class="info-item">
-              <span class="info-label">Apparent MBTI</span>
+              <span class="info-label">{{ $tr('Apparent MBTI', '表观 MBTI') }}</span>
               <span class="info-value mbti">{{ selectedProfile.mbti || '-' }}</span>
             </div>
           </div>
 
           <!-- Bio -->
           <div class="modal-section">
-            <span class="section-label">Persona Summary</span>
-            <p class="section-bio">{{ selectedProfile.bio || 'No bio available' }}</p>
+            <span class="section-label">{{ $tr('Persona Summary', '人设摘要') }}</span>
+            <p class="section-bio">{{ selectedProfile.bio || $tr('No bio available', '暂无简介') }}</p>
           </div>
 
           <!-- Related Topics -->
           <div class="modal-section" v-if="selectedProfile.interested_topics?.length">
-            <span class="section-label">Real-World Seed Related Topics</span>
+            <span class="section-label">{{ $tr('Real-World Seed Related Topics', '现实种子相关话题') }}</span>
             <div class="topics-grid">
-              <span 
-                v-for="topic in selectedProfile.interested_topics" 
-                :key="topic" 
+              <span
+                v-for="topic in selectedProfile.interested_topics"
+                :key="topic"
                 class="topic-item"
               >{{ topic }}</span>
             </div>
@@ -649,25 +649,25 @@
 
           <!-- Detailed Persona -->
           <div class="modal-section" v-if="selectedProfile.persona">
-            <span class="section-label">Detailed Persona Background</span>
-            
+            <span class="section-label">{{ $tr('Detailed Persona Background', '详细人设背景') }}</span>
+
             <!-- Persona Dimension Overview -->
             <div class="persona-dimensions">
               <div class="dimension-card">
-                <span class="dim-title">Full Event Experience</span>
-                <span class="dim-desc">Complete behavioral trajectory in this event</span>
+                <span class="dim-title">{{ $tr('Full Event Experience', '完整事件经历') }}</span>
+                <span class="dim-desc">{{ $tr('Complete behavioral trajectory in this event', '在此事件中的完整行为轨迹') }}</span>
               </div>
               <div class="dimension-card">
-                <span class="dim-title">Behavioral Pattern Profile</span>
-                <span class="dim-desc">Experience summary and behavioral style preferences</span>
+                <span class="dim-title">{{ $tr('Behavioral Pattern Profile', '行为模式画像') }}</span>
+                <span class="dim-desc">{{ $tr('Experience summary and behavioral style preferences', '经历摘要与行为风格偏好') }}</span>
               </div>
               <div class="dimension-card">
-                <span class="dim-title">Unique Memory Imprint</span>
-                <span class="dim-desc">Memories formed from real-world seeds</span>
+                <span class="dim-title">{{ $tr('Unique Memory Imprint', '独特记忆烙印') }}</span>
+                <span class="dim-desc">{{ $tr('Memories formed from real-world seeds', '由现实种子形成的记忆') }}</span>
               </div>
               <div class="dimension-card">
-                <span class="dim-title">Social Relationship Network</span>
-                <span class="dim-desc">Individual connections and interaction graph</span>
+                <span class="dim-title">{{ $tr('Social Relationship Network', '社交关系网络') }}</span>
+                <span class="dim-desc">{{ $tr('Individual connections and interaction graph', '个体连接与互动图') }}</span>
               </div>
             </div>
 
@@ -683,8 +683,8 @@
     <!-- Bottom Info / Logs -->
     <div class="system-logs" :class="{ collapsed: dashboardCollapsed }">
       <div class="log-header" @click="dashboardCollapsed = !dashboardCollapsed">
-        <span class="log-title">SYSTEM DASHBOARD <span class="log-toggle">{{ dashboardCollapsed ? '▲' : '▼' }}</span></span>
-        <span class="log-id">{{ simulationId || 'NO_SIMULATION' }}</span>
+        <span class="log-title">{{ $tr('SYSTEM DASHBOARD', '系统面板') }} <span class="log-toggle">{{ dashboardCollapsed ? '▲' : '▼' }}</span></span>
+        <span class="log-id">{{ simulationId || $tr('NO_SIMULATION', '无模拟') }}</span>
       </div>
       <div v-show="!dashboardCollapsed" class="log-content" ref="logContent">
         <div class="log-line" v-for="(log, idx) in systemLogs" :key="idx">
@@ -707,6 +707,7 @@ import {
   retrySimulationConfig,
   getRunStatus
 } from '../api/simulation'
+import { tr } from '../i18n'
 
 const props = defineProps({
   simulationId: String,  // passed from parent component
@@ -760,7 +761,7 @@ watch(currentStage, (newStage) => {
     phase.value = 2
     // Entering config generation phase, start polling config
     if (!configTimer) {
-      addLog('Starting to generate Dual-Platform Simulation Config...')
+      addLog(tr('Starting to generate Dual-Platform Simulation Config...', '开始生成双平台模拟配置…'))
       startConfigPolling()
     }
   } else if (newStage === 'Preparing Simulation Scripts' || newStage === 'copying_scripts') {
@@ -838,10 +839,10 @@ const handleStartSimulation = () => {
   if (useCustomRounds.value) {
     // User custom rounds, pass max_rounds parameter
     params.maxRounds = customMaxRounds.value
-    addLog(`Starting simulation, custom rounds: ${customMaxRounds.value} rounds`)
+    addLog(tr(`Starting simulation, custom rounds: ${customMaxRounds.value} rounds`, `开始模拟,自定义轮次:${customMaxRounds.value} 轮`))
   } else {
     // User chose to keep auto-generated rounds, no max_rounds parameter passed
-    addLog(`Starting simulation, using auto-configured rounds: ${autoGeneratedRounds.value} rounds`)
+    addLog(tr(`Starting simulation, using auto-configured rounds: ${autoGeneratedRounds.value} rounds`, `开始模拟,使用自动配置轮次:${autoGeneratedRounds.value} 轮`))
   }
   
   emit('next-step', params)
@@ -861,15 +862,15 @@ const selectProfile = (profile) => {
 // Automatically start simulation preparation
 const startPrepareSimulation = async () => {
   if (!props.simulationId) {
-    addLog('Error: missing simulationId')
+    addLog(tr('Error: missing simulationId', '错误:缺少 simulationId'))
     emit('update-status', 'error')
     return
   }
-  
+
   // Mark first step complete, start second step
   phase.value = 1
-  addLog(`Simulation instance created: ${props.simulationId}`)
-  addLog('Preparing simulation environment...')
+  addLog(tr(`Simulation instance created: ${props.simulationId}`, `模拟实例已创建:${props.simulationId}`))
+  addLog(tr('Preparing simulation environment...', '正在准备模拟环境…'))
   emit('update-status', 'processing')
   
   try {
@@ -881,35 +882,35 @@ const startPrepareSimulation = async () => {
     
     if (res.success && res.data) {
       if (res.data.already_prepared) {
-        addLog('Detected existing completed preparation, using directly')
+        addLog(tr('Detected existing completed preparation, using directly', '检测到已完成的准备,直接使用'))
         await loadPreparedData()
         return
       }
-      
+
       taskId.value = res.data.task_id
-      addLog(`Preparation task started`)
-      addLog(`  └─ Task ID: ${res.data.task_id}`)
-      
+      addLog(tr(`Preparation task started`, '准备任务已启动'))
+      addLog(tr(`  └─ Task ID: ${res.data.task_id}`, `  └─ 任务 ID:${res.data.task_id}`))
+
       // Set Expected Total Agents immediately (from prepare API response)
       if (res.data.expected_entities_count) {
         expectedTotal.value = res.data.expected_entities_count
-        addLog(`Read ${res.data.expected_entities_count} entities from knowledge graph`)
+        addLog(tr(`Read ${res.data.expected_entities_count} entities from knowledge graph`, `从知识图谱读取 ${res.data.expected_entities_count} 个实体`))
         if (res.data.entity_types && res.data.entity_types.length > 0) {
-          addLog(`  └─ Entity types: ${res.data.entity_types.join(', ')}`)
+          addLog(tr(`  └─ Entity types: ${res.data.entity_types.join(', ')}`, `  └─ 实体类型:${res.data.entity_types.join('、')}`))
         }
       }
-      
-      addLog('Starting to poll preparation progress...')
+
+      addLog(tr('Starting to poll preparation progress...', '开始轮询准备进度…'))
       // Start polling progress
       startPolling()
       // Start fetching profiles in real-time
       startProfilesPolling()
     } else {
-      addLog(`Preparation failed: ${res.error || 'Unknown error'}`)
+      addLog(tr(`Preparation failed: ${res.error || 'Unknown error'}`, `准备失败:${res.error || '未知错误'}`))
       emit('update-status', 'error')
     }
   } catch (err) {
-    addLog(`Preparation error: ${err.message}`)
+    addLog(tr(`Preparation error: ${err.message}`, `准备出错:${err.message}`))
     emit('update-status', 'error')
   }
 }
@@ -983,12 +984,12 @@ const pollPrepareStatus = async () => {
       
       // Check if completed
       if (data.status === 'completed' || data.status === 'ready' || data.already_prepared) {
-        addLog('✓ Preparation completed')
+        addLog(tr('✓ Preparation completed', '✓ 准备完成'))
         stopPolling()
         stopProfilesPolling()
         await loadPreparedData()
       } else if (data.status === 'failed') {
-        addLog(`✗ Preparation failed: ${data.error || 'Unknown error'}`)
+        addLog(tr(`✗ Preparation failed: ${data.error || 'Unknown error'}`, `✗ 准备失败:${data.error || '未知错误'}`))
         stopPolling()
         stopProfilesPolling()
       }
@@ -1027,13 +1028,13 @@ const fetchProfilesRealtime = async () => {
         const latestProfile = profiles.value[currentCount - 1]
         const profileName = latestProfile?.name || latestProfile?.username || `Agent_${currentCount}`
         if (currentCount === 1) {
-          addLog(`Starting to generate agent personas...`)
+          addLog(tr(`Starting to generate agent personas...`, '开始生成智能体人设…'))
         }
-        addLog(`→ Agent persona ${currentCount}/${total}: ${profileName} (${latestProfile?.profession || 'Unknown Profession'})`)
-        
+        addLog(tr(`→ Agent persona ${currentCount}/${total}: ${profileName} (${latestProfile?.profession || 'Unknown Profession'})`, `→ 智能体人设 ${currentCount}/${total}:${profileName}(${latestProfile?.profession || '未知职业'})`))
+
         // If all generated
         if (expectedTotal.value && currentCount >= expectedTotal.value) {
-          addLog(`✓ All ${currentCount} agent personas generated`)
+          addLog(tr(`✓ All ${currentCount} agent personas generated`, `✓ 已生成全部 ${currentCount} 个智能体人设`))
         }
       }
     }
@@ -1062,8 +1063,8 @@ const fetchConfigRealtime = async () => {
   // Client-side timeout: give up after CONFIG_POLL_TIMEOUT_MS
   if (configPollStartTime && Date.now() - configPollStartTime > CONFIG_POLL_TIMEOUT_MS) {
     stopConfigPolling()
-    configError.value = 'Config generation timed out after 90 seconds. The LLM may be unresponsive or overloaded.'
-    addLog('✗ Config generation timed out (90s). Use "Retry Config" to try again.')
+    configError.value = tr('Config generation timed out after 90 seconds. The LLM may be unresponsive or overloaded.', '配置生成在 90 秒后超时。LLM 可能无响应或负载过高。')
+    addLog(tr('✗ Config generation timed out (90s). Use "Retry Config" to try again.', '✗ 配置生成超时(90 秒)。请使用「重新生成配置」再次尝试。'))
     return
   }
 
@@ -1076,9 +1077,9 @@ const fetchConfigRealtime = async () => {
       // Backend reported a generation failure
       if (data.config_error || data.status === 'failed') {
         stopConfigPolling()
-        const reason = data.config_error || 'Generation failed — check your OpenRouter API key and model name'
+        const reason = data.config_error || tr('Generation failed — check your OpenRouter API key and model name', '生成失败 — 请检查您的 OpenRouter API 密钥与模型名称')
         configError.value = reason
-        addLog(`✗ Config generation failed: ${reason}`)
+        addLog(tr(`✗ Config generation failed: ${reason}`, `✗ 配置生成失败:${reason}`))
         return
       }
 
@@ -1086,41 +1087,41 @@ const fetchConfigRealtime = async () => {
       if (data.generation_stage && data.generation_stage !== lastLoggedConfigStage) {
         lastLoggedConfigStage = data.generation_stage
         if (data.generation_stage === 'generating_profiles') {
-          addLog('Generating agent persona configuration...')
+          addLog(tr('Generating agent persona configuration...', '生成智能体人设配置中…'))
         } else if (data.generation_stage === 'generating_config') {
-          addLog('Calling LLM to generate simulation configuration parameters...')
+          addLog(tr('Calling LLM to generate simulation configuration parameters...', '调用 LLM 生成模拟配置参数中…'))
         }
       }
 
       // If config has been generated
       if (data.config_generated && data.config) {
         simulationConfig.value = data.config
-        addLog('✓ Simulation configuration generated')
+        addLog(tr('✓ Simulation configuration generated', '✓ 模拟配置已生成'))
 
         // Show detailed config summary
         if (data.summary) {
-          addLog(`  ├─ Agent count: ${data.summary.total_agents}`)
-          addLog(`  ├─ Simulation duration: ${data.summary.simulation_hours} hours`)
-          addLog(`  ├─ Initial posts: ${data.summary.initial_posts_count}`)
-          addLog(`  ├─ Hot topics: ${data.summary.hot_topics_count}`)
-          addLog(`  └─ Platform config: Twitter ${data.summary.has_twitter_config ? '✓' : '✗'}, Reddit ${data.summary.has_reddit_config ? '✓' : '✗'}`)
+          addLog(tr(`  ├─ Agent count: ${data.summary.total_agents}`, `  ├─ 智能体数量:${data.summary.total_agents}`))
+          addLog(tr(`  ├─ Simulation duration: ${data.summary.simulation_hours} hours`, `  ├─ 模拟时长:${data.summary.simulation_hours} 小时`))
+          addLog(tr(`  ├─ Initial posts: ${data.summary.initial_posts_count}`, `  ├─ 初始帖子:${data.summary.initial_posts_count}`))
+          addLog(tr(`  ├─ Hot topics: ${data.summary.hot_topics_count}`, `  ├─ 热门话题:${data.summary.hot_topics_count}`))
+          addLog(tr(`  └─ Platform config: Twitter ${data.summary.has_twitter_config ? '✓' : '✗'}, Reddit ${data.summary.has_reddit_config ? '✓' : '✗'}`, `  └─ 平台配置:Twitter ${data.summary.has_twitter_config ? '✓' : '✗'},Reddit ${data.summary.has_reddit_config ? '✓' : '✗'}`))
         }
 
         // Show time configuration details
         if (data.config.time_config) {
           const tc = data.config.time_config
-          addLog(`Time config: ${tc.minutes_per_round} minutes per round, ${Math.floor((tc.total_simulation_hours * 60) / tc.minutes_per_round)} rounds total`)
+          addLog(tr(`Time config: ${tc.minutes_per_round} minutes per round, ${Math.floor((tc.total_simulation_hours * 60) / tc.minutes_per_round)} rounds total`, `时间配置:每轮 ${tc.minutes_per_round} 分钟,共 ${Math.floor((tc.total_simulation_hours * 60) / tc.minutes_per_round)} 轮`))
         }
 
         // Show event configuration
         if (data.config.event_config?.narrative_direction) {
           const narrative = data.config.event_config.narrative_direction
-          addLog(`Narrative direction: ${narrative.length > 50 ? narrative.substring(0, 50) + '...' : narrative}`)
+          addLog(tr(`Narrative direction: ${narrative.length > 50 ? narrative.substring(0, 50) + '...' : narrative}`, `叙事方向:${narrative.length > 50 ? narrative.substring(0, 50) + '…' : narrative}`))
         }
 
         stopConfigPolling()
         phase.value = 4
-        addLog('✓ Environment setup complete, ready to start simulation')
+        addLog(tr('✓ Environment setup complete, ready to start simulation', '✓ 环境配置完成,可开始模拟'))
         emit('update-status', 'completed')
       }
     }
@@ -1134,20 +1135,20 @@ const handleConfigRetry = async () => {
   isConfigRetrying.value = true
   configError.value = null
   lastLoggedConfigStage = ''
-  addLog('Retrying config generation...')
+  addLog(tr('Retrying config generation...', '正在重试配置生成…'))
 
   try {
     const res = await retrySimulationConfig(props.simulationId)
     if (res.success) {
-      addLog('Config retry started — waiting for LLM...')
+      addLog(tr('Config retry started — waiting for LLM...', '配置重试已启动 — 正在等待 LLM…'))
       startConfigPolling()
     } else {
-      configError.value = res.error || 'Retry failed — check backend logs'
-      addLog(`✗ Retry failed: ${res.error || 'unknown error'}`)
+      configError.value = res.error || tr('Retry failed — check backend logs', '重试失败 — 请检查后端日志')
+      addLog(tr(`✗ Retry failed: ${res.error || 'unknown error'}`, `✗ 重试失败:${res.error || '未知错误'}`))
     }
   } catch (err) {
-    configError.value = err.message || 'Retry request failed'
-    addLog(`✗ Retry error: ${err.message}`)
+    configError.value = err.message || tr('Retry request failed', '重试请求失败')
+    addLog(tr(`✗ Retry error: ${err.message}`, `✗ 重试出错:${err.message}`))
   } finally {
     isConfigRetrying.value = false
   }
@@ -1155,11 +1156,11 @@ const handleConfigRetry = async () => {
 
 const loadPreparedData = async () => {
   phase.value = 2
-  addLog('Loading existing configuration data...')
+  addLog(tr('Loading existing configuration data...', '正在加载已有配置数据…'))
 
   // Fetch profiles one last time
   await fetchProfilesRealtime()
-  addLog(`Loaded ${profiles.value.length} agent personas`)
+  addLog(tr(`Loaded ${profiles.value.length} agent personas`, `已加载 ${profiles.value.length} 个智能体人设`))
 
   // Get config (using real-time API)
   try {
@@ -1167,26 +1168,26 @@ const loadPreparedData = async () => {
     if (res.success && res.data) {
       if (res.data.config_generated && res.data.config) {
         simulationConfig.value = res.data.config
-        addLog('✓ Simulation configuration loaded successfully')
+        addLog(tr('✓ Simulation configuration loaded successfully', '✓ 模拟配置加载成功'))
 
         // Show detailed config summary
         if (res.data.summary) {
-          addLog(`  ├─ Agent count: ${res.data.summary.total_agents}`)
-          addLog(`  ├─ Simulation duration: ${res.data.summary.simulation_hours} hours`)
-          addLog(`  └─ Initial posts: ${res.data.summary.initial_posts_count}`)
+          addLog(tr(`  ├─ Agent count: ${res.data.summary.total_agents}`, `  ├─ 智能体数量:${res.data.summary.total_agents}`))
+          addLog(tr(`  ├─ Simulation duration: ${res.data.summary.simulation_hours} hours`, `  ├─ 模拟时长:${res.data.summary.simulation_hours} 小时`))
+          addLog(tr(`  └─ Initial posts: ${res.data.summary.initial_posts_count}`, `  └─ 初始帖子:${res.data.summary.initial_posts_count}`))
         }
-        
-        addLog('✓ Environment setup complete, ready to start simulation')
+
+        addLog(tr('✓ Environment setup complete, ready to start simulation', '✓ 环境配置完成,可开始模拟'))
         phase.value = 4
         emit('update-status', 'completed')
       } else {
         // Config not yet generated, start polling
-        addLog('Config generating, starting to poll...')
+        addLog(tr('Config generating, starting to poll...', '配置生成中,开始轮询…'))
         startConfigPolling()
       }
     }
   } catch (err) {
-    addLog(`Failed to load configuration: ${err.message}`)
+    addLog(tr(`Failed to load configuration: ${err.message}`, `加载配置失败:${err.message}`))
     emit('update-status', 'error')
   }
 }
@@ -1220,7 +1221,7 @@ onMounted(async () => {
       // no run state — fresh simulation
     }
 
-    addLog('Step 2 Agent Setup Initializing')
+    addLog(tr('Step 2 Agent Setup Initializing', '第 2 步 智能体配置初始化中'))
     startPrepareSimulation()
   }
 })

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -7,7 +7,7 @@
         v-if="phase !== 1"
         class="action-btn secondary"
         @click="emit('go-back')"
-      >← Config</button>
+      >{{ $tr('← Config', '← 配置') }}</button>
 
       <!-- Pause (while running) -->
       <button
@@ -17,7 +17,7 @@
         @click="handleStopSimulation"
       >
         <span v-if="isStopping" class="loading-spinner-small"></span>
-        {{ isStopping ? 'Pausing...' : 'Pause' }}
+        {{ isStopping ? $tr('Pausing...', '暂停中…') : $tr('Pause', '暂停') }}
       </button>
 
       <!-- Restart (when stopped, completed, or failed) -->
@@ -27,7 +27,7 @@
         :disabled="isStarting"
         @click="handleRestart"
       >
-        ↻ {{ runStatus.runner_status === 'failed' ? 'Restart (failed)' : 'Restart' }}
+        ↻ {{ runStatus.runner_status === 'failed' ? $tr('Restart (failed)', '重启(失败)') : $tr('Restart', '重启') }}
       </button>
 
       <!-- Replay (when simulation has data) -->
@@ -36,7 +36,7 @@
         class="action-btn secondary"
         @click="openReplay"
       >
-        ▶ Replay
+        ▶ {{ $tr('Replay', '回放') }}
       </button>
 
       <!-- Generate Article (when simulation has data) -->
@@ -44,9 +44,9 @@
         v-if="phase === 2 && allActions.length > 0"
         class="action-btn secondary"
         @click="openArticleDrawer"
-        title="Generate a publishable article brief from simulation results"
+        :title="$tr('Generate a publishable article brief from simulation results', '从模拟结果生成可发布的文章简报')"
       >
-        ▤ Article
+        ▤ {{ $tr('Article', '文章') }}
       </button>
 
       <!-- Influence Leaderboard toggle -->
@@ -55,9 +55,9 @@
         class="action-btn secondary"
         :class="{ active: showInfluence }"
         @click="toggleOverlay('influence')"
-        title="Agent influence leaderboard"
+        :title="$tr('Agent influence leaderboard', '智能体影响力排行榜')"
       >
-        ◈ Influence
+        ◈ {{ $tr('Influence', '影响力') }}
       </button>
 
       <!-- Belief Drift Chart toggle -->
@@ -66,9 +66,9 @@
         class="action-btn secondary"
         :class="{ active: showBeliefDrift }"
         @click="toggleOverlay('drift')"
-        title="Aggregate belief drift chart"
+        :title="$tr('Aggregate belief drift chart', '群体信念漂移图')"
       >
-        ◎ Drift
+        ◎ {{ $tr('Drift', '漂移') }}
       </button>
 
       <!-- Interaction Network toggle -->
@@ -77,9 +77,9 @@
         class="action-btn secondary"
         :class="{ active: showNetwork }"
         @click="toggleOverlay('network')"
-        title="Agent interaction network graph"
+        :title="$tr('Agent interaction network graph', '智能体互动网络图')"
       >
-        ⬡ Network
+        ⬡ {{ $tr('Network', '网络') }}
       </button>
 
       <!-- Demographic Breakdown toggle -->
@@ -88,9 +88,9 @@
         class="action-btn secondary"
         :class="{ active: showDemographics }"
         @click="toggleOverlay('demographics')"
-        title="Agent demographic breakdown (age, gender, country, actor type, platform)"
+        :title="$tr('Agent demographic breakdown (age, gender, country, actor type, platform)', '智能体人口统计分布(年龄、性别、国家、角色类型、平台)')"
       >
-        ◇ Demographics
+        ◇ {{ $tr('Demographics', '人口统计') }}
       </button>
 
       <!-- Prediction Markets (only when polymarket is enabled/has data) -->
@@ -99,10 +99,10 @@
         class="action-btn secondary polymarket-btn"
         :class="{ active: showPolymarketChart }"
         @click="toggleOverlay('markets')"
-        title="Live prediction market price chart"
+        :title="$tr('Live prediction market price chart', '实时预测市场价格图')"
       >
         <img src="/pm.png" class="btn-platform-icon" alt="" />
-        Markets
+        {{ $tr('Markets', '市场') }}
       </button>
 
       <!-- What If? Counterfactual toggle -->
@@ -111,9 +111,9 @@
         class="action-btn secondary"
         :class="{ active: showWhatIf }"
         @click="toggleOverlay('whatif')"
-        title="What If? — remove agents and recompute belief drift from existing trajectory"
+        :title="$tr('What If? — remove agents and recompute belief drift from existing trajectory', '假如?— 移除智能体并基于现有轨迹重新计算信念漂移')"
       >
-        ◐ What If?
+        ◐ {{ $tr('What If?', '假如?') }}
       </button>
 
       <!-- Director Mode toggle (only while simulation is running) -->
@@ -122,9 +122,9 @@
         class="action-btn secondary director-btn"
         :class="{ active: showDirector }"
         @click="toggleOverlay('director')"
-        :title="directorEventsTotal >= 10 ? 'Director Mode — max events reached' : 'Director Mode — inject a breaking event into the simulation'"
+        :title="directorEventsTotal >= 10 ? $tr('Director Mode — max events reached', '导演模式 — 已达事件上限') : $tr('Director Mode — inject a breaking event into the simulation', '导演模式 — 向模拟中注入突发事件')"
       >
-        ⚡ Director
+        ⚡ {{ $tr('Director', '导演') }}
         <span v-if="directorEventsTotal > 0" class="director-badge">{{ directorEventsTotal }}/10</span>
       </button>
 
@@ -134,9 +134,9 @@
         class="action-btn secondary"
         :class="{ active: showBranch }"
         @click="toggleOverlay('branch')"
-        title="Fork this simulation with a narrative injection scheduled for a specific round"
+        :title="$tr('Fork this simulation with a narrative injection scheduled for a specific round', '在指定轮次插入叙事注入,以分支此模拟')"
       >
-        ⤷ Branch
+        ⤷ {{ $tr('Branch', '分支') }}
       </button>
 
       <!-- Resume (when paused/stopped/failed with partial data) -->
@@ -147,7 +147,7 @@
         @click="handleResume"
       >
         <span v-if="isStarting" class="loading-spinner-small"></span>
-        {{ isStarting ? 'Resuming...' : 'Resume' }}
+        {{ isStarting ? $tr('Resuming...', '继续中…') : $tr('Resume', '继续') }}
       </button>
 
       <!-- Skip to Report / Generate Report -->
@@ -157,15 +157,15 @@
         @click="handleNextStep"
       >
         <span v-if="isGeneratingReport" class="loading-spinner-small"></span>
-        <template v-if="isGeneratingReport">Starting...</template>
-        <template v-else-if="phase === 1">Skip to Report ⟶</template>
-        <template v-else>Report →</template>
+        <template v-if="isGeneratingReport">{{ $tr('Starting...', '启动中…') }}</template>
+        <template v-else-if="phase === 1">{{ $tr('Skip to Report ⟶', '跳至报告 ⟶') }}</template>
+        <template v-else>{{ $tr('Report →', '报告 →') }}</template>
       </button>
     </div>
 
     <!-- Total Events Summary -->
     <div class="events-summary">
-      <span class="events-label">TOTAL EVENTS:</span>
+      <span class="events-label">{{ $tr('TOTAL EVENTS:', '总事件数:') }}</span>
       <span class="events-total">{{ (runStatus.twitter_actions_count || 0) + (runStatus.reddit_actions_count || 0) + (runStatus.polymarket_actions_count || 0) }}</span>
       <span class="events-divider"></span>
       <span class="events-platform">X <span class="events-count">{{ runStatus.twitter_actions_count || 0 }}</span></span>
@@ -189,32 +189,32 @@
     <!-- Quality Diagnostics Panel (expandable) -->
     <div v-if="showQualityPanel && qualityData" class="quality-panel">
       <div class="qp-header">
-        <span class="qp-title">QUALITY DIAGNOSTICS</span>
+        <span class="qp-title">{{ $tr('QUALITY DIAGNOSTICS', '质量诊断') }}</span>
         <button class="qp-close" @click="showQualityPanel = false">×</button>
       </div>
       <div class="qp-metrics">
         <div class="qp-metric">
-          <span class="qp-label">Participation</span>
+          <span class="qp-label">{{ $tr('Participation', '参与度') }}</span>
           <div class="qp-bar-wrap"><div class="qp-bar" :class="qualityData.participation_rate >= 0.8 ? 'qp-good' : qualityData.participation_rate >= 0.6 ? 'qp-ok' : 'qp-low'" :style="{ width: Math.round(qualityData.participation_rate * 100) + '%' }"></div></div>
           <span class="qp-val">{{ Math.round(qualityData.participation_rate * 100) }}%</span>
         </div>
         <div v-if="qualityData.stance_entropy !== null" class="qp-metric">
-          <span class="qp-label">Stance Diversity</span>
+          <span class="qp-label">{{ $tr('Stance Diversity', '立场多样性') }}</span>
           <div class="qp-bar-wrap"><div class="qp-bar" :class="qualityData.stance_entropy >= 0.5 ? 'qp-good' : qualityData.stance_entropy >= 0.3 ? 'qp-ok' : 'qp-low'" :style="{ width: Math.round(qualityData.stance_entropy * 100) + '%' }"></div></div>
           <span class="qp-val">{{ Math.round(qualityData.stance_entropy * 100) }}%</span>
         </div>
         <div class="qp-metric">
-          <span class="qp-label">Cross-Platform</span>
+          <span class="qp-label">{{ $tr('Cross-Platform', '跨平台') }}</span>
           <div class="qp-bar-wrap"><div class="qp-bar" :class="qualityData.cross_platform_rate >= 0.2 ? 'qp-good' : qualityData.cross_platform_rate >= 0.1 ? 'qp-ok' : 'qp-low'" :style="{ width: Math.min(Math.round(qualityData.cross_platform_rate * 100), 100) + '%' }"></div></div>
           <span class="qp-val">{{ Math.round(qualityData.cross_platform_rate * 100) }}%</span>
         </div>
         <div v-if="qualityData.convergence_round !== null" class="qp-metric">
-          <span class="qp-label">Consensus</span>
-          <span class="qp-val qp-convergence">Round {{ qualityData.convergence_round }}</span>
+          <span class="qp-label">{{ $tr('Consensus', '共识') }}</span>
+          <span class="qp-val qp-convergence">{{ $tr('Round', '第') }} {{ qualityData.convergence_round }} {{ $tr('', '轮') }}</span>
         </div>
       </div>
       <div v-if="qualityData.suggestions && qualityData.suggestions.length" class="qp-suggestions">
-        <div class="qp-suggestions-title">Try for next run:</div>
+        <div class="qp-suggestions-title">{{ $tr('Try for next run:', '下次运行可尝试:') }}</div>
         <div v-for="(s, i) in qualityData.suggestions" :key="i" class="qp-suggestion">{{ s }}</div>
       </div>
     </div>
@@ -227,12 +227,12 @@
           <div class="platform-left">
             <svg class="platform-icon" viewBox="0 0 24 24" width="11" height="11" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
             <span class="platform-name">X</span>
-            <span v-if="runStatus.twitter_completed" class="status-badge done">done</span>
+            <span v-if="runStatus.twitter_completed" class="status-badge done">{{ $tr('done', '完成') }}</span>
           </div>
           <div class="platform-stats">
-            <span class="stat"><span class="stat-label">RND</span><span class="stat-value mono">{{ runStatus.twitter_current_round || 0 }}<span class="stat-total">/{{ runStatus.total_rounds || maxRounds || '-' }}</span></span></span>
-            <span class="stat"><span class="stat-label">TIME</span><span class="stat-value mono">{{ twitterElapsedTime }}</span></span>
-            <span class="stat"><span class="stat-label">ACTS</span><span class="stat-value mono">{{ runStatus.twitter_actions_count || 0 }}</span></span>
+            <span class="stat"><span class="stat-label">{{ $tr('RND', '轮次') }}</span><span class="stat-value mono">{{ runStatus.twitter_current_round || 0 }}<span class="stat-total">/{{ runStatus.total_rounds || maxRounds || '-' }}</span></span></span>
+            <span class="stat"><span class="stat-label">{{ $tr('TIME', '时间') }}</span><span class="stat-value mono">{{ twitterElapsedTime }}</span></span>
+            <span class="stat"><span class="stat-label">{{ $tr('ACTS', '动作') }}</span><span class="stat-value mono">{{ runStatus.twitter_actions_count || 0 }}</span></span>
           </div>
           <div class="platform-actions-list"><span class="action-tag">POST</span><span class="action-tag">LIKE</span><span class="action-tag">REPOST</span><span class="action-tag">QUOTE</span><span class="action-tag">FOLLOW</span></div>
         </div>
@@ -242,12 +242,12 @@
           <div class="platform-left">
             <img src="/reddit.png" class="platform-icon-img" alt="Reddit" />
             <span class="platform-name">Reddit</span>
-            <span v-if="runStatus.reddit_completed" class="status-badge done">done</span>
+            <span v-if="runStatus.reddit_completed" class="status-badge done">{{ $tr('done', '完成') }}</span>
           </div>
           <div class="platform-stats">
-            <span class="stat"><span class="stat-label">RND</span><span class="stat-value mono">{{ runStatus.reddit_current_round || 0 }}<span class="stat-total">/{{ runStatus.total_rounds || maxRounds || '-' }}</span></span></span>
-            <span class="stat"><span class="stat-label">TIME</span><span class="stat-value mono">{{ redditElapsedTime }}</span></span>
-            <span class="stat"><span class="stat-label">ACTS</span><span class="stat-value mono">{{ runStatus.reddit_actions_count || 0 }}</span></span>
+            <span class="stat"><span class="stat-label">{{ $tr('RND', '轮次') }}</span><span class="stat-value mono">{{ runStatus.reddit_current_round || 0 }}<span class="stat-total">/{{ runStatus.total_rounds || maxRounds || '-' }}</span></span></span>
+            <span class="stat"><span class="stat-label">{{ $tr('TIME', '时间') }}</span><span class="stat-value mono">{{ redditElapsedTime }}</span></span>
+            <span class="stat"><span class="stat-label">{{ $tr('ACTS', '动作') }}</span><span class="stat-value mono">{{ runStatus.reddit_actions_count || 0 }}</span></span>
           </div>
           <div class="platform-actions-list"><span class="action-tag">POST</span><span class="action-tag">COMMENT</span><span class="action-tag">LIKE</span><span class="action-tag">DISLIKE</span><span class="action-tag">SEARCH</span><span class="action-tag">FOLLOW</span></div>
         </div>
@@ -257,12 +257,12 @@
           <div class="platform-left">
             <img src="/pm.png" class="platform-icon-img" alt="Polymarket" />
             <span class="platform-name">Polymarket</span>
-            <span v-if="runStatus.polymarket_completed" class="status-badge done">done</span>
+            <span v-if="runStatus.polymarket_completed" class="status-badge done">{{ $tr('done', '完成') }}</span>
           </div>
           <div class="platform-stats">
-            <span class="stat"><span class="stat-label">RND</span><span class="stat-value mono">{{ runStatus.polymarket_current_round || 0 }}<span class="stat-total">/{{ runStatus.total_rounds || maxRounds || '-' }}</span></span></span>
-            <span class="stat"><span class="stat-label">TIME</span><span class="stat-value mono">{{ polymarketElapsedTime }}</span></span>
-            <span class="stat"><span class="stat-label">TRADES</span><span class="stat-value mono">{{ runStatus.polymarket_actions_count || 0 }}</span></span>
+            <span class="stat"><span class="stat-label">{{ $tr('RND', '轮次') }}</span><span class="stat-value mono">{{ runStatus.polymarket_current_round || 0 }}<span class="stat-total">/{{ runStatus.total_rounds || maxRounds || '-' }}</span></span></span>
+            <span class="stat"><span class="stat-label">{{ $tr('TIME', '时间') }}</span><span class="stat-value mono">{{ polymarketElapsedTime }}</span></span>
+            <span class="stat"><span class="stat-label">{{ $tr('TRADES', '交易') }}</span><span class="stat-value mono">{{ runStatus.polymarket_actions_count || 0 }}</span></span>
           </div>
           <div class="platform-actions-list"><span class="action-tag">BROWSE</span><span class="action-tag">BUY</span><span class="action-tag">SELL</span><span class="action-tag">CREATE</span><span class="action-tag">COMMENT</span></div>
         </div>
@@ -335,16 +335,16 @@
       <div class="director-header">
         <div class="director-title">
           <span class="director-icon">⚡</span>
-          <span class="director-label">DIRECTOR MODE</span>
+          <span class="director-label">{{ $tr('DIRECTOR MODE', '导演模式') }}</span>
         </div>
-        <span class="director-hint">Inject a breaking event — all agents receive it at the next round boundary</span>
+        <span class="director-hint">{{ $tr('Inject a breaking event — all agents receive it at the next round boundary', '注入一个突发事件 — 所有智能体将在下一轮边界接收到它') }}</span>
       </div>
 
       <div class="director-form">
         <textarea
           v-model="directorEventText"
           class="director-input"
-          placeholder="Describe the event (e.g. 'Central bank unexpectedly raised rates by 100bps')..."
+          :placeholder="$tr(`Describe the event (e.g. 'Central bank unexpectedly raised rates by 100bps')...`, `描述事件(例如「央行意外加息 100 个基点」)…`)"
           maxlength="500"
           :disabled="directorEventsTotal >= 10 || isInjectingEvent"
           rows="3"
@@ -357,7 +357,7 @@
             @click="handleInjectEvent"
           >
             <span v-if="isInjectingEvent" class="loading-spinner-small"></span>
-            {{ isInjectingEvent ? 'Injecting...' : directorEventsTotal >= 10 ? 'Max events reached' : 'Inject Event' }}
+            {{ isInjectingEvent ? $tr('Injecting...', '注入中…') : directorEventsTotal >= 10 ? $tr('Max events reached', '已达事件上限') : $tr('Inject Event', '注入事件') }}
           </button>
         </div>
         <div v-if="directorError" class="director-error">{{ directorError }}</div>
@@ -365,17 +365,17 @@
 
       <!-- Event History -->
       <div v-if="directorEventHistory.length > 0" class="director-history">
-        <div class="director-history-title">Injected Events</div>
+        <div class="director-history-title">{{ $tr('Injected Events', '已注入事件') }}</div>
         <button
           v-for="evt in directorEventHistory"
           :key="evt.id"
           class="director-event-card director-event-card-clickable"
           type="button"
-          title="Show this event on the timeline"
+          :title="$tr('Show this event on the timeline', '在时间线上显示此事件')"
           @click="jumpToDirectorEvent(evt)"
         >
           <div class="director-event-header">
-            <span class="director-event-badge">⚡ ROUND {{ evt.injected_at_round || evt.submitted_at_round }}</span>
+            <span class="director-event-badge">⚡ {{ $tr('ROUND', '轮次') }} {{ evt.injected_at_round || evt.submitted_at_round }}</span>
             <span class="director-event-time">{{ formatEventTime(evt.timestamp) }}</span>
             <span class="director-event-jump">↗</span>
           </div>
@@ -385,14 +385,14 @@
 
       <!-- Pending Events -->
       <div v-if="directorPendingEvents.length > 0" class="director-history">
-        <div class="director-history-title">Pending (will inject next round)</div>
+        <div class="director-history-title">{{ $tr('Pending (will inject next round)', '等待中(将在下一轮注入)') }}</div>
         <div
           v-for="evt in directorPendingEvents"
           :key="evt.id"
           class="director-event-card pending"
         >
           <div class="director-event-header">
-            <span class="director-event-badge pending-badge">◌ QUEUED</span>
+            <span class="director-event-badge pending-badge">◌ {{ $tr('QUEUED', '已排队') }}</span>
           </div>
           <div class="director-event-text">{{ evt.event_text }}</div>
         </div>
@@ -412,9 +412,9 @@
       <div v-if="filteredPlatform" class="agent-filter-bar">
         <div class="filter-info">
           <span class="filter-name" :class="filteredPlatform">{{ filteredPlatform === 'twitter' ? 'X' : filteredPlatform === 'reddit' ? 'Reddit' : 'Polymarket' }}</span>
-          <span class="filter-count">{{ chronologicalActions.length }} events</span>
+          <span class="filter-count">{{ chronologicalActions.length }} {{ $tr('events', '事件') }}</span>
         </div>
-        <button class="filter-clear" @click="clearPlatformFilter">Clear</button>
+        <button class="filter-clear" @click="clearPlatformFilter">{{ $tr('Clear', '清除') }}</button>
       </div>
 
       <!-- Agent Filter Bar -->
@@ -422,9 +422,9 @@
         <div class="filter-info">
           <div class="avatar-placeholder">{{ filteredAgent[0] }}</div>
           <span class="filter-name">{{ filteredAgent }}</span>
-          <span class="filter-count">{{ chronologicalActions.length }} events</span>
+          <span class="filter-count">{{ chronologicalActions.length }} {{ $tr('events', '事件') }}</span>
         </div>
-        <button class="filter-clear" @click="clearAgentFilter">Clear</button>
+        <button class="filter-clear" @click="clearAgentFilter">{{ $tr('Clear', '清除') }}</button>
       </div>
 
       <!-- Timeline Feed -->
@@ -447,7 +447,7 @@
             <div v-if="action._isDirectorEvent" class="timeline-card director-card">
               <div class="director-inline-banner">
                 <span class="director-inline-icon">⚡</span>
-                <span class="director-inline-label">BREAKING — Round {{ action.round_num }}</span>
+                <span class="director-inline-label">{{ $tr('BREAKING — Round', '突发 — 第') }} {{ action.round_num }}{{ $tr('', ' 轮') }}</span>
               </div>
               <div class="director-inline-text">{{ action.action_args?.content }}</div>
             </div>
@@ -486,7 +486,7 @@
                   <div v-if="action.action_args?.original_content" class="quoted-block">
                     <div class="quote-header">
                       <svg class="icon-small" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
-                      <span class="quote-label">@{{ action.action_args.original_author_name || 'User' }}</span>
+                      <span class="quote-label">@{{ action.action_args.original_author_name || $tr('User', '用户') }}</span>
                     </div>
                     <div class="quote-text">
                       {{ truncateContent(action.action_args.original_content, 150) }}
@@ -498,7 +498,7 @@
                 <template v-if="action.action_type === 'REPOST'">
                   <div class="repost-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="17 1 21 5 17 9"></polyline><path d="M3 11V9a4 4 0 0 1 4-4h14"></path><polyline points="7 23 3 19 7 15"></polyline><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>
-                    <span class="repost-label">Reposted from @{{ action.action_args?.original_author_name || 'User' }}</span>
+                    <span class="repost-label">{{ $tr('Reposted from @', '转发自 @') }}{{ action.action_args?.original_author_name || $tr('User', '用户') }}</span>
                   </div>
                   <div v-if="action.action_args?.original_content" class="repost-content">
                     {{ truncateContent(action.action_args.original_content, 200) }}
@@ -509,7 +509,7 @@
                 <template v-if="action.action_type === 'LIKE_POST'">
                   <div class="like-info">
                     <svg class="icon-small filled" viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                    <span class="like-label">Liked @{{ action.action_args?.post_author_name || 'User' }}'s post</span>
+                    <span class="like-label">{{ $tr('Liked @', '点赞了 @') }}{{ action.action_args?.post_author_name || $tr('User', '用户') }}{{ $tr(`'s post`, ' 的帖子') }}</span>
                   </div>
                   <div v-if="action.action_args?.post_content" class="liked-content">
                     "{{ truncateContent(action.action_args.post_content, 120) }}"
@@ -523,7 +523,7 @@
                   </div>
                   <div v-if="action.action_args?.post_id" class="comment-context">
                     <svg class="icon-small" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>
-                    <span>Reply to post #{{ action.action_args.post_id }}</span>
+                    <span>{{ $tr('Reply to post #', '回复帖子 #') }}{{ action.action_args.post_id }}</span>
                   </div>
                 </template>
 
@@ -531,7 +531,7 @@
                 <template v-if="action.action_type === 'SEARCH_POSTS'">
                   <div class="search-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
-                    <span class="search-label">Search Query:</span>
+                    <span class="search-label">{{ $tr('Search Query:', '搜索查询:') }}</span>
                     <span class="search-query">"{{ action.action_args?.query || '' }}"</span>
                   </div>
                 </template>
@@ -540,7 +540,7 @@
                 <template v-if="action.action_type === 'FOLLOW'">
                   <div class="follow-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="8.5" cy="7" r="4"></circle><line x1="20" y1="8" x2="20" y2="14"></line><line x1="23" y1="11" x2="17" y2="11"></line></svg>
-                    <span class="follow-label">Followed @{{ action.action_args?.target_user_name || action.action_args?.target_user || action.action_args?.user_id || 'User' }}</span>
+                    <span class="follow-label">{{ $tr('Followed @', '关注了 @') }}{{ action.action_args?.target_user_name || action.action_args?.target_user || action.action_args?.user_id || $tr('User', '用户') }}</span>
                   </div>
                 </template>
 
@@ -548,7 +548,7 @@
                 <template v-if="action.action_type === 'DISLIKE_POST'">
                   <div class="like-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"></path></svg>
-                    <span class="like-label">Disliked @{{ action.action_args?.post_author_name || 'User' }}'s post</span>
+                    <span class="like-label">{{ $tr('Disliked @', '踩了 @') }}{{ action.action_args?.post_author_name || $tr('User', '用户') }}{{ $tr(`'s post`, ' 的帖子') }}</span>
                   </div>
                   <div v-if="action.action_args?.post_content" class="liked-content">
                     "{{ truncateContent(action.action_args.post_content, 120) }}"
@@ -559,7 +559,7 @@
                 <template v-if="action.action_type === 'DISLIKE_COMMENT'">
                   <div class="like-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"></path></svg>
-                    <span class="like-label">Disliked @{{ action.action_args?.comment_author_name || 'User' }}'s comment</span>
+                    <span class="like-label">{{ $tr('Disliked @', '踩了 @') }}{{ action.action_args?.comment_author_name || $tr('User', '用户') }}{{ $tr(`'s comment`, ' 的评论') }}</span>
                   </div>
                   <div v-if="action.action_args?.comment_content" class="liked-content">
                     "{{ truncateContent(action.action_args.comment_content, 120) }}"
@@ -570,7 +570,7 @@
                 <template v-if="action.action_type === 'MUTE'">
                   <div class="follow-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 5L6 9H2v6h4l5 4V5z"></path><line x1="23" y1="9" x2="17" y2="15"></line><line x1="17" y1="9" x2="23" y2="15"></line></svg>
-                    <span class="follow-label">Muted @{{ action.action_args?.target_user_name || action.action_args?.user_id || 'User' }}</span>
+                    <span class="follow-label">{{ $tr('Muted @', '静音了 @') }}{{ action.action_args?.target_user_name || action.action_args?.user_id || $tr('User', '用户') }}</span>
                   </div>
                 </template>
 
@@ -579,7 +579,7 @@
                   <div class="vote-info">
                     <svg v-if="action.action_type === 'UPVOTE_POST'" class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"></polyline></svg>
                     <svg v-else class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                    <span class="vote-label">{{ action.action_type === 'UPVOTE_POST' ? 'Upvoted' : 'Downvoted' }} Post</span>
+                    <span class="vote-label">{{ action.action_type === 'UPVOTE_POST' ? $tr('Upvoted', '顶') : $tr('Downvoted', '踩') }} {{ $tr('Post', '帖子') }}</span>
                   </div>
                   <div v-if="action.action_args?.post_content" class="voted-content">
                     "{{ truncateContent(action.action_args.post_content, 120) }}"
@@ -590,50 +590,50 @@
                 <template v-if="action.action_type === 'DO_NOTHING'">
                   <div class="idle-info">
                     <svg class="icon-small" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
-                    <span class="idle-label">Action Skipped</span>
+                    <span class="idle-label">{{ $tr('Action Skipped', '跳过此动作') }}</span>
                   </div>
                 </template>
 
                 <!-- BUY_SHARES -->
                 <template v-if="action.action_type === 'BUY_SHARES'">
                   <div class="trade-info">
-                    <span class="trade-direction buy">BUY</span>
-                    <span class="trade-detail">{{ formatShares(action.action_args?.shares) }} <strong>{{ action.action_args?.outcome }}</strong> shares</span>
+                    <span class="trade-direction buy">{{ $tr('BUY', '买入') }}</span>
+                    <span class="trade-detail">{{ formatShares(action.action_args?.shares) }} <strong>{{ action.action_args?.outcome }}</strong> {{ $tr('shares', '份额') }}</span>
                     <span class="trade-cost">@ ${{ formatPrice(action.action_args?.price) }}</span>
                     <span class="trade-total">${{ formatPrice(action.action_args?.cost) }}</span>
                   </div>
-                  <div v-if="action.action_args?.market_id" class="market-ref">Market #{{ action.action_args.market_id }}</div>
+                  <div v-if="action.action_args?.market_id" class="market-ref">{{ $tr('Market #', '市场 #') }}{{ action.action_args.market_id }}</div>
                 </template>
 
                 <!-- SELL_SHARES -->
                 <template v-if="action.action_type === 'SELL_SHARES'">
                   <div class="trade-info">
-                    <span class="trade-direction sell">SELL</span>
-                    <span class="trade-detail">{{ formatShares(action.action_args?.shares) }} <strong>{{ action.action_args?.outcome }}</strong> shares</span>
+                    <span class="trade-direction sell">{{ $tr('SELL', '卖出') }}</span>
+                    <span class="trade-detail">{{ formatShares(action.action_args?.shares) }} <strong>{{ action.action_args?.outcome }}</strong> {{ $tr('shares', '份额') }}</span>
                     <span class="trade-cost">@ ${{ formatPrice(action.action_args?.price || (action.action_args?.usd_received && action.action_args?.shares ? action.action_args.usd_received / action.action_args.shares : null)) }}</span>
                     <span class="trade-total text-green">${{ formatPrice(action.action_args?.usd_received) }}</span>
                   </div>
-                  <div v-if="action.action_args?.market_id" class="market-ref">Market #{{ action.action_args.market_id }}</div>
+                  <div v-if="action.action_args?.market_id" class="market-ref">{{ $tr('Market #', '市场 #') }}{{ action.action_args.market_id }}</div>
                 </template>
 
                 <!-- CREATE_MARKET -->
                 <template v-if="action.action_type === 'CREATE_MARKET'">
                   <div class="market-question">"{{ action.action_args?.question }}"</div>
-                  <div v-if="action.action_args?.market_id" class="market-ref">Market #{{ action.action_args.market_id }}</div>
+                  <div v-if="action.action_args?.market_id" class="market-ref">{{ $tr('Market #', '市场 #') }}{{ action.action_args.market_id }}</div>
                 </template>
 
                 <!-- COMMENT_ON_MARKET -->
                 <template v-if="action.action_type === 'COMMENT_ON_MARKET'">
                   <div v-if="action.action_args?.content" class="content-text">{{ action.action_args.content }}</div>
-                  <div v-if="action.action_args?.market_id" class="market-ref">Market #{{ action.action_args.market_id }}</div>
+                  <div v-if="action.action_args?.market_id" class="market-ref">{{ $tr('Market #', '市场 #') }}{{ action.action_args.market_id }}</div>
                 </template>
 
                 <!-- BROWSE_MARKETS / VIEW_PORTFOLIO -->
                 <template v-if="action.action_type === 'BROWSE_MARKETS'">
-                  <div class="idle-info"><span class="idle-label">Browsed active markets</span></div>
+                  <div class="idle-info"><span class="idle-label">{{ $tr('Browsed active markets', '浏览活跃市场') }}</span></div>
                 </template>
                 <template v-if="action.action_type === 'VIEW_PORTFOLIO'">
-                  <div class="idle-info"><span class="idle-label">Checked portfolio</span></div>
+                  <div class="idle-info"><span class="idle-label">{{ $tr('Checked portfolio', '查看持仓') }}</span></div>
                 </template>
 
                 <!-- Generic fallback -->
@@ -643,7 +643,7 @@
               </div>
 
               <div class="card-footer">
-                <span class="time-tag">R{{ action.round_num }} • {{ formatActionTime(action.timestamp) }}</span>
+                <span class="time-tag">{{ $tr('R', '第') }}{{ action.round_num }}{{ $tr('', ' 轮') }} • {{ formatActionTime(action.timestamp) }}</span>
                 <!-- Platform tag removed as it is in header now -->
               </div>
             </div>
@@ -652,7 +652,7 @@
 
         <div v-if="allActions.length === 0" class="waiting-state">
           <div class="pulse-ring"></div>
-          <span>Waiting for agent actions...</span>
+          <span>{{ $tr('Waiting for agent actions...', '等待智能体动作…') }}</span>
         </div>
       </div>
     </div>
@@ -660,8 +660,8 @@
     <!-- Bottom Info / Logs -->
     <div class="system-logs" :class="{ collapsed: monitorCollapsed }">
       <div class="log-header" @click="monitorCollapsed = !monitorCollapsed">
-        <span class="log-title">SIMULATION MONITOR <span class="log-toggle">{{ monitorCollapsed ? '▲' : '▼' }}</span></span>
-        <span class="log-id copyable" @click.stop="copySimId" :title="copied ? 'Copied!' : 'Click to copy'">{{ simulationId || 'NO_SIMULATION' }}{{ copied ? ' ✓' : '' }}</span>
+        <span class="log-title">{{ $tr('SIMULATION MONITOR', '模拟监控') }} <span class="log-toggle">{{ monitorCollapsed ? '▲' : '▼' }}</span></span>
+        <span class="log-id copyable" @click.stop="copySimId" :title="copied ? $tr('Copied!', '已复制!') : $tr('Click to copy', '点击复制')">{{ simulationId || $tr('NO_SIMULATION', '无模拟') }}{{ copied ? ' ✓' : '' }}</span>
       </div>
       <div v-show="!monitorCollapsed" class="log-content" ref="logContent">
         <div class="log-line" v-for="(log, idx) in systemLogs" :key="idx">
@@ -676,20 +676,20 @@
       <div v-if="showArticleDrawer" class="article-drawer-overlay" @click.self="showArticleDrawer = false">
         <div class="article-drawer">
           <div class="article-drawer-header">
-            <span class="article-drawer-title">Generated Article</span>
+            <span class="article-drawer-title">{{ $tr('Generated Article', '已生成的文章') }}</span>
             <div class="article-drawer-actions">
               <button
                 class="article-action-btn"
                 :disabled="isGeneratingArticle || !articleText"
                 @click="copyArticle"
-                :title="articleCopied ? 'Copied!' : 'Copy to clipboard'"
-              >{{ articleCopied ? 'Copied!' : 'Copy' }}</button>
+                :title="articleCopied ? $tr('Copied!', '已复制!') : $tr('Copy to clipboard', '复制到剪贴板')"
+              >{{ articleCopied ? $tr('Copied!', '已复制!') : $tr('Copy', '复制') }}</button>
               <button
                 class="article-action-btn"
                 :disabled="isGeneratingArticle || !articleText"
                 @click="downloadArticle"
-                title="Download as .md"
-              >Download .md</button>
+                :title="$tr('Download as .md', '下载为 .md 文件')"
+              >{{ $tr('Download .md', '下载 .md') }}</button>
               <button class="article-close-btn" @click="showArticleDrawer = false">&#x2715;</button>
             </div>
           </div>
@@ -709,13 +709,13 @@
                 <div class="skel-line long"></div>
                 <div class="skel-line short"></div>
               </div>
-              <span class="article-loading-label">Generating article from simulation data...</span>
+              <span class="article-loading-label">{{ $tr('Generating article from simulation data...', '正在从模拟数据生成文章…') }}</span>
             </div>
 
             <!-- Error state -->
             <div v-else-if="articleError" class="article-error">
               <span class="article-error-msg">{{ articleError }}</span>
-              <button class="article-action-btn" @click="generateArticle">Retry</button>
+              <button class="article-action-btn" @click="generateArticle">{{ $tr('Retry', '重试') }}</button>
             </div>
 
             <!-- Article content -->
@@ -756,6 +756,7 @@ import DemographicBreakdown from './DemographicBreakdown.vue'
 import WhatIfPanel from './WhatIfPanel.vue'
 import CounterfactualBranchPanel from './CounterfactualBranchPanel.vue'
 import PolymarketChart from './PolymarketChart.vue'
+import { tr } from '../i18n'
 
 const props = defineProps({
   simulationId: String,
@@ -843,10 +844,10 @@ const showQualityPanel = ref(false)
 const qualityTooltip = computed(() => {
   const q = qualityData.value
   if (!q) return ''
-  const parts = [`Health: ${q.health}`, `Participation ${Math.round(q.participation_rate * 100)}%`]
+  const parts = [tr(`Health: ${q.health}`, `健康度:${q.health}`), tr(`Participation ${Math.round(q.participation_rate * 100)}%`, `参与度 ${Math.round(q.participation_rate * 100)}%`)]
   if (q.stance_entropy !== null) {
-    const level = q.stance_entropy >= 0.7 ? 'high' : q.stance_entropy >= 0.4 ? 'medium' : 'low'
-    parts.push(`Diversity: ${level}`)
+    const level = q.stance_entropy >= 0.7 ? tr('high', '高') : q.stance_entropy >= 0.4 ? tr('medium', '中') : tr('low', '低')
+    parts.push(tr(`Diversity: ${level}`, `多样性:${level}`))
   }
   return parts.join(' · ')
 })
@@ -885,10 +886,10 @@ const handleInjectEvent = async () => {
       directorEventsTotal.value = res.total_events
       await loadDirectorEvents()
     } else {
-      directorError.value = res.error || 'Failed to inject event'
+      directorError.value = res.error || tr('Failed to inject event', '注入事件失败')
     }
   } catch (err) {
-    directorError.value = err.response?.data?.error || err.message || 'Failed to inject event'
+    directorError.value = err.response?.data?.error || err.message || tr('Failed to inject event', '注入事件失败')
   } finally {
     isInjectingEvent.value = false
   }
@@ -1078,7 +1079,7 @@ const resetAllState = () => {
 // Start simulation
 const doStartSimulation = async () => {
   if (!props.simulationId) {
-    addLog('Error: missing simulationId')
+    addLog(tr('Error: missing simulationId', '错误:缺少 simulationId'))
     return
   }
 
@@ -1087,7 +1088,7 @@ const doStartSimulation = async () => {
 
   isStarting.value = true
   startError.value = null
-  addLog('Starting dual-platform parallel simulation...')
+  addLog(tr('Starting dual-platform parallel simulation...', '正在启动双平台并行模拟…'))
   emit('update-status', 'processing')
   
   try {
@@ -1101,33 +1102,33 @@ const doStartSimulation = async () => {
     
     if (props.maxRounds) {
       params.max_rounds = props.maxRounds
-      addLog(`Set max simulation rounds: ${props.maxRounds}`)
+      addLog(tr(`Set max simulation rounds: ${props.maxRounds}`, `设定最大模拟轮次:${props.maxRounds}`))
     }
 
-    addLog('Dynamic graph memory update mode enabled')
-    
+    addLog(tr('Dynamic graph memory update mode enabled', '已启用动态图记忆更新模式'))
+
     const res = await startSimulation(params)
-    
+
     if (res.success && res.data) {
       if (res.data.force_restarted) {
-        addLog('Old simulation logs cleaned, restarting simulation')
+        addLog(tr('Old simulation logs cleaned, restarting simulation', '已清理旧的模拟日志,重新启动模拟'))
       }
-      addLog('Simulation engine started successfully')
-      addLog(`  ├─ PID: ${res.data.process_pid || '-'}`)
-      
+      addLog(tr('Simulation engine started successfully', '模拟引擎启动成功'))
+      addLog(tr(`  ├─ PID: ${res.data.process_pid || '-'}`, `  ├─ PID:${res.data.process_pid || '-'}`))
+
       phase.value = 1
       runStatus.value = res.data
-      
+
       startStatusPolling()
       startDetailPolling()
     } else {
-      startError.value = res.error || 'Start failed'
-      addLog(`Start failed: ${res.error || 'Unknown error'}`)
+      startError.value = res.error || tr('Start failed', '启动失败')
+      addLog(tr(`Start failed: ${res.error || 'Unknown error'}`, `启动失败:${res.error || '未知错误'}`))
       emit('update-status', 'error')
     }
   } catch (err) {
     startError.value = err.message
-    addLog(`Start error: ${err.message}`)
+    addLog(tr(`Start error: ${err.message}`, `启动出错:${err.message}`))
     emit('update-status', 'error')
   } finally {
     isStarting.value = false
@@ -1142,7 +1143,7 @@ const handleResume = async () => {
   if (!props.simulationId) return
 
   const fromRound = runStatus.value.current_round || 0
-  addLog(`Resuming simulation from round ${fromRound}...`)
+  addLog(tr(`Resuming simulation from round ${fromRound}...`, `从第 ${fromRound} 轮继续模拟…`))
 
   isStarting.value = true
   startError.value = null
@@ -1162,20 +1163,20 @@ const handleResume = async () => {
     const res = await resumeSimulation(params)
 
     if (res.success && res.data) {
-      addLog(`Resumed from round ${res.data.resumed_from_round || fromRound}`)
-      addLog(`  ├─ PID: ${res.data.process_pid || '-'}`)
+      addLog(tr(`Resumed from round ${res.data.resumed_from_round || fromRound}`, `已从第 ${res.data.resumed_from_round || fromRound} 轮继续`))
+      addLog(tr(`  ├─ PID: ${res.data.process_pid || '-'}`, `  ├─ PID:${res.data.process_pid || '-'}`))
       phase.value = 1
       runStatus.value = { ...runStatus.value, ...res.data }
       startStatusPolling()
       startDetailPolling()
     } else {
-      startError.value = res.error || 'Resume failed'
-      addLog(`Resume failed: ${res.error || 'Unknown error'}`)
+      startError.value = res.error || tr('Resume failed', '继续失败')
+      addLog(tr(`Resume failed: ${res.error || 'Unknown error'}`, `继续失败:${res.error || '未知错误'}`))
       emit('update-status', 'error')
     }
   } catch (err) {
     startError.value = err.message
-    addLog(`Resume error: ${err.message}`)
+    addLog(tr(`Resume error: ${err.message}`, `继续出错:${err.message}`))
     emit('update-status', 'error')
   } finally {
     isStarting.value = false
@@ -1190,7 +1191,7 @@ const openReplay = () => {
 // Restart simulation (force restart from scratch)
 const handleRestart = async () => {
   if (!props.simulationId) return
-  addLog('Restarting simulation from scratch...')
+  addLog(tr('Restarting simulation from scratch...', '从零重新启动模拟…'))
   resetAllState()
   doStartSimulation()
 }
@@ -1200,21 +1201,21 @@ const handleStopSimulation = async () => {
   if (!props.simulationId) return
 
   isStopping.value = true
-  addLog('Stopping simulation...')
-  
+  addLog(tr('Stopping simulation...', '正在停止模拟…'))
+
   try {
     const res = await stopSimulation({ simulation_id: props.simulationId })
-    
+
     if (res.success) {
-      addLog('Simulation stopped')
+      addLog(tr('Simulation stopped', '模拟已停止'))
       phase.value = 2
       stopPolling()
       emit('update-status', 'completed')
     } else {
-      addLog(`Stop failed: ${res.error || 'Unknown error'}`)
+      addLog(tr(`Stop failed: ${res.error || 'Unknown error'}`, `停止失败:${res.error || '未知错误'}`))
     }
   } catch (err) {
-    addLog(`Stop error: ${err.message}`)
+    addLog(tr(`Stop error: ${err.message}`, `停止出错:${err.message}`))
   } finally {
     isStopping.value = false
   }
@@ -1260,12 +1261,12 @@ const fetchRunStatus = async () => {
       
       // Detect round changes for each platform and output logs
       if (data.twitter_current_round > prevTwitterRound.value) {
-        addLog(`[Plaza] R${data.twitter_current_round}/${data.total_rounds} | T:${data.twitter_simulated_hours || 0}h | A:${data.twitter_actions_count}`)
+        addLog(tr(`[Plaza] R${data.twitter_current_round}/${data.total_rounds} | T:${data.twitter_simulated_hours || 0}h | A:${data.twitter_actions_count}`, `[广场] R${data.twitter_current_round}/${data.total_rounds} | T:${data.twitter_simulated_hours || 0}h | A:${data.twitter_actions_count}`))
         prevTwitterRound.value = data.twitter_current_round
       }
-      
+
       if (data.reddit_current_round > prevRedditRound.value) {
-        addLog(`[Community] R${data.reddit_current_round}/${data.total_rounds} | T:${data.reddit_simulated_hours || 0}h | A:${data.reddit_actions_count}`)
+        addLog(tr(`[Community] R${data.reddit_current_round}/${data.total_rounds} | T:${data.reddit_simulated_hours || 0}h | A:${data.reddit_actions_count}`, `[社区] R${data.reddit_current_round}/${data.total_rounds} | T:${data.reddit_simulated_hours || 0}h | A:${data.reddit_actions_count}`))
         prevRedditRound.value = data.reddit_current_round
       }
       
@@ -1278,9 +1279,9 @@ const fetchRunStatus = async () => {
       
       if (isCompleted || platformsCompleted) {
         if (platformsCompleted && !isCompleted) {
-          addLog('All platform simulations have ended')
+          addLog(tr('All platform simulations have ended', '所有平台模拟均已结束'))
         }
-        addLog('Simulation completed')
+        addLog(tr('Simulation completed', '模拟已完成'))
         phase.value = 2
         stopPolling()
         emit('update-status', 'completed')
@@ -1379,7 +1380,7 @@ const getActionTypeLabel = (type) => {
     'VIEW_PORTFOLIO': 'PORTFOLIO',
     'COMMENT_ON_MARKET': 'COMMENT',
   }
-  return labels[type] || type || 'UNKNOWN'
+  return labels[type] || type || tr('UNKNOWN', '未知')
 }
 
 const getActionTypeClass = (type) => {
@@ -1430,12 +1431,12 @@ const formatActionTime = (timestamp) => {
 
 const handleNextStep = async () => {
   if (!props.simulationId) {
-    addLog('Error: missing simulationId')
+    addLog(tr('Error: missing simulationId', '错误:缺少 simulationId'))
     return
   }
 
   if (isGeneratingReport.value) {
-    addLog('Report generation request already sent, please wait...')
+    addLog(tr('Report generation request already sent, please wait...', '报告生成请求已发送,请稍候…'))
     return
   }
 
@@ -1443,15 +1444,15 @@ const handleNextStep = async () => {
 
   // If simulation is still running, stop it first
   if (phase.value === 1) {
-    addLog('Stopping simulation before generating report...')
+    addLog(tr('Stopping simulation before generating report...', '正在停止模拟以生成报告…'))
     try {
       await stopSimulation({ simulation_id: props.simulationId })
       phase.value = 2
       stopPolling()
-      addLog('Simulation stopped — proceeding with partial data')
+      addLog(tr('Simulation stopped — proceeding with partial data', '模拟已停止 — 将使用部分数据继续'))
       emit('update-status', 'completed')
     } catch (err) {
-      addLog(`Warning: could not stop simulation (${err.message}), proceeding anyway`)
+      addLog(tr(`Warning: could not stop simulation (${err.message}), proceeding anyway`, `警告:无法停止模拟(${err.message}),仍将继续`))
       stopPolling()
       phase.value = 2
     }
@@ -1459,7 +1460,7 @@ const handleNextStep = async () => {
 
   try {
     // First try to get existing report (don't regenerate)
-    addLog('Checking for existing report...')
+    addLog(tr('Checking for existing report...', '正在检查已有报告…'))
     const res = await generateReport({
       simulation_id: props.simulationId,
       force_regenerate: false
@@ -1468,17 +1469,17 @@ const handleNextStep = async () => {
     if (res.success && res.data) {
       const reportId = res.data.report_id
       if (res.data.already_generated) {
-        addLog(`Found existing report: ${reportId}`)
+        addLog(tr(`Found existing report: ${reportId}`, `找到已有报告:${reportId}`))
       } else {
-        addLog(`Report generation started: ${reportId}`)
+        addLog(tr(`Report generation started: ${reportId}`, `报告生成已启动:${reportId}`))
       }
       router.push({ name: 'Report', params: { reportId } })
     } else {
-      addLog(`Failed to start report generation: ${res.error || 'Unknown error'}`)
+      addLog(tr(`Failed to start report generation: ${res.error || 'Unknown error'}`, `启动报告生成失败:${res.error || '未知错误'}`))
       isGeneratingReport.value = false
     }
   } catch (err) {
-    addLog(`Report generation error: ${err.message}`)
+    addLog(tr(`Report generation error: ${err.message}`, `报告生成出错:${err.message}`))
     isGeneratingReport.value = false
   }
 }
@@ -1505,7 +1506,7 @@ const tryResumeOrStart = async () => {
 
       if (status === 'running' || status === 'starting') {
         // Simulation is still running — reconnect to it
-        addLog(`Reconnecting to running simulation (round ${res.data.current_round}/${res.data.total_rounds})...`)
+        addLog(tr(`Reconnecting to running simulation (round ${res.data.current_round}/${res.data.total_rounds})...`, `正在重新连接运行中的模拟(第 ${res.data.current_round}/${res.data.total_rounds} 轮)…`))
         runStatus.value = res.data
         phase.value = 1
         emit('update-status', 'processing')
@@ -1517,7 +1518,7 @@ const tryResumeOrStart = async () => {
       if (status === 'completed' || status === 'stopped') {
         // Already finished — show completed state
         const totalActions = (res.data.twitter_actions_count || 0) + (res.data.reddit_actions_count || 0)
-        addLog(`Previous simulation found: ${status} (${totalActions} actions, round ${res.data.current_round}/${res.data.total_rounds})`)
+        addLog(tr(`Previous simulation found: ${status} (${totalActions} actions, round ${res.data.current_round}/${res.data.total_rounds})`, `发现之前的模拟:${status}(${totalActions} 个动作,第 ${res.data.current_round}/${res.data.total_rounds} 轮)`))
         runStatus.value = res.data
         phase.value = 2
         emit('update-status', 'completed')
@@ -1530,8 +1531,8 @@ const tryResumeOrStart = async () => {
         // Crashed — show partial data, let user decide
         const totalActions = (res.data.twitter_actions_count || 0) + (res.data.reddit_actions_count || 0)
         if (totalActions > 0) {
-          addLog(`Previous simulation crashed at round ${res.data.current_round}/${res.data.total_rounds} with ${totalActions} actions`)
-          addLog('You can generate a report from partial data or restart')
+          addLog(tr(`Previous simulation crashed at round ${res.data.current_round}/${res.data.total_rounds} with ${totalActions} actions`, `之前的模拟在第 ${res.data.current_round}/${res.data.total_rounds} 轮崩溃,共 ${totalActions} 个动作`))
+          addLog(tr('You can generate a report from partial data or restart', '您可以基于部分数据生成报告或重新启动'))
           runStatus.value = res.data
           phase.value = 2  // treat as completed so buttons work
           emit('update-status', 'completed')
@@ -1539,7 +1540,7 @@ const tryResumeOrStart = async () => {
           return
         }
         // No data — just start fresh
-        addLog('Previous simulation failed with no data — starting fresh')
+        addLog(tr('Previous simulation failed with no data — starting fresh', '之前的模拟失败且无数据 — 重新开始'))
       }
     }
   } catch (err) {
@@ -1565,10 +1566,10 @@ const generateArticle = async () => {
     if (res.success && res.data?.article_text) {
       articleText.value = res.data.article_text
     } else {
-      articleError.value = res.error || 'Failed to generate article.'
+      articleError.value = res.error || tr('Failed to generate article.', '生成文章失败。')
     }
   } catch (err) {
-    articleError.value = err?.message || 'Network error generating article.'
+    articleError.value = err?.message || tr('Network error generating article.', '生成文章时发生网络错误。')
   } finally {
     isGeneratingArticle.value = false
   }
@@ -1607,7 +1608,7 @@ watch(phase, (newPhase) => {
 })
 
 onMounted(() => {
-  addLog('Step3 Simulation Run initialized')
+  addLog(tr('Step3 Simulation Run initialized', '第 3 步 模拟运行已初始化'))
   tryResumeOrStart()
 })
 

--- a/frontend/src/components/Step4Report.vue
+++ b/frontend/src/components/Step4Report.vue
@@ -8,7 +8,7 @@
           <!-- Report Header -->
           <div class="report-header-block">
             <div class="report-meta">
-              <span class="report-tag">Prediction Report</span>
+              <span class="report-tag">{{ $tr('Prediction Report', '预测报告') }}</span>
               <span class="report-id copyable" @click="copyReportId">ID: {{ reportId || 'REF-2024-X92' }}</span>
             </div>
             <h1 class="main-title">{{ reportOutline.title }}</h1>
@@ -58,7 +58,7 @@
                       <path d="M12 2a10 10 0 0 1 10 10" stroke-width="4" stroke="#4B5563" stroke-linecap="round"></path>
                     </svg>
                   </div>
-                  <span class="loading-text">Generating {{ section.title }}...</span>
+                  <span class="loading-text">{{ $tr('Generating', '正在生成') }} {{ section.title }}...</span>
                 </div>
               </div>
             </div>
@@ -72,7 +72,7 @@
             <div class="waiting-ring"></div>
             <div class="waiting-ring"></div>
           </div>
-          <span class="waiting-text">Waiting for Report Agent...</span>
+          <span class="waiting-text">{{ $tr('Waiting for Report Agent...', '等待报告智能体...') }}</span>
         </div>
       </div>
 
@@ -89,15 +89,15 @@
         <div class="workflow-overview" v-if="agentLogs.length > 0 || reportOutline">
           <div class="workflow-metrics">
             <div class="metric">
-              <span class="metric-label">Sections</span>
+              <span class="metric-label">{{ $tr('Sections', '章节') }}</span>
               <span class="metric-value mono">{{ completedSections }}/{{ totalSections }}</span>
             </div>
             <div class="metric">
-              <span class="metric-label">Elapsed</span>
+              <span class="metric-label">{{ $tr('Elapsed', '已耗时') }}</span>
               <span class="metric-value mono">{{ formatElapsedTime }}</span>
             </div>
             <div class="metric">
-              <span class="metric-label">Tools</span>
+              <span class="metric-label">{{ $tr('Tools', '工具') }}</span>
               <span class="metric-value mono">{{ totalToolCalls }}</span>
             </div>
             <div class="metric metric-right">
@@ -129,7 +129,7 @@
 
           <!-- Next Step Button - shown after completion -->
           <button v-if="isComplete" class="next-step-btn" @click="goToInteraction">
-            <span>Enter Deep Interaction</span>
+            <span>{{ $tr('Enter Deep Interaction', '进入深度交互') }}</span>
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="5" y1="12" x2="19" y2="12"></line>
               <polyline points="12 5 19 12 12 19"></polyline>
@@ -144,7 +144,7 @@
                 <polyline points="7 10 12 15 17 10"></polyline>
                 <line x1="12" y1="15" x2="12" y2="3"></line>
               </svg>
-              <span>{{ isExporting === 'json' ? 'Exporting...' : 'Export JSON' }}</span>
+              <span>{{ isExporting === 'json' ? $tr('Exporting...', '导出中...') : $tr('Export JSON', '导出 JSON') }}</span>
             </button>
             <button class="export-btn" @click="downloadExport('csv')" :disabled="isExporting">
               <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
@@ -152,7 +152,7 @@
                 <polyline points="7 10 12 15 17 10"></polyline>
                 <line x1="12" y1="15" x2="12" y2="3"></line>
               </svg>
-              <span>{{ isExporting === 'csv' ? 'Exporting...' : 'Export CSV' }}</span>
+              <span>{{ isExporting === 'csv' ? $tr('Exporting...', '导出中...') : $tr('Export CSV', '导出 CSV') }}</span>
             </button>
           </div>
 
@@ -186,11 +186,11 @@
                   <!-- Report Start -->
                   <template v-if="log.action === 'report_start'">
                     <div class="info-row">
-                      <span class="info-key">Simulation</span>
+                      <span class="info-key">{{ $tr('Simulation', '模拟') }}</span>
                       <span class="info-val mono">{{ log.details?.simulation_id }}</span>
                     </div>
                     <div class="info-row" v-if="log.details?.simulation_requirement">
-                      <span class="info-key">Requirement</span>
+                      <span class="info-key">{{ $tr('Requirement', '需求') }}</span>
                       <span class="info-val">{{ log.details.simulation_requirement }}</span>
                     </div>
                   </template>
@@ -202,7 +202,7 @@
                   <template v-if="log.action === 'planning_complete'">
                     <div class="status-message success">{{ log.details?.message }}</div>
                     <div class="outline-badge" v-if="log.details?.outline">
-                      {{ log.details.outline.sections?.length || 0 }} sections planned
+                      {{ log.details.outline.sections?.length || 0 }} {{ $tr('sections planned', '个章节已规划') }}
                     </div>
                   </template>
 
@@ -327,12 +327,12 @@
                   <!-- LLM Response -->
                   <template v-if="log.action === 'llm_response'">
                     <div class="llm-meta">
-                      <span class="meta-tag">Iteration {{ log.details?.iteration }}</span>
+                      <span class="meta-tag">{{ $tr('Iteration', '迭代') }} {{ log.details?.iteration }}</span>
                       <span class="meta-tag" :class="{ active: log.details?.has_tool_calls }">
-                        Tools: {{ log.details?.has_tool_calls ? 'Yes' : 'No' }}
+                        {{ $tr('Tools:', '工具:') }} {{ log.details?.has_tool_calls ? $tr('Yes', '是') : $tr('No', '否') }}
                       </span>
                       <span class="meta-tag" :class="{ active: log.details?.has_final_answer, 'final-answer': log.details?.has_final_answer }">
-                        Final: {{ log.details?.has_final_answer ? 'Yes' : 'No' }}
+                        {{ $tr('Final:', '最终:') }} {{ log.details?.has_final_answer ? $tr('Yes', '是') : $tr('No', '否') }}
                       </span>
                     </div>
                     <!-- Show special hint when this is the final answer -->
@@ -340,7 +340,7 @@
                       <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
                         <polyline points="20 6 9 17 4 12"></polyline>
                       </svg>
-                      <span>Section "{{ log.section_title }}" content generated</span>
+                      <span>{{ $tr('Section', '章节') }} "{{ log.section_title }}" {{ $tr('content generated', '内容已生成') }}</span>
                     </div>
                     <div v-if="expandedLogs.has(log.timestamp) && log.details?.response" class="llm-content">
                       <pre>{{ log.details.response }}</pre>
@@ -354,7 +354,7 @@
                         <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
                         <polyline points="22 4 12 14.01 9 11.01"></polyline>
                       </svg>
-                      <span>Report Generation Complete</span>
+                      <span>{{ $tr('Report Generation Complete', '报告生成完成') }}</span>
                     </div>
                   </template>
                 </div>
@@ -367,17 +367,17 @@
                   <div class="footer-actions">
                     <!-- Tool Call: Show/Hide Params -->
                     <button v-if="log.action === 'tool_call' && log.details?.parameters" class="action-btn" @click.stop="toggleLogExpand(log)">
-                      {{ expandedLogs.has(log.timestamp) ? 'Hide Params' : 'Show Params' }}
+                      {{ expandedLogs.has(log.timestamp) ? $tr('Hide Params', '隐藏参数') : $tr('Show Params', '显示参数') }}
                     </button>
-                    
+
                     <!-- Tool Result: Raw/Structured View -->
                     <button v-if="log.action === 'tool_result'" class="action-btn" @click.stop="toggleRawResult(log.timestamp, $event)">
-                      {{ showRawResult[log.timestamp] ? 'Structured View' : 'Raw Output' }}
+                      {{ showRawResult[log.timestamp] ? $tr('Structured View', '结构化视图') : $tr('Raw Output', '原始输出') }}
                     </button>
-                    
+
                     <!-- LLM Response: Show/Hide Response -->
                     <button v-if="log.action === 'llm_response' && log.details?.response" class="action-btn" @click.stop="toggleLogExpand(log)">
-                      {{ expandedLogs.has(log.timestamp) ? 'Hide Response' : 'Show Response' }}
+                      {{ expandedLogs.has(log.timestamp) ? $tr('Hide Response', '隐藏响应') : $tr('Show Response', '显示响应') }}
                     </button>
                   </div>
                 </div>
@@ -388,7 +388,7 @@
           <!-- Empty State -->
           <div v-if="agentLogs.length === 0 && !isComplete" class="workflow-empty">
             <div class="empty-pulse"></div>
-            <span>Waiting for agent activity...</span>
+            <span>{{ $tr('Waiting for agent activity...', '等待智能体活动...') }}</span>
           </div>
         </div>
       </div>
@@ -397,7 +397,7 @@
     <!-- Bottom Console Logs -->
     <div class="console-logs" :class="{ collapsed: consoleCollapsed }">
       <div class="log-header" @click="consoleCollapsed = !consoleCollapsed">
-        <span class="log-title">CONSOLE OUTPUT <span class="log-toggle">{{ consoleCollapsed ? '▲' : '▼' }}</span></span>
+        <span class="log-title">{{ $tr('CONSOLE OUTPUT', '控制台输出') }} <span class="log-toggle">{{ consoleCollapsed ? '▲' : '▼' }}</span></span>
         <span class="log-id">{{ reportId || 'NO_REPORT' }}</span>
       </div>
       <div v-show="!consoleCollapsed" class="log-content" ref="logContent">
@@ -416,6 +416,7 @@ import { getAgentLog, getConsoleLog } from '../api/report'
 import { exportSimulationData } from '../api/simulation'
 import { renderMarkdown } from '../utils/markdown'
 import { truncate as truncateText } from '../utils/text'
+import { tr } from '../i18n'
 
 const router = useRouter()
 
@@ -548,38 +549,46 @@ const isLogCollapsed = (log) => {
 const toolConfig = {
   'insight_forge': {
     name: 'Deep Insight',
+    nameZh: '深度洞察',
     color: 'purple',
     icon: 'lightbulb' // Lightbulb icon - represents insight
   },
   'panorama_search': {
     name: 'Panorama Search',
+    nameZh: '全景检索',
     color: 'blue',
     icon: 'globe' // Globe icon - represents panoramic search
   },
   'interview_agents': {
     name: 'Agent Interview',
+    nameZh: '智能体访谈',
     color: 'green',
     icon: 'users' // Users icon - represents conversation
   },
   'quick_search': {
     name: 'Quick Search',
+    nameZh: '快速检索',
     color: 'orange',
     icon: 'zap' // Lightning icon - represents speed
   },
   'get_graph_statistics': {
     name: 'Graph Stats',
+    nameZh: '图谱统计',
     color: 'cyan',
     icon: 'chart' // Chart icon - represents statistics
   },
   'get_entities_by_type': {
     name: 'Entity Query',
+    nameZh: '实体查询',
     color: 'pink',
     icon: 'database' // Database icon - represents entities
   }
 }
 
 const getToolDisplayName = (toolName) => {
-  return toolConfig[toolName]?.name || toolName
+  const cfg = toolConfig[toolName]
+  if (!cfg) return toolName
+  return tr(cfg.name, cfg.nameZh)
 }
 
 const getToolColor = (toolName) => {
@@ -1023,30 +1032,30 @@ const InsightDisplay = {
     const formatSize = (length) => {
       if (!length) return ''
       if (length >= 1000) {
-        return `${(length / 1000).toFixed(1)}k chars`
+        return `${(length / 1000).toFixed(1)}${tr('k chars', 'k 字符')}`
       }
-      return `${length} chars`
+      return `${length} ${tr('chars', '字符')}`
     }
-    
+
     return () => h('div', { class: 'insight-display' }, [
       // Header Section - like interview header
       h('div', { class: 'insight-header' }, [
         h('div', { class: 'header-main' }, [
-          h('div', { class: 'header-title' }, 'Deep Insight'),
+          h('div', { class: 'header-title' }, tr('Deep Insight', '深度洞察')),
           h('div', { class: 'header-stats' }, [
             h('span', { class: 'stat-item' }, [
               h('span', { class: 'stat-value' }, props.result.stats.facts || props.result.facts.length),
-              h('span', { class: 'stat-label' }, 'Facts')
+              h('span', { class: 'stat-label' }, tr('Facts', '事实'))
             ]),
             h('span', { class: 'stat-divider' }, '/'),
             h('span', { class: 'stat-item' }, [
               h('span', { class: 'stat-value' }, props.result.stats.entities || props.result.entities.length),
-              h('span', { class: 'stat-label' }, 'Entities')
+              h('span', { class: 'stat-label' }, tr('Entities', '实体'))
             ]),
             h('span', { class: 'stat-divider' }, '/'),
             h('span', { class: 'stat-item' }, [
               h('span', { class: 'stat-value' }, props.result.stats.relationships || props.result.relations.length),
-              h('span', { class: 'stat-label' }, 'Relations')
+              h('span', { class: 'stat-label' }, tr('Relations', '关系'))
             ]),
             props.resultLength && h('span', { class: 'stat-divider' }, '·'),
             props.resultLength && h('span', { class: 'stat-size' }, formatSize(props.resultLength))
@@ -1054,36 +1063,36 @@ const InsightDisplay = {
         ]),
         props.result.query && h('div', { class: 'header-topic' }, props.result.query),
         props.result.simulationRequirement && h('div', { class: 'header-scenario' }, [
-          h('span', { class: 'scenario-label' }, 'Prediction Scenario: '),
+          h('span', { class: 'scenario-label' }, tr('Prediction Scenario: ', '预测情景:')),
           h('span', { class: 'scenario-text' }, props.result.simulationRequirement)
         ])
       ]),
-      
+
       // Tab Navigation
       h('div', { class: 'insight-tabs' }, [
         h('button', {
           class: ['insight-tab', { active: activeTab.value === 'facts' }],
           onClick: () => { activeTab.value = 'facts' }
         }, [
-          h('span', { class: 'tab-label' }, `Current Key Memories (${props.result.facts.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Current Key Memories', '当前关键记忆')} (${props.result.facts.length})`)
         ]),
         h('button', {
           class: ['insight-tab', { active: activeTab.value === 'entities' }],
           onClick: () => { activeTab.value = 'entities' }
         }, [
-          h('span', { class: 'tab-label' }, `Core Entities (${props.result.entities.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Core Entities', '核心实体')} (${props.result.entities.length})`)
         ]),
         h('button', {
           class: ['insight-tab', { active: activeTab.value === 'relations' }],
           onClick: () => { activeTab.value = 'relations' }
         }, [
-          h('span', { class: 'tab-label' }, `Relationship Chains (${props.result.relations.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Relationship Chains', '关系链')} (${props.result.relations.length})`)
         ]),
         props.result.subQueries.length > 0 && h('button', {
           class: ['insight-tab', { active: activeTab.value === 'subqueries' }],
           onClick: () => { activeTab.value = 'subqueries' }
         }, [
-          h('span', { class: 'tab-label' }, `Sub-questions (${props.result.subQueries.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Sub-questions', '子问题')} (${props.result.subQueries.length})`)
         ])
       ]),
       
@@ -1092,11 +1101,11 @@ const InsightDisplay = {
         // Facts Tab
         activeTab.value === 'facts' && props.result.facts.length > 0 && h('div', { class: 'facts-panel' }, [
           h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Latest key facts associated with temporal memory'),
-            h('span', { class: 'panel-count' }, `${props.result.facts.length} items`)
+            h('span', { class: 'panel-title' }, tr('Latest key facts associated with temporal memory', '与时序记忆相关的最新关键事实')),
+            h('span', { class: 'panel-count' }, `${props.result.facts.length} ${tr('items', '项')}`)
           ]),
           h('div', { class: 'facts-list' },
-            (expandedFacts.value ? props.result.facts : props.result.facts.slice(0, INITIAL_SHOW_COUNT)).map((fact, i) => 
+            (expandedFacts.value ? props.result.facts : props.result.facts.slice(0, INITIAL_SHOW_COUNT)).map((fact, i) =>
               h('div', { class: 'fact-item', key: i }, [
                 h('span', { class: 'fact-number' }, i + 1),
                 h('div', { class: 'fact-content' }, fact)
@@ -1106,35 +1115,35 @@ const InsightDisplay = {
           props.result.facts.length > INITIAL_SHOW_COUNT && h('button', {
             class: 'expand-btn',
             onClick: () => { expandedFacts.value = !expandedFacts.value }
-          }, expandedFacts.value ? `Collapse ▲` : `Expand All ${props.result.facts.length} items ▼`)
+          }, expandedFacts.value ? `${tr('Collapse', '收起')} ▲` : `${tr('Expand All', '全部展开')} ${props.result.facts.length} ${tr('items', '项')} ▼`)
         ]),
 
         // Entities Tab
         activeTab.value === 'entities' && props.result.entities.length > 0 && h('div', { class: 'entities-panel' }, [
           h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Core Entities'),
-            h('span', { class: 'panel-count' }, `${props.result.entities.length} entities`)
+            h('span', { class: 'panel-title' }, tr('Core Entities', '核心实体')),
+            h('span', { class: 'panel-count' }, `${props.result.entities.length} ${tr('entities', '个实体')}`)
           ]),
           h('div', { class: 'entities-grid' },
             (expandedEntities.value ? props.result.entities : props.result.entities.slice(0, 12)).map((entity, i) =>
               h('div', { class: 'entity-tag', key: i, title: entity.summary || '' }, [
                 h('span', { class: 'entity-name' }, entity.name),
                 h('span', { class: 'entity-type' }, entity.type),
-                entity.relatedFactsCount > 0 && h('span', { class: 'entity-fact-count' }, `${entity.relatedFactsCount} facts`)
+                entity.relatedFactsCount > 0 && h('span', { class: 'entity-fact-count' }, `${entity.relatedFactsCount} ${tr('facts', '事实')}`)
               ])
             )
           ),
           props.result.entities.length > 12 && h('button', {
             class: 'expand-btn',
             onClick: () => { expandedEntities.value = !expandedEntities.value }
-          }, expandedEntities.value ? `Collapse ▲` : `Expand All ${props.result.entities.length} entities ▼`)
+          }, expandedEntities.value ? `${tr('Collapse', '收起')} ▲` : `${tr('Expand All', '全部展开')} ${props.result.entities.length} ${tr('entities', '个实体')} ▼`)
         ]),
 
         // Relations Tab
         activeTab.value === 'relations' && props.result.relations.length > 0 && h('div', { class: 'relations-panel' }, [
           h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Relationship Chains'),
-            h('span', { class: 'panel-count' }, `${props.result.relations.length} items`)
+            h('span', { class: 'panel-title' }, tr('Relationship Chains', '关系链')),
+            h('span', { class: 'panel-count' }, `${props.result.relations.length} ${tr('items', '项')}`)
           ]),
           h('div', { class: 'relations-list' },
             (expandedRelations.value ? props.result.relations : props.result.relations.slice(0, INITIAL_SHOW_COUNT)).map((rel, i) => 
@@ -1152,17 +1161,17 @@ const InsightDisplay = {
           props.result.relations.length > INITIAL_SHOW_COUNT && h('button', {
             class: 'expand-btn',
             onClick: () => { expandedRelations.value = !expandedRelations.value }
-          }, expandedRelations.value ? `Collapse ▲` : `Expand All ${props.result.relations.length} items ▼`)
+          }, expandedRelations.value ? `${tr('Collapse', '收起')} ▲` : `${tr('Expand All', '全部展开')} ${props.result.relations.length} ${tr('items', '项')} ▼`)
         ]),
-        
+
         // Sub-queries Tab
         activeTab.value === 'subqueries' && props.result.subQueries.length > 0 && h('div', { class: 'subqueries-panel' }, [
           h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Drift query generated analysis sub-questions'),
-            h('span', { class: 'panel-count' }, `${props.result.subQueries.length} questions`)
+            h('span', { class: 'panel-title' }, tr('Drift query generated analysis sub-questions', '漂移查询生成的分析子问题')),
+            h('span', { class: 'panel-count' }, `${props.result.subQueries.length} ${tr('questions', '个问题')}`)
           ]),
           h('div', { class: 'subqueries-list' },
-            props.result.subQueries.map((sq, i) => 
+            props.result.subQueries.map((sq, i) =>
               h('div', { class: 'subquery-item', key: i }, [
                 h('span', { class: 'subquery-number' }, `Q${i + 1}`),
                 h('div', { class: 'subquery-text' }, sq)
@@ -1170,11 +1179,11 @@ const InsightDisplay = {
             )
           )
         ]),
-        
+
         // Empty state
-        activeTab.value === 'facts' && props.result.facts.length === 0 && h('div', { class: 'empty-state' }, 'No current key memories'),
-        activeTab.value === 'entities' && props.result.entities.length === 0 && h('div', { class: 'empty-state' }, 'No core entities'),
-        activeTab.value === 'relations' && props.result.relations.length === 0 && h('div', { class: 'empty-state' }, 'No relationship chains')
+        activeTab.value === 'facts' && props.result.facts.length === 0 && h('div', { class: 'empty-state' }, tr('No current key memories', '暂无当前关键记忆')),
+        activeTab.value === 'entities' && props.result.entities.length === 0 && h('div', { class: 'empty-state' }, tr('No core entities', '暂无核心实体')),
+        activeTab.value === 'relations' && props.result.relations.length === 0 && h('div', { class: 'empty-state' }, tr('No relationship chains', '暂无关系链'))
       ])
     ])
   }
@@ -1194,25 +1203,25 @@ const PanoramaDisplay = {
     const formatSize = (length) => {
       if (!length) return ''
       if (length >= 1000) {
-        return `${(length / 1000).toFixed(1)}k chars`
+        return `${(length / 1000).toFixed(1)}${tr('k chars', 'k 字符')}`
       }
-      return `${length} chars`
+      return `${length} ${tr('chars', '字符')}`
     }
     
     return () => h('div', { class: 'panorama-display' }, [
       // Header Section
       h('div', { class: 'panorama-header' }, [
         h('div', { class: 'header-main' }, [
-          h('div', { class: 'header-title' }, 'Panorama Search'),
+          h('div', { class: 'header-title' }, tr('Panorama Search', '全景检索')),
           h('div', { class: 'header-stats' }, [
             h('span', { class: 'stat-item' }, [
               h('span', { class: 'stat-value' }, props.result.stats.nodes),
-              h('span', { class: 'stat-label' }, 'Nodes')
+              h('span', { class: 'stat-label' }, tr('Nodes', '节点'))
             ]),
             h('span', { class: 'stat-divider' }, '/'),
             h('span', { class: 'stat-item' }, [
               h('span', { class: 'stat-value' }, props.result.stats.edges),
-              h('span', { class: 'stat-label' }, 'Edges')
+              h('span', { class: 'stat-label' }, tr('Edges', '边'))
             ]),
             props.resultLength && h('span', { class: 'stat-divider' }, '·'),
             props.resultLength && h('span', { class: 'stat-size' }, formatSize(props.resultLength))
@@ -1220,26 +1229,26 @@ const PanoramaDisplay = {
         ]),
         props.result.query && h('div', { class: 'header-topic' }, props.result.query)
       ]),
-      
+
       // Tab Navigation
       h('div', { class: 'panorama-tabs' }, [
         h('button', {
           class: ['panorama-tab', { active: activeTab.value === 'active' }],
           onClick: () => { activeTab.value = 'active' }
         }, [
-          h('span', { class: 'tab-label' }, `Current Valid Memories (${props.result.activeFacts.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Current Valid Memories', '当前有效记忆')} (${props.result.activeFacts.length})`)
         ]),
         h('button', {
           class: ['panorama-tab', { active: activeTab.value === 'historical' }],
           onClick: () => { activeTab.value = 'historical' }
         }, [
-          h('span', { class: 'tab-label' }, `Historical Memories (${props.result.historicalFacts.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Historical Memories', '历史记忆')} (${props.result.historicalFacts.length})`)
         ]),
         h('button', {
           class: ['panorama-tab', { active: activeTab.value === 'entities' }],
           onClick: () => { activeTab.value = 'entities' }
         }, [
-          h('span', { class: 'tab-label' }, `Involved Entities (${props.result.entities.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Involved Entities', '相关实体')} (${props.result.entities.length})`)
         ])
       ]),
       
@@ -1248,28 +1257,28 @@ const PanoramaDisplay = {
         // Active Facts Tab
         activeTab.value === 'active' && h('div', { class: 'facts-panel active-facts' }, [
           h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Current Valid Memories'),
-            h('span', { class: 'panel-count' }, `${props.result.activeFacts.length} items`)
+            h('span', { class: 'panel-title' }, tr('Current Valid Memories', '当前有效记忆')),
+            h('span', { class: 'panel-count' }, `${props.result.activeFacts.length} ${tr('items', '项')}`)
           ]),
           props.result.activeFacts.length > 0 ? h('div', { class: 'facts-list' },
-            (expandedActive.value ? props.result.activeFacts : props.result.activeFacts.slice(0, INITIAL_SHOW_COUNT)).map((fact, i) => 
+            (expandedActive.value ? props.result.activeFacts : props.result.activeFacts.slice(0, INITIAL_SHOW_COUNT)).map((fact, i) =>
               h('div', { class: 'fact-item active', key: i }, [
                 h('span', { class: 'fact-number' }, i + 1),
                 h('div', { class: 'fact-content' }, fact)
               ])
             )
-          ) : h('div', { class: 'empty-state' }, 'No current valid memories'),
+          ) : h('div', { class: 'empty-state' }, tr('No current valid memories', '暂无当前有效记忆')),
           props.result.activeFacts.length > INITIAL_SHOW_COUNT && h('button', {
             class: 'expand-btn',
             onClick: () => { expandedActive.value = !expandedActive.value }
-          }, expandedActive.value ? `Collapse ▲` : `Expand All ${props.result.activeFacts.length} items ▼`)
+          }, expandedActive.value ? `${tr('Collapse', '收起')} ▲` : `${tr('Expand All', '全部展开')} ${props.result.activeFacts.length} ${tr('items', '项')} ▼`)
         ]),
-        
+
         // Historical Facts Tab
         activeTab.value === 'historical' && h('div', { class: 'facts-panel historical-facts' }, [
           h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Historical Memories'),
-            h('span', { class: 'panel-count' }, `${props.result.historicalFacts.length} items`)
+            h('span', { class: 'panel-title' }, tr('Historical Memories', '历史记忆')),
+            h('span', { class: 'panel-count' }, `${props.result.historicalFacts.length} ${tr('items', '项')}`)
           ]),
           props.result.historicalFacts.length > 0 ? h('div', { class: 'facts-list' },
             (expandedHistorical.value ? props.result.historicalFacts : props.result.historicalFacts.slice(0, INITIAL_SHOW_COUNT)).map((fact, i) => 
@@ -1290,31 +1299,31 @@ const PanoramaDisplay = {
                 ])
               ])
             )
-          ) : h('div', { class: 'empty-state' }, 'No historical memories'),
+          ) : h('div', { class: 'empty-state' }, tr('No historical memories', '暂无历史记忆')),
           props.result.historicalFacts.length > INITIAL_SHOW_COUNT && h('button', {
             class: 'expand-btn',
             onClick: () => { expandedHistorical.value = !expandedHistorical.value }
-          }, expandedHistorical.value ? `Collapse ▲` : `Expand All ${props.result.historicalFacts.length} items ▼`)
+          }, expandedHistorical.value ? `${tr('Collapse', '收起')} ▲` : `${tr('Expand All', '全部展开')} ${props.result.historicalFacts.length} ${tr('items', '项')} ▼`)
         ]),
-        
+
         // Entities Tab
         activeTab.value === 'entities' && h('div', { class: 'entities-panel' }, [
           h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Involved Entities'),
-            h('span', { class: 'panel-count' }, `${props.result.entities.length} entities`)
+            h('span', { class: 'panel-title' }, tr('Involved Entities', '相关实体')),
+            h('span', { class: 'panel-count' }, `${props.result.entities.length} ${tr('entities', '个实体')}`)
           ]),
           props.result.entities.length > 0 ? h('div', { class: 'entities-grid' },
-            (expandedEntities.value ? props.result.entities : props.result.entities.slice(0, 8)).map((entity, i) => 
+            (expandedEntities.value ? props.result.entities : props.result.entities.slice(0, 8)).map((entity, i) =>
               h('div', { class: 'entity-tag', key: i }, [
                 h('span', { class: 'entity-name' }, entity.name),
                 entity.type && h('span', { class: 'entity-type' }, entity.type)
               ])
             )
-          ) : h('div', { class: 'empty-state' }, 'No involved entities'),
+          ) : h('div', { class: 'empty-state' }, tr('No involved entities', '暂无相关实体')),
           props.result.entities.length > 8 && h('button', {
             class: 'expand-btn',
             onClick: () => { expandedEntities.value = !expandedEntities.value }
-          }, expandedEntities.value ? `Collapse ▲` : `Expand All ${props.result.entities.length} entities ▼`)
+          }, expandedEntities.value ? `${tr('Collapse', '收起')} ▲` : `${tr('Expand All', '全部展开')} ${props.result.entities.length} ${tr('entities', '个实体')} ▼`)
         ])
       ])
     ])
@@ -1329,9 +1338,9 @@ const InterviewDisplay = {
     const formatSize = (length) => {
       if (!length) return ''
       if (length >= 1000) {
-        return `${(length / 1000).toFixed(1)}k chars`
+        return `${(length / 1000).toFixed(1)}${tr('k chars', 'k 字符')}`
       }
-      return `${length} chars`
+      return `${length} ${tr('chars', '字符')}`
     }
     
     // Clean quote text - remove leading list numbers to avoid double numbering
@@ -1474,16 +1483,16 @@ const InterviewDisplay = {
       // Header Section
       h('div', { class: 'interview-header' }, [
         h('div', { class: 'header-main' }, [
-          h('div', { class: 'header-title' }, 'Agent Interview'),
+          h('div', { class: 'header-title' }, tr('Agent Interview', '智能体访谈')),
           h('div', { class: 'header-stats' }, [
             h('span', { class: 'stat-item' }, [
               h('span', { class: 'stat-value' }, props.result.successCount || props.result.interviews.length),
-              h('span', { class: 'stat-label' }, 'Interviewed')
+              h('span', { class: 'stat-label' }, tr('Interviewed', '已访谈'))
             ]),
             props.result.totalCount > 0 && h('span', { class: 'stat-divider' }, '/'),
             props.result.totalCount > 0 && h('span', { class: 'stat-item' }, [
               h('span', { class: 'stat-value' }, props.result.totalCount),
-              h('span', { class: 'stat-label' }, 'Total')
+              h('span', { class: 'stat-label' }, tr('Total', '总数'))
             ]),
             props.resultLength && h('span', { class: 'stat-divider' }, '·'),
             props.resultLength && h('span', { class: 'stat-size' }, formatSize(props.resultLength))
@@ -1500,7 +1509,7 @@ const InterviewDisplay = {
           onClick: () => { activeIndex.value = i }
         }, [
           h('span', { class: 'tab-avatar' }, interview.name ? interview.name.charAt(0) : (i + 1)),
-          h('span', { class: 'tab-name' }, interview.title || interview.name || `Agent ${i + 1}`)
+          h('span', { class: 'tab-name' }, interview.title || interview.name || `${tr('Agent', '智能体')} ${i + 1}`)
         ]))
       ),
       
@@ -1510,15 +1519,15 @@ const InterviewDisplay = {
         h('div', { class: 'agent-profile' }, [
           h('div', { class: 'profile-avatar' }, props.result.interviews[activeIndex.value]?.name?.charAt(0) || 'A'),
           h('div', { class: 'profile-info' }, [
-            h('div', { class: 'profile-name' }, props.result.interviews[activeIndex.value]?.name || 'Agent'),
+            h('div', { class: 'profile-name' }, props.result.interviews[activeIndex.value]?.name || tr('Agent', '智能体')),
             h('div', { class: 'profile-role' }, props.result.interviews[activeIndex.value]?.role || ''),
             props.result.interviews[activeIndex.value]?.bio && h('div', { class: 'profile-bio' }, props.result.interviews[activeIndex.value].bio)
           ])
         ]),
-        
+
         // Selection Reason
         props.result.interviews[activeIndex.value]?.selectionReason && h('div', { class: 'selection-reason' }, [
-          h('div', { class: 'reason-label' }, 'Selection Reason'),
+          h('div', { class: 'reason-label' }, tr('Selection Reason', '选择理由')),
           h('div', { class: 'reason-content' }, props.result.interviews[activeIndex.value].selectionReason)
         ]),
         
@@ -1526,7 +1535,7 @@ const InterviewDisplay = {
         h('div', { class: 'qa-thread' }, 
           (props.result.interviews[activeIndex.value]?.questions?.length > 0 
             ? props.result.interviews[activeIndex.value].questions 
-            : [props.result.interviews[activeIndex.value]?.question || 'No question available']
+            : [props.result.interviews[activeIndex.value]?.question || tr('No question available', '暂无问题')]
           ).map((question, qIdx) => {
             const interview = props.result.interviews[activeIndex.value]
             const currentPlatform = getPlatformTab(activeIndex.value, qIdx)
@@ -1541,7 +1550,7 @@ const InterviewDisplay = {
               h('div', { class: 'qa-question' }, [
                 h('div', { class: 'qa-badge q-badge' }, `Q${qIdx + 1}`),
                 h('div', { class: 'qa-content' }, [
-                  h('div', { class: 'qa-sender' }, 'Interviewer'),
+                  h('div', { class: 'qa-sender' }, tr('Interviewer', '访谈者')),
                   h('div', { class: 'qa-text' }, question)
                 ])
               ]),
@@ -1551,7 +1560,7 @@ const InterviewDisplay = {
                 h('div', { class: 'qa-badge a-badge' }, `A${qIdx + 1}`),
                 h('div', { class: 'qa-content' }, [
                   h('div', { class: 'qa-answer-header' }, [
-                    h('div', { class: 'qa-sender' }, interview?.name || 'Agent'),
+                    h('div', { class: 'qa-sender' }, interview?.name || tr('Agent', '智能体')),
                     // Dual platform toggle buttons (only shown when both platforms have real answers)
                     hasDualPlatform && h('div', { class: 'platform-switch' }, [
                       h('button', {
@@ -1588,7 +1597,7 @@ const InterviewDisplay = {
                   !isPlaceholder && answerText.length > 400 && h('button', {
                     class: 'expand-answer-btn',
                     onClick: () => toggleAnswer(expandKey)
-                  }, isExpanded ? 'Show Less' : 'Show More')
+                  }, isExpanded ? tr('Show Less', '收起') : tr('Show More', '查看更多'))
                 ])
               ])
             ])
@@ -1597,7 +1606,7 @@ const InterviewDisplay = {
         
         // Key Quotes Section
         props.result.interviews[activeIndex.value]?.quotes?.length > 0 && h('div', { class: 'quotes-section' }, [
-          h('div', { class: 'quotes-header' }, 'Key Quotes'),
+          h('div', { class: 'quotes-header' }, tr('Key Quotes', '关键引述')),
           h('div', { class: 'quotes-list' },
             props.result.interviews[activeIndex.value].quotes.slice(0, 3).map((quote, qi) => {
               const cleanedQuote = cleanQuoteText(quote)
@@ -1614,7 +1623,7 @@ const InterviewDisplay = {
 
       // Summary Section (Collapsible)
       props.result.summary && h('div', { class: 'summary-section' }, [
-        h('div', { class: 'summary-header' }, 'Interview Summary'),
+        h('div', { class: 'summary-header' }, tr('Interview Summary', '访谈总结')),
         h('div', { 
           class: 'summary-content',
           innerHTML: renderMarkdown(props.result.summary.length > 500 ? props.result.summary.substring(0, 500) + '...' : props.result.summary)
@@ -1641,80 +1650,80 @@ const QuickSearchDisplay = {
     const formatSize = (length) => {
       if (!length) return ''
       if (length >= 1000) {
-        return `${(length / 1000).toFixed(1)}k chars`
+        return `${(length / 1000).toFixed(1)}${tr('k chars', 'k 字符')}`
       }
-      return `${length} chars`
+      return `${length} ${tr('chars', '字符')}`
     }
     
     return () => h('div', { class: 'quick-search-display' }, [
       // Header Section
       h('div', { class: 'quicksearch-header' }, [
         h('div', { class: 'header-main' }, [
-          h('div', { class: 'header-title' }, 'Quick Search'),
+          h('div', { class: 'header-title' }, tr('Quick Search', '快速检索')),
           h('div', { class: 'header-stats' }, [
             h('span', { class: 'stat-item' }, [
               h('span', { class: 'stat-value' }, props.result.count || props.result.facts.length),
-              h('span', { class: 'stat-label' }, 'Results')
+              h('span', { class: 'stat-label' }, tr('Results', '结果'))
             ]),
             props.resultLength && h('span', { class: 'stat-divider' }, '·'),
             props.resultLength && h('span', { class: 'stat-size' }, formatSize(props.resultLength))
           ])
         ]),
         props.result.query && h('div', { class: 'header-query' }, [
-          h('span', { class: 'query-label' }, 'Search: '),
+          h('span', { class: 'query-label' }, tr('Search: ', '搜索:')),
           h('span', { class: 'query-text' }, props.result.query)
         ])
       ]),
-      
+
       // Tab Navigation (only show if there are edges or nodes)
       showTabs.value && h('div', { class: 'quicksearch-tabs' }, [
         h('button', {
           class: ['quicksearch-tab', { active: activeTab.value === 'facts' }],
           onClick: () => { activeTab.value = 'facts' }
         }, [
-          h('span', { class: 'tab-label' }, `Facts (${props.result.facts.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Facts', '事实')} (${props.result.facts.length})`)
         ]),
         hasEdges.value && h('button', {
           class: ['quicksearch-tab', { active: activeTab.value === 'edges' }],
           onClick: () => { activeTab.value = 'edges' }
         }, [
-          h('span', { class: 'tab-label' }, `Relationships (${props.result.edges.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Relationships', '关系')} (${props.result.edges.length})`)
         ]),
         hasNodes.value && h('button', {
           class: ['quicksearch-tab', { active: activeTab.value === 'nodes' }],
           onClick: () => { activeTab.value = 'nodes' }
         }, [
-          h('span', { class: 'tab-label' }, `Nodes (${props.result.nodes.length})`)
+          h('span', { class: 'tab-label' }, `${tr('Nodes', '节点')} (${props.result.nodes.length})`)
         ])
       ]),
-      
+
       // Content Area
       h('div', { class: ['quicksearch-content', { 'no-tabs': !showTabs.value }] }, [
         // Facts (always show if no tabs, or when facts tab is active)
         ((!showTabs.value) || activeTab.value === 'facts') && h('div', { class: 'facts-panel' }, [
           !showTabs.value && h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Search Results'),
-            h('span', { class: 'panel-count' }, `${props.result.facts.length} items`)
+            h('span', { class: 'panel-title' }, tr('Search Results', '搜索结果')),
+            h('span', { class: 'panel-count' }, `${props.result.facts.length} ${tr('items', '项')}`)
           ]),
           props.result.facts.length > 0 ? h('div', { class: 'facts-list' },
-            (expandedFacts.value ? props.result.facts : props.result.facts.slice(0, INITIAL_SHOW_COUNT)).map((fact, i) => 
+            (expandedFacts.value ? props.result.facts : props.result.facts.slice(0, INITIAL_SHOW_COUNT)).map((fact, i) =>
               h('div', { class: 'fact-item', key: i }, [
                 h('span', { class: 'fact-number' }, i + 1),
                 h('div', { class: 'fact-content' }, fact)
               ])
             )
-          ) : h('div', { class: 'empty-state' }, 'No relevant results found'),
+          ) : h('div', { class: 'empty-state' }, tr('No relevant results found', '未找到相关结果')),
           props.result.facts.length > INITIAL_SHOW_COUNT && h('button', {
             class: 'expand-btn',
             onClick: () => { expandedFacts.value = !expandedFacts.value }
-          }, expandedFacts.value ? `Collapse ▲` : `Expand All ${props.result.facts.length} items ▼`)
+          }, expandedFacts.value ? `${tr('Collapse', '收起')} ▲` : `${tr('Expand All', '全部展开')} ${props.result.facts.length} ${tr('items', '项')} ▼`)
         ]),
-        
+
         // Edges Tab
         activeTab.value === 'edges' && hasEdges.value && h('div', { class: 'edges-panel' }, [
           h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Related Relationships'),
-            h('span', { class: 'panel-count' }, `${props.result.edges.length} items`)
+            h('span', { class: 'panel-title' }, tr('Related Relationships', '相关关系')),
+            h('span', { class: 'panel-count' }, `${props.result.edges.length} ${tr('items', '项')}`)
           ]),
           h('div', { class: 'edges-list' },
             props.result.edges.map((edge, i) => 
@@ -1734,8 +1743,8 @@ const QuickSearchDisplay = {
         // Nodes Tab
         activeTab.value === 'nodes' && hasNodes.value && h('div', { class: 'nodes-panel' }, [
           h('div', { class: 'panel-header' }, [
-            h('span', { class: 'panel-title' }, 'Related Nodes'),
-            h('span', { class: 'panel-count' }, `${props.result.nodes.length} nodes`)
+            h('span', { class: 'panel-title' }, tr('Related Nodes', '相关节点')),
+            h('span', { class: 'panel-count' }, `${props.result.nodes.length} ${tr('nodes', '个节点')}`)
           ]),
           h('div', { class: 'nodes-grid' },
             props.result.nodes.map((node, i) => 
@@ -1759,9 +1768,9 @@ const statusClass = computed(() => {
 })
 
 const statusText = computed(() => {
-  if (isComplete.value) return 'Completed'
-  if (agentLogs.value.length > 0) return 'Generating...'
-  return 'Waiting'
+  if (isComplete.value) return tr('Completed', '已完成')
+  if (agentLogs.value.length > 0) return tr('Generating...', '生成中...')
+  return tr('Waiting', '等待中')
 })
 
 const totalSections = computed(() => {
@@ -1827,7 +1836,7 @@ const activeStep = computed(() => {
   if (doneSteps.length > 0) return doneSteps[doneSteps.length - 1]
   
   // Otherwise return the first step
-  return steps[0] || { noLabel: '--', title: 'Waiting to Start', status: 'todo', meta: '' }
+  return steps[0] || { noLabel: '--', title: tr('Waiting to Start', '等待开始'), status: 'todo', meta: '' }
 })
 
 const workflowSteps = computed(() => {
@@ -1838,9 +1847,9 @@ const workflowSteps = computed(() => {
   steps.push({
     key: 'planning',
     noLabel: 'PL',
-    title: 'Planning / Outline',
+    title: tr('Planning / Outline', '规划 / 大纲'),
     status: planningStatus,
-    meta: planningStatus === 'active' ? 'IN PROGRESS' : ''
+    meta: planningStatus === 'active' ? tr('IN PROGRESS', '进行中') : ''
   })
 
   // Sections (if outline exists)
@@ -1856,7 +1865,7 @@ const workflowSteps = computed(() => {
       noLabel: String(idx).padStart(2, '0'),
       title: section.title,
       status,
-      meta: status === 'active' ? 'IN PROGRESS' : ''
+      meta: status === 'active' ? tr('IN PROGRESS', '进行中') : ''
     })
   })
 
@@ -1865,9 +1874,9 @@ const workflowSteps = computed(() => {
   steps.push({
     key: 'complete',
     noLabel: 'OK',
-    title: 'Complete',
+    title: tr('Complete', '完成'),
     status: completeStatus,
-    meta: completeStatus === 'active' ? 'FINALIZING' : ''
+    meta: completeStatus === 'active' ? tr('FINALIZING', '收尾中') : ''
   })
 
   return steps
@@ -1907,8 +1916,8 @@ const formatParams = (params) => {
 
 const formatResultSize = (length) => {
   if (!length) return ''
-  if (length < 1000) return `${length} chars`
-  return `${(length / 1000).toFixed(1)}k chars`
+  if (length < 1000) return `${length} ${tr('chars', '字符')}`
+  return `${(length / 1000).toFixed(1)}${tr('k chars', 'k 字符')}`
 }
 
 const getTimelineItemClass = (log, idx, total) => {
@@ -1931,16 +1940,16 @@ const getConnectorClass = (log, idx, total) => {
 
 const getActionLabel = (action) => {
   const labels = {
-    'report_start': 'Report Started',
-    'planning_start': 'Planning',
-    'planning_complete': 'Plan Complete',
-    'section_start': 'Section Start',
-    'section_content': 'Content Ready',
-    'section_complete': 'Section Done',
-    'tool_call': 'Tool Call',
-    'tool_result': 'Tool Result',
-    'llm_response': 'LLM Response',
-    'report_complete': 'Complete'
+    'report_start': tr('Report Started', '报告已启动'),
+    'planning_start': tr('Planning', '规划中'),
+    'planning_complete': tr('Plan Complete', '规划完成'),
+    'section_start': tr('Section Start', '章节开始'),
+    'section_content': tr('Content Ready', '内容就绪'),
+    'section_complete': tr('Section Done', '章节完成'),
+    'tool_call': tr('Tool Call', '工具调用'),
+    'tool_result': tr('Tool Result', '工具结果'),
+    'llm_response': tr('LLM Response', 'LLM 响应'),
+    'report_complete': tr('Complete', '完成')
   }
   return labels[action] || action
 }
@@ -2113,7 +2122,7 @@ const stopPolling = () => {
 // Lifecycle
 onMounted(() => {
   if (props.reportId) {
-    addLog(`Report Agent initialized: ${props.reportId}`)
+    addLog(`${tr('Report Agent initialized', '报告智能体已初始化')}: ${props.reportId}`)
     startPolling()
   }
 })

--- a/frontend/src/components/Step5Interaction.vue
+++ b/frontend/src/components/Step5Interaction.vue
@@ -8,7 +8,7 @@
           <!-- Report Header -->
           <div class="report-header-block">
             <div class="report-meta">
-              <span class="report-tag">Prediction Report</span>
+              <span class="report-tag">{{ $tr('Prediction Report', '预测报告') }}</span>
               <span class="report-id">ID: {{ reportId || 'REF-2024-X92' }}</span>
             </div>
             <h1 class="main-title">{{ reportOutline.title }}</h1>
@@ -58,7 +58,7 @@
                       <path d="M12 2a10 10 0 0 1 10 10" stroke-width="4" stroke="#4B5563" stroke-linecap="round"></path>
                     </svg>
                   </div>
-                  <span class="loading-text">Generating {{ section.title }}...</span>
+                  <span class="loading-text">{{ $tr('Generating', '正在生成') }} {{ section.title }}...</span>
                 </div>
               </div>
             </div>
@@ -72,7 +72,7 @@
             <div class="waiting-ring"></div>
             <div class="waiting-ring"></div>
           </div>
-          <span class="waiting-text">Waiting for Report Agent...</span>
+          <span class="waiting-text">{{ $tr('Waiting for Report Agent...', '等待报告智能体...') }}</span>
         </div>
       </div>
 
@@ -85,8 +85,8 @@
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
           </svg>
           <div class="action-bar-text">
-            <span class="action-bar-title">Interactive Tools</span>
-            <span class="action-bar-subtitle mono">{{ profiles.length }} personas available</span>
+            <span class="action-bar-title">{{ $tr('Interactive Tools', '交互工具') }}</span>
+            <span class="action-bar-subtitle mono">{{ profiles.length }} {{ $tr('personas available', '个可用人设') }}</span>
           </div>
         </div>
           <div class="action-bar-tabs">
@@ -98,7 +98,7 @@
               <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path>
               </svg>
-              <span>Chat with Report Agent</span>
+              <span>{{ $tr('Chat with Report Agent', '与报告智能体对话') }}</span>
             </button>
             <div class="agent-dropdown" v-if="profiles.length > 0">
               <button 
@@ -110,13 +110,13 @@
                   <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
                   <circle cx="12" cy="7" r="4"></circle>
                 </svg>
-                <span>{{ selectedAgent ? selectedAgent.username : 'Persona Chat' }}</span>
+                <span>{{ selectedAgent ? selectedAgent.username : $tr('Persona Chat', '人设对话') }}</span>
                 <svg class="dropdown-arrow" :class="{ open: showAgentDropdown }" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
                   <polyline points="6 9 12 15 18 9"></polyline>
                 </svg>
               </button>
               <div v-if="showAgentDropdown" class="dropdown-menu">
-                <div class="dropdown-header">Select Chat Target</div>
+                <div class="dropdown-header">{{ $tr('Select Chat Target', '选择对话对象') }}</div>
                 <div 
                   v-for="(agent, idx) in profiles" 
                   :key="idx"
@@ -126,7 +126,7 @@
                   <div class="agent-avatar">{{ (agent.username || 'A')[0] }}</div>
                   <div class="agent-info">
                     <span class="agent-name">{{ agent.username }}</span>
-                    <span class="agent-role">{{ agent.profession || 'Unknown Profession' }}</span>
+                    <span class="agent-role">{{ agent.profession || $tr('Unknown Profession', '未知职业') }}</span>
                   </div>
                 </div>
               </div>
@@ -141,7 +141,7 @@
                 <path d="M9 11l3 3L22 4"></path>
                 <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
               </svg>
-              <span>Group Questions</span>
+              <span>{{ $tr('Group Questions', '群组提问') }}</span>
             </button>
           </div>
         </div>
@@ -154,8 +154,8 @@
             <div class="tools-card-header">
               <div class="tools-card-avatar">R</div>
               <div class="tools-card-info">
-                <div class="tools-card-name">Report Agent - Chat</div>
-                <div class="tools-card-subtitle">Quick chat version of the report generation agent. Can call 4 professional tools. Has complete MiroShark memory</div>
+                <div class="tools-card-name">{{ $tr('Report Agent - Chat', '报告智能体 - 对话') }}</div>
+                <div class="tools-card-subtitle">{{ $tr('Quick chat version of the report generation agent. Can call 4 professional tools. Has complete MiroShark memory', '报告生成智能体的快速对话版本。可调用 4 个专业工具,具备完整的 MiroShark 记忆') }}</div>
               </div>
               <button class="tools-card-toggle" @click="showToolsDetail = !showToolsDetail">
                 <svg :class="{ 'is-expanded': showToolsDetail }" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
@@ -172,8 +172,8 @@
                     </svg>
                   </div>
                   <div class="tool-content">
-                    <div class="tool-name">InsightForge Deep Attribution</div>
-                    <div class="tool-desc">Aligns real-world seed data with simulation environment state, combining Global/Local Memory mechanisms to provide cross-temporal deep attribution analysis</div>
+                    <div class="tool-name">{{ $tr('InsightForge Deep Attribution', 'InsightForge 深度归因') }}</div>
+                    <div class="tool-desc">{{ $tr('Aligns real-world seed data with simulation environment state, combining Global/Local Memory mechanisms to provide cross-temporal deep attribution analysis', '将真实世界种子数据与模拟环境状态对齐,结合全局/局部记忆机制提供跨时序深度归因分析') }}</div>
                   </div>
                 </div>
                 <div class="tool-item tool-blue">
@@ -184,8 +184,8 @@
                     </svg>
                   </div>
                   <div class="tool-content">
-                    <div class="tool-name">PanoramaSearch Panoramic Tracking</div>
-                    <div class="tool-desc">Graph-based breadth traversal algorithm that reconstructs event propagation paths and captures the full topology of information flow</div>
+                    <div class="tool-name">{{ $tr('PanoramaSearch Panoramic Tracking', 'PanoramaSearch 全景追踪') }}</div>
+                    <div class="tool-desc">{{ $tr('Graph-based breadth traversal algorithm that reconstructs event propagation paths and captures the full topology of information flow', '基于图的广度遍历算法,重建事件传播路径并捕捉信息流的完整拓扑结构') }}</div>
                   </div>
                 </div>
                 <div class="tool-item tool-orange">
@@ -195,8 +195,8 @@
                     </svg>
                   </div>
                   <div class="tool-content">
-                    <div class="tool-name">QuickSearch Quick Retrieval</div>
-                    <div class="tool-desc">GraphRAG-based instant query interface with optimized indexing efficiency for quickly extracting specific node attributes and discrete facts</div>
+                    <div class="tool-name">{{ $tr('QuickSearch Quick Retrieval', 'QuickSearch 快速检索') }}</div>
+                    <div class="tool-desc">{{ $tr('GraphRAG-based instant query interface with optimized indexing efficiency for quickly extracting specific node attributes and discrete facts', '基于 GraphRAG 的即时查询接口,优化索引效率,快速提取特定节点属性和离散事实') }}</div>
                   </div>
                 </div>
                 <div class="tool-item tool-green">
@@ -208,8 +208,8 @@
                     </svg>
                   </div>
                   <div class="tool-content">
-                    <div class="tool-name">InterviewSubAgent Virtual Interview</div>
-                    <div class="tool-desc">Autonomous interviews that conduct parallel multi-round dialogues with individuals in the simulated world, collecting unstructured opinion data and psychological states</div>
+                    <div class="tool-name">{{ $tr('InterviewSubAgent Virtual Interview', 'InterviewSubAgent 虚拟访谈') }}</div>
+                    <div class="tool-desc">{{ $tr('Autonomous interviews that conduct parallel multi-round dialogues with individuals in the simulated world, collecting unstructured opinion data and psychological states', '自主访谈,与模拟世界中的个体进行并行多轮对话,采集非结构化的观点数据与心理状态') }}</div>
                   </div>
                 </div>
               </div>
@@ -224,7 +224,7 @@
                 <div class="profile-card-name">{{ selectedAgent.username }}</div>
                 <div class="profile-card-meta">
                   <span v-if="selectedAgent.name" class="profile-card-handle">@{{ selectedAgent.name }}</span>
-                  <span class="profile-card-profession">{{ selectedAgent.profession || 'Unknown Profession' }}</span>
+                  <span class="profile-card-profession">{{ selectedAgent.profession || $tr('Unknown Profession', '未知职业') }}</span>
                 </div>
               </div>
               <button class="profile-card-toggle" @click="showFullProfile = !showFullProfile">
@@ -235,7 +235,7 @@
             </div>
             <div v-if="showFullProfile && selectedAgent.bio" class="profile-card-body">
               <div class="profile-card-bio">
-                <div class="profile-card-label">Bio</div>
+                <div class="profile-card-label">{{ $tr('Bio', '简介') }}</div>
                 <p>{{ selectedAgent.bio }}</p>
               </div>
             </div>
@@ -250,7 +250,7 @@
                 </svg>
               </div>
               <p class="empty-text">
-                {{ chatTarget === 'report_agent' ? 'Chat with Report Agent to explore report details' : 'Chat with simulated individuals to understand their perspectives' }}
+                {{ chatTarget === 'report_agent' ? $tr('Chat with Report Agent to explore report details', '与报告智能体对话,探索报告详情') : $tr('Chat with simulated individuals to understand their perspectives', '与模拟个体对话,了解他们的观点') }}
               </p>
             </div>
             <div 
@@ -266,7 +266,7 @@
               <div class="message-content">
                 <div class="message-header">
                   <span class="sender-name">
-                    {{ msg.role === 'user' ? 'You' : (chatTarget === 'report_agent' ? 'Report Agent' : (selectedAgent?.username || 'Agent')) }}
+                    {{ msg.role === 'user' ? $tr('You', '你') : (chatTarget === 'report_agent' ? $tr('Report Agent', '报告智能体') : (selectedAgent?.username || $tr('Agent', '智能体'))) }}
                   </span>
                   <span class="message-time">{{ formatTime(msg.timestamp) }}</span>
                 </div>
@@ -292,7 +292,7 @@
             <textarea 
               v-model="chatInput"
               class="chat-input"
-              placeholder="Enter your question..."
+              :placeholder="$tr('Enter your question...', '请输入你的问题...')"
               @keydown.enter.exact.prevent="sendMessage"
               :disabled="isSending || (!selectedAgent && chatTarget === 'agent')"
               rows="1"
@@ -321,9 +321,9 @@
                   <svg :class="['toggle-chevron', { expanded: showPersonaSection }]" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
                     <polyline points="9 18 15 12 9 6"></polyline>
                   </svg>
-                  <span class="section-title">Select Persona</span>
+                  <span class="section-title">{{ $tr('Select Persona', '选择人设') }}</span>
                 </div>
-                <span class="selection-count">Selected {{ selectedAgents.size }} / {{ profiles.length }}</span>
+                <span class="selection-count">{{ $tr('Selected', '已选') }} {{ selectedAgents.size }} / {{ profiles.length }}</span>
               </div>
               <div v-show="showPersonaSection" class="agents-grid">
                 <label
@@ -340,7 +340,7 @@
                   <div class="checkbox-avatar">{{ (agent.username || 'A')[0] }}</div>
                   <div class="checkbox-info">
                     <span class="checkbox-name">{{ agent.username }}</span>
-                    <span class="checkbox-role">{{ agent.profession || 'Unknown Profession' }}</span>
+                    <span class="checkbox-role">{{ agent.profession || $tr('Unknown Profession', '未知职业') }}</span>
                   </div>
                   <div class="checkbox-indicator">
                     <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="3">
@@ -350,20 +350,20 @@
                 </label>
               </div>
               <div v-show="showPersonaSection" class="selection-actions">
-                <button class="action-link" @click="selectAllAgents">Select All</button>
+                <button class="action-link" @click="selectAllAgents">{{ $tr('Select All', '全选') }}</button>
                 <span class="action-divider">|</span>
-                <button class="action-link" @click="clearAgentSelection">Clear</button>
+                <button class="action-link" @click="clearAgentSelection">{{ $tr('Clear', '清空') }}</button>
               </div>
             </div>
 
             <div class="setup-section">
               <div class="section-header">
-                <span class="section-title">Persona Question</span>
+                <span class="section-title">{{ $tr('Persona Question', '人设问题') }}</span>
               </div>
-              <textarea 
+              <textarea
                 v-model="surveyQuestion"
                 class="survey-input"
-                placeholder="Enter the question you want to ask all selected targets..."
+                :placeholder="$tr('Enter the question you want to ask all selected targets...', '输入你想向所有选中对象提出的问题...')"
                 rows="3"
               ></textarea>
             </div>
@@ -374,15 +374,15 @@
               @click="submitSurvey"
             >
               <span v-if="isSurveying" class="loading-spinner"></span>
-              <span v-else>Send Question</span>
+              <span v-else>{{ $tr('Send Question', '发送问题') }}</span>
             </button>
           </div>
 
           <!-- Results -->
           <div v-if="surveyResults.length > 0" class="survey-results">
             <div class="results-header">
-              <span class="results-title">Results</span>
-              <span class="results-count">{{ surveyResults.length }} responses</span>
+              <span class="results-title">{{ $tr('Results', '结果') }}</span>
+              <span class="results-count">{{ surveyResults.length }} {{ $tr('responses', '条回复') }}</span>
             </div>
             <div class="results-list">
               <div 
@@ -394,7 +394,7 @@
                   <div class="result-avatar">{{ (result.agent_name || 'A')[0] }}</div>
                   <div class="result-info">
                     <span class="result-name">{{ result.agent_name }}</span>
-                    <span class="result-role">{{ result.profession || 'Unknown Profession' }}</span>
+                    <span class="result-role">{{ result.profession || $tr('Unknown Profession', '未知职业') }}</span>
                   </div>
                 </div>
                 <div class="result-question">
@@ -430,25 +430,25 @@
 
           <div class="profile-popup-details">
             <div class="profile-popup-row" v-if="profilePopupAgent.bio">
-              <span class="popup-label">Bio</span>
+              <span class="popup-label">{{ $tr('Bio', '简介') }}</span>
               <span class="popup-value">{{ profilePopupAgent.bio }}</span>
             </div>
             <div class="profile-popup-stats">
-              <span v-if="profilePopupAgent.age" class="popup-stat">{{ profilePopupAgent.age }}y</span>
+              <span v-if="profilePopupAgent.age" class="popup-stat">{{ profilePopupAgent.age }}{{ $tr('y', '岁') }}</span>
               <span v-if="profilePopupAgent.gender" class="popup-stat">{{ profilePopupAgent.gender }}</span>
               <span v-if="profilePopupAgent.mbti" class="popup-stat">{{ profilePopupAgent.mbti }}</span>
               <span v-if="profilePopupAgent.country" class="popup-stat">{{ profilePopupAgent.country }}</span>
             </div>
             <div class="profile-popup-row" v-if="profilePopupAgent.persona">
-              <span class="popup-label" @click="showFullPersona = !showFullPersona" style="cursor:pointer">Persona {{ showFullPersona ? '▼' : '▶' }}</span>
+              <span class="popup-label" @click="showFullPersona = !showFullPersona" style="cursor:pointer">{{ $tr('Persona', '人设') }} {{ showFullPersona ? '▼' : '▶' }}</span>
               <span class="popup-value popup-persona" :class="{ clamped: !showFullPersona }">{{ profilePopupAgent.persona }}</span>
             </div>
           </div>
 
           <div class="profile-popup-activity">
-            <div class="popup-section-title">Simulation Activity ({{ profilePopupActions.length }})</div>
-            <div v-if="profilePopupLoading" class="popup-loading">Loading...</div>
-            <div v-else-if="profilePopupActions.length === 0" class="popup-empty">No activity recorded</div>
+            <div class="popup-section-title">{{ $tr('Simulation Activity', '模拟活动') }} ({{ profilePopupActions.length }})</div>
+            <div v-if="profilePopupLoading" class="popup-loading">{{ $tr('Loading...', '加载中...') }}</div>
+            <div v-else-if="profilePopupActions.length === 0" class="popup-empty">{{ $tr('No activity recorded', '没有活动记录') }}</div>
             <div v-else class="popup-actions-list">
               <div
                 v-for="(action, i) in profilePopupActions"
@@ -467,11 +467,11 @@
                 </div>
                 <div v-if="expandedActions.has(i)" class="popup-action-full">
                   <p v-if="action.action_args?.content">{{ action.action_args.content }}</p>
-                  <p v-if="action.action_args?.quote_content"><strong>Quote:</strong> {{ action.action_args.quote_content }}</p>
-                  <p v-if="action.action_args?.post_content"><strong>Original:</strong> {{ action.action_args.post_content }}</p>
-                  <p v-if="action.action_args?.original_content"><strong>Ref:</strong> {{ action.action_args.original_content }}</p>
-                  <p v-if="action.action_args?.target_user_name"><strong>Target:</strong> @{{ action.action_args.target_user_name }}</p>
-                  <p v-if="action.action_args?.query"><strong>Query:</strong> {{ action.action_args.query }}</p>
+                  <p v-if="action.action_args?.quote_content"><strong>{{ $tr('Quote:', '引用:') }}</strong> {{ action.action_args.quote_content }}</p>
+                  <p v-if="action.action_args?.post_content"><strong>{{ $tr('Original:', '原文:') }}</strong> {{ action.action_args.post_content }}</p>
+                  <p v-if="action.action_args?.original_content"><strong>{{ $tr('Ref:', '引用:') }}</strong> {{ action.action_args.original_content }}</p>
+                  <p v-if="action.action_args?.target_user_name"><strong>{{ $tr('Target:', '对象:') }}</strong> @{{ action.action_args.target_user_name }}</p>
+                  <p v-if="action.action_args?.query"><strong>{{ $tr('Query:', '查询:') }}</strong> {{ action.action_args.query }}</p>
                 </div>
               </div>
             </div>
@@ -487,6 +487,7 @@ import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { chatWithReport, getReport, getAgentLog } from '../api/report'
 import { interviewAgents, getSimulationProfilesRealtime, getSimulationActions } from '../api/simulation'
 import { renderMarkdown } from '../utils/markdown'
+import { tr } from '../i18n'
 
 const props = defineProps({
   reportId: String,
@@ -658,7 +659,7 @@ const selectAgent = (agent, idx) => {
 
   // Restore this Agent's chat records
   chatHistory.value = chatHistoryCache.value[`agent_${idx}`] || []
-  addLog(`Select chat target: ${agent.username}`)
+  addLog(`${tr('Select chat target', '选择对话对象')}: ${agent.username}`)
 }
 
 const formatTime = (timestamp) => {
@@ -698,10 +699,10 @@ const sendMessage = async () => {
       await sendToAgent(message)
     }
   } catch (err) {
-    addLog(`Send failed: ${err.message}`)
+    addLog(`${tr('Send failed', '发送失败')}: ${err.message}`)
     chatHistory.value.push({
       role: 'assistant',
-      content: `Sorry, an error occurred: ${err.message}`,
+      content: `${tr('Sorry, an error occurred', '抱歉,发生了错误')}: ${err.message}`,
       timestamp: new Date().toISOString()
     })
   } finally {
@@ -713,7 +714,7 @@ const sendMessage = async () => {
 }
 
 const sendToReportAgent = async (message) => {
-  addLog(`Sending to Report Agent: ${message.substring(0, 50)}...`)
+  addLog(`${tr('Sending to Report Agent', '发送至报告智能体')}: ${message.substring(0, 50)}...`)
   
   // Build chat history for API
   const historyForApi = chatHistory.value
@@ -733,21 +734,21 @@ const sendToReportAgent = async (message) => {
   if (res.success && res.data) {
     chatHistory.value.push({
       role: 'assistant',
-      content: res.data.response || res.data.answer || 'No response',
+      content: res.data.response || res.data.answer || tr('No response', '无响应'),
       timestamp: new Date().toISOString()
     })
-    addLog('Report Agent has replied')
+    addLog(tr('Report Agent has replied', '报告智能体已回复'))
   } else {
-    throw new Error(res.error || 'Request failed')
+    throw new Error(res.error || tr('Request failed', '请求失败'))
   }
 }
 
 const sendToAgent = async (message) => {
   if (!selectedAgent.value || selectedAgentIndex.value === null) {
-    throw new Error('Please select a simulated individual first')
+    throw new Error(tr('Please select a simulated individual first', '请先选择一个模拟个体'))
   }
   
-  addLog(`Sending to ${selectedAgent.value.username}: ${message.substring(0, 50)}...`)
+  addLog(`${tr('Sending to', '发送至')} ${selectedAgent.value.username}: ${message.substring(0, 50)}...`)
   
   // Build prompt with chat history
   let prompt = message
@@ -797,12 +798,12 @@ const sendToAgent = async (message) => {
         content: responseContent,
         timestamp: new Date().toISOString()
       })
-      addLog(`${selectedAgent.value.username} has replied`)
+      addLog(`${selectedAgent.value.username} ${tr('has replied', '已回复')}`)
     } else {
-      throw new Error('No response data')
+      throw new Error(tr('No response data', '没有响应数据'))
     }
   } else {
-    throw new Error(res.error || 'Request failed')
+    throw new Error(res.error || tr('Request failed', '请求失败'))
   }
 }
 
@@ -839,7 +840,7 @@ const submitSurvey = async () => {
   if (selectedAgents.value.size === 0 || !surveyQuestion.value.trim()) return
   
   isSurveying.value = true
-  addLog(`Sending survey to ${selectedAgents.value.size} targets...`)
+  addLog(`${tr('Sending survey to', '正在向')} ${selectedAgents.value.size} ${tr('targets...', '个对象发送问卷...')}`)
   
   try {
     const interviews = Array.from(selectedAgents.value).map(idx => ({
@@ -864,25 +865,25 @@ const submitSurvey = async () => {
       for (const interview of interviews) {
         const agentIdx = interview.agent_id
         const agent = profiles.value[agentIdx]
-        
+
         // Prefer reddit platform reply, then twitter
-        let responseContent = 'No response'
-        
+        let responseContent = tr('No response', '无响应')
+
         if (typeof resultsDict === 'object' && !Array.isArray(resultsDict)) {
           const redditKey = `reddit_${agentIdx}`
           const twitterKey = `twitter_${agentIdx}`
           const agentResult = resultsDict[redditKey] || resultsDict[twitterKey]
           if (agentResult) {
-            responseContent = agentResult.response || agentResult.answer || 'No response'
+            responseContent = agentResult.response || agentResult.answer || tr('No response', '无响应')
           }
         } else if (Array.isArray(resultsDict)) {
           // Compatible with array format
           const matchedResult = resultsDict.find(r => r.agent_id === agentIdx)
           if (matchedResult) {
-            responseContent = matchedResult.response || matchedResult.answer || 'No response'
+            responseContent = matchedResult.response || matchedResult.answer || tr('No response', '无响应')
           }
         }
-        
+
         surveyResultsList.push({
           agent_id: agentIdx,
           agent_name: agent?.username || `Agent ${agentIdx}`,
@@ -891,14 +892,14 @@ const submitSurvey = async () => {
           answer: responseContent
         })
       }
-      
+
       surveyResults.value = surveyResultsList
-      addLog(`Received ${surveyResults.value.length} replies`)
+      addLog(`${tr('Received', '已收到')} ${surveyResults.value.length} ${tr('replies', '条回复')}`)
     } else {
-      throw new Error(res.error || 'Request failed')
+      throw new Error(res.error || tr('Request failed', '请求失败'))
     }
   } catch (err) {
-    addLog(`Survey send failed: ${err.message}`)
+    addLog(`${tr('Survey send failed', '问卷发送失败')}: ${err.message}`)
   } finally {
     isSurveying.value = false
   }
@@ -909,7 +910,7 @@ const loadReportData = async () => {
   if (!props.reportId) return
   
   try {
-    addLog(`Loading report data: ${props.reportId}`)
+    addLog(`${tr('Loading report data', '加载报告数据')}: ${props.reportId}`)
     
     // Get report info
     const reportRes = await getReport(props.reportId)
@@ -918,7 +919,7 @@ const loadReportData = async () => {
       await loadAgentLogs()
     }
   } catch (err) {
-    addLog(`Failed to load report: ${err.message}`)
+    addLog(`${tr('Failed to load report', '加载报告失败')}: ${err.message}`)
   }
 }
 
@@ -940,10 +941,10 @@ const loadAgentLogs = async () => {
         }
       })
       
-      addLog('Report data loaded')
+      addLog(tr('Report data loaded', '报告数据已加载'))
     }
   } catch (err) {
-    addLog(`Failed to load report logs: ${err.message}`)
+    addLog(`${tr('Failed to load report logs', '加载报告日志失败')}: ${err.message}`)
   }
 }
 
@@ -954,10 +955,10 @@ const loadProfiles = async () => {
     const res = await getSimulationProfilesRealtime(props.simulationId, 'reddit')
     if (res.success && res.data) {
       profiles.value = res.data.profiles || []
-      addLog(`Loaded ${profiles.value.length} simulated individuals`)
+      addLog(`${tr('Loaded', '已加载')} ${profiles.value.length} ${tr('simulated individuals', '个模拟个体')}`)
     }
   } catch (err) {
-    addLog(`Failed to load simulated individuals: ${err.message}`)
+    addLog(`${tr('Failed to load simulated individuals', '加载模拟个体失败')}: ${err.message}`)
   }
 }
 
@@ -971,7 +972,7 @@ const handleClickOutside = (e) => {
 
 // Lifecycle
 onMounted(() => {
-  addLog('Step 5 Deep Interaction initializing')
+  addLog(tr('Step 5 Deep Interaction initializing', '步骤 5 深度交互初始化中'))
   loadReportData()
   loadProfiles()
   document.addEventListener('click', handleClickOutside)

--- a/frontend/src/components/TemplateGallery.vue
+++ b/frontend/src/components/TemplateGallery.vue
@@ -3,17 +3,17 @@
     <div class="gallery-header">
       <div class="header-left">
         <span class="header-icon">◈</span>
-        <span class="header-label">Quick Start Templates</span>
+        <span class="header-label">{{ $tr('Quick Start Templates', '快速启动模板') }}</span>
       </div>
-      <span class="header-meta">{{ templates.length }} scenarios ready to launch</span>
+      <span class="header-meta">{{ templates.length }} {{ $tr('scenarios ready to launch', '个可用情景') }}</span>
     </div>
 
     <div v-if="loading" class="gallery-loading">
-      Loading templates...
+      {{ $tr('Loading templates...', '加载模板中...') }}
     </div>
 
     <div v-else-if="templates.length === 0" class="gallery-empty">
-      No templates available.
+      {{ $tr('No templates available.', '暂无可用模板。') }}
     </div>
 
     <div v-else class="template-grid">
@@ -33,16 +33,16 @@
         <p class="card-desc">{{ template.description }}</p>
 
         <div class="card-meta">
-          <span class="meta-item" :title="`~${template.estimated_agents} agents`">
-            {{ template.estimated_agents }} agents
+          <span class="meta-item" :title="`~${template.estimated_agents} ` + $tr('agents', '个智能体')">
+            {{ template.estimated_agents }} {{ $tr('agents', '智能体') }}
           </span>
           <span class="meta-dot">·</span>
-          <span class="meta-item" :title="`~${template.estimated_rounds} rounds`">
-            {{ template.estimated_rounds }} rounds
+          <span class="meta-item" :title="`~${template.estimated_rounds} ` + $tr('rounds', '轮次')">
+            {{ template.estimated_rounds }} {{ $tr('rounds', '轮次') }}
           </span>
           <span class="meta-dot">·</span>
           <span class="meta-item difficulty" :class="template.difficulty">
-            {{ template.difficulty }}
+            {{ template.difficulty === 'easy' ? $tr('easy', '简单') : template.difficulty === 'medium' ? $tr('medium', '中等') : template.difficulty === 'hard' ? $tr('hard', '困难') : template.difficulty }}
           </span>
         </div>
 
@@ -51,16 +51,16 @@
           <span
             v-if="template.has_counterfactuals"
             class="platform-badge platform-badge--cf"
-            :title="`${template.counterfactual_count} preset counterfactual branches`"
+            :title="`${template.counterfactual_count} ` + $tr('preset counterfactual branches', '个预设反事实分支')"
           >
-            ⤷ {{ template.counterfactual_count }} branches
+            ⤷ {{ template.counterfactual_count }} {{ $tr('branches', '分支') }}
           </span>
           <span
             v-if="template.has_oracle_tools"
             class="platform-badge platform-badge--oracle"
-            :title="`${template.oracle_tool_count} FeedOracle tools declared`"
+            :title="`${template.oracle_tool_count} ` + $tr('FeedOracle tools declared', '个 FeedOracle 工具已声明')"
           >
-            ◎ live data
+            ◎ {{ $tr('live data', '实时数据') }}
           </span>
         </div>
 
@@ -69,8 +69,8 @@
           class="oracle-toggle"
           :class="{ disabled: !capabilities.oracle_seed_enabled }"
           :title="capabilities.oracle_seed_enabled
-            ? 'Dispatch this template\'s oracle_tools against FeedOracle MCP before ingest.'
-            : 'Oracle seeds disabled server-side. Set ORACLE_SEED_ENABLED=true in .env to enable.'"
+            ? $tr(`Dispatch this template's oracle_tools against FeedOracle MCP before ingest.`, '在注入前调度此模板的 oracle_tools 对接 FeedOracle MCP。')
+            : $tr('Oracle seeds disabled server-side. Set ORACLE_SEED_ENABLED=true in .env to enable.', '服务器已禁用 Oracle 种子。请在 .env 中设置 ORACLE_SEED_ENABLED=true 启用。')"
           @click.stop
         >
           <input
@@ -79,7 +79,7 @@
             :disabled="!capabilities.oracle_seed_enabled"
             @change="toggleOracleOpt(template.id, $event.target.checked)"
           />
-          <span>Use live oracle data</span>
+          <span>{{ $tr('Use live oracle data', '使用实时 oracle 数据') }}</span>
         </label>
 
         <button
@@ -87,9 +87,9 @@
           :disabled="launchingId === template.id"
           @click.stop="launchTemplate(template)"
         >
-          <span v-if="launchingId === template.id">Loading...</span>
-          <span v-else-if="oracleOptIn[template.id] && capabilities.oracle_seed_enabled">Launch (live) →</span>
-          <span v-else>Launch →</span>
+          <span v-if="launchingId === template.id">{{ $tr('Loading...', '加载中...') }}</span>
+          <span v-else-if="oracleOptIn[template.id] && capabilities.oracle_seed_enabled">{{ $tr('Launch (live) →', '启动(实时)→') }}</span>
+          <span v-else>{{ $tr('Launch →', '启动 →') }}</span>
         </button>
       </div>
     </div>

--- a/frontend/src/components/TrendingTopics.vue
+++ b/frontend/src/components/TrendingTopics.vue
@@ -2,21 +2,21 @@
   <div v-if="shouldRender" class="tt-wrap">
     <div class="tt-head">
       <span class="tt-label">
-        <span class="tt-dot">◉</span> What's Trending
+        <span class="tt-dot">◉</span> {{ $tr(`What's Trending`, '热门话题') }}
         <span class="tt-sub">{{ statusLine }}</span>
       </span>
       <button
         v-if="!loading"
         class="tt-refresh"
         type="button"
-        title="Refresh feeds"
+        :title="$tr('Refresh feeds', '刷新源')"
         @click="refresh"
       >↻</button>
     </div>
 
     <div v-if="loading && items.length === 0" class="tt-loading">
       <span class="tt-spinner"></span>
-      Pulling current headlines from public feeds…
+      {{ $tr('Pulling current headlines from public feeds…', '正在从公共源拉取最新头条…') }}
     </div>
 
     <div v-else-if="items.length > 0" class="tt-grid">
@@ -37,7 +37,7 @@
         </div>
         <div class="tt-title">{{ item.title }}</div>
         <div class="tt-cta">
-          <span class="tt-cta-text">Simulate</span>
+          <span class="tt-cta-text">{{ $tr('Simulate', '模拟') }}</span>
           <span class="tt-cta-arrow">→</span>
         </div>
       </button>
@@ -63,6 +63,7 @@
 
 import { computed, onMounted, ref } from 'vue'
 import { getTrendingTopics } from '../api/simulation'
+import { tr } from '../i18n'
 
 const props = defineProps({
   // When true, the parent has an active fetch underway and we should
@@ -84,10 +85,10 @@ const shouldRender = computed(() => {
 })
 
 const statusLine = computed(() => {
-  if (loading.value) return '// fetching…'
+  if (loading.value) return tr('// fetching…', '// 抓取中…')
   if (!fetchedAt.value) return ''
   const ago = relativeTime(fetchedAt.value)
-  return cached.value ? `// cached · refreshed ${ago}` : `// refreshed ${ago}`
+  return cached.value ? `// ${tr('cached · refreshed', '已缓存 · 刷新于')} ${ago}` : `// ${tr('refreshed', '刷新于')} ${ago}`
 })
 
 const relativeTime = (iso) => {
@@ -95,13 +96,13 @@ const relativeTime = (iso) => {
   const t = Date.parse(iso)
   if (Number.isNaN(t)) return ''
   const diffSec = Math.max(0, Math.floor((Date.now() - t) / 1000))
-  if (diffSec < 60) return 'just now'
+  if (diffSec < 60) return tr('just now', '刚刚')
   const diffMin = Math.floor(diffSec / 60)
-  if (diffMin < 60) return `${diffMin}m ago`
+  if (diffMin < 60) return `${diffMin}${tr('m ago', ' 分钟前')}`
   const diffHr = Math.floor(diffMin / 60)
-  if (diffHr < 24) return `${diffHr}h ago`
+  if (diffHr < 24) return `${diffHr}${tr('h ago', ' 小时前')}`
   const diffDay = Math.floor(diffHr / 24)
-  return `${diffDay}d ago`
+  return `${diffDay}${tr('d ago', ' 天前')}`
 }
 
 const load = async ({ force = false } = {}) => {

--- a/frontend/src/components/WhatIfPanel.vue
+++ b/frontend/src/components/WhatIfPanel.vue
@@ -4,54 +4,53 @@
     <div class="wi-header">
       <div class="wi-title">
         <span class="wi-icon">◐</span>
-        <span class="wi-label">WHAT IF? — COUNTERFACTUAL</span>
+        <span class="wi-label">{{ $tr('WHAT IF? — COUNTERFACTUAL', '假设性 — 反事实') }}</span>
       </div>
       <div class="wi-header-actions">
         <button
           class="wi-export-btn"
           :disabled="!hasChartData || exporting || !copySupported"
-          :title="copySupported ? 'Copy chart as PNG (with MiroShark watermark)' : 'Image copy not supported in this browser'"
+          :title="copySupported ? $tr('Copy chart as PNG (with MiroShark watermark)', '复制图表为 PNG(含 MiroShark 水印)') : $tr('Image copy not supported in this browser', '此浏览器不支持图像复制')"
           @click="copyChart"
         >
-          {{ copiedFlash ? 'Copied' : 'Copy' }}
+          {{ copiedFlash ? $tr('Copied', '已复制') : $tr('Copy', '复制') }}
         </button>
         <button
           class="wi-export-btn"
           :disabled="!hasChartData || exporting"
           @click="downloadChart"
-          title="Download chart as PNG (with MiroShark watermark)"
+          :title="$tr('Download chart as PNG (with MiroShark watermark)', '下载图表为 PNG(含 MiroShark 水印)')"
         >
-          Download ↓
+          {{ $tr('Download ↓', '下载 ↓') }}
         </button>
       </div>
     </div>
 
     <div class="wi-hint">
-      Pick up to {{ MAX_PICKS }} agents to remove, then recompute to see how
-      consensus would have shifted. Uses existing trajectory data — no re-run.
+      {{ $tr('Pick up to', '最多挑选') }} {{ MAX_PICKS }} {{ $tr('agents to remove, then recompute to see how consensus would have shifted. Uses existing trajectory data — no re-run.', '个智能体进行移除,然后重新计算以查看共识将如何变化。使用现有轨迹数据 — 无需重新运行。') }}
     </div>
 
     <!-- Loading agents -->
     <div v-if="agentsLoading" class="wi-state">
       <div class="pulse-ring"></div>
-      <span>Loading agents...</span>
+      <span>{{ $tr('Loading agents...', '加载智能体中...') }}</span>
     </div>
 
     <!-- No agents -->
     <div v-else-if="!agents.length" class="wi-state">
-      <span>No influence data yet — run the simulation first.</span>
+      <span>{{ $tr('No influence data yet — run the simulation first.', '暂无影响力数据 — 请先运行模拟。') }}</span>
     </div>
 
     <template v-else>
       <!-- Agent picker row -->
       <div class="wi-picker">
         <div class="wi-picker-header">
-          <span class="wi-picker-title">Top agents by influence</span>
+          <span class="wi-picker-title">{{ $tr('Top agents by influence', '影响力排名靠前的智能体') }}</span>
           <button
             v-if="selectedNames.length"
             class="wi-clear"
             @click="clearSelection"
-          >Clear ({{ selectedNames.length }})</button>
+          >{{ $tr('Clear', '清除') }} ({{ selectedNames.length }})</button>
         </div>
         <div class="wi-agent-grid">
           <label
@@ -82,7 +81,7 @@
             @click="compute"
           >
             <span v-if="computing" class="wi-spinner"></span>
-            {{ computing ? 'Recomputing...' : 'Recompute counterfactual' }}
+            {{ computing ? $tr('Recomputing...', '重新计算中...') : $tr('Recompute counterfactual', '重新计算反事实') }}
           </button>
         </div>
       </div>
@@ -166,7 +165,7 @@
                 :x="xS(origData.consensus_round) + 4" :y="MT + 10"
                 fill="rgba(10,10,10,0.45)" font-size="9"
                 font-family="'Space Mono', monospace"
-              >orig r{{ origData.consensus_round }}</text>
+              >{{ $tr('orig r', '原 r') }}{{ origData.consensus_round }}</text>
             </g>
             <g v-if="cfData?.consensus_round != null && cfData.consensus_round !== origData?.consensus_round">
               <line
@@ -179,7 +178,7 @@
                 :x="xS(cfData.consensus_round) + 4" :y="MT + 22"
                 fill="#43C165" font-size="9"
                 font-family="'Space Mono', monospace"
-              >cf r{{ cfData.consensus_round }}</text>
+              >{{ $tr('cf r', '反 r') }}{{ cfData.consensus_round }}</text>
             </g>
 
             <!-- X axis -->
@@ -194,17 +193,17 @@
               :x="ML + (W - ML - MR) / 2" :y="H - 2"
               fill="rgba(10,10,10,0.3)" font-size="9"
               font-family="'Space Mono', monospace" text-anchor="middle"
-            >Round — bullish %</text>
+            >{{ $tr('Round — bullish %', '轮次 — 看涨 %') }}</text>
           </svg>
 
           <div class="wi-legend">
             <span class="wi-legend-item">
               <span class="wi-legend-swatch orig"></span>
-              Original ({{ origData?.agent_count ?? '–' }} agents)
+              {{ $tr('Original', '原始') }} ({{ origData?.agent_count ?? '–' }} {{ $tr('agents', '智能体') }})
             </span>
             <span class="wi-legend-item">
               <span class="wi-legend-swatch cf"></span>
-              Counterfactual ({{ cfData?.agent_count ?? '–' }} agents)
+              {{ $tr('Counterfactual', '反事实') }} ({{ cfData?.agent_count ?? '–' }} {{ $tr('agents', '智能体') }})
             </span>
           </div>
         </div>
@@ -212,7 +211,7 @@
         <!-- Impact summary -->
         <div class="wi-impact">
           <div class="wi-impact-row">
-            <span class="wi-impact-label">Final bullish share</span>
+            <span class="wi-impact-label">{{ $tr('Final bullish share', '最终看涨占比') }}</span>
             <span class="wi-impact-values">
               <span class="wi-val orig">{{ fmtPct(origData?.final_bullish_pct) }}</span>
               <span class="wi-arrow">→</span>
@@ -221,11 +220,11 @@
                 v-if="result?.delta_final_bullish != null"
                 class="wi-delta"
                 :class="deltaClass(result.delta_final_bullish)"
-              >{{ fmtDelta(result.delta_final_bullish) }} pts</span>
+              >{{ fmtDelta(result.delta_final_bullish) }} {{ $tr('pts', '点') }}</span>
             </span>
           </div>
           <div class="wi-impact-row">
-            <span class="wi-impact-label">Consensus round</span>
+            <span class="wi-impact-label">{{ $tr('Consensus round', '共识轮次') }}</span>
             <span class="wi-impact-values">
               <span class="wi-val orig">{{ fmtRound(origData?.consensus_round) }}</span>
               <span class="wi-arrow">→</span>
@@ -234,20 +233,20 @@
                 v-if="result?.delta_consensus_round != null"
                 class="wi-delta"
                 :class="deltaClass(result.delta_consensus_round, true)"
-              >{{ fmtDelta(result.delta_consensus_round) }} rounds</span>
+              >{{ fmtDelta(result.delta_consensus_round) }} {{ $tr('rounds', '轮次') }}</span>
             </span>
           </div>
           <div v-if="result?.impact" class="wi-impact-badge-row">
             <span
               class="wi-impact-badge"
               :class="'impact-' + result.impact"
-            >{{ impactLabel(result.impact) }} influence</span>
+            >{{ impactLabel(result.impact) }} {{ $tr('influence', '影响力') }}</span>
           </div>
           <div v-if="result?.summary" class="wi-summary">
             {{ result.summary }}
           </div>
           <div v-if="result?.excluded_unresolved?.length" class="wi-warn">
-            Couldn't match: {{ result.excluded_unresolved.join(', ') }}
+            {{ $tr(`Couldn't match:`, '未能匹配:') }} {{ result.excluded_unresolved.join(', ') }}
           </div>
         </div>
       </div>
@@ -265,6 +264,7 @@ import {
   canCopyImageToClipboard,
   buildTitledHeader,
 } from '../utils/chartExport'
+import { tr } from '../i18n'
 
 const props = defineProps({
   simulationId: { type: String, required: true },
@@ -362,7 +362,7 @@ const cfEnd = computed(() => {
 })
 
 const fmtPct = (v) => (v == null ? '–' : `${v}%`)
-const fmtRound = (v) => (v == null ? 'no consensus' : `r${v}`)
+const fmtRound = (v) => (v == null ? tr('no consensus', '未达成共识') : `r${v}`)
 const fmtDelta = (v) => {
   if (v == null) return '–'
   const sign = v > 0 ? '+' : ''
@@ -377,9 +377,9 @@ const deltaClass = (v, invert = false) => {
   return 'neutral'
 }
 const impactLabel = (kind) => {
-  if (kind === 'strong') return 'Strong'
-  if (kind === 'moderate') return 'Moderate'
-  return 'Minimal'
+  if (kind === 'strong') return tr('Strong', '强')
+  if (kind === 'moderate') return tr('Moderate', '中等')
+  return tr('Minimal', '微小')
 }
 
 const loadAgents = async () => {
@@ -423,12 +423,12 @@ const compute = async () => {
     if (res?.success && res.data) {
       result.value = res.data
     } else if (res?.success && !res.data) {
-      error.value = res.message || 'No trajectory data available for this simulation.'
+      error.value = res.message || tr('No trajectory data available for this simulation.', '此模拟暂无轨迹数据。')
     } else {
-      error.value = res?.error || 'Failed to compute counterfactual.'
+      error.value = res?.error || tr('Failed to compute counterfactual.', '反事实计算失败。')
     }
   } catch (err) {
-    error.value = err?.message || 'Failed to compute counterfactual.'
+    error.value = err?.message || tr('Failed to compute counterfactual.', '反事实计算失败。')
   } finally {
     computing.value = false
   }
@@ -441,13 +441,13 @@ const _buildExportCanvas = () => {
     throw new Error('No chart to export')
   }
   const removed = selectedNames.value.length
-    ? `Removed ${selectedNames.value.join(', ')}`
-    : 'Counterfactual drift'
+    ? `${tr('Removed', '已移除')} ${selectedNames.value.join(', ')}`
+    : tr('Counterfactual drift', '反事实漂移')
   const deltaStr = result.value?.delta_final_bullish != null
-    ? `${result.value.delta_final_bullish >= 0 ? '+' : ''}${result.value.delta_final_bullish} pts on bullish share`
+    ? `${result.value.delta_final_bullish >= 0 ? '+' : ''}${result.value.delta_final_bullish} ${tr('pts on bullish share', '点看涨占比')}`
     : null
   const { drawHeader, headerHeight } = buildTitledHeader({
-    title: `What If? — ${removed}`,
+    title: `${tr('What If?', '假设性?')} — ${removed}`,
     subtitle: deltaStr,
     width: W,
   })

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,0 +1,54 @@
+import { ref, computed } from 'vue'
+
+const STORAGE_KEY = 'miroshark.locale'
+const SUPPORTED = ['en', 'zh-CN']
+const DEFAULT_LOCALE = 'en'
+
+function readInitial() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved && SUPPORTED.includes(saved)) return saved
+  } catch (_) {}
+  return DEFAULT_LOCALE
+}
+
+export const locale = ref(readInitial())
+
+export const isZh = computed(() => locale.value === 'zh-CN')
+
+if (typeof document !== 'undefined') {
+  document.documentElement.lang = locale.value
+}
+
+export function setLocale(next) {
+  if (!SUPPORTED.includes(next)) return
+  locale.value = next
+  try { localStorage.setItem(STORAGE_KEY, next) } catch (_) {}
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = next
+  }
+}
+
+export function toggleLocale() {
+  setLocale(locale.value === 'zh-CN' ? 'en' : 'zh-CN')
+}
+
+export function tr(en, zh) {
+  if (locale.value === 'zh-CN' && zh != null && zh !== '') return zh
+  return en
+}
+
+export function useI18n() {
+  return { locale, isZh, setLocale, toggleLocale, tr }
+}
+
+export const i18nPlugin = {
+  install(app) {
+    app.config.globalProperties.$tr = tr
+    app.config.globalProperties.$isZh = () => locale.value === 'zh-CN'
+    app.config.globalProperties.$setLocale = setLocale
+    app.config.globalProperties.$toggleLocale = toggleLocale
+  },
+}
+
+export const SUPPORTED_LOCALES = SUPPORTED

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,10 +1,12 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import { i18nPlugin } from './i18n'
 
 const app = createApp(App)
 
 app.use(router)
+app.use(i18nPlugin)
 
 app.mount('#app')
 

--- a/frontend/src/views/ComparisonView.vue
+++ b/frontend/src/views/ComparisonView.vue
@@ -6,33 +6,34 @@
         <div class="brand" @click="router.push('/')">MIROSHARK</div>
       </div>
       <div class="header-center">
-        <span class="page-tag">Simulation Comparison</span>
+        <span class="page-tag">{{ $tr('Simulation Comparison', '模拟对比') }}</span>
       </div>
       <div class="header-right">
         <button v-if="data" class="download-btn" @click="downloadComparison">
-          ↓ Export JSON
+          {{ $tr('↓ Export JSON', '↓ 导出 JSON') }}
         </button>
+        <LocaleToggle />
       </div>
     </header>
 
     <!-- Simulation Selector -->
     <div class="selector-bar">
       <div class="selector-group">
-        <label class="selector-label">Simulation A</label>
+        <label class="selector-label">{{ $tr('Simulation A', '模拟 A') }}</label>
         <select class="sim-select" v-model="selectedId1" @change="onSelectionChange">
-          <option value="">Select simulation…</option>
+          <option value="">{{ $tr('Select simulation…', '选择模拟…') }}</option>
           <option v-for="s in simulations" :key="s.simulation_id" :value="s.simulation_id">
             {{ formatId(s.simulation_id) }} — {{ s.status }}
           </option>
         </select>
       </div>
 
-      <div class="vs-badge">VS</div>
+      <div class="vs-badge">{{ $tr('VS', '对比') }}</div>
 
       <div class="selector-group">
-        <label class="selector-label">Simulation B</label>
+        <label class="selector-label">{{ $tr('Simulation B', '模拟 B') }}</label>
         <select class="sim-select" v-model="selectedId2" @change="onSelectionChange">
-          <option value="">Select simulation…</option>
+          <option value="">{{ $tr('Select simulation…', '选择模拟…') }}</option>
           <option v-for="s in simulations" :key="s.simulation_id" :value="s.simulation_id">
             {{ formatId(s.simulation_id) }} — {{ s.status }}
           </option>
@@ -45,7 +46,7 @@
         @click="runComparison"
       >
         <span v-if="loading" class="loading-spinner-small"></span>
-        {{ loading ? 'Comparing…' : 'Compare' }}
+        {{ loading ? $tr('Comparing…', '对比中…') : $tr('Compare', '对比') }}
       </button>
     </div>
 
@@ -55,7 +56,7 @@
     <!-- Loading -->
     <div v-else-if="loading" class="cmp-loading">
       <div class="loading-ring"></div>
-      <span>Running comparison…</span>
+      <span>{{ $tr('Running comparison…', '正在对比…') }}</span>
     </div>
 
     <!-- Results -->
@@ -63,7 +64,7 @@
 
       <!-- Divergence Banner -->
       <div class="divergence-banner">
-        <div class="divergence-label">Outcome Divergence Score</div>
+        <div class="divergence-label">{{ $tr('Outcome Divergence Score', '结果分歧度') }}</div>
         <div class="divergence-score" :class="divergenceClass">
           {{ (data.divergence_score * 100).toFixed(1) }}%
         </div>
@@ -77,15 +78,15 @@
           <div class="metric-grid">
             <div class="metric-item">
               <span class="metric-val">{{ data.sim1.profiles_count }}</span>
-              <span class="metric-lbl">Agents</span>
+              <span class="metric-lbl">{{ $tr('Agents', '智能体') }}</span>
             </div>
             <div class="metric-item">
               <span class="metric-val">{{ data.sim1.total_rounds }}</span>
-              <span class="metric-lbl">Rounds</span>
+              <span class="metric-lbl">{{ $tr('Rounds', '轮次') }}</span>
             </div>
             <div class="metric-item">
               <span class="metric-val">{{ data.sim1.total_actions.toLocaleString() }}</span>
-              <span class="metric-lbl">Actions</span>
+              <span class="metric-lbl">{{ $tr('Actions', '动作') }}</span>
             </div>
           </div>
         </div>
@@ -95,15 +96,15 @@
           <div class="metric-grid">
             <div class="metric-item">
               <span class="metric-val">{{ data.sim2.profiles_count }}</span>
-              <span class="metric-lbl">Agents</span>
+              <span class="metric-lbl">{{ $tr('Agents', '智能体') }}</span>
             </div>
             <div class="metric-item">
               <span class="metric-val">{{ data.sim2.total_rounds }}</span>
-              <span class="metric-lbl">Rounds</span>
+              <span class="metric-lbl">{{ $tr('Rounds', '轮次') }}</span>
             </div>
             <div class="metric-item">
               <span class="metric-val">{{ data.sim2.total_actions.toLocaleString() }}</span>
-              <span class="metric-lbl">Actions</span>
+              <span class="metric-lbl">{{ $tr('Actions', '动作') }}</span>
             </div>
           </div>
         </div>
@@ -114,7 +115,7 @@
 
         <!-- Influence Leaderboard Comparison -->
         <div class="cmp-section full-width">
-          <div class="section-title">Influence Leaderboard</div>
+          <div class="section-title">{{ $tr('Influence Leaderboard', '影响力榜单') }}</div>
           <div class="leaderboard-compare">
             <div class="lb-col">
               <div class="lb-header sim-a-color">{{ formatId(data.id1) }}</div>
@@ -132,7 +133,7 @@
                   :title="getRankDeltaTitle(agent.agent_name, 'sim1')"
                 >{{ getRankDeltaLabel(agent.agent_name, 'sim1') }}</span>
               </div>
-              <div v-if="!data.sim1.influence.length" class="lb-empty">No data</div>
+              <div v-if="!data.sim1.influence.length" class="lb-empty">{{ $tr('No data', '无数据') }}</div>
             </div>
 
             <div class="lb-col">
@@ -151,14 +152,14 @@
                   :title="getRankDeltaTitle(agent.agent_name, 'sim2')"
                 >{{ getRankDeltaLabel(agent.agent_name, 'sim2') }}</span>
               </div>
-              <div v-if="!data.sim2.influence.length" class="lb-empty">No data</div>
+              <div v-if="!data.sim2.influence.length" class="lb-empty">{{ $tr('No data', '无数据') }}</div>
             </div>
           </div>
         </div>
 
         <!-- Activity Timeline Chart -->
         <div class="cmp-section full-width" v-if="data.sim1.timeline.length || data.sim2.timeline.length">
-          <div class="section-title">Activity per Round</div>
+          <div class="section-title">{{ $tr('Activity per Round', '每轮活动量') }}</div>
           <div class="chart-container">
             <svg ref="chartSvg" class="activity-chart" :viewBox="`0 0 ${chartW} ${chartH}`" preserveAspectRatio="none">
               <!-- Grid lines -->
@@ -210,7 +211,7 @@
             <div class="chart-legend">
               <span class="legend-item sim-a-color">● {{ formatId(data.id1) }}</span>
               <span class="legend-item sim-b-color">● {{ formatId(data.id2) }}</span>
-              <span class="legend-label">Total actions / round</span>
+              <span class="legend-label">{{ $tr('Total actions / round', '每轮动作总数') }}</span>
             </div>
           </div>
         </div>
@@ -220,26 +221,26 @@
           class="cmp-section full-width"
           v-if="data.sim1.markets.length || data.sim2.markets.length"
         >
-          <div class="section-title">Prediction Market Final Prices</div>
+          <div class="section-title">{{ $tr('Prediction Market Final Prices', '预测市场最终价格') }}</div>
           <div class="markets-compare">
             <div class="market-col">
               <div class="market-col-header sim-a-color">{{ formatId(data.id1) }}</div>
               <div v-for="m in data.sim1.markets" :key="m.market_id" class="market-row">
-                <span class="market-id">Market {{ m.market_id }}</span>
+                <span class="market-id">{{ $tr('Market', '市场') }} {{ m.market_id }}</span>
                 <div class="market-bar-wrap">
                   <div class="market-bar" :style="{ width: (m.price_yes * 100) + '%', background: '#FF6B1A' }"></div>
                 </div>
-                <span class="market-price">{{ (m.price_yes * 100).toFixed(1) }}% YES</span>
+                <span class="market-price">{{ (m.price_yes * 100).toFixed(1) }}% {{ $tr('YES', '是') }}</span>
               </div>
             </div>
             <div class="market-col">
               <div class="market-col-header sim-b-color">{{ formatId(data.id2) }}</div>
               <div v-for="m in data.sim2.markets" :key="m.market_id" class="market-row">
-                <span class="market-id">Market {{ m.market_id }}</span>
+                <span class="market-id">{{ $tr('Market', '市场') }} {{ m.market_id }}</span>
                 <div class="market-bar-wrap">
                   <div class="market-bar" :style="{ width: (m.price_yes * 100) + '%', background: '#43C165' }"></div>
                 </div>
-                <span class="market-price">{{ (m.price_yes * 100).toFixed(1) }}% YES</span>
+                <span class="market-price">{{ (m.price_yes * 100).toFixed(1) }}% {{ $tr('YES', '是') }}</span>
               </div>
             </div>
           </div>
@@ -250,7 +251,7 @@
 
     <!-- Empty State -->
     <div v-else-if="!loading && !error" class="cmp-empty">
-      <p>Select two simulations above and click Compare to see the diff.</p>
+      <p>{{ $tr('Select two simulations above and click Compare to see the diff.', '在上方选择两个模拟并点击对比以查看差异。') }}</p>
     </div>
   </div>
 </template>
@@ -259,6 +260,8 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { compareSimulations, listSimulations } from '../api/simulation'
+import LocaleToggle from '../components/LocaleToggle.vue'
+import { tr } from '../i18n'
 
 const router = useRouter()
 const route = useRoute()
@@ -314,10 +317,10 @@ const runComparison = async () => {
     if (res.data?.success) {
       data.value = res.data.data
     } else {
-      error.value = res.data?.error || 'Comparison failed'
+      error.value = res.data?.error || tr('Comparison failed', '对比失败')
     }
   } catch (err) {
-    error.value = err?.response?.data?.error || err.message || 'Comparison failed'
+    error.value = err?.response?.data?.error || err.message || tr('Comparison failed', '对比失败')
   } finally {
     loading.value = false
   }
@@ -339,9 +342,9 @@ const divergenceClass = computed(() => {
 const divergenceDescription = computed(() => {
   if (!data.value) return ''
   const s = data.value.divergence_score
-  if (s < 0.2) return 'Simulations produced very similar influence rankings — comparable outcomes.'
-  if (s < 0.5) return 'Moderate divergence — some agents shifted in relative influence between runs.'
-  return 'High divergence — the two simulations produced substantially different influence outcomes.'
+  if (s < 0.2) return tr('Simulations produced very similar influence rankings — comparable outcomes.', '两次模拟的影响力排名非常相似 — 结果可比。')
+  if (s < 0.5) return tr('Moderate divergence — some agents shifted in relative influence between runs.', '中等分歧 — 部分智能体在两次运行中相对影响力发生变化。')
+  return tr('High divergence — the two simulations produced substantially different influence outcomes.', '高度分歧 — 两次模拟产生了截然不同的影响力结果。')
 })
 
 // Rank delta helpers
@@ -366,9 +369,9 @@ const getRankDeltaClass = (name, simKey) => {
 
 const getRankDeltaTitle = (name, simKey) => {
   const label = getRankDeltaLabel(name, simKey)
-  if (label === '—') return 'Not in other simulation\'s top 10'
-  if (label === '=') return 'Same rank in both simulations'
-  return `Rank difference: ${label.replace(/[▲▼]/, '')}`
+  if (label === '—') return tr('Not in other simulation\'s top 10', '不在另一次模拟的前 10 名中')
+  if (label === '=') return tr('Same rank in both simulations', '两次模拟中排名相同')
+  return `${tr('Rank difference:', '排名差:')} ${label.replace(/[▲▼]/, '')}`
 }
 
 // Chart point computation — shared Y-axis scale across both timelines

--- a/frontend/src/views/EmbedView.vue
+++ b/frontend/src/views/EmbedView.vue
@@ -5,13 +5,13 @@
   >
     <div v-if="loading" class="embed-state">
       <div class="embed-spinner"></div>
-      <span>Loading simulation…</span>
+      <span>{{ $tr('Loading simulation…', '加载模拟中…') }}</span>
     </div>
 
     <div v-else-if="error" class="embed-state embed-error">
       <span>{{ error }}</span>
       <a class="embed-footer-link" :href="simulationUrl" target="_blank" rel="noopener">
-        Open on MiroShark ↗
+        {{ $tr('Open on MiroShark ↗', '在 MiroShark 中打开 ↗') }}
       </a>
     </div>
 
@@ -21,9 +21,9 @@
         <div class="embed-meta">
           <span class="embed-pill status" :class="statusClass">{{ statusLabel }}</span>
           <span v-if="hasRounds" class="embed-pill">
-            Round {{ summary.current_round }}/{{ summary.total_rounds || summary.current_round }}
+            {{ $tr('Round', '轮次') }} {{ summary.current_round }}/{{ summary.total_rounds || summary.current_round }}
           </span>
-          <span class="embed-pill">{{ summary.profiles_count || 0 }} agents</span>
+          <span class="embed-pill">{{ summary.profiles_count || 0 }} {{ $tr('agents', '智能体') }}</span>
           <span v-if="summary.quality && summary.quality.health" class="embed-pill quality" :class="qualityClass">
             {{ summary.quality.health }}
           </span>
@@ -53,21 +53,21 @@
           />
         </svg>
         <div v-else class="embed-empty-chart">
-          <span>No belief trajectory yet</span>
+          <span>{{ $tr('No belief trajectory yet', '暂无信念轨迹') }}</span>
         </div>
 
         <div v-if="hasBelief && !chartOnly" class="embed-final-row">
           <span class="final-chip bullish">
             <span class="chip-dot"></span>
-            Bullish {{ finalBullish }}%
+            {{ $tr('Bullish', '看涨') }} {{ finalBullish }}%
           </span>
           <span class="final-chip neutral">
             <span class="chip-dot"></span>
-            Neutral {{ finalNeutral }}%
+            {{ $tr('Neutral', '中立') }} {{ finalNeutral }}%
           </span>
           <span class="final-chip bearish">
             <span class="chip-dot"></span>
-            Bearish {{ finalBearish }}%
+            {{ $tr('Bearish', '看跌') }} {{ finalBearish }}%
           </span>
         </div>
       </div>
@@ -80,7 +80,7 @@
           </span>
         </div>
         <a class="embed-footer-link" :href="simulationUrl" target="_blank" rel="noopener">
-          Powered by <strong>MiroShark</strong> ↗
+          {{ $tr('Powered by', '技术支持:') }} <strong>MiroShark</strong> ↗
         </a>
       </footer>
     </template>
@@ -91,6 +91,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { getEmbedSummary } from '../api/simulation'
+import { tr } from '../i18n'
 
 const props = defineProps({
   simulationId: {
@@ -115,7 +116,7 @@ const summary = ref(null)
 
 const scenarioTitle = computed(() => {
   const raw = (summary.value?.scenario || '').trim()
-  if (!raw) return 'Untitled simulation'
+  if (!raw) return tr('Untitled simulation', '未命名模拟')
   return raw.length > 140 ? raw.slice(0, 140).trimEnd() + '…' : raw
 })
 
@@ -125,12 +126,12 @@ const simulationUrl = computed(() => {
 })
 
 const statusLabel = computed(() => {
-  if (!summary.value) return 'Unknown'
+  if (!summary.value) return tr('Unknown', '未知')
   const s = (summary.value.runner_status || summary.value.status || '').toLowerCase()
-  if (s === 'completed' || s === 'finished' || s === 'stopped') return 'Completed'
-  if (s === 'running' || s === 'in_progress') return 'Running'
-  if (s === 'error' || s === 'failed') return 'Failed'
-  return s ? s.charAt(0).toUpperCase() + s.slice(1) : 'Ready'
+  if (s === 'completed' || s === 'finished' || s === 'stopped') return tr('Completed', '已完成')
+  if (s === 'running' || s === 'in_progress') return tr('Running', '运行中')
+  if (s === 'error' || s === 'failed') return tr('Failed', '失败')
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : tr('Ready', '就绪')
 })
 
 const statusClass = computed(() => {
@@ -159,18 +160,18 @@ const qualityClass = computed(() => {
 const consensusLabel = computed(() => {
   const b = summary.value?.belief
   if (!b?.consensus_round) return ''
-  return `Consensus formed at round ${b.consensus_round} (${b.consensus_stance})`
+  return `${tr('Consensus formed at round', '共识形成于第')} ${b.consensus_round}${tr('', '轮')} (${b.consensus_stance})`
 })
 
 const resolutionLabel = computed(() => {
   const r = summary.value?.resolution
   if (!r) return ''
   if (r.accuracy_score !== null && r.accuracy_score !== undefined) {
-    if (r.accuracy_score >= 1.0) return `✓ Correct · Actual ${r.actual_outcome}`
-    if (r.accuracy_score <= 0.0) return `✗ Missed · Actual ${r.actual_outcome}`
-    return `~ Split · Actual ${r.actual_outcome}`
+    if (r.accuracy_score >= 1.0) return `✓ ${tr('Correct', '正确')} · ${tr('Actual', '实际')} ${r.actual_outcome}`
+    if (r.accuracy_score <= 0.0) return `✗ ${tr('Missed', '未中')} · ${tr('Actual', '实际')} ${r.actual_outcome}`
+    return `~ ${tr('Split', '部分')} · ${tr('Actual', '实际')} ${r.actual_outcome}`
   }
-  return `Actual ${r.actual_outcome}`
+  return `${tr('Actual', '实际')} ${r.actual_outcome}`
 })
 
 const resolutionClass = computed(() => {
@@ -182,8 +183,8 @@ const resolutionClass = computed(() => {
 })
 
 const chartAriaLabel = computed(() => {
-  if (!hasBelief.value) return 'No belief trajectory'
-  return `Belief drift across ${summary.value.belief.rounds.length} rounds`
+  if (!hasBelief.value) return tr('No belief trajectory', '无信念轨迹')
+  return `${tr('Belief drift across', '信念漂移历经')} ${summary.value.belief.rounds.length} ${tr('rounds', '轮次')}`
 })
 
 // Stacked area chart paths — stack order bullish (top), neutral (middle), bearish (bottom).
@@ -251,7 +252,7 @@ const isCompact = computed(() => {
 
 const fetchData = async () => {
   if (!simulationId.value) {
-    error.value = 'Missing simulation id'
+    error.value = tr('Missing simulation id', '缺少模拟 ID')
     loading.value = false
     return
   }
@@ -260,10 +261,10 @@ const fetchData = async () => {
     if (res?.success) {
       summary.value = res.data
     } else {
-      error.value = res?.error || 'Failed to load simulation'
+      error.value = res?.error || tr('Failed to load simulation', '加载模拟失败')
     }
   } catch (err) {
-    error.value = err?.response?.data?.error || err?.message || 'Failed to load simulation'
+    error.value = err?.response?.data?.error || err?.message || tr('Failed to load simulation', '加载模拟失败')
   } finally {
     loading.value = false
   }

--- a/frontend/src/views/ExploreView.vue
+++ b/frontend/src/views/ExploreView.vue
@@ -2,10 +2,10 @@
   <div class="explore-container">
     <!-- Top Navigation Bar (mirrors Home.vue nav for visual consistency) -->
     <nav class="navbar">
-      <router-link to="/" class="nav-brand" title="Back to home">MIROSHARK</router-link>
+      <router-link to="/" class="nav-brand" :title="$tr('Back to home', '返回首页')">MIROSHARK</router-link>
       <div class="nav-links">
-        <router-link to="/" class="nav-link" title="Back to home">
-          <span class="arrow">←</span> Home
+        <router-link to="/" class="nav-link" :title="$tr('Back to home', '返回首页')">
+          <span class="arrow">←</span> {{ $tr('Home', '首页') }}
         </router-link>
         <a
           href="https://github.com/aaronjmars/MiroShark"
@@ -15,6 +15,7 @@
         >
           GitHub <span class="arrow">↗</span>
         </a>
+        <LocaleToggle />
       </div>
     </nav>
 
@@ -22,38 +23,33 @@
       <!-- Header -->
       <header class="explore-header">
         <div class="tag-row">
-          <span class="orange-tag">{{ verifiedOnly ? '📍 Verified' : '◎ Explore' }}</span>
+          <span class="orange-tag">{{ verifiedOnly ? $tr('📍 Verified', '📍 已验证') : $tr('◎ Explore', '◎ 浏览') }}</span>
           <span class="meta-sep">·</span>
           <span class="meta-text">
-            {{ verifiedOnly ? 'Predictions that called real events' : 'Public simulation gallery' }}
+            {{ verifiedOnly ? $tr('Predictions that called real events', '预言已对应真实事件') : $tr('Public simulation gallery', '公开模拟图库') }}
           </span>
         </div>
-        <h1 class="page-title">{{ verifiedOnly ? 'Calls that landed.' : 'Simulations the community ran.' }}</h1>
+        <h1 class="page-title">{{ verifiedOnly ? $tr('Calls that landed.', '命中的预言。') : $tr('Simulations the community ran.', '社区运行的模拟。') }}</h1>
         <p class="page-subtitle">
           <template v-if="verifiedOnly">
-            Each card is a public MiroShark run whose operator marked the
-            real-world outcome. Hover the badge for the source link, open
-            one to see how the agent consensus formed, or fork it to test
-            the same agent population on a fresh scenario.
+            {{ $tr('Each card is a public MiroShark run whose operator marked the real-world outcome. Hover the badge for the source link, open one to see how the agent consensus formed, or fork it to test the same agent population on a fresh scenario.', '每张卡片都是一次由运营者标注了真实结果的公开 MiroShark 运行。将鼠标悬停在徽章上查看出处链接,点击查看智能体共识如何形成,或派生它以使用同一组智能体测试新的情景。') }}
           </template>
           <template v-else>
-            Every card is a real MiroShark run someone published. Open one to see
-            the full belief drift, agent network, and prediction outcome — or fork
-            it in one click and run your own variant with the same agent population.
+            {{ $tr("Every card is a real MiroShark run someone published. Open one to see the full belief drift, agent network, and prediction outcome — or fork it in one click and run your own variant with the same agent population.", '每张卡片都是有人发布的真实 MiroShark 运行。打开任一张可查看完整的信念漂移、智能体网络与预测结果 — 或一键派生,使用同一组智能体运行你自己的变体。') }}
           </template>
         </p>
         <div class="stats-row">
           <span class="stat-chip">
             <span class="stat-num">{{ loading ? '…' : total }}</span>
-            <span class="stat-label">{{ verifiedOnly ? 'verified' : 'published' }}</span>
+            <span class="stat-label">{{ verifiedOnly ? $tr('verified', '已验证') : $tr('published', '已发布') }}</span>
           </span>
           <span v-if="!verifiedOnly && !loading && items.length > 0" class="stat-chip">
             <span class="stat-num">{{ resolvedCount }}</span>
-            <span class="stat-label">resolved</span>
+            <span class="stat-label">{{ $tr('resolved', '已结算') }}</span>
           </span>
           <span v-if="!verifiedOnly && !loading && items.length > 0" class="stat-chip">
             <span class="stat-num">{{ verifiedCount }}</span>
-            <span class="stat-label">verified</span>
+            <span class="stat-label">{{ $tr('verified', '已验证') }}</span>
           </span>
 
           <!-- Verified filter chip — toggles a `?verified=1` fetch + the
@@ -63,10 +59,10 @@
             :class="{ 'filter-chip-active': verifiedFilter }"
             @click="toggleVerifiedFilter"
             :disabled="loading"
-            :title="verifiedFilter ? 'Show all public simulations' : 'Show only simulations with a recorded outcome'"
+            :title="verifiedFilter ? $tr('Show all public simulations', '显示全部公开模拟') : $tr('Show only simulations with a recorded outcome', '只显示已记录结果的模拟')"
           >
             <span class="filter-chip-icon">📍</span>
-            <span>Verified only</span>
+            <span>{{ $tr('Verified only', '仅已验证') }}</span>
           </button>
 
           <!-- RSS subscription chip — feed mirrors the active view
@@ -79,22 +75,22 @@
             rel="noopener"
             :title="
               verifiedFilter
-                ? 'Subscribe to verified-only Atom feed in Feedly / Readwise / Inoreader / NetNewsWire'
-                : 'Subscribe to all public simulations as an Atom feed in Feedly / Readwise / Inoreader / NetNewsWire'
+                ? $tr('Subscribe to verified-only Atom feed in Feedly / Readwise / Inoreader / NetNewsWire', '在 Feedly / Readwise / Inoreader / NetNewsWire 中订阅仅含已验证内容的 Atom 源')
+                : $tr('Subscribe to all public simulations as an Atom feed in Feedly / Readwise / Inoreader / NetNewsWire', '在 Feedly / Readwise / Inoreader / NetNewsWire 中以 Atom 源订阅全部公开模拟')
             "
           >
             <span class="filter-chip-icon">📡</span>
-            <span>Subscribe via RSS</span>
+            <span>{{ $tr('Subscribe via RSS', '通过 RSS 订阅') }}</span>
           </a>
 
           <button
             class="refresh-btn"
             @click="refresh"
             :disabled="loading"
-            title="Re-fetch the gallery"
+            :title="$tr('Re-fetch the gallery', '重新获取图库')"
           >
             <span v-if="loading">…</span>
-            <span v-else>↻ Refresh</span>
+            <span v-else>{{ $tr('↻ Refresh', '↻ 刷新') }}</span>
           </button>
         </div>
       </header>
@@ -109,34 +105,31 @@
       <!-- Error -->
       <div v-else-if="error" class="gallery-error">
         <div class="error-icon">⚠</div>
-        <div class="error-title">Couldn't load the gallery</div>
+        <div class="error-title">{{ $tr("Couldn't load the gallery", '无法加载图库') }}</div>
         <div class="error-msg">{{ error }}</div>
-        <button class="error-retry" @click="refresh">Try again</button>
+        <button class="error-retry" @click="refresh">{{ $tr('Try again', '重试') }}</button>
       </div>
 
       <!-- Empty -->
       <div v-else-if="items.length === 0" class="gallery-empty">
         <div class="empty-icon">{{ verifiedFilter ? '📍' : '◇' }}</div>
         <div class="empty-title">
-          {{ verifiedFilter ? 'No verified predictions yet.' : 'No public simulations yet.' }}
+          {{ verifiedFilter ? $tr('No verified predictions yet.', '暂无已验证的预言。') : $tr('No public simulations yet.', '暂无公开模拟。') }}
         </div>
         <div class="empty-msg">
           <template v-if="verifiedFilter">
-            Once an operator marks a public simulation's real-world outcome
-            from the Embed dialog, it shows up here. In the meantime, browse
-            every published run on
+            {{ $tr("Once an operator marks a public simulation's real-world outcome from the Embed dialog, it shows up here. In the meantime, browse every published run on", '当运营者从嵌入对话框中标记公开模拟的真实结果后,它会出现在这里。在此期间,可在以下位置浏览所有已发布的运行') }}
             <router-link to="/explore" class="inline-link">/explore</router-link>.
           </template>
           <template v-else>
-            Yours could be first. Run a simulation, click the share icon on the
-            result page, toggle "Public" — it'll appear here within 30 seconds.
+            {{ $tr(`Yours could be first. Run a simulation, click the share icon on the result page, toggle "Public" — it'll appear here within 30 seconds.`, '你的可能是第一个。运行一次模拟,在结果页点击分享图标,切换为「公开」 — 它会在 30 秒内出现在这里。') }}
           </template>
         </div>
         <router-link
           :to="verifiedFilter ? '/explore' : '/'"
           class="empty-cta"
         >
-          {{ verifiedFilter ? 'Browse all public sims →' : 'Run a simulation →' }}
+          {{ verifiedFilter ? $tr('Browse all public sims →', '浏览全部公开模拟 →') : $tr('Run a simulation →', '运行一次模拟 →') }}
         </router-link>
       </div>
 
@@ -157,7 +150,7 @@
           <router-link
             :to="{ name: 'SimulationRun', params: { simulationId: item.simulation_id } }"
             class="card-thumb-link"
-            :title="item.scenario || 'Open simulation'"
+            :title="item.scenario || $tr('Open simulation', '打开模拟')"
           >
             <img
               :src="shareCardSrc(item)"
@@ -172,7 +165,7 @@
           <!-- Body -->
           <div class="card-body">
             <h2 class="card-scenario" :title="item.scenario">
-              {{ item.scenario || '(untitled scenario)' }}
+              {{ item.scenario || $tr('(untitled scenario)', '(未命名情景)') }}
             </h2>
 
             <div class="card-pills">
@@ -194,7 +187,7 @@
                 v-if="item.quality_health"
                 class="pill"
                 :class="qualityPillClass(item.quality_health)"
-                :title="'Quality health: ' + item.quality_health"
+                :title="$tr('Quality health: ', '质量健康度:') + item.quality_health"
               >
                 ◉ {{ item.quality_health }}
               </span>
@@ -202,22 +195,22 @@
                 v-if="dominantStance(item)"
                 class="pill"
                 :class="stancePillClass(dominantStance(item).label)"
-                :title="'Final consensus: ' + stanceTooltip(item)"
+                :title="$tr('Final consensus: ', '最终共识:') + stanceTooltip(item)"
               >
                 {{ stanceGlyph(dominantStance(item).label) }}
-                {{ dominantStance(item).label }} {{ dominantStance(item).pct }}%
+                {{ stanceLabel(dominantStance(item).label) }} {{ dominantStance(item).pct }}%
               </span>
               <span
                 v-if="item.resolution_outcome"
                 class="pill pill-resolved"
-                :title="'Real-world outcome recorded: ' + item.resolution_outcome"
+                :title="$tr('Real-world outcome recorded: ', '真实结果已记录:') + item.resolution_outcome"
               >
-                ✓ Resolved · {{ item.resolution_outcome }}
+                ✓ {{ $tr('Resolved', '已结算') }} · {{ item.resolution_outcome }}
               </span>
               <span
                 v-else
                 class="pill pill-status"
-                :title="'Runner status: ' + item.runner_status"
+                :title="$tr('Runner status: ', '运行状态:') + item.runner_status"
               >
                 {{ formatStatus(item) }}
               </span>
@@ -244,12 +237,12 @@
 
             <div class="card-meta">
               <span class="meta-item">
-                <span class="meta-label">Agents</span>
+                <span class="meta-label">{{ $tr('Agents', '智能体') }}</span>
                 <span class="meta-val">{{ item.agent_count || 0 }}</span>
               </span>
               <span class="meta-sep">·</span>
               <span class="meta-item">
-                <span class="meta-label">Rounds</span>
+                <span class="meta-label">{{ $tr('Rounds', '轮次') }}</span>
                 <span class="meta-val">
                   {{ item.current_round || 0 }}<span v-if="item.total_rounds">/{{ item.total_rounds }}</span>
                 </span>
@@ -266,16 +259,16 @@
                 :to="{ name: 'SimulationRun', params: { simulationId: item.simulation_id } }"
                 class="action-btn action-view"
               >
-                Open →
+                {{ $tr('Open →', '打开 →') }}
               </router-link>
               <button
                 class="action-btn action-fork"
                 @click="forkAndOpen(item)"
                 :disabled="forkingId === item.simulation_id"
-                :title="'Copy this simulation\'s agents + config into a new run'"
+                :title="$tr(`Copy this simulation's agents + config into a new run`, '将此模拟的智能体与配置复制到一次新的运行')"
               >
-                <span v-if="forkingId === item.simulation_id">Forking…</span>
-                <span v-else>Fork this →</span>
+                <span v-if="forkingId === item.simulation_id">{{ $tr('Forking…', '派生中…') }}</span>
+                <span v-else>{{ $tr('Fork this →', '派生此项 →') }}</span>
               </button>
             </div>
             <div
@@ -295,8 +288,8 @@
           @click="loadMore"
           :disabled="loadingMore"
         >
-          <span v-if="loadingMore">Loading…</span>
-          <span v-else>Load more ({{ total - items.length }} remaining)</span>
+          <span v-if="loadingMore">{{ $tr('Loading…', '加载中…') }}</span>
+          <span v-else>{{ $tr('Load more', '加载更多') }} ({{ total - items.length }} {{ $tr('remaining', '剩余') }})</span>
         </button>
       </div>
     </div>
@@ -304,7 +297,7 @@
     <footer class="explore-footer">
       <span class="footer-line"></span>
       <span class="footer-text">
-        Want yours here? Run a sim, open the Embed dialog, toggle "Public."
+        {{ $tr(`Want yours here? Run a sim, open the Embed dialog, toggle "Public."`, '想让你的也出现在这里?运行一次模拟,打开嵌入对话框,切换为「公开」即可。') }}
       </span>
       <span class="footer-line"></span>
     </footer>
@@ -320,6 +313,8 @@ import {
   getShareCardUrl,
   getFeedUrl,
 } from '../api/simulation'
+import LocaleToggle from '../components/LocaleToggle.vue'
+import { tr } from '../i18n'
 
 const props = defineProps({
   // When true, the view boots in verified-only mode. Wired to the
@@ -400,13 +395,20 @@ const stancePillClass = (label) => {
   return 'pill-neutral'
 }
 
+const stanceLabel = (label) => {
+  if (label === 'Bullish') return tr('Bullish', '看涨')
+  if (label === 'Bearish') return tr('Bearish', '看跌')
+  if (label === 'Neutral') return tr('Neutral', '中立')
+  return label
+}
+
 const stanceTooltip = (item) => {
   const c = item.final_consensus
   if (!c) return ''
   const b = (c.bullish ?? 0).toFixed(1)
   const n = (c.neutral ?? 0).toFixed(1)
   const be = (c.bearish ?? 0).toFixed(1)
-  return `Bullish ${b}% · Neutral ${n}% · Bearish ${be}%`
+  return `${tr('Bullish', '看涨')} ${b}% · ${tr('Neutral', '中立')} ${n}% · ${tr('Bearish', '看跌')} ${be}%`
 }
 
 const qualityPillClass = (health) => {
@@ -430,9 +432,9 @@ const formatDate = (iso) => {
 }
 
 const outcomePillLabel = (label) => {
-  if (label === 'correct') return 'Verified'
-  if (label === 'incorrect') return 'Called wrong'
-  if (label === 'partial') return 'Partial'
+  if (label === 'correct') return tr('Verified', '已验证')
+  if (label === 'incorrect') return tr('Called wrong', '预言落空')
+  if (label === 'partial') return tr('Partial', '部分命中')
   return ''
 }
 
@@ -465,7 +467,7 @@ const loadPage = async (offset = 0) => {
     verifiedOnly: verifiedFilter.value,
   })
   if (!res?.success) {
-    throw new Error(res?.error || 'Request failed')
+    throw new Error(res?.error || tr('Request failed', '请求失败'))
   }
   return {
     data: res.data || [],
@@ -509,7 +511,7 @@ const refresh = async () => {
     forkErrors.value = {}
   } catch (err) {
     error.value =
-      err?.response?.data?.error || err?.message || 'Failed to load gallery'
+      err?.response?.data?.error || err?.message || tr('Failed to load gallery', '无法加载图库')
   } finally {
     loading.value = false
   }
@@ -528,7 +530,7 @@ const loadMore = async () => {
     hasMore.value = page.hasMore
   } catch (err) {
     error.value =
-      err?.response?.data?.error || err?.message || 'Failed to load more'
+      err?.response?.data?.error || err?.message || tr('Failed to load more', '加载更多失败')
   } finally {
     loadingMore.value = false
   }
@@ -543,16 +545,16 @@ const forkAndOpen = async (item) => {
       parent_simulation_id: item.simulation_id,
     })
     if (!res?.success) {
-      throw new Error(res?.error || 'Fork failed')
+      throw new Error(res?.error || tr('Fork failed', '派生失败'))
     }
     const newId = res.data?.simulation_id
-    if (!newId) throw new Error('Fork did not return a simulation_id')
+    if (!newId) throw new Error(tr('Fork did not return a simulation_id', '派生未返回 simulation_id'))
     router.push({ name: 'SimulationRun', params: { simulationId: newId } })
   } catch (err) {
     forkErrors.value = {
       ...forkErrors.value,
       [item.simulation_id]:
-        err?.response?.data?.error || err?.message || 'Fork failed',
+        err?.response?.data?.error || err?.message || tr('Fork failed', '派生失败'),
     }
   } finally {
     forkingId.value = ''

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -4,13 +4,14 @@
     <nav class="navbar">
       <div class="nav-brand">MIROSHARK</div>
       <div class="nav-links">
-        <router-link to="/explore" class="explore-link" title="Browse public simulations">
-          <span class="compass">◎</span> Explore
+        <router-link to="/explore" class="explore-link" :title="$tr('Browse public simulations', '浏览公开模拟')">
+          <span class="compass">◎</span> {{ $tr('Explore', '浏览') }}
         </router-link>
         <a href="https://github.com/aaronjmars/MiroShark" target="_blank" class="github-link">
           GitHub <span class="arrow">↗</span>
         </a>
-        <button class="settings-btn" @click="settingsOpen = true" title="Settings">
+        <LocaleToggle />
+        <button class="settings-btn" @click="settingsOpen = true" :title="$tr('Settings', '设置')">
           ⚙
         </button>
       </div>
@@ -44,19 +45,22 @@
       <!-- Upper Section: Hero Area -->
       <section class="hero-section">
         <div class="tag-row">
-          <span class="orange-tag">Universal Swarm Intelligence Engine</span>
+          <span class="orange-tag">{{ $tr('Universal Swarm Intelligence Engine', '通用群体智能引擎') }}</span>
         </div>
 
         <h1 class="main-title">
-          <span class="gradient-text">Simulate anything, for $1</span>
+          <span class="gradient-text">{{ $tr('Simulate anything, for $1', '一切皆可模拟,只需 $1') }}</span>
         </h1>
 
         <div class="hero-desc">
-          <p>
+          <p v-if="!$isZh()">
             Drop in anything — a press release, a news headline, a policy draft, a question you can't answer, a historical what-if — and <span class="highlight-bold">MiroShark</span> spawns <span class="highlight-orange">hundreds of agents</span> that react to it hour by hour. Posting, arguing, trading, changing their minds.
           </p>
+          <p v-else>
+            放入任何素材 — 新闻稿、头条、政策草案、一个无解的问题、一段历史假设 — <span class="highlight-bold">MiroShark</span> 会派出<span class="highlight-orange">数百个智能体</span>,每小时一轮地做出反应。发帖、辩论、交易、改变想法。
+          </p>
           <p class="slogan-text">
-            Don't predict the future. Simulate it<span class="blinking-cursor">_</span>
+            {{ $tr("Don't predict the future. Simulate it", '不要预测未来。模拟它') }}<span class="blinking-cursor">_</span>
           </p>
         </div>
 
@@ -72,47 +76,47 @@
         <!-- Left Column: Status & Steps -->
         <div class="left-panel">
           <div class="panel-header">
-            <span class="status-dot">■</span> System Status
+            <span class="status-dot">■</span> {{ $tr('System Status', '系统状态') }}
           </div>
-          
-          <h2 class="section-title">Ready</h2>
+
+          <h2 class="section-title">{{ $tr('Ready', '就绪') }}</h2>
           <p class="section-desc">
-            First simulation in ~10 min, ~$1 on the cloud preset. Drop in a doc or pick a trending headline to start.
+            {{ $tr('First simulation in ~10 min, ~$1 on the cloud preset. Drop in a doc or pick a trending headline to start.', '使用云端预设,首次模拟约 10 分钟、约 $1。投入一份文档或挑一条热门头条即可开始。') }}
           </p>
 
 
           <!-- What it does (from README) -->
           <div class="steps-container">
             <div class="steps-header">
-               <span class="diamond-icon">◇</span> What it does
+               <span class="diamond-icon">◇</span> {{ $tr('What it does', '它做什么') }}
             </div>
             <div class="workflow-list">
               <div class="workflow-item">
                 <span class="step-num">01</span>
                 <div class="step-info">
-                  <div class="step-title">You bring a scenario</div>
-                  <div class="step-desc">MiroShark builds the world around it — extracts actors, stakes, and open questions from your input.</div>
+                  <div class="step-title">{{ $tr('You bring a scenario', '你提供一个情景') }}</div>
+                  <div class="step-desc">{{ $tr('MiroShark builds the world around it — extracts actors, stakes, and open questions from your input.', 'MiroShark 围绕它构建世界 — 从你的输入中提取角色、利害关系与待解问题。') }}</div>
                 </div>
               </div>
               <div class="workflow-item">
                 <span class="step-num">02</span>
                 <div class="step-info">
-                  <div class="step-title">Hundreds of grounded agents</div>
-                  <div class="step-desc">React on Twitter, Reddit, and a prediction market. Hour by hour, round after round.</div>
+                  <div class="step-title">{{ $tr('Hundreds of grounded agents', '数百个有据可依的智能体') }}</div>
+                  <div class="step-desc">{{ $tr('React on Twitter, Reddit, and a prediction market. Hour by hour, round after round.', '在 Twitter、Reddit 与预测市场上做出反应。每小时一轮,一轮接一轮。') }}</div>
                 </div>
               </div>
               <div class="workflow-item">
                 <span class="step-num">03</span>
                 <div class="step-info">
-                  <div class="step-title">Steer the timeline</div>
-                  <div class="step-desc">Chat with any agent. Drop breaking news mid-run. Fork a counterfactual and watch it diverge.</div>
+                  <div class="step-title">{{ $tr('Steer the timeline', '掌舵时间线') }}</div>
+                  <div class="step-desc">{{ $tr('Chat with any agent. Drop breaking news mid-run. Fork a counterfactual and watch it diverge.', '与任意智能体对话。在运行中投入突发新闻。派生一个反事实分支并观察其偏离。') }}</div>
                 </div>
               </div>
               <div class="workflow-item">
                 <span class="step-num">04</span>
                 <div class="step-info">
-                  <div class="step-title">Get a report</div>
-                  <div class="step-desc">A Substack-style write-up of what happened, citing actual posts and trades from the run.</div>
+                  <div class="step-title">{{ $tr('Get a report', '生成报告') }}</div>
+                  <div class="step-desc">{{ $tr('A Substack-style write-up of what happened, citing actual posts and trades from the run.', 'Substack 风格的复盘文章,引用本次运行中的真实发帖与交易。') }}</div>
                 </div>
               </div>
             </div>
@@ -125,8 +129,8 @@
             <!-- Upload Area -->
             <div class="console-section">
               <div class="console-header">
-                <span class="console-label">01 / Reality Seeds</span>
-                <span class="console-meta">Supported formats: PDF, MD, TXT</span>
+                <span class="console-label">{{ $tr('01 / Reality Seeds', '01 / 现实种子') }}</span>
+                <span class="console-meta">{{ $tr('Supported formats: PDF, MD, TXT', '支持格式:PDF、MD、TXT') }}</span>
               </div>
               
               <div 
@@ -149,8 +153,8 @@
                 
                 <div v-if="files.length === 0" class="upload-placeholder">
                   <div class="upload-icon">↑</div>
-                  <div class="upload-title">Drop Files to Upload</div>
-                  <div class="upload-hint">or click to browse the file system</div>
+                  <div class="upload-title">{{ $tr('Drop Files to Upload', '拖入文件以上传') }}</div>
+                  <div class="upload-hint">{{ $tr('or click to browse the file system', '或点击浏览文件系统') }}</div>
                 </div>
                 
                 <div v-else class="file-list">
@@ -166,15 +170,15 @@
             <!-- Ask Mode (no document needed) -->
             <div class="console-section url-section">
               <div class="console-header">
-                <span class="console-label">01a / Just Ask</span>
-                <span class="console-meta">No document? Type a question, we synthesize a briefing.</span>
+                <span class="console-label">{{ $tr('01a / Just Ask', '01a / 直接提问') }}</span>
+                <span class="console-meta">{{ $tr('No document? Type a question, we synthesize a briefing.', '没有文档?输入一个问题,我们会合成一份简报。') }}</span>
               </div>
               <div class="url-input-row">
                 <input
                   v-model="askQuestion"
                   class="url-input"
                   type="text"
-                  placeholder="e.g. Will the EU AI Act's biometrics clause survive the final trilogue?"
+                  :placeholder="$tr(`e.g. Will the EU AI Act's biometrics clause survive the final trilogue?`, '例如:欧盟人工智能法案的生物识别条款能否在最终三方会议中存活?')"
                   :disabled="loading || askBusy"
                   @keydown.enter.prevent="runAskMode"
                 />
@@ -184,11 +188,11 @@
                   :disabled="!askQuestion.trim() || loading || askBusy"
                 >
                   <span v-if="askBusy">...</span>
-                  <span v-else>Research →</span>
+                  <span v-else>{{ $tr('Research →', '研究 →') }}</span>
                 </button>
               </div>
               <div v-if="askError" class="url-error">{{ askError }}</div>
-              <div v-if="askBusy" class="url-doc-meta" style="margin-top:6px">Synthesizing briefing — this uses the Smart model and takes ~20–30s.</div>
+              <div v-if="askBusy" class="url-doc-meta" style="margin-top:6px">{{ $tr('Synthesizing briefing — this uses the Smart model and takes ~20–30s.', '正在合成简报 — 使用 Smart 模型,大约需要 20–30 秒。') }}</div>
               <div v-if="askDocs.length > 0" class="url-doc-list">
                 <div
                   v-for="doc in askDocs"
@@ -196,7 +200,7 @@
                   class="url-doc-item"
                   role="button"
                   tabindex="0"
-                  title="Click to preview the generated briefing"
+                  :title="$tr('Click to preview the generated briefing', '点击预览生成的简报')"
                   @click="previewDoc = doc"
                   @keydown.enter.prevent="previewDoc = doc"
                   @keydown.space.prevent="previewDoc = doc"
@@ -204,7 +208,7 @@
                   <span class="url-doc-icon">◈</span>
                   <div class="url-doc-info">
                     <div class="url-doc-title" :title="doc.title">{{ truncate(doc.title, 70) }}</div>
-                    <div class="url-doc-meta" :title="doc.url">{{ doc.char_count.toLocaleString() }} chars · {{ truncate(doc.url, 72) }}</div>
+                    <div class="url-doc-meta" :title="doc.url">{{ doc.char_count.toLocaleString() }} {{ $tr('chars', '字符') }} · {{ truncate(doc.url, 72) }}</div>
                   </div>
                   <button @click.stop="removeUrlDocByRef(doc)" class="remove-btn">×</button>
                 </div>
@@ -214,8 +218,8 @@
             <!-- URL Input Section -->
             <div class="console-section url-section">
               <div class="console-header">
-                <span class="console-label">01b / URL Import</span>
-                <span class="console-meta">Paste article or report URL</span>
+                <span class="console-label">{{ $tr('01b / URL Import', '01b / 网址导入') }}</span>
+                <span class="console-meta">{{ $tr('Paste article or report URL', '粘贴文章或报告网址') }}</span>
               </div>
               <div class="url-input-row">
                 <input
@@ -232,7 +236,7 @@
                   :disabled="!urlInput.trim() || loading || urlFetching"
                 >
                   <span v-if="urlFetching">...</span>
-                  <span v-else>Fetch →</span>
+                  <span v-else>{{ $tr('Fetch →', '抓取 →') }}</span>
                 </button>
               </div>
               <div v-if="urlError" class="url-error">{{ urlError }}</div>
@@ -243,7 +247,7 @@
                   class="url-doc-item"
                   role="button"
                   tabindex="0"
-                  title="Click to preview the extracted content"
+                  :title="$tr('Click to preview the extracted content', '点击预览提取的内容')"
                   @click="previewDoc = doc"
                   @keydown.enter.prevent="previewDoc = doc"
                   @keydown.space.prevent="previewDoc = doc"
@@ -251,7 +255,7 @@
                   <span class="url-doc-icon">◈</span>
                   <div class="url-doc-info">
                     <div class="url-doc-title" :title="doc.title">{{ truncate(doc.title, 70) }}</div>
-                    <div class="url-doc-meta" :title="doc.url">{{ doc.char_count.toLocaleString() }} chars · {{ truncate(doc.url, 72) }}</div>
+                    <div class="url-doc-meta" :title="doc.url">{{ doc.char_count.toLocaleString() }} {{ $tr('chars', '字符') }} · {{ truncate(doc.url, 72) }}</div>
                   </div>
                   <button @click.stop="removeUrlDocByRef(doc)" class="remove-btn">×</button>
                 </div>
@@ -264,13 +268,13 @@
 
             <!-- Divider -->
             <div class="console-divider">
-              <span>Input Parameters</span>
+              <span>{{ $tr('Input Parameters', '输入参数') }}</span>
             </div>
 
             <!-- Input Area -->
             <div class="console-section">
               <div class="console-header">
-                <span class="console-label">>_ 02 / Simulation Prompt</span>
+                <span class="console-label">{{ $tr('>_ 02 / Simulation Prompt', '>_ 02 / 模拟提示词') }}</span>
               </div>
               <ScenarioSuggestions
                 :text-preview="scenarioSuggestPreview"
@@ -281,23 +285,23 @@
                 <textarea
                   v-model="formData.simulationRequirement"
                   class="code-input"
-                  placeholder="// Enter your simulation or prediction requirements in natural language (e.g., If a university announces the revocation of a disciplinary action against a student, what public opinion trends will emerge?)"
+                  :placeholder="$tr('// Enter your simulation or prediction requirements in natural language (e.g., If a university announces the revocation of a disciplinary action against a student, what public opinion trends will emerge?)', '// 用自然语言描述你的模拟或预测需求(例如:如果一所大学宣布撤销对一名学生的纪律处分,会出现哪些舆论走向?)')"
                   rows="6"
                   :disabled="loading"
                 ></textarea>
-                <div class="model-badge">Engine: MiroShark-V1.0</div>
+                <div class="model-badge">{{ $tr('Engine: MiroShark-V1.0', '引擎:MiroShark-V1.0') }}</div>
               </div>
             </div>
 
             <!-- Start Button -->
             <div class="console-section btn-section">
-              <button 
+              <button
                 class="start-engine-btn"
                 @click="startSimulation"
                 :disabled="!canSubmit || loading"
               >
-                <span v-if="!loading">Launch Simulation</span>
-                <span v-else>Initializing...</span>
+                <span v-if="!loading">{{ $tr('Launch Simulation', '启动模拟') }}</span>
+                <span v-else>{{ $tr('Initializing...', '初始化中...') }}</span>
                 <span class="btn-arrow">→</span>
               </button>
             </div>
@@ -323,8 +327,10 @@ import TemplateGallery from '../components/TemplateGallery.vue'
 import SettingsPanel from '../components/SettingsPanel.vue'
 import ScenarioSuggestions from '../components/ScenarioSuggestions.vue'
 import TrendingTopics from '../components/TrendingTopics.vue'
+import LocaleToggle from '../components/LocaleToggle.vue'
 import { fetchUrl } from '../api/graph'
 import { askMode } from '../api/simulation'
+import { tr } from '../i18n'
 
 const settingsOpen = ref(false)
 const previewDoc = ref(null)
@@ -487,7 +493,7 @@ const fetchUrlDoc = async () => {
 
   // Prevent duplicate URLs
   if (urlDocs.value.some(d => d.url === url)) {
-    urlError.value = 'This URL has already been added.'
+    urlError.value = tr('This URL has already been added.', '此网址已添加过。')
     return
   }
 
@@ -499,10 +505,10 @@ const fetchUrlDoc = async () => {
       urlDocs.value.push(res.data)
       urlInput.value = ''
     } else {
-      urlError.value = res.error || 'Failed to fetch URL.'
+      urlError.value = res.error || tr('Failed to fetch URL.', '抓取网址失败。')
     }
   } catch (err) {
-    urlError.value = err.message || 'Failed to fetch URL.'
+    urlError.value = err.message || tr('Failed to fetch URL.', '抓取网址失败。')
   } finally {
     urlFetching.value = false
   }
@@ -519,7 +525,7 @@ const runAskMode = async () => {
   try {
     const res = await askMode(q)
     if (!res.success) {
-      askError.value = res.error || 'Ask mode failed.'
+      askError.value = res.error || tr('Ask mode failed.', '提问模式失败。')
       return
     }
     const d = res.data
@@ -539,7 +545,7 @@ const runAskMode = async () => {
     }
     askQuestion.value = ''
   } catch (err) {
-    askError.value = err?.response?.data?.error || err?.message || 'Ask mode failed.'
+    askError.value = err?.response?.data?.error || err?.message || tr('Ask mode failed.', '提问模式失败。')
   } finally {
     askBusy.value = false
   }
@@ -552,7 +558,7 @@ const runAskMode = async () => {
 const handleTrendingSelect = ({ url }) => {
   if (!url || urlFetching.value) return
   if (urlDocs.value.some(d => d.url === url)) {
-    urlError.value = 'This URL is already loaded.'
+    urlError.value = tr('This URL is already loaded.', '此网址已加载。')
     return
   }
   urlInput.value = url

--- a/frontend/src/views/InteractionView.vue
+++ b/frontend/src/views/InteractionView.vue
@@ -8,28 +8,29 @@
       
       <div class="header-center">
         <div class="view-switcher">
-          <button 
+          <button
             v-for="mode in ['graph', 'workbench']"
             :key="mode"
             class="switch-btn"
             :class="{ active: viewMode === mode }"
             @click="viewMode = mode"
           >
-            {{ { graph: 'Graph', workbench: 'Workbench' }[mode] }}
+            {{ { graph: $tr('Graph', '图谱'), workbench: $tr('Workbench', '工作台') }[mode] }}
           </button>
         </div>
       </div>
 
       <div class="header-right">
         <div class="workflow-step">
-          <span class="step-num">Step 4/4</span>
-          <span class="step-name">Deep Interaction</span>
+          <span class="step-num">{{ $tr('Step 4/4', '第 4/4 步') }}</span>
+          <span class="step-name">{{ $tr('Deep Interaction', '深度交互') }}</span>
         </div>
         <div class="step-divider"></div>
         <span class="status-indicator" :class="statusClass">
           <span class="dot"></span>
           {{ statusText }}
         </span>
+        <LocaleToggle />
       </div>
     </header>
 
@@ -67,6 +68,8 @@ import { ref, computed, watchEffect, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import GraphPanel from '../components/GraphPanel.vue'
 import Step5Interaction from '../components/Step5Interaction.vue'
+import LocaleToggle from '../components/LocaleToggle.vue'
+import { tr } from '../i18n'
 import { getProject, getGraphData } from '../api/graph'
 import { getSimulation } from '../api/simulation'
 import { getReport } from '../api/report'
@@ -110,10 +113,10 @@ const statusClass = computed(() => {
 })
 
 const statusText = computed(() => {
-  if (currentStatus.value === 'error') return 'Error'
-  if (currentStatus.value === 'completed') return 'Completed'
-  if (currentStatus.value === 'processing') return 'Processing'
-  return 'Ready'
+  if (currentStatus.value === 'error') return tr('Error', '错误')
+  if (currentStatus.value === 'completed') return tr('Completed', '已完成')
+  if (currentStatus.value === 'processing') return tr('Processing', '处理中')
+  return tr('Ready', '就绪')
 })
 
 // --- Helpers ---

--- a/frontend/src/views/MainView.vue
+++ b/frontend/src/views/MainView.vue
@@ -8,28 +8,29 @@
       
       <div class="header-center">
         <div class="view-switcher">
-          <button 
-            v-for="mode in ['graph', 'split', 'workbench']" 
+          <button
+            v-for="mode in ['graph', 'split', 'workbench']"
             :key="mode"
             class="switch-btn"
             :class="{ active: viewMode === mode }"
             @click="viewMode = mode"
           >
-            {{ { graph: 'Graph', split: 'Split', workbench: 'Workbench' }[mode] }}
+            {{ viewModeLabel(mode) }}
           </button>
         </div>
       </div>
 
       <div class="header-right">
         <div class="workflow-step">
-          <span class="step-num">Step {{ currentStep }}/4</span>
-          <span class="step-name">{{ stepNames[currentStep - 1] }}</span>
+          <span class="step-num">{{ $tr('Step', '步骤') }} {{ currentStep }}/4</span>
+          <span class="step-name">{{ stepName(currentStep - 1) }}</span>
         </div>
         <div class="step-divider"></div>
         <span class="status-indicator" :class="statusClass">
           <span class="dot"></span>
           {{ statusText }}
         </span>
+        <LocaleToggle />
       </div>
     </header>
 
@@ -80,8 +81,10 @@ import { useRoute, useRouter } from 'vue-router'
 import GraphPanel from '../components/GraphPanel.vue'
 import Step1GraphBuild from '../components/Step1GraphBuild.vue'
 import Step2EnvSetup from '../components/Step2EnvSetup.vue'
+import LocaleToggle from '../components/LocaleToggle.vue'
 import { generateOntology, getProject, buildGraph, getTaskStatus, getGraphData } from '../api/graph'
 import { getPendingUpload, clearPendingUpload } from '../store/pendingUpload'
+import { tr } from '../i18n'
 
 const route = useRoute()
 const router = useRouter()
@@ -91,7 +94,15 @@ const viewMode = ref('split') // graph | split | workbench
 
 // Step State
 const currentStep = ref(1) // 1: Graph Construction, 2: Agent Setup, 3: Start Simulation, 4: Report Generation, 5: Deep Interaction
-const stepNames = ['Graph Construction', 'Agent Setup', 'Start Simulation', 'Report Generation']
+const stepNamesEn = ['Graph Construction', 'Agent Setup', 'Start Simulation', 'Report Generation']
+const stepNamesZh = ['图谱构建', '智能体配置', '启动模拟', '生成报告']
+const stepNames = stepNamesEn // legacy ref kept for handlers below
+const stepName = (i) => tr(stepNamesEn[i] || '', stepNamesZh[i] || '')
+const viewModeLabel = (mode) => {
+  const en = { graph: 'Graph', split: 'Split', workbench: 'Workbench' }
+  const zh = { graph: '图谱', split: '分屏', workbench: '工作台' }
+  return tr(en[mode], zh[mode])
+}
 
 // Data State
 const currentProjectId = ref(route.params.projectId)
@@ -131,11 +142,11 @@ const statusClass = computed(() => {
 })
 
 const statusText = computed(() => {
-  if (error.value) return 'Error'
-  if (currentPhase.value >= 2) return 'Ready'
-  if (currentPhase.value === 1) return 'Building Graph'
-  if (currentPhase.value === 0) return 'Generating Ontology'
-  return 'Idle'
+  if (error.value) return tr('Error', '错误')
+  if (currentPhase.value >= 2) return tr('Ready', '就绪')
+  if (currentPhase.value === 1) return tr('Building Graph', '构建图谱中')
+  if (currentPhase.value === 0) return tr('Generating Ontology', '生成本体中')
+  return tr('Idle', '空闲')
 })
 
 // --- Helpers ---
@@ -193,7 +204,7 @@ const handleNewProject = async () => {
   const hasTemplate = !!pending.templateSeedText
   const hasUrlDocs = pending.urlDocs && pending.urlDocs.length > 0
   if (!pending.isPending || (!hasFiles && !hasTemplate && !hasUrlDocs)) {
-    error.value = 'No pending files found.'
+    error.value = tr('No pending files found.', '没有待处理的文件。')
     addLog('Error: No pending files found for new project.')
     return
   }
@@ -232,7 +243,7 @@ const handleNewProject = async () => {
       addLog(`Ontology generated successfully for project ${res.data.project_id}`)
       await startBuildGraph()
     } else {
-      error.value = res.error || 'Ontology generation failed'
+      error.value = res.error || tr('Ontology generation failed', '本体生成失败')
       addLog(`Error generating ontology: ${error.value}`)
     }
   } catch (err) {
@@ -281,7 +292,7 @@ const updatePhaseByStatus = (status) => {
     case 'ontology_generated': currentPhase.value = 0; break;
     case 'graph_building': currentPhase.value = 1; break;
     case 'graph_completed': currentPhase.value = 2; break;
-    case 'failed': error.value = 'Project failed'; break;
+    case 'failed': error.value = tr('Project failed', '项目失败'); break;
   }
 }
 

--- a/frontend/src/views/ReplayView.vue
+++ b/frontend/src/views/ReplayView.vue
@@ -7,24 +7,25 @@
       </div>
 
       <div class="header-center">
-        <div class="replay-badge">REPLAY</div>
+        <div class="replay-badge">{{ $tr('REPLAY', '回放') }}</div>
       </div>
 
       <div class="header-right">
-        <button class="back-btn" @click="goBack">← Back</button>
+        <button class="back-btn" @click="goBack">{{ $tr('← Back', '← 返回') }}</button>
+        <LocaleToggle />
       </div>
     </header>
 
     <!-- Loading State -->
     <div v-if="loading" class="loading-state">
       <div class="pulse-ring"></div>
-      <span>Loading simulation data...</span>
+      <span>{{ $tr('Loading simulation data...', '加载模拟数据中...') }}</span>
     </div>
 
     <!-- Error State -->
     <div v-else-if="error" class="error-state">
       <span>{{ error }}</span>
-      <button class="action-btn secondary" @click="router.push('/')">Home</button>
+      <button class="action-btn secondary" @click="router.push('/')">{{ $tr('Home', '首页') }}</button>
     </div>
 
     <!-- Main Replay -->
@@ -56,7 +57,7 @@
 
           <!-- Round Info -->
           <div class="round-display">
-            <span class="round-label">ROUND</span>
+            <span class="round-label">{{ $tr('ROUND', '轮次') }}</span>
             <span class="round-current">{{ currentRound }}</span>
             <span class="round-separator">/</span>
             <span class="round-total">{{ totalRounds }}</span>
@@ -79,7 +80,7 @@
         <!-- Stats -->
         <div class="playback-stats">
           <span class="stat-item">
-            <span class="stat-label">EVENTS</span>
+            <span class="stat-label">{{ $tr('EVENTS', '事件') }}</span>
             <span class="stat-value">{{ visibleActions.length }}</span>
             <span class="stat-total">/ {{ allActions.length }}</span>
           </span>
@@ -95,7 +96,7 @@
           </span>
           <span class="stat-divider"></span>
           <span class="stat-item">
-            <span class="stat-label">PM</span>
+            <span class="stat-label">{{ $tr('PM', '预测市场') }}</span>
             <span class="stat-value">{{ visiblePolymarketCount }}</span>
           </span>
         </div>
@@ -116,7 +117,7 @@
             >
               <!-- Round Divider -->
               <div v-if="action._isRoundStart" class="round-divider">
-                <span class="round-tag">ROUND {{ action.round_num }}</span>
+                <span class="round-tag">{{ $tr('ROUND', '轮次') }} {{ action.round_num }}</span>
               </div>
 
               <div class="timeline-marker">
@@ -154,14 +155,14 @@
                       {{ action.action_args.quote_content }}
                     </div>
                     <div v-if="action.action_args?.original_content" class="quoted-block">
-                      <div class="quote-label">@{{ action.action_args.original_author_name || 'User' }}</div>
+                      <div class="quote-label">@{{ action.action_args.original_author_name || $tr('User', '用户') }}</div>
                       <div class="quote-text">{{ truncate(action.action_args.original_content, 150) }}</div>
                     </div>
                   </template>
 
                   <!-- REPOST -->
                   <template v-if="action.action_type === 'REPOST'">
-                    <div class="repost-info">Reposted @{{ action.action_args?.original_author_name || 'User' }}</div>
+                    <div class="repost-info">{{ $tr('Reposted', '已转发') }} @{{ action.action_args?.original_author_name || $tr('User', '用户') }}</div>
                     <div v-if="action.action_args?.original_content" class="repost-content">
                       {{ truncate(action.action_args.original_content, 200) }}
                     </div>
@@ -169,7 +170,7 @@
 
                   <!-- LIKE_POST -->
                   <template v-if="action.action_type === 'LIKE_POST'">
-                    <div class="like-info">Liked @{{ action.action_args?.post_author_name || 'User' }}'s post</div>
+                    <div class="like-info">{{ $tr('Liked', '点赞') }} @{{ action.action_args?.post_author_name || $tr('User', '用户') }}{{ $tr("'s post", ' 的帖子') }}</div>
                     <div v-if="action.action_args?.post_content" class="liked-content">
                       "{{ truncate(action.action_args.post_content, 120) }}"
                     </div>
@@ -181,29 +182,29 @@
                       {{ action.action_args.content }}
                     </div>
                     <div v-if="action.action_args?.post_id" class="comment-context">
-                      Reply to post #{{ action.action_args.post_id }}
+                      {{ $tr('Reply to post', '回复帖子') }} #{{ action.action_args.post_id }}
                     </div>
                   </template>
 
                   <!-- FOLLOW -->
                   <template v-if="action.action_type === 'FOLLOW'">
-                    <div class="follow-info">Followed @{{ action.action_args?.target_user_name || action.action_args?.target_user || 'User' }}</div>
+                    <div class="follow-info">{{ $tr('Followed', '已关注') }} @{{ action.action_args?.target_user_name || action.action_args?.target_user || $tr('User', '用户') }}</div>
                   </template>
 
                   <!-- SEARCH_POSTS -->
                   <template v-if="action.action_type === 'SEARCH_POSTS'">
-                    <div class="search-info">Search: <span class="search-query">"{{ action.action_args?.query || '' }}"</span></div>
+                    <div class="search-info">{{ $tr('Search:', '搜索:') }} <span class="search-query">"{{ action.action_args?.query || '' }}"</span></div>
                   </template>
 
                   <!-- DISLIKE_POST -->
                   <template v-if="action.action_type === 'DISLIKE_POST'">
-                    <div class="like-info">Disliked @{{ action.action_args?.post_author_name || 'User' }}'s post</div>
+                    <div class="like-info">{{ $tr('Disliked', '已踩') }} @{{ action.action_args?.post_author_name || $tr('User', '用户') }}{{ $tr("'s post", ' 的帖子') }}</div>
                   </template>
 
                   <!-- BUY_SHARES -->
                   <template v-if="action.action_type === 'BUY_SHARES'">
                     <div class="trade-info">
-                      <span class="trade-direction buy">BUY</span>
+                      <span class="trade-direction buy">{{ $tr('BUY', '买入') }}</span>
                       <span>{{ formatNum(action.action_args?.shares) }} <strong>{{ action.action_args?.outcome }}</strong> @ ${{ formatNum(action.action_args?.price) }}</span>
                     </div>
                   </template>
@@ -211,7 +212,7 @@
                   <!-- SELL_SHARES -->
                   <template v-if="action.action_type === 'SELL_SHARES'">
                     <div class="trade-info">
-                      <span class="trade-direction sell">SELL</span>
+                      <span class="trade-direction sell">{{ $tr('SELL', '卖出') }}</span>
                       <span>{{ formatNum(action.action_args?.shares) }} <strong>{{ action.action_args?.outcome }}</strong> → ${{ formatNum(action.action_args?.usd_received) }}</span>
                     </div>
                   </template>
@@ -223,7 +224,7 @@
 
                   <!-- DO_NOTHING -->
                   <template v-if="action.action_type === 'DO_NOTHING'">
-                    <div class="idle-info">Action Skipped</div>
+                    <div class="idle-info">{{ $tr('Action Skipped', '已跳过动作') }}</div>
                   </template>
 
                   <!-- Generic fallback -->
@@ -240,7 +241,7 @@
           </TransitionGroup>
 
           <div v-if="allActions.length === 0" class="empty-state">
-            <span>No simulation data found</span>
+            <span>{{ $tr('No simulation data found', '未找到模拟数据') }}</span>
           </div>
         </div>
       </div>
@@ -253,6 +254,8 @@ import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { getRunStatusDetail } from '../api/simulation'
 import { truncate } from '../utils/text'
+import LocaleToggle from '../components/LocaleToggle.vue'
+import { tr } from '../i18n'
 
 const route = useRoute()
 const router = useRouter()
@@ -302,13 +305,13 @@ const loadData = async () => {
     const detailRes = await getRunStatusDetail(simulationId.value)
 
     if (!detailRes.success || !detailRes.data) {
-      error.value = 'Failed to load simulation data'
+      error.value = tr('Failed to load simulation data', '加载模拟数据失败')
       return
     }
 
     const actions = detailRes.data.all_actions || []
     if (actions.length === 0) {
-      error.value = 'No actions found for this simulation'
+      error.value = tr('No actions found for this simulation', '此模拟未找到任何动作')
       return
     }
 
@@ -335,7 +338,7 @@ const loadData = async () => {
     totalRounds.value = detailRes.data.total_rounds || maxRound
     currentRound.value = 0
   } catch (err) {
-    error.value = `Error: ${err.message}`
+    error.value = `${tr('Error', '错误')}: ${err.message}`
   } finally {
     loading.value = false
   }
@@ -416,15 +419,15 @@ const goBack = () => {
 // Helpers
 const getActionTypeLabel = (type) => {
   const labels = {
-    'CREATE_POST': 'POST', 'REPOST': 'REPOST', 'LIKE_POST': 'LIKE',
-    'CREATE_COMMENT': 'COMMENT', 'LIKE_COMMENT': 'LIKE', 'DISLIKE_POST': 'DISLIKE',
-    'DISLIKE_COMMENT': 'DISLIKE', 'MUTE': 'MUTE', 'DO_NOTHING': 'IDLE',
-    'FOLLOW': 'FOLLOW', 'SEARCH_POSTS': 'SEARCH', 'QUOTE_POST': 'QUOTE',
-    'UPVOTE_POST': 'UPVOTE', 'DOWNVOTE_POST': 'DOWNVOTE',
-    'BUY_SHARES': 'BUY', 'SELL_SHARES': 'SELL', 'CREATE_MARKET': 'NEW MARKET',
-    'BROWSE_MARKETS': 'BROWSE', 'VIEW_PORTFOLIO': 'PORTFOLIO', 'COMMENT_ON_MARKET': 'COMMENT',
+    'CREATE_POST': tr('POST', '发帖'), 'REPOST': tr('REPOST', '转发'), 'LIKE_POST': tr('LIKE', '点赞'),
+    'CREATE_COMMENT': tr('COMMENT', '评论'), 'LIKE_COMMENT': tr('LIKE', '点赞'), 'DISLIKE_POST': tr('DISLIKE', '踩'),
+    'DISLIKE_COMMENT': tr('DISLIKE', '踩'), 'MUTE': tr('MUTE', '静音'), 'DO_NOTHING': tr('IDLE', '空闲'),
+    'FOLLOW': tr('FOLLOW', '关注'), 'SEARCH_POSTS': tr('SEARCH', '搜索'), 'QUOTE_POST': tr('QUOTE', '引用'),
+    'UPVOTE_POST': tr('UPVOTE', '顶'), 'DOWNVOTE_POST': tr('DOWNVOTE', '踩'),
+    'BUY_SHARES': tr('BUY', '买入'), 'SELL_SHARES': tr('SELL', '卖出'), 'CREATE_MARKET': tr('NEW MARKET', '新市场'),
+    'BROWSE_MARKETS': tr('BROWSE', '浏览'), 'VIEW_PORTFOLIO': tr('PORTFOLIO', '组合'), 'COMMENT_ON_MARKET': tr('COMMENT', '评论'),
   }
-  return labels[type] || type || 'UNKNOWN'
+  return labels[type] || type || tr('UNKNOWN', '未知')
 }
 
 const getActionTypeClass = (type) => {

--- a/frontend/src/views/ReportView.vue
+++ b/frontend/src/views/ReportView.vue
@@ -15,21 +15,22 @@
             :class="{ active: viewMode === mode }"
             @click="viewMode = mode"
           >
-            {{ { graph: 'Graph', network: 'Network', workbench: 'Workbench' }[mode] }}
+            {{ { graph: $tr('Graph', '图谱'), network: $tr('Network', '网络'), workbench: $tr('Workbench', '工作台') }[mode] }}
           </button>
         </div>
       </div>
 
       <div class="header-right">
         <div class="workflow-step">
-          <span class="step-num">Step 4/4</span>
-          <span class="step-name">Report Generation</span>
+          <span class="step-num">{{ $tr('Step 4/4', '第 4/4 步') }}</span>
+          <span class="step-name">{{ $tr('Report Generation', '报告生成') }}</span>
         </div>
         <div class="step-divider"></div>
         <span class="status-indicator" :class="statusClass">
           <span class="dot"></span>
           {{ statusText }}
         </span>
+        <LocaleToggle />
       </div>
     </header>
 
@@ -74,6 +75,8 @@ import { useRoute, useRouter } from 'vue-router'
 import GraphPanel from '../components/GraphPanel.vue'
 import NetworkPanel from '../components/NetworkPanel.vue'
 import Step4Report from '../components/Step4Report.vue'
+import LocaleToggle from '../components/LocaleToggle.vue'
+import { tr } from '../i18n'
 import { getProject, getGraphData } from '../api/graph'
 import { getSimulation } from '../api/simulation'
 import { getReport } from '../api/report'
@@ -117,9 +120,9 @@ const statusClass = computed(() => {
 })
 
 const statusText = computed(() => {
-  if (currentStatus.value === 'error') return 'Error'
-  if (currentStatus.value === 'completed') return 'Completed'
-  return 'Generating'
+  if (currentStatus.value === 'error') return tr('Error', '错误')
+  if (currentStatus.value === 'completed') return tr('Completed', '已完成')
+  return tr('Generating', '生成中')
 })
 
 // --- Helpers ---

--- a/frontend/src/views/SimulationRunView.vue
+++ b/frontend/src/views/SimulationRunView.vue
@@ -15,21 +15,22 @@
             :class="{ active: viewMode === mode }"
             @click="viewMode = mode"
           >
-            {{ { graph: 'Graph', network: 'Network', split: 'Split View', workbench: 'Workbench' }[mode] }}
+            {{ { graph: $tr('Graph', '图谱'), network: $tr('Network', '网络'), split: $tr('Split View', '分屏视图'), workbench: $tr('Workbench', '工作台') }[mode] }}
           </button>
         </div>
       </div>
 
       <div class="header-right">
         <div class="workflow-step">
-          <span class="step-num">Step 3/4</span>
-          <span class="step-name">Simulation</span>
+          <span class="step-num">{{ $tr('Step 3/4', '第 3/4 步') }}</span>
+          <span class="step-name">{{ $tr('Simulation', '模拟') }}</span>
         </div>
         <div class="step-divider"></div>
         <span class="status-indicator" :class="statusClass">
           <span class="dot"></span>
           {{ statusText }}
         </span>
+        <LocaleToggle />
       </div>
     </header>
 
@@ -79,6 +80,8 @@ import { useRoute, useRouter } from 'vue-router'
 import GraphPanel from '../components/GraphPanel.vue'
 import NetworkPanel from '../components/NetworkPanel.vue'
 import Step3Simulation from '../components/Step3Simulation.vue'
+import LocaleToggle from '../components/LocaleToggle.vue'
+import { tr } from '../i18n'
 import { getProject, getGraphData } from '../api/graph'
 import { getSimulation, getSimulationConfig, stopSimulation, closeSimulationEnv, getEnvStatus } from '../api/simulation'
 
@@ -123,9 +126,9 @@ const statusClass = computed(() => {
 })
 
 const statusText = computed(() => {
-  if (currentStatus.value === 'error') return 'Error'
-  if (currentStatus.value === 'completed') return 'Completed'
-  return 'Running'
+  if (currentStatus.value === 'error') return tr('Error', '错误')
+  if (currentStatus.value === 'completed') return tr('Completed', '已完成')
+  return tr('Running', '运行中')
 })
 
 const isSimulating = computed(() => currentStatus.value === 'processing')

--- a/frontend/src/views/SimulationView.vue
+++ b/frontend/src/views/SimulationView.vue
@@ -5,31 +5,32 @@
       <div class="header-left">
         <div class="brand" @click="router.push('/')">MIROSHARK</div>
       </div>
-      
+
       <div class="header-center">
         <div class="view-switcher">
-          <button 
-            v-for="mode in ['graph', 'split', 'workbench']" 
+          <button
+            v-for="mode in ['graph', 'split', 'workbench']"
             :key="mode"
             class="switch-btn"
             :class="{ active: viewMode === mode }"
             @click="viewMode = mode"
           >
-            {{ { graph: 'Graph', split: 'Split View', workbench: 'Workbench' }[mode] }}
+            {{ { graph: $tr('Graph', '图谱'), split: $tr('Split View', '分屏视图'), workbench: $tr('Workbench', '工作台') }[mode] }}
           </button>
         </div>
       </div>
 
       <div class="header-right">
         <div class="workflow-step">
-          <span class="step-num">Step 2/4</span>
-          <span class="step-name">Agent Setup</span>
+          <span class="step-num">{{ $tr('Step 2/4', '第 2/4 步') }}</span>
+          <span class="step-name">{{ $tr('Agent Setup', '智能体设置') }}</span>
         </div>
         <div class="step-divider"></div>
         <span class="status-indicator" :class="statusClass">
           <span class="dot"></span>
           {{ statusText }}
         </span>
+        <LocaleToggle />
       </div>
     </header>
 
@@ -70,6 +71,8 @@ import { ref, computed, watchEffect, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import GraphPanel from '../components/GraphPanel.vue'
 import Step2EnvSetup from '../components/Step2EnvSetup.vue'
+import LocaleToggle from '../components/LocaleToggle.vue'
+import { tr } from '../i18n'
 import { getProject, getGraphData } from '../api/graph'
 import { getSimulation, stopSimulation, getEnvStatus, closeSimulationEnv } from '../api/simulation'
 
@@ -112,15 +115,15 @@ const statusClass = computed(() => {
 })
 
 const statusText = computed(() => {
-  if (currentStatus.value === 'error') return 'Error'
-  if (currentStatus.value === 'completed') return 'Ready'
+  if (currentStatus.value === 'error') return tr('Error', '错误')
+  if (currentStatus.value === 'completed') return tr('Ready', '就绪')
   switch (currentPhase.value) {
-    case 0: return 'Initializing'
-    case 1: return 'Generating Profiles'
-    case 2: return 'Generating Config'
-    case 3: return 'Orchestrating'
-    case 4: return 'Ready'
-    default: return 'Preparing'
+    case 0: return tr('Initializing', '初始化中')
+    case 1: return tr('Generating Profiles', '生成画像中')
+    case 2: return tr('Generating Config', '生成配置中')
+    case 3: return tr('Orchestrating', '编排中')
+    case 4: return tr('Ready', '就绪')
+    default: return tr('Preparing', '准备中')
   }
 })
 


### PR DESCRIPTION
## Summary
- Opt-in Chinese locale for the SPA — flip via a `中 / EN` button in the navbar (also surfaced inside `SettingsPanel`). English stays the default; choice persists in `localStorage` and is forwarded to the backend on every API call.
- ~1,300 user-visible strings wrapped across all 30 `.vue` files using a tiny inline `tr(en, zh)` helper (`frontend/src/i18n.js`) — translations live next to each source string for easy review.
- Backend localization via `backend/app/utils/i18n.py` (`get_locale` + `apply_i18n`). All 6 preset templates carry an embedded `i18n["zh-CN"]` block (name, category, description, tags, counterfactual labels) — gallery cards swap on the fly. `/api/templates/list` and `/<id>` apply the locale, plus localized error messages.
- README: a `## 中文` section sits at the top right after the badges (full quick-start, feature table, use cases, docs index, license). English version follows under `## English` with `English · 中文` anchor links.

## Out of scope (Tier 3)
- Agent system prompts and report-writer prompts remain English — running simulations still produce English content. Localizing those changes what the LLMs actually generate, which is a separate effort with its own model-quality eval.

## Test plan
- [ ] `npm run build` clean (verified locally)
- [ ] Click `中 / EN` toggle — full page (nav, hero, step cards, settings, error states) flips to Chinese
- [ ] Reload — locale persists
- [ ] Navigate `/` → `/explore` → `/verified` — locale survives navigation
- [ ] Open `/api/templates/list` with `Accept-Language: zh-CN` — names + descriptions return in Chinese, `i18n` block stripped from response
- [ ] Open `/api/templates/list` with default locale — English unchanged
- [ ] README renders both languages, anchor links work
- [ ] Simulation content (agent posts, report) stays English regardless of locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)