### PR TITLE
feat(i18n): localize backend errors + bilingual docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+<sup>English · [中文](CONTRIBUTING.zh-CN.md)</sup>
+
 ## Testing
 
 A pytest suite lives at `backend/tests/`.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,30 @@
+<sup>[English](CONTRIBUTING.md) · 中文</sup>
+
+# 贡献指南
+
+## 测试
+
+pytest 测试套件位于 `backend/tests/`。
+
+### 快速离线单元测试套件
+
+```bash
+cd backend && pytest -m "not integration"
+```
+
+### 集成测试
+
+集成测试会访问位于 `MIROSHARK_API_URL`（默认为 `http://localhost:5001`）的实时后端。旧版 E2E 脚本被封装为 `slow` 测试：
+
+```bash
+pytest -m integration                # 端点契约（秒级）
+pytest -m "integration and slow"     # 完整流水线烟雾测试（分钟级）
+```
+
+某些集成测试需要一个预先存在的模拟 —— 请设置 `MIROSHARK_TEST_SIM_ID=sim_xxx`。
+
+`backend/scripts/test_*.py` 中的手动运行脚本仍可作为独立程序使用；pytest 层只是将它们注册以供发现。
+
+### CI
+
+`.github/workflows/tests.yml` 工作流会在每次推送和 PR 时运行单元测试套件。

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ cp .env.example .env
 
 **界面语言** — 启动后,在导航栏右上角点击「中 / EN」按钮即可切换中英文。语言选择会保存在浏览器中,下次访问时自动应用。模板画廊与公开模拟列表的卡片标题/描述也会随之切换。
 
-**其他部署路径** — [一键 Railway / Render](docs/INSTALL.md#one-click-cloud)、[Docker + Ollama](docs/INSTALL.md#option-b-docker--local-ollama)、[手动 Ollama](docs/INSTALL.md#option-c-manual--local-ollama)、[Claude Code CLI](docs/INSTALL.md#option-d-claude-code-no-api-key) — 详见 **[docs/INSTALL.md](docs/INSTALL.md)**。
+**其他部署路径** — [一键 Railway / Render](docs/INSTALL.zh-CN.md)、[Docker + Ollama](docs/INSTALL.zh-CN.md)、[手动 Ollama](docs/INSTALL.zh-CN.md)、[Claude Code CLI](docs/INSTALL.zh-CN.md) — 详见 **[docs/INSTALL.zh-CN.md](docs/INSTALL.zh-CN.md)**。
 
 ### 主要功能
 
@@ -94,7 +94,7 @@ cp .env.example .env
 | **推送通知** | 长耗时图谱 / 模拟 / 报告任务完成时的浏览器推送提醒 |
 | **完成 Webhook** | 模拟一结束即 POST 一份 JSON 摘要 — 一个 URL 字段即可连通 Slack、Discord、Zapier、Make、n8n 或任意自定义端点 |
 
-每项功能详见 **[docs/FEATURES.md](docs/FEATURES.md)**。
+每项功能详见 **[docs/FEATURES.zh-CN.md](docs/FEATURES.zh-CN.md)**。
 
 ### 应用场景
 
@@ -110,17 +110,17 @@ cp .env.example .env
 
 | | |
 |---|---|
-| [安装](docs/INSTALL.md) | 全部部署路径:云端、Docker、Ollama、Claude Code |
-| [配置](docs/CONFIGURATION.md) | 环境变量、模型路由、特性开关 |
-| [模型](docs/MODELS.md) | 云端预设、本地 Ollama 模型、基准发现 |
-| [架构](docs/ARCHITECTURE.md) | 模拟引擎、记忆管线、图谱检索 |
-| [功能](docs/FEATURES.md) | 上述功能表的深入解析 |
-| [HTTP API](docs/API.md) | 全部端点,按关注点分组 — 含 `/api/docs` 交互式 Swagger UI 与 `/api/openapi.yaml` 规范 |
-| [CLI](docs/CLI.md) | `miroshark-cli` 参考 |
-| [MCP](docs/MCP.md) | Claude Desktop / Cursor / Windsurf / Continue 集成 + 报告智能体工具(可在「设置 → AI 集成」中获取自动生成的片段) |
-| [Webhook](docs/WEBHOOKS.md) | 完成 Webhook 载荷、头部、投递语义、Slack/Discord/Zapier/n8n 食谱 |
-| [可观测性](docs/OBSERVABILITY.md) | 调试面板、事件流、日志 |
-| [贡献](CONTRIBUTING.md) | 测试与开发 |
+| [安装](docs/INSTALL.zh-CN.md) | 全部部署路径:云端、Docker、Ollama、Claude Code |
+| [配置](docs/CONFIGURATION.zh-CN.md) | 环境变量、模型路由、特性开关 |
+| [模型](docs/MODELS.zh-CN.md) | 云端预设、本地 Ollama 模型、基准发现 |
+| [架构](docs/ARCHITECTURE.zh-CN.md) | 模拟引擎、记忆管线、图谱检索 |
+| [功能](docs/FEATURES.zh-CN.md) | 上述功能表的深入解析 |
+| [HTTP API](docs/API.zh-CN.md) | 全部端点,按关注点分组 — 含 `/api/docs` 交互式 Swagger UI 与 `/api/openapi.yaml` 规范 |
+| [CLI](docs/CLI.zh-CN.md) | `miroshark-cli` 参考 |
+| [MCP](docs/MCP.zh-CN.md) | Claude Desktop / Cursor / Windsurf / Continue 集成 + 报告智能体工具(可在「设置 → AI 集成」中获取自动生成的片段) |
+| [Webhook](docs/WEBHOOKS.zh-CN.md) | 完成 Webhook 载荷、头部、投递语义、Slack/Discord/Zapier/n8n 食谱 |
+| [可观测性](docs/OBSERVABILITY.zh-CN.md) | 调试面板、事件流、日志 |
+| [贡献](CONTRIBUTING.zh-CN.md) | 测试与开发 |
 
 ### 许可证
 

--- a/backend/app/api/feed.py
+++ b/backend/app/api/feed.py
@@ -33,6 +33,7 @@ from ..services.feed import (
     render_feed,
     select_public_cards,
 )
+from ..utils.i18n import get_locale
 from ..utils.logger import get_logger
 
 
@@ -99,6 +100,7 @@ def _serve_feed(fmt: str) -> Response:
 
     base_url = _resolve_base_url()
     feed_path = request.full_path.rstrip("?") or request.path
+    locale = get_locale(request)
 
     body, mime = render_feed(
         fmt,
@@ -106,6 +108,7 @@ def _serve_feed(fmt: str) -> Response:
         base_url=base_url,
         feed_path=feed_path,
         verified_only=verified_only,
+        locale=locale,
     )
 
     response = Response(body, mimetype=mime)

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -18,6 +18,7 @@ from ..services.graph_builder import GraphBuilderService
 from ..services.text_processor import TextProcessor
 from ..utils.file_parser import FileParser
 from ..utils.logger import get_logger
+from ..utils.i18n import get_locale, t as _t
 from ..models.task import TaskManager, TaskStatus
 from ..models.project import ProjectManager, ProjectStatus
 
@@ -40,12 +41,13 @@ def get_project(project_id: str):
     """
     Get project details
     """
+    locale = get_locale(request)
     project = ProjectManager.get_project(project_id)
-    
+
     if not project:
         return jsonify({
             "success": False,
-            "error": f"Project not found: {project_id}"
+            "error": _t(f"Project not found: {project_id}", f"未找到项目:{project_id}", locale)
         }), 404
 
     return jsonify({
@@ -76,12 +78,13 @@ def fetch_url():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
         url = data.get('url', '').strip()
 
         if not url:
-            return jsonify({"success": False, "error": "url is required"}), 400
+            return jsonify({"success": False, "error": _t("url is required", "缺少 url", locale)}), 400
 
         from ..utils.url_fetcher import fetch_url_text
         result = fetch_url_text(url)
@@ -94,7 +97,7 @@ def fetch_url():
         logger.error(f"URL fetch error: {e}")
         return jsonify({
             "success": False,
-            "error": f"Failed to fetch URL: {str(e)}"
+            "error": _t(f"Failed to fetch URL: {str(e)}", f"抓取 URL 失败:{str(e)}", locale)
         }), 500
 
 
@@ -129,6 +132,7 @@ def generate_ontology():
             }
         }
     """
+    locale = get_locale(request)
     try:
         logger.info("=== Starting ontology generation ===")
 
@@ -144,7 +148,11 @@ def generate_ontology():
         if not simulation_requirement:
             return jsonify({
                 "success": False,
-                "error": "Please provide a simulation requirement description (simulation_requirement)"
+                "error": _t(
+                    "Please provide a simulation requirement description (simulation_requirement)",
+                    "请提供模拟需求描述(simulation_requirement)",
+                    locale,
+                )
             }), 400
 
         # Parse URL docs (pre-fetched via /fetch-url)
@@ -162,7 +170,11 @@ def generate_ontology():
         if not has_files and not url_docs:
             return jsonify({
                 "success": False,
-                "error": "Please upload at least one document file or provide URL documents"
+                "error": _t(
+                    "Please upload at least one document file or provide URL documents",
+                    "请至少上传一个文档文件或提供 URL 文档",
+                    locale,
+                )
             }), 400
 
         # Create project
@@ -214,7 +226,11 @@ def generate_ontology():
             ProjectManager.delete_project(project.project_id)
             return jsonify({
                 "success": False,
-                "error": "No documents were successfully processed, please check file formats"
+                "error": _t(
+                    "No documents were successfully processed, please check file formats",
+                    "未成功处理任何文档,请检查文件格式",
+                    locale,
+                )
             }), 400
         
         # Save extracted text
@@ -290,6 +306,7 @@ def build_graph():
             }
         }
     """
+    locale = get_locale(request)
     try:
         logger.info("=== Starting graph build ===")
 
@@ -299,41 +316,49 @@ def build_graph():
             logger.error("Neo4j storage not initialized")
             return jsonify({
                 "success": False,
-                "error": "Neo4j storage is not initialized"
+                "error": _t("Neo4j storage is not initialized", "Neo4j 存储尚未初始化", locale)
             }), 503
-        
+
         # Parse request
         data = request.get_json() or {}
         project_id = data.get('project_id')
         logger.debug(f"Request parameters: project_id={project_id}")
-        
+
         if not project_id:
             return jsonify({
                 "success": False,
-                "error": "Please provide project_id"
+                "error": _t("Please provide project_id", "请提供 project_id", locale)
             }), 400
-        
+
         # Get project
         project = ProjectManager.get_project(project_id)
         if not project:
             return jsonify({
                 "success": False,
-                "error": f"Project not found: {project_id}"
+                "error": _t(f"Project not found: {project_id}", f"未找到项目:{project_id}", locale)
             }), 404
-        
+
         # Check project status
         force = data.get('force', False)  # Force rebuild
-        
+
         if project.status == ProjectStatus.CREATED:
             return jsonify({
                 "success": False,
-                "error": "Ontology not yet generated for this project, please call /ontology/generate first"
+                "error": _t(
+                    "Ontology not yet generated for this project, please call /ontology/generate first",
+                    "该项目尚未生成本体,请先调用 /ontology/generate",
+                    locale,
+                )
             }), 400
-        
+
         if project.status == ProjectStatus.GRAPH_BUILDING and not force:
             return jsonify({
                 "success": False,
-                "error": "Graph is currently being built, please do not resubmit. To force rebuild, add force: true",
+                "error": _t(
+                    "Graph is currently being built, please do not resubmit. To force rebuild, add force: true",
+                    "图谱正在构建中,请勿重复提交。如需强制重建,请添加 force: true",
+                    locale,
+                ),
                 "task_id": project.graph_build_task_id
             }), 400
         
@@ -358,15 +383,15 @@ def build_graph():
         if not text:
             return jsonify({
                 "success": False,
-                "error": "Extracted text content not found"
+                "error": _t("Extracted text content not found", "未找到已提取的文本内容", locale)
             }), 400
-        
+
         # Get ontology
         ontology = project.ontology
         if not ontology:
             return jsonify({
                 "success": False,
-                "error": "Ontology definition not found"
+                "error": _t("Ontology definition not found", "未找到本体定义", locale)
             }), 400
         
         # Create async task
@@ -526,12 +551,13 @@ def get_task(task_id: str):
     """
     Query task status
     """
+    locale = get_locale(request)
     task = TaskManager().get_task(task_id)
-    
+
     if not task:
         return jsonify({
             "success": False,
-            "error": f"Task not found: {task_id}"
+            "error": _t(f"Task not found: {task_id}", f"未找到任务:{task_id}", locale)
         }), 404
     
     return jsonify({
@@ -547,12 +573,13 @@ def get_graph_data(graph_id: str):
     """
     Get graph data (nodes and edges)
     """
+    locale = get_locale(request)
     try:
         storage = current_app.extensions.get('neo4j_storage')
         if not storage:
             return jsonify({
                 "success": False,
-                "error": "Neo4j storage is not initialized"
+                "error": _t("Neo4j storage is not initialized", "Neo4j 存储尚未初始化", locale)
             }), 503
 
         builder = GraphBuilderService(storage=storage)

--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -15,6 +15,7 @@ from ..services.simulation_manager import SimulationManager
 from ..models.project import ProjectManager
 from ..models.task import TaskManager, TaskStatus
 from ..utils.logger import get_logger
+from ..utils.i18n import get_locale, t as _t
 from ..utils.validation import validate_simulation_id
 
 logger = get_logger('miroshark.api.report')
@@ -59,6 +60,7 @@ def generate_report():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
 
@@ -66,7 +68,7 @@ def generate_report():
         if not simulation_id:
             return jsonify({
                 "success": False,
-                "error": "Please provide simulation_id"
+                "error": _t("Please provide simulation_id", "请提供 simulation_id", locale)
             }), 400
         try:
             validate_simulation_id(simulation_id)
@@ -82,7 +84,7 @@ def generate_report():
         if not state:
             return jsonify({
                 "success": False,
-                "error": f"Simulation not found: {simulation_id}"
+                "error": _t(f"Simulation not found: {simulation_id}", f"未找到模拟:{simulation_id}", locale)
             }), 404
 
         # Check if a report already exists
@@ -105,21 +107,25 @@ def generate_report():
         if not project:
             return jsonify({
                 "success": False,
-                "error": f"Project not found: {state.project_id}"
+                "error": _t(f"Project not found: {state.project_id}", f"未找到项目:{state.project_id}", locale)
             }), 404
 
         graph_id = state.graph_id or project.graph_id
         if not graph_id:
             return jsonify({
                 "success": False,
-                "error": "Missing graph ID, please ensure the graph has been built"
+                "error": _t(
+                    "Missing graph ID, please ensure the graph has been built",
+                    "缺少图谱 ID,请确认图谱已构建完成",
+                    locale,
+                )
             }), 400
 
         simulation_requirement = project.simulation_requirement
         if not simulation_requirement:
             return jsonify({
                 "success": False,
-                "error": "Missing simulation requirement description"
+                "error": _t("Missing simulation requirement description", "缺少模拟需求描述", locale)
             }), 400
 
         # Pre-generate report_id for immediate return to frontend
@@ -141,7 +147,10 @@ def generate_report():
         # (current_app is not available inside background threads)
         storage = current_app.extensions.get('neo4j_storage')
         if not storage:
-            return jsonify({"success": False, "error": "Neo4j storage not initialized"}), 503
+            return jsonify({
+                "success": False,
+                "error": _t("Neo4j storage not initialized", "Neo4j 存储尚未初始化", locale)
+            }), 503
         graph_tools = GraphToolsService(storage=storage)
 
         # Define background task
@@ -242,6 +251,7 @@ def get_generate_status():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
 
@@ -272,7 +282,11 @@ def get_generate_status():
         if not task_id:
             return jsonify({
                 "success": False,
-                "error": "Please provide task_id or simulation_id"
+                "error": _t(
+                    "Please provide task_id or simulation_id",
+                    "请提供 task_id 或 simulation_id",
+                    locale,
+                )
             }), 400
 
         task_manager = TaskManager()
@@ -281,7 +295,7 @@ def get_generate_status():
         if not task:
             return jsonify({
                 "success": False,
-                "error": f"Task not found: {task_id}"
+                "error": _t(f"Task not found: {task_id}", f"未找到任务:{task_id}", locale)
             }), 404
 
         return jsonify({
@@ -318,13 +332,14 @@ def get_report(report_id: str):
             }
         }
     """
+    locale = get_locale(request)
     try:
         report = ReportManager.get_report(report_id)
 
         if not report:
             return jsonify({
                 "success": False,
-                "error": f"Report not found: {report_id}"
+                "error": _t(f"Report not found: {report_id}", f"未找到报告:{report_id}", locale)
             }), 404
 
         return jsonify({
@@ -355,13 +370,18 @@ def get_report_by_simulation(simulation_id: str):
             }
         }
     """
+    locale = get_locale(request)
     try:
         report = ReportManager.get_report_by_simulation(simulation_id)
 
         if not report:
             return jsonify({
                 "success": False,
-                "error": f"No report available for this simulation: {simulation_id}",
+                "error": _t(
+                    f"No report available for this simulation: {simulation_id}",
+                    f"该模拟尚无可用报告:{simulation_id}",
+                    locale,
+                ),
                 "has_report": False
             }), 404
 
@@ -387,13 +407,14 @@ def download_report(report_id: str):
 
     Returns a Markdown file
     """
+    locale = get_locale(request)
     try:
         report = ReportManager.get_report(report_id)
 
         if not report:
             return jsonify({
                 "success": False,
-                "error": f"Report not found: {report_id}"
+                "error": _t(f"Report not found: {report_id}", f"未找到报告:{report_id}", locale)
             }), 404
 
         md_path = ReportManager._get_report_markdown_path(report_id)
@@ -429,13 +450,14 @@ def download_report(report_id: str):
 @report_bp.route('/<report_id>', methods=['DELETE'])
 def delete_report(report_id: str):
     """Delete report"""
+    locale = get_locale(request)
     try:
         success = ReportManager.delete_report(report_id)
 
         if not success:
             return jsonify({
                 "success": False,
-                "error": f"Report not found: {report_id}"
+                "error": _t(f"Report not found: {report_id}", f"未找到报告:{report_id}", locale)
             }), 404
 
         return jsonify({
@@ -481,6 +503,7 @@ def chat_with_report_agent():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
 
@@ -491,7 +514,7 @@ def chat_with_report_agent():
         if not simulation_id:
             return jsonify({
                 "success": False,
-                "error": "Please provide simulation_id"
+                "error": _t("Please provide simulation_id", "请提供 simulation_id", locale)
             }), 400
         try:
             validate_simulation_id(simulation_id)
@@ -501,7 +524,7 @@ def chat_with_report_agent():
         if not message:
             return jsonify({
                 "success": False,
-                "error": "Please provide message"
+                "error": _t("Please provide message", "请提供 message", locale)
             }), 400
 
         # Get simulation and project info
@@ -511,21 +534,21 @@ def chat_with_report_agent():
         if not state:
             return jsonify({
                 "success": False,
-                "error": f"Simulation not found: {simulation_id}"
+                "error": _t(f"Simulation not found: {simulation_id}", f"未找到模拟:{simulation_id}", locale)
             }), 404
 
         project = ProjectManager.get_project(state.project_id)
         if not project:
             return jsonify({
                 "success": False,
-                "error": f"Project not found: {state.project_id}"
+                "error": _t(f"Project not found: {state.project_id}", f"未找到项目:{state.project_id}", locale)
             }), 404
 
         graph_id = state.graph_id or project.graph_id
         if not graph_id:
             return jsonify({
                 "success": False,
-                "error": "Missing graph ID"
+                "error": _t("Missing graph ID", "缺少图谱 ID", locale)
             }), 400
 
         simulation_requirement = project.simulation_requirement or ""
@@ -533,7 +556,10 @@ def chat_with_report_agent():
         # Create Agent and start conversation
         storage = current_app.extensions.get('neo4j_storage')
         if not storage:
-            return jsonify({"success": False, "error": "Neo4j storage not initialized"}), 503
+            return jsonify({
+                "success": False,
+                "error": _t("Neo4j storage not initialized", "Neo4j 存储尚未初始化", locale)
+            }), 503
         graph_tools = GraphToolsService(storage=storage)
 
         agent = ReportAgent(
@@ -803,6 +829,7 @@ def search_graph_tool():
             "limit": 10
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
 
@@ -813,7 +840,7 @@ def search_graph_tool():
         if not graph_id or not query:
             return jsonify({
                 "success": False,
-                "error": "Please provide graph_id and query"
+                "error": _t("Please provide graph_id and query", "请提供 graph_id 和 query", locale)
             }), 400
 
         from flask import current_app
@@ -821,7 +848,10 @@ def search_graph_tool():
 
         storage = current_app.extensions.get('neo4j_storage')
         if not storage:
-            return jsonify({"success": False, "error": "Neo4j storage is not initialized"}), 503
+            return jsonify({
+                "success": False,
+                "error": _t("Neo4j storage is not initialized", "Neo4j 存储尚未初始化", locale)
+            }), 503
 
         tools = GraphToolsService(storage=storage)
         result = tools.search_graph(
@@ -854,6 +884,7 @@ def get_graph_statistics_tool():
             "graph_id": "miroshark_xxxx"
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
 
@@ -862,7 +893,7 @@ def get_graph_statistics_tool():
         if not graph_id:
             return jsonify({
                 "success": False,
-                "error": "Please provide graph_id"
+                "error": _t("Please provide graph_id", "请提供 graph_id", locale)
             }), 400
 
         from flask import current_app
@@ -870,7 +901,10 @@ def get_graph_statistics_tool():
 
         storage = current_app.extensions.get('neo4j_storage')
         if not storage:
-            return jsonify({"success": False, "error": "Neo4j storage is not initialized"}), 503
+            return jsonify({
+                "success": False,
+                "error": _t("Neo4j storage is not initialized", "Neo4j 存储尚未初始化", locale)
+            }), 503
 
         tools = GraphToolsService(storage=storage)
         result = tools.get_graph_statistics(graph_id)

--- a/backend/app/api/share.py
+++ b/backend/app/api/share.py
@@ -22,6 +22,7 @@ import html
 from flask import Blueprint, Response, request
 
 from ..services.simulation_manager import SimulationManager
+from ..utils.i18n import get_locale, t as _t
 from ..utils.validation import validate_simulation_id
 
 
@@ -131,10 +132,15 @@ def share_landing(simulation_id: str):
     so private sims fall back to a generic preview rather than leaking
     scenario detail through the meta tags.
     """
+    locale = get_locale(request)
     try:
         validate_simulation_id(simulation_id)
     except ValueError as exc:
-        return Response(f"Invalid simulation id: {exc}", status=400, mimetype="text/plain")
+        return Response(
+            _t(f"Invalid simulation id: {exc}", f"无效的模拟 ID:{exc}", locale),
+            status=400,
+            mimetype="text/plain",
+        )
 
     # Pull just enough to populate OG tags — never raise on missing data.
     scenario = ""

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -15,6 +15,7 @@ from flask import request, jsonify, send_file, current_app
 
 from . import simulation_bp
 from ..utils.llm_client import create_smart_llm_client, create_llm_client
+from ..utils.i18n import get_locale, t as _t
 from ..utils.validation import validate_simulation_id
 from ..config import Config
 from ..services.entity_reader import EntityReader
@@ -116,6 +117,7 @@ def require_admin_token(view_func):
 
     @wraps(view_func)
     def _wrapper(*args, **kwargs):
+        locale = get_locale(request)
         expected = _load_admin_token()
         if not expected:
             logger.error(
@@ -125,7 +127,11 @@ def require_admin_token(view_func):
             )
             return jsonify({
                 "success": False,
-                "error": "Admin authentication is not configured on this deployment.",
+                "error": _t(
+                    "Admin authentication is not configured on this deployment.",
+                    "此部署尚未配置管理员身份验证。",
+                    locale,
+                ),
             }), 503
 
         provided = _extract_bearer_token()
@@ -137,7 +143,7 @@ def require_admin_token(view_func):
         ):
             return jsonify({
                 "success": False,
-                "error": "Unauthorized",
+                "error": _t("Unauthorized", "未授权", locale),
             }), 401
 
         return view_func(*args, **kwargs)
@@ -145,14 +151,17 @@ def require_admin_token(view_func):
     return _wrapper
 
 
-def _get_simulation_id_or_400(data: dict) -> tuple:
+def _get_simulation_id_or_400(data: dict, locale: str = "en") -> tuple:
     """Extract and validate simulation_id from POST body.
 
     Returns (simulation_id, None) on success or (None, error_response) on failure.
     """
     simulation_id = data.get('simulation_id')
     if not simulation_id:
-        return None, (jsonify({"success": False, "error": "Please provide simulation_id"}), 400)
+        return None, (jsonify({
+            "success": False,
+            "error": _t("Please provide simulation_id", "请提供 simulation_id", locale),
+        }), 400)
     try:
         validate_simulation_id(simulation_id)
     except ValueError as exc:
@@ -454,6 +463,7 @@ def suggest_scenarios():
             }
         }
     """
+    locale = get_locale(request)
     try:
         client_ip = _client_ip()
         if _scenario_rate_limited(client_ip):
@@ -467,7 +477,11 @@ def suggest_scenarios():
         if not isinstance(preview, str):
             return jsonify({
                 "success": False,
-                "error": "text_preview must be a string"
+                "error": _t(
+                    "text_preview must be a string",
+                    "text_preview 必须是字符串",
+                    locale,
+                )
             }), 400
 
         sim_prompt_raw = data.get('simulation_prompt') or ''
@@ -683,6 +697,7 @@ def ask_mode():
     ``{"success": true, "data": {title, simulation_requirement, seed_document,
     key_actors, suggested_platforms, model, cached}}``.
     """
+    locale = get_locale(request)
     try:
         client_ip = _client_ip()
         if _ask_rate_limited(client_ip):
@@ -696,12 +711,20 @@ def ask_mode():
         if not isinstance(question, str) or len(question) < 8:
             return jsonify({
                 "success": False,
-                "error": "question must be at least 8 characters",
+                "error": _t(
+                    "question must be at least 8 characters",
+                    "问题至少需要 8 个字符",
+                    locale,
+                ),
             }), 400
         if len(question) > _ASK_QUESTION_MAX_CHARS:
             return jsonify({
                 "success": False,
-                "error": f"question too long (max {_ASK_QUESTION_MAX_CHARS} chars)",
+                "error": _t(
+                    f"question too long (max {_ASK_QUESTION_MAX_CHARS} chars)",
+                    f"问题过长(最多 {_ASK_QUESTION_MAX_CHARS} 字符)",
+                    locale,
+                ),
             }), 400
 
         import hashlib
@@ -1267,17 +1290,18 @@ def get_graph_entities(graph_id: str):
 @simulation_bp.route('/entities/<graph_id>/<entity_uuid>', methods=['GET'])
 def get_entity_detail(graph_id: str, entity_uuid: str):
     """Get detailed information for a single entity"""
+    locale = get_locale(request)
     try:
         storage = current_app.extensions.get('neo4j_storage')
         if not storage:
             raise ValueError("GraphStorage not initialized")
         reader = EntityReader(storage)
         entity = reader.get_entity_with_context(graph_id, entity_uuid)
-        
+
         if not entity:
             return jsonify({
                 "success": False,
-                "error": f"Entity not found: {entity_uuid}"
+                "error": _t(f"Entity not found: {entity_uuid}", f"未找到实体:{entity_uuid}", locale)
             }), 404
         
         return jsonify({
@@ -1360,30 +1384,35 @@ def create_simulation():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        
+
         project_id = data.get('project_id')
         if not project_id:
             return jsonify({
                 "success": False,
-                "error": "Please provide project_id"
+                "error": _t("Please provide project_id", "请提供 project_id", locale)
             }), 400
-        
+
         project = ProjectManager.get_project(project_id)
         if not project:
             return jsonify({
                 "success": False,
-                "error": f"Project not found: {project_id}"
+                "error": _t(f"Project not found: {project_id}", f"未找到项目:{project_id}", locale)
             }), 404
-        
+
         graph_id = data.get('graph_id') or project.graph_id
         if not graph_id:
             return jsonify({
                 "success": False,
-                "error": "Graph not yet built for this project, please call /api/graph/build first"
+                "error": _t(
+                    "Graph not yet built for this project, please call /api/graph/build first",
+                    "该项目尚未构建图谱,请先调用 /api/graph/build",
+                    locale,
+                )
             }), 400
-        
+
         manager = SimulationManager()
         state = manager.create_simulation(
             project_id=project_id,
@@ -1428,6 +1457,7 @@ def branch_counterfactual_simulation():
     prepends ``injection_text`` to every agent's observation prompt starting
     at ``trigger_round``.
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
         parent_id = data.get("parent_simulation_id")
@@ -1437,17 +1467,37 @@ def branch_counterfactual_simulation():
         branch_id = data.get("branch_id")
 
         if not parent_id:
-            return jsonify({"success": False, "error": "parent_simulation_id is required"}), 400
+            return jsonify({"success": False, "error": _t(
+                "parent_simulation_id is required",
+                "缺少 parent_simulation_id",
+                locale,
+            )}), 400
         if not injection:
-            return jsonify({"success": False, "error": "injection_text is required"}), 400
+            return jsonify({"success": False, "error": _t(
+                "injection_text is required",
+                "缺少 injection_text",
+                locale,
+            )}), 400
         if len(injection) > 2000:
-            return jsonify({"success": False, "error": "injection_text must be <= 2000 chars"}), 400
+            return jsonify({"success": False, "error": _t(
+                "injection_text must be <= 2000 chars",
+                "injection_text 不能超过 2000 个字符",
+                locale,
+            )}), 400
         try:
             trigger_int = int(trigger)
         except (TypeError, ValueError):
-            return jsonify({"success": False, "error": "trigger_round must be an integer >= 0"}), 400
+            return jsonify({"success": False, "error": _t(
+                "trigger_round must be an integer >= 0",
+                "trigger_round 必须为大于等于 0 的整数",
+                locale,
+            )}), 400
         if trigger_int < 0:
-            return jsonify({"success": False, "error": "trigger_round must be >= 0"}), 400
+            return jsonify({"success": False, "error": _t(
+                "trigger_round must be >= 0",
+                "trigger_round 必须 >= 0",
+                locale,
+            )}), 400
 
         manager = SimulationManager()
         state = manager.branch_counterfactual(
@@ -1492,6 +1542,7 @@ def fork_simulation():
             "data": { ...simulation state... }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
 
@@ -1499,7 +1550,11 @@ def fork_simulation():
         if not parent_simulation_id:
             return jsonify({
                 "success": False,
-                "error": "Please provide parent_simulation_id"
+                "error": _t(
+                    "Please provide parent_simulation_id",
+                    "请提供 parent_simulation_id",
+                    locale,
+                )
             }), 400
 
         simulation_requirement = data.get('simulation_requirement') or None
@@ -1691,21 +1746,22 @@ def prepare_simulation():
     """
     import threading
     from ..models.task import TaskManager, TaskStatus
-    
+
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        
-        simulation_id, err = _get_simulation_id_or_400(data)
+
+        simulation_id, err = _get_simulation_id_or_400(data, locale)
         if err:
             return err
 
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
-        
+
         if not state:
             return jsonify({
                 "success": False,
-                "error": f"Simulation not found: {simulation_id}"
+                "error": _t(f"Simulation not found: {simulation_id}", f"未找到模拟:{simulation_id}", locale)
             }), 404
         
         # Check if force regeneration is requested
@@ -1737,15 +1793,19 @@ def prepare_simulation():
         if not project:
             return jsonify({
                 "success": False,
-                "error": f"Project not found: {state.project_id}"
+                "error": _t(f"Project not found: {state.project_id}", f"未找到项目:{state.project_id}", locale)
             }), 404
-        
+
         # Get simulation requirement
         simulation_requirement = project.simulation_requirement or ""
         if not simulation_requirement:
             return jsonify({
                 "success": False,
-                "error": "Project missing simulation requirement description (simulation_requirement)"
+                "error": _t(
+                    "Project missing simulation requirement description (simulation_requirement)",
+                    "项目缺少模拟需求描述(simulation_requirement)",
+                    locale,
+                )
             }), 400
         
         # Get document text
@@ -1957,10 +2017,11 @@ def get_prepare_status():
         }
     """
     from ..models.task import TaskManager
-    
+
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        
+
         task_id = data.get('task_id')
         simulation_id = data.get('simulation_id')
         if simulation_id:
@@ -2001,9 +2062,13 @@ def get_prepare_status():
                 })
             return jsonify({
                 "success": False,
-                "error": "Please provide task_id or simulation_id"
+                "error": _t(
+                    "Please provide task_id or simulation_id",
+                    "请提供 task_id 或 simulation_id",
+                    locale,
+                )
             }), 400
-        
+
         task_manager = TaskManager()
         task = task_manager.get_task(task_id)
         
@@ -2027,9 +2092,9 @@ def get_prepare_status():
             
             return jsonify({
                 "success": False,
-                "error": f"Task not found: {task_id}"
+                "error": _t(f"Task not found: {task_id}", f"未找到任务:{task_id}", locale)
             }), 404
-        
+
         task_dict = task.to_dict()
         task_dict["already_prepared"] = False
         
@@ -2049,14 +2114,15 @@ def get_prepare_status():
 @simulation_bp.route('/<simulation_id>', methods=['GET'])
 def get_simulation(simulation_id: str):
     """Get simulation status"""
+    locale = get_locale(request)
     try:
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
-        
+
         if not state:
             return jsonify({
                 "success": False,
-                "error": f"Simulation not found: {simulation_id}"
+                "error": _t(f"Simulation not found: {simulation_id}", f"未找到模拟:{simulation_id}", locale)
             }), 404
         
         result = state.to_dict()
@@ -2378,17 +2444,18 @@ def get_simulation_profiles_realtime(simulation_id: str):
     import json
     import csv
     from datetime import datetime
-    
+
+    locale = get_locale(request)
     try:
         platform = request.args.get('platform', 'reddit')
-        
+
         # Get simulation directory
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
 
         if not os.path.exists(sim_dir):
             return jsonify({
                 "success": False,
-                "error": f"Simulation not found: {simulation_id}"
+                "error": _t(f"Simulation not found: {simulation_id}", f"未找到模拟:{simulation_id}", locale)
             }), 404
 
         # Determine file path
@@ -2483,7 +2550,8 @@ def get_simulation_config_realtime(simulation_id: str):
     """
     import json
     from datetime import datetime
-    
+
+    locale = get_locale(request)
     try:
         # Get simulation directory
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
@@ -2491,7 +2559,7 @@ def get_simulation_config_realtime(simulation_id: str):
         if not os.path.exists(sim_dir):
             return jsonify({
                 "success": False,
-                "error": f"Simulation not found: {simulation_id}"
+                "error": _t(f"Simulation not found: {simulation_id}", f"未找到模拟:{simulation_id}", locale)
             }), 404
 
         # Config file path
@@ -2601,11 +2669,16 @@ def retry_simulation_config(simulation_id: str):
     from ..models.task import TaskManager, TaskStatus
     from ..config import Config
 
+    locale = get_locale(request)
     try:
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
         if not state:
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         # Profiles must exist before we can retry config generation
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
@@ -2616,20 +2689,32 @@ def retry_simulation_config(simulation_id: str):
         if not profiles_exist:
             return jsonify({
                 "success": False,
-                "error": "Agent profiles not found — run /prepare first"
+                "error": _t(
+                    "Agent profiles not found — run /prepare first",
+                    "未找到 Agent 配置文件 — 请先运行 /prepare",
+                    locale,
+                )
             }), 400
 
         # Get project data needed for config generation
         project = ProjectManager.get_project(state.project_id)
         if not project:
-            return jsonify({"success": False, "error": f"Project not found: {state.project_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Project not found: {state.project_id}",
+                f"未找到项目:{state.project_id}",
+                locale,
+            )}), 404
 
         simulation_requirement = project.simulation_requirement or ""
         document_text = ProjectManager.get_extracted_text(state.project_id) or ""
 
         storage = current_app.extensions.get('neo4j_storage')
         if not storage:
-            return jsonify({"success": False, "error": "GraphStorage not initialized"}), 500
+            return jsonify({"success": False, "error": _t(
+                "GraphStorage not initialized",
+                "GraphStorage 尚未初始化",
+                locale,
+            )}), 500
 
         # Reset state so the frontend polling loop sees "preparing" again
         state.status = SimulationStatus.PREPARING
@@ -2723,14 +2808,19 @@ def get_simulation_config(simulation_id: str):
         - platform_configs: Platform configuration
         - generation_reasoning: LLM configuration reasoning explanation
     """
+    locale = get_locale(request)
     try:
         manager = SimulationManager()
         config = manager.get_simulation_config(simulation_id)
-        
+
         if not config:
             return jsonify({
                 "success": False,
-                "error": "Simulation configuration does not exist, please call /prepare endpoint first"
+                "error": _t(
+                    "Simulation configuration does not exist, please call /prepare endpoint first",
+                    "模拟配置不存在,请先调用 /prepare 端点",
+                    locale,
+                )
             }), 404
         
         return jsonify({
@@ -2752,11 +2842,12 @@ def download_project_file(project_id: str, saved_filename: str):
     """Stream a project's uploaded file back to the browser by its
     UUID-based saved_filename. Used by the History modal's file list
     so users can re-download originals they ingested earlier."""
+    locale = get_locale(request)
     try:
         # Reject path-traversal attempts — saved_filename is supposed
         # to be a single segment, not a path.
         if '/' in saved_filename or '\\' in saved_filename or '..' in saved_filename:
-            return jsonify({"success": False, "error": "Invalid filename"}), 400
+            return jsonify({"success": False, "error": _t("Invalid filename", "无效的文件名", locale)}), 400
 
         files_dir = os.path.abspath(
             ProjectManager._get_project_files_dir(project_id)
@@ -2764,9 +2855,9 @@ def download_project_file(project_id: str, saved_filename: str):
         file_path = os.path.abspath(os.path.join(files_dir, saved_filename))
         # Defense-in-depth: ensure resolved path is still inside files_dir
         if not file_path.startswith(files_dir + os.sep):
-            return jsonify({"success": False, "error": "Invalid filename"}), 400
+            return jsonify({"success": False, "error": _t("Invalid filename", "无效的文件名", locale)}), 400
         if not os.path.exists(file_path):
-            return jsonify({"success": False, "error": "File not found"}), 404
+            return jsonify({"success": False, "error": _t("File not found", "未找到文件", locale)}), 404
 
         # Look up the original filename from the project record so the
         # browser saves it with a meaningful name, not the UUID.
@@ -2791,15 +2882,20 @@ def download_project_file(project_id: str, saved_filename: str):
 @simulation_bp.route('/<simulation_id>/config/download', methods=['GET'])
 def download_simulation_config(simulation_id: str):
     """Download simulation configuration file"""
+    locale = get_locale(request)
     try:
         manager = SimulationManager()
         sim_dir = manager._get_simulation_dir(simulation_id)
         config_path = os.path.join(sim_dir, "simulation_config.json")
-        
+
         if not os.path.exists(config_path):
             return jsonify({
                 "success": False,
-                "error": "Configuration file does not exist, please call /prepare endpoint first"
+                "error": _t(
+                    "Configuration file does not exist, please call /prepare endpoint first",
+                    "配置文件不存在,请先调用 /prepare 端点",
+                    locale,
+                )
             }), 404
         
         return send_file(
@@ -2828,30 +2924,39 @@ def download_simulation_script(script_name: str):
         - run_parallel_simulation.py
         - action_logger.py
     """
+    locale = get_locale(request)
     try:
         # Scripts located at backend/scripts/ directory
         scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../scripts'))
-        
+
         # Validate script name
         allowed_scripts = [
             "run_twitter_simulation.py",
-            "run_reddit_simulation.py", 
+            "run_reddit_simulation.py",
             "run_parallel_simulation.py",
             "action_logger.py"
         ]
-        
+
         if script_name not in allowed_scripts:
             return jsonify({
                 "success": False,
-                "error": f"Unknown script: {script_name}, options: {allowed_scripts}"
+                "error": _t(
+                    f"Unknown script: {script_name}, options: {allowed_scripts}",
+                    f"未知脚本:{script_name},可选项:{allowed_scripts}",
+                    locale,
+                )
             }), 400
-        
+
         script_path = os.path.join(scripts_dir, script_name)
-        
+
         if not os.path.exists(script_path):
             return jsonify({
                 "success": False,
-                "error": f"Script file does not exist: {script_name}"
+                "error": _t(
+                    f"Script file does not exist: {script_name}",
+                    f"脚本文件不存在:{script_name}",
+                    locale,
+                )
             }), 404
         
         return send_file(
@@ -2884,16 +2989,17 @@ def generate_profiles():
             "platform": "reddit"              // Optional
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        
+
         graph_id = data.get('graph_id')
         if not graph_id:
             return jsonify({
                 "success": False,
-                "error": "Please provide graph_id"
+                "error": _t("Please provide graph_id", "请提供 graph_id", locale)
             }), 400
-        
+
         entity_types = data.get('entity_types')
         use_llm = data.get('use_llm', True)
         platform = data.get('platform', 'reddit')
@@ -2907,11 +3013,15 @@ def generate_profiles():
             defined_entity_types=entity_types,
             enrich_with_edges=True
         )
-        
+
         if filtered.filtered_count == 0:
             return jsonify({
                 "success": False,
-                "error": "No matching entities found"
+                "error": _t(
+                    "No matching entities found",
+                    "未找到匹配的实体",
+                    locale,
+                )
             }), 400
         
         generator = WonderwallProfileGenerator()
@@ -2989,10 +3099,11 @@ def start_simulation():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
 
-        simulation_id, err = _get_simulation_id_or_400(data)
+        simulation_id, err = _get_simulation_id_or_400(data, locale)
         if err:
             return err
 
@@ -3017,18 +3128,30 @@ def start_simulation():
                 if max_rounds <= 0:
                     return jsonify({
                         "success": False,
-                        "error": "max_rounds must be a positive integer"
+                        "error": _t(
+                            "max_rounds must be a positive integer",
+                            "max_rounds 必须为正整数",
+                            locale,
+                        )
                     }), 400
             except (ValueError, TypeError):
                 return jsonify({
                     "success": False,
-                    "error": "max_rounds must be a valid integer"
+                    "error": _t(
+                        "max_rounds must be a valid integer",
+                        "max_rounds 必须是有效的整数",
+                        locale,
+                    )
                 }), 400
 
         if platform not in ['twitter', 'reddit', 'polymarket', 'parallel']:
             return jsonify({
                 "success": False,
-                "error": f"Invalid platform type: {platform}, options: twitter/reddit/polymarket/parallel"
+                "error": _t(
+                    f"Invalid platform type: {platform}, options: twitter/reddit/polymarket/parallel",
+                    f"无效的平台类型:{platform},可选项:twitter/reddit/polymarket/parallel",
+                    locale,
+                )
             }), 400
 
         enable_cross_platform = data.get('enable_cross_platform', True)
@@ -3040,7 +3163,7 @@ def start_simulation():
         if not state:
             return jsonify({
                 "success": False,
-                "error": f"Simulation not found: {simulation_id}"
+                "error": _t(f"Simulation not found: {simulation_id}", f"未找到模拟:{simulation_id}", locale)
             }), 404
 
         force_restarted = False
@@ -3067,7 +3190,11 @@ def start_simulation():
                         else:
                             return jsonify({
                                 "success": False,
-                                "error": "Simulation is running, please call /stop endpoint to stop first, or use force=true to force restart"
+                                "error": _t(
+                                    "Simulation is running, please call /stop endpoint to stop first, or use force=true to force restart",
+                                    "模拟正在运行,请先调用 /stop 端点停止,或使用 force=true 强制重启",
+                                    locale,
+                                )
                             }), 400
 
                 # If force mode (and not resuming), clean up run logs
@@ -3086,7 +3213,11 @@ def start_simulation():
                 # Preparation incomplete
                 return jsonify({
                     "success": False,
-                    "error": f"Simulation not ready, current status: {state.status.value}, please call /prepare endpoint first"
+                    "error": _t(
+                        f"Simulation not ready, current status: {state.status.value}, please call /prepare endpoint first",
+                        f"模拟尚未就绪,当前状态:{state.status.value},请先调用 /prepare 端点",
+                        locale,
+                    )
                 }), 400
         
         # Get graph ID (for graph memory update)
@@ -3103,7 +3234,11 @@ def start_simulation():
             if not graph_id:
                 return jsonify({
                     "success": False,
-                    "error": "Enabling graph memory update requires a valid graph_id, please ensure the project has built a graph"
+                    "error": _t(
+                        "Enabling graph memory update requires a valid graph_id, please ensure the project has built a graph",
+                        "启用图谱记忆更新需要有效的 graph_id,请确保项目已构建图谱",
+                        locale,
+                    )
                 }), 400
             
             logger.info(f"Enable graph memory update: simulation_id={simulation_id}, graph_id={graph_id}")
@@ -3180,10 +3315,11 @@ def stop_simulation():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        
-        simulation_id, err = _get_simulation_id_or_400(data)
+
+        simulation_id, err = _get_simulation_id_or_400(data, locale)
         if err:
             return err
 
@@ -3615,10 +3751,15 @@ def get_influence_leaderboard(simulation_id: str):
     Compute agent influence scores from simulation action JSONL logs.
     Returns the top 20 agents sorted by score descending.
     """
+    locale = get_locale(request)
     try:
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         ranked = _compute_influence_ranked(simulation_id, top_n=20)
 
@@ -3648,10 +3789,15 @@ def get_belief_drift(simulation_id: str):
     consensus round (where one stance exceeds 50%), and a plain-English summary.
     Requires trajectory.json generated by the belief tracking system.
     """
+    locale = get_locale(request)
     try:
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         trajectory_path = os.path.join(sim_dir, "trajectory.json")
         if not os.path.exists(trajectory_path):
@@ -3851,10 +3997,15 @@ def get_counterfactual_drift(simulation_id: str):
 
     Pure data transform over trajectory.json — no LLM calls, no re-simulation.
     """
+    locale = get_locale(request)
     try:
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         trajectory_path = os.path.join(sim_dir, "trajectory.json")
         if not os.path.exists(trajectory_path):
@@ -4025,10 +4176,15 @@ def get_simulation_quality(simulation_id: str):
     badge (Excellent / Good / Low) plus actionable suggestions.
     Results are cached in quality.json inside the simulation directory.
     """
+    locale = get_locale(request)
     try:
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         quality_path = os.path.join(sim_dir, "quality.json")
         if os.path.exists(quality_path):
@@ -4425,11 +4581,16 @@ def polymarket_market_prices(simulation_id: str, market_id: int):
     Response: { success, data: { market, points: [{t, price_yes, side, outcome,
     shares, trade_id}] } }
     """
+    locale = get_locale(request)
     try:
         validate_simulation_id(simulation_id)
         db_path = _polymarket_db_path(simulation_id)
         if not os.path.exists(db_path):
-            return jsonify({"success": False, "error": "Polymarket not enabled for this simulation"}), 404
+            return jsonify({"success": False, "error": _t(
+                "Polymarket not enabled for this simulation",
+                "该模拟未启用 Polymarket",
+                locale,
+            )}), 404
 
         import sqlite3
         with sqlite3.connect(db_path) as con:
@@ -4440,7 +4601,11 @@ def polymarket_market_prices(simulation_id: str, market_id: int):
                 (market_id,),
             ).fetchone()
             if not market_row:
-                return jsonify({"success": False, "error": f"Market {market_id} not found"}), 404
+                return jsonify({"success": False, "error": _t(
+                    f"Market {market_id} not found",
+                    f"未找到市场 {market_id}",
+                    locale,
+                )}), 404
             trades = cur.execute(
                 "SELECT trade_id, user_id, side, outcome, shares, price, created_at "
                 "FROM trade WHERE market_id = ? ORDER BY created_at ASC, trade_id ASC",
@@ -4512,11 +4677,16 @@ def publish_simulation(simulation_id: str):
 
     Auth: requires ``Authorization: Bearer $MIROSHARK_ADMIN_TOKEN``.
     """
+    locale = get_locale(request)
     try:
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
         if not state:
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         payload = request.get_json(silent=True) or {}
         new_value = bool(payload.get("public", True))
@@ -4683,6 +4853,7 @@ def get_embed_summary(simulation_id: str):
     Access: requires ``is_public=True`` on the simulation state. Use the
     ``/publish`` endpoint to toggle.
     """
+    locale = get_locale(request)
     try:
         try:
             summary = _build_embed_summary_payload(simulation_id)
@@ -4692,7 +4863,11 @@ def get_embed_summary(simulation_id: str):
         if not summary.get("is_public"):
             return jsonify({
                 "success": False,
-                "error": "Simulation is not published for embedding. POST /api/simulation/<id>/publish to enable.",
+                "error": _t(
+                    "Simulation is not published for embedding. POST /api/simulation/<id>/publish to enable.",
+                    "该模拟未发布为可嵌入,请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
             }), 403
 
         response = jsonify({"success": True, "data": summary})
@@ -4721,6 +4896,7 @@ def get_share_card(simulation_id: str):
     from ..services import share_card as share_card_renderer
     from flask import Response
 
+    locale = get_locale(request)
     try:
         try:
             summary = _build_embed_summary_payload(simulation_id)
@@ -4730,7 +4906,11 @@ def get_share_card(simulation_id: str):
         if not summary.get("is_public"):
             return jsonify({
                 "success": False,
-                "error": "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                    "该模拟未发布,请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
             }), 403
 
         cache_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id, "share-cards")
@@ -4781,6 +4961,7 @@ def get_replay_gif(simulation_id: str):
     from ..services import replay_gif as replay_renderer
     from flask import Response
 
+    locale = get_locale(request)
     try:
         try:
             summary = _build_embed_summary_payload(simulation_id)
@@ -4790,7 +4971,11 @@ def get_replay_gif(simulation_id: str):
         if not summary.get("is_public"):
             return jsonify({
                 "success": False,
-                "error": "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                    "该模拟未发布,请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
             }), 403
 
         cache_dir = os.path.join(
@@ -4838,6 +5023,7 @@ def _serve_transcript(simulation_id: str, fmt: str):
     from ..services import transcript as transcript_renderer
     from flask import Response
 
+    locale = get_locale(request)
     try:
         try:
             summary = _build_embed_summary_payload(simulation_id)
@@ -4847,7 +5033,11 @@ def _serve_transcript(simulation_id: str, fmt: str):
         if not summary.get("is_public"):
             return jsonify({
                 "success": False,
-                "error": "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                    "该模拟未发布,请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
             }), 403
 
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
@@ -5325,10 +5515,11 @@ def interview_agent():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        
-        simulation_id, err = _get_simulation_id_or_400(data)
+
+        simulation_id, err = _get_simulation_id_or_400(data, locale)
         if err:
             return err
         agent_id = data.get('agent_id')
@@ -5339,27 +5530,39 @@ def interview_agent():
         if agent_id is None:
             return jsonify({
                 "success": False,
-                "error": "Please provide agent_id"
+                "error": _t("Please provide agent_id", "请提供 agent_id", locale)
             }), 400
-        
+
         if not prompt:
             return jsonify({
                 "success": False,
-                "error": "Please provide prompt (interview question)"
+                "error": _t(
+                    "Please provide prompt (interview question)",
+                    "请提供 prompt(访谈问题)",
+                    locale,
+                )
             }), 400
 
         # Validate platform parameter
         if platform and platform not in ("twitter", "reddit"):
             return jsonify({
                 "success": False,
-                "error": "platform parameter can only be 'twitter' or 'reddit'"
+                "error": _t(
+                    "platform parameter can only be 'twitter' or 'reddit'",
+                    "platform 参数只能为 'twitter' 或 'reddit'",
+                    locale,
+                )
             }), 400
 
         # Check environment status — auto-restart if needed
         if not _ensure_env_alive(simulation_id):
             return jsonify({
                 "success": False,
-                "error": "Simulation environment could not be started. Please try again."
+                "error": _t(
+                    "Simulation environment could not be started. Please try again.",
+                    "无法启动模拟环境,请重试。",
+                    locale,
+                )
             }), 400
 
         # Optimize prompt, add prefix to prevent agent from calling tools
@@ -5443,10 +5646,11 @@ def interview_agents_batch():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
 
-        simulation_id, err = _get_simulation_id_or_400(data)
+        simulation_id, err = _get_simulation_id_or_400(data, locale)
         if err:
             return err
         interviews = data.get('interviews')
@@ -5456,14 +5660,22 @@ def interview_agents_batch():
         if not interviews or not isinstance(interviews, list):
             return jsonify({
                 "success": False,
-                "error": "Please provide interviews (interview list)"
+                "error": _t(
+                    "Please provide interviews (interview list)",
+                    "请提供 interviews(访谈列表)",
+                    locale,
+                )
             }), 400
 
         # Validate platform parameter
         if platform and platform not in ("twitter", "reddit"):
             return jsonify({
                 "success": False,
-                "error": "platform parameter can only be 'twitter' or 'reddit'"
+                "error": _t(
+                    "platform parameter can only be 'twitter' or 'reddit'",
+                    "platform 参数只能为 'twitter' 或 'reddit'",
+                    locale,
+                )
             }), 400
 
         # Validate each interview item
@@ -5471,26 +5683,42 @@ def interview_agents_batch():
             if 'agent_id' not in interview:
                 return jsonify({
                     "success": False,
-                    "error": f"Interview list item {i+1} is missing agent_id"
+                    "error": _t(
+                        f"Interview list item {i+1} is missing agent_id",
+                        f"访谈列表第 {i+1} 项缺少 agent_id",
+                        locale,
+                    )
                 }), 400
             if 'prompt' not in interview:
                 return jsonify({
                     "success": False,
-                    "error": f"Interview list item {i+1} is missing prompt"
+                    "error": _t(
+                        f"Interview list item {i+1} is missing prompt",
+                        f"访谈列表第 {i+1} 项缺少 prompt",
+                        locale,
+                    )
                 }), 400
             # Validate each item's platform (if present)
             item_platform = interview.get('platform')
             if item_platform and item_platform not in ("twitter", "reddit"):
                 return jsonify({
                     "success": False,
-                    "error": f"Interview list item {i+1} platform can only be 'twitter' or 'reddit'"
+                    "error": _t(
+                        f"Interview list item {i+1} platform can only be 'twitter' or 'reddit'",
+                        f"访谈列表第 {i+1} 项的 platform 只能为 'twitter' 或 'reddit'",
+                        locale,
+                    )
                 }), 400
 
         # Check environment status — auto-restart if needed
         if not _ensure_env_alive(simulation_id):
             return jsonify({
                 "success": False,
-                "error": "Simulation environment could not be started. Please try again."
+                "error": _t(
+                    "Simulation environment could not be started. Please try again.",
+                    "无法启动模拟环境,请重试。",
+                    locale,
+                )
             }), 400
 
         # Optimize each interview item's prompt, add prefix to prevent agent from calling tools
@@ -5567,10 +5795,11 @@ def get_interview_history():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        
-        simulation_id, err = _get_simulation_id_or_400(data)
+
+        simulation_id, err = _get_simulation_id_or_400(data, locale)
         if err:
             return err
         platform = data.get('platform')  # If not specified, return history for both platforms
@@ -5625,10 +5854,11 @@ def get_env_status():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        
-        simulation_id, err = _get_simulation_id_or_400(data)
+
+        simulation_id, err = _get_simulation_id_or_400(data, locale)
         if err:
             return err
 
@@ -5668,9 +5898,10 @@ def restart_env():
     Restart simulation environment for interviews (without running simulation).
     Launches the simulation script with --env-only flag.
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        simulation_id, err = _get_simulation_id_or_400(data)
+        simulation_id, err = _get_simulation_id_or_400(data, locale)
         if err:
             return err
 
@@ -5688,7 +5919,11 @@ def restart_env():
         # Check if simulation is prepared
         is_prepared, _ = _check_simulation_prepared(simulation_id)
         if not is_prepared:
-            return jsonify({"success": False, "error": "Simulation not prepared"}), 400
+            return jsonify({"success": False, "error": _t(
+                "Simulation not prepared",
+                "模拟尚未准备完成",
+                locale,
+            )}), 400
 
         # Start the simulation script with --env-only
         run_state = SimulationRunner.start_simulation(
@@ -5743,10 +5978,11 @@ def close_simulation_env():
             }
         }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
-        
-        simulation_id, err = _get_simulation_id_or_400(data)
+
+        simulation_id, err = _get_simulation_id_or_400(data, locale)
         if err:
             return err
         timeout = data.get('timeout', 30)
@@ -5799,6 +6035,7 @@ def export_simulation_data(simulation_id: str):
     Returns:
         File download (application/json or text/csv)
     """
+    locale = get_locale(request)
     try:
         export_format = request.args.get('format', 'json').lower()
         include_raw = request.args.get('include', 'actions,posts,timeline,agent_stats,metadata')
@@ -5807,7 +6044,11 @@ def export_simulation_data(simulation_id: str):
         if export_format not in ('json', 'csv'):
             return jsonify({
                 "success": False,
-                "error": "Unsupported format. Use 'json' or 'csv'."
+                "error": _t(
+                    "Unsupported format. Use 'json' or 'csv'.",
+                    "不支持的格式,请使用 'json' 或 'csv'。",
+                    locale,
+                )
             }), 400
 
         export_data = {}
@@ -5883,7 +6124,11 @@ def export_simulation_data(simulation_id: str):
         if not rows:
             return jsonify({
                 "success": False,
-                "error": "No action data available to export as CSV"
+                "error": _t(
+                    "No action data available to export as CSV",
+                    "没有可导出为 CSV 的动作数据",
+                    locale,
+                )
             }), 404
 
         fieldnames = ['round_num', 'timestamp', 'platform', 'agent_id',
@@ -5941,15 +6186,24 @@ def compare_simulations():
         the other contribute a penalty of 0.5 per missing agent. The final score
         is the mean across all compared agents, clamped to [0, 1].
     """
+    locale = get_locale(request)
     try:
         id1 = request.args.get('id1', '').strip()
         id2 = request.args.get('id2', '').strip()
 
         if not id1 or not id2:
-            return jsonify({"success": False, "error": "Both id1 and id2 are required"}), 400
+            return jsonify({"success": False, "error": _t(
+                "Both id1 and id2 are required",
+                "需要同时提供 id1 和 id2",
+                locale,
+            )}), 400
 
         if id1 == id2:
-            return jsonify({"success": False, "error": "id1 and id2 must be different simulations"}), 400
+            return jsonify({"success": False, "error": _t(
+                "id1 and id2 must be different simulations",
+                "id1 和 id2 必须是不同的模拟",
+                locale,
+            )}), 400
 
         def _load_state(sim_id):
             m = SimulationManager()
@@ -6013,9 +6267,17 @@ def compare_simulations():
         state2 = _load_state(id2)
 
         if not state1:
-            return jsonify({"success": False, "error": f"Simulation not found: {id1}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {id1}",
+                f"未找到模拟:{id1}",
+                locale,
+            )}), 404
         if not state2:
-            return jsonify({"success": False, "error": f"Simulation not found: {id2}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {id2}",
+                f"未找到模拟:{id2}",
+                locale,
+            )}), 404
 
         influence1 = _compute_influence_ranked(id1, top_n=10)
         influence2 = _compute_influence_ranked(id2, top_n=10)
@@ -6123,6 +6385,7 @@ def resolve_simulation(simulation_id: str):
     """
     import sqlite3
 
+    locale = get_locale(request)
     try:
         data = request.get_json(force=True) or {}
         actual_outcome = (data.get("actual_outcome") or "").strip().upper()
@@ -6131,7 +6394,11 @@ def resolve_simulation(simulation_id: str):
         if actual_outcome not in ("YES", "NO"):
             return jsonify({
                 "success": False,
-                "error": "actual_outcome must be 'YES' or 'NO'"
+                "error": _t(
+                    "actual_outcome must be 'YES' or 'NO'",
+                    "actual_outcome 必须为 'YES' 或 'NO'",
+                    locale,
+                )
             }), 400
 
         manager = SimulationManager()
@@ -6139,7 +6406,7 @@ def resolve_simulation(simulation_id: str):
         if not state:
             return jsonify({
                 "success": False,
-                "error": f"Simulation not found: {simulation_id}"
+                "error": _t(f"Simulation not found: {simulation_id}", f"未找到模拟:{simulation_id}", locale)
             }), 404
 
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
@@ -6252,6 +6519,7 @@ def simulation_outcome(simulation_id: str):
     Auth: POST requires ``Authorization: Bearer $MIROSHARK_ADMIN_TOKEN``.
     GET is unauthenticated — the gallery and embed widgets read this.
     """
+    locale = get_locale(request)
     # Gate POST writes on the admin token (GET stays public — the
     # gallery reads this and the embed dialog re-renders the existing
     # annotation when an operator re-opens it).
@@ -6264,19 +6532,27 @@ def simulation_outcome(simulation_id: str):
             )
             return jsonify({
                 "success": False,
-                "error": "Admin authentication is not configured on this deployment.",
+                "error": _t(
+                    "Admin authentication is not configured on this deployment.",
+                    "此部署尚未配置管理员身份验证。",
+                    locale,
+                ),
             }), 503
         provided = _extract_bearer_token()
         if not provided or not hmac.compare_digest(
             provided.encode("utf-8"), expected.encode("utf-8")
         ):
-            return jsonify({"success": False, "error": "Unauthorized"}), 401
+            return jsonify({"success": False, "error": _t("Unauthorized", "未授权", locale)}), 401
 
     try:
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
         if not state:
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
 
@@ -6287,7 +6563,11 @@ def simulation_outcome(simulation_id: str):
         if not bool(getattr(state, "is_public", False)):
             return jsonify({
                 "success": False,
-                "error": "Simulation must be public to record an outcome. POST /api/simulation/<id>/publish to enable.",
+                "error": _t(
+                    "Simulation must be public to record an outcome. POST /api/simulation/<id>/publish to enable.",
+                    "必须将模拟设为公开后才能记录结果。请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
             }), 403
 
         data = request.get_json(force=True, silent=True) or {}
@@ -6295,33 +6575,53 @@ def simulation_outcome(simulation_id: str):
         if label not in _VALID_OUTCOME_LABELS:
             return jsonify({
                 "success": False,
-                "error": "label must be one of: correct, incorrect, partial",
+                "error": _t(
+                    "label must be one of: correct, incorrect, partial",
+                    "label 必须为以下之一:correct、incorrect、partial",
+                    locale,
+                ),
             }), 400
 
         outcome_url = (data.get("outcome_url") or "").strip()
         if outcome_url and not (outcome_url.startswith("http://") or outcome_url.startswith("https://")):
             return jsonify({
                 "success": False,
-                "error": "outcome_url must be an http(s) URL",
+                "error": _t(
+                    "outcome_url must be an http(s) URL",
+                    "outcome_url 必须是 http(s) URL",
+                    locale,
+                ),
             }), 400
         if len(outcome_url) > 500:
             return jsonify({
                 "success": False,
-                "error": "outcome_url must be 500 characters or fewer",
+                "error": _t(
+                    "outcome_url must be 500 characters or fewer",
+                    "outcome_url 不能超过 500 个字符",
+                    locale,
+                ),
             }), 400
 
         outcome_summary = (data.get("outcome_summary") or "").strip()
         if len(outcome_summary) > 280:
             return jsonify({
                 "success": False,
-                "error": "outcome_summary must be 280 characters or fewer",
+                "error": _t(
+                    "outcome_summary must be 280 characters or fewer",
+                    "outcome_summary 不能超过 280 个字符",
+                    locale,
+                ),
             }), 400
 
         try:
             os.makedirs(sim_dir, exist_ok=True)
         except OSError as exc:
             logger.error(f"outcome: failed to ensure sim_dir for {simulation_id}: {exc}")
-            return jsonify({"success": False, "error": "Could not persist outcome."}), 500
+            return jsonify({"success": False, "error": _t(
+                "Could not persist outcome.",
+                "无法保存结果。",
+                locale,
+            )}), 500
 
         record = {
             "simulation_id": simulation_id,
@@ -6337,7 +6637,11 @@ def simulation_outcome(simulation_id: str):
                 json.dump(record, f, ensure_ascii=False, indent=2)
         except OSError as exc:
             logger.error(f"outcome: failed to write {outcome_path}: {exc}")
-            return jsonify({"success": False, "error": "Could not persist outcome."}), 500
+            return jsonify({"success": False, "error": _t(
+                "Could not persist outcome.",
+                "无法保存结果。",
+                locale,
+            )}), 500
 
         logger.info(
             f"outcome: recorded label={label} for {simulation_id} (url_set={bool(outcome_url)})"
@@ -6380,6 +6684,7 @@ def generate_simulation_article(simulation_id: str):
             }
         }
     """
+    locale = get_locale(request)
     try:
         body = request.get_json(silent=True) or {}
         force_regenerate = body.get('force_regenerate', False)
@@ -6389,7 +6694,7 @@ def generate_simulation_article(simulation_id: str):
         if not os.path.exists(sim_dir):
             return jsonify({
                 "success": False,
-                "error": f"Simulation not found: {simulation_id}"
+                "error": _t(f"Simulation not found: {simulation_id}", f"未找到模拟:{simulation_id}", locale)
             }), 404
 
         # --- Cache check ---
@@ -6800,17 +7105,26 @@ def trace_interview_agent(simulation_id: str, agent_name: str):
             }
         }
     """
+    locale = get_locale(request)
     try:
         body = request.get_json(silent=True) or {}
         question = (body.get('question') or '').strip()
         history = body.get('history') or []
 
         if not question:
-            return jsonify({"success": False, "error": "Please provide a question"}), 400
+            return jsonify({"success": False, "error": _t(
+                "Please provide a question",
+                "请提供问题",
+                locale,
+            )}), 400
 
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         # --- Get simulation scenario ---
         scenario = ''
@@ -6983,10 +7297,15 @@ def get_agent_interview_transcript(simulation_id: str, agent_name: str):
             }
         }
     """
+    locale = get_locale(request)
     try:
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         safe_name = ''.join(c if c.isalnum() or c in '-_.' else '_' for c in agent_name)
         transcript_path = os.path.join(sim_dir, 'interviews', f'{safe_name}.json')
@@ -7079,17 +7398,30 @@ def subscribe_push_notification():
     Returns:
         { "success": true }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json(force=True) or {}
         simulation_id = data.get('simulation_id', '').strip()
         subscription = data.get('subscription')
 
         if not simulation_id:
-            return jsonify({"success": False, "error": "simulation_id is required"}), 400
+            return jsonify({"success": False, "error": _t(
+                "simulation_id is required",
+                "缺少 simulation_id",
+                locale,
+            )}), 400
         if not subscription or not isinstance(subscription, dict):
-            return jsonify({"success": False, "error": "subscription object is required"}), 400
+            return jsonify({"success": False, "error": _t(
+                "subscription object is required",
+                "缺少 subscription 对象",
+                locale,
+            )}), 400
         if not subscription.get('endpoint'):
-            return jsonify({"success": False, "error": "subscription.endpoint is required"}), 400
+            return jsonify({"success": False, "error": _t(
+                "subscription.endpoint is required",
+                "缺少 subscription.endpoint",
+                locale,
+            )}), 400
 
         try:
             validate_simulation_id(simulation_id)
@@ -7123,12 +7455,17 @@ def test_push_notification():
     Returns:
         { "success": true }
     """
+    locale = get_locale(request)
     try:
         data = request.get_json(force=True) or {}
         simulation_id = data.get('simulation_id', '').strip()
 
         if not simulation_id:
-            return jsonify({"success": False, "error": "simulation_id is required"}), 400
+            return jsonify({"success": False, "error": _t(
+                "simulation_id is required",
+                "缺少 simulation_id",
+                locale,
+            )}), 400
 
         try:
             validate_simulation_id(simulation_id)
@@ -7182,29 +7519,50 @@ def inject_director_event(simulation_id: str):
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../scripts'))
     from director_events import add_event, get_event_count
 
+    locale = get_locale(request)
     try:
         data = request.get_json() or {}
         event_text = (data.get('event_text') or '').strip()
 
         if not event_text:
-            return jsonify({"success": False, "error": "event_text is required"}), 400
+            return jsonify({"success": False, "error": _t(
+                "event_text is required",
+                "缺少 event_text",
+                locale,
+            )}), 400
 
         if len(event_text) > 500:
-            return jsonify({"success": False, "error": "event_text must be under 500 characters"}), 400
+            return jsonify({"success": False, "error": _t(
+                "event_text must be under 500 characters",
+                "event_text 不能超过 500 个字符",
+                locale,
+            )}), 400
 
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         # Check simulation is running
         state = SimulationRunner.get_run_state(simulation_id)
         if not state or state.runner_status not in [RunnerStatus.RUNNING]:
-            return jsonify({"success": False, "error": "Simulation is not currently running"}), 400
+            return jsonify({"success": False, "error": _t(
+                "Simulation is not currently running",
+                "模拟当前未在运行",
+                locale,
+            )}), 400
 
         # Enforce max 10 events per simulation
         total = get_event_count(sim_dir)
         if total >= 10:
-            return jsonify({"success": False, "error": "Maximum 10 events per simulation reached"}), 400
+            return jsonify({"success": False, "error": _t(
+                "Maximum 10 events per simulation reached",
+                "每次模拟最多 10 个事件,已达上限",
+                locale,
+            )}), 400
 
         current_round = state.current_round or 0
         event = add_event(sim_dir, event_text, current_round)
@@ -7236,10 +7594,15 @@ def get_director_events(simulation_id: str):
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../scripts'))
     from director_events import get_event_history, get_pending_events
 
+    locale = get_locale(request)
     try:
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         return jsonify({
             "success": True,
@@ -7262,10 +7625,15 @@ def get_interaction_network(simulation_id: str):
     Results are cached in network.json.
     """
 
+    locale = get_locale(request)
     try:
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         cache_path = os.path.join(sim_dir, "network.json")
         if os.path.exists(cache_path):
@@ -7760,10 +8128,15 @@ def get_demographic_breakdown(simulation_id: str):
     so no extra collection is required. Results are cached in demographics.json
     inside the simulation directory.
     """
+    locale = get_locale(request)
     try:
         sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
         if not os.path.exists(sim_dir):
-            return jsonify({"success": False, "error": f"Simulation not found: {simulation_id}"}), 404
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
 
         force_refresh = request.args.get('refresh', '').lower() in ('1', 'true', 'yes')
         cache_path = os.path.join(sim_dir, "demographics.json")

--- a/backend/app/services/feed.py
+++ b/backend/app/services/feed.py
@@ -379,6 +379,7 @@ def render_rss(
     title: str,
     subtitle: str,
     verified_only: bool = False,
+    locale: str = "en",
 ) -> bytes:
     """Render the public-gallery cards as an RSS 2.0 XML feed.
 
@@ -409,7 +410,7 @@ def render_rss(
     ET.SubElement(channel, "generator").text = (
         f"{FEED_GENERATOR_NAME} (https://github.com/aaronjmars/MiroShark)"
     )
-    ET.SubElement(channel, "language").text = "en"
+    ET.SubElement(channel, "language").text = "zh-CN" if locale == "zh-CN" else "en"
 
     cards_list = list(cards)
     most_recent_iso = ""
@@ -496,26 +497,47 @@ def render_feed(
     base_url: str,
     feed_path: str,
     verified_only: bool = False,
+    locale: str = "en",
 ) -> tuple[bytes, str]:
     """Render the feed in the requested format.
 
     Returns ``(body_bytes, mime_type)``. ``fmt`` accepts ``"atom"`` (the
     default) or ``"rss"`` — anything else falls back to Atom so a
     misrouted call still returns a valid feed.
+
+    ``locale`` switches the channel title + description between English
+    (default) and ``zh-CN``. Per-entry scenario text and the bracketed
+    feature names (Feedly / Readwise / Inoreader / NetNewsWire) stay in
+    their source language so reader auto-discovery still matches.
     """
+    is_zh = locale == "zh-CN"
     if verified_only:
-        title = "MiroShark · Verified Predictions"
-        subtitle = (
-            "Public MiroShark simulations whose operators marked a "
-            "real-world outcome — calls that landed (and those that didn't)."
-        )
+        if is_zh:
+            title = "MiroShark · 已验证预言"
+            subtitle = (
+                "已被运营者标注真实世界结果的 MiroShark 公开模拟——"
+                "应验的预言(以及未应验的)。"
+            )
+        else:
+            title = "MiroShark · Verified Predictions"
+            subtitle = (
+                "Public MiroShark simulations whose operators marked a "
+                "real-world outcome — calls that landed (and those that didn't)."
+            )
     else:
-        title = "MiroShark · Public Simulations"
-        subtitle = (
-            "Newest published MiroShark simulations — agent populations, "
-            "belief drift, and prediction outcomes you can fork into your "
-            "own scenarios."
-        )
+        if is_zh:
+            title = "MiroShark · 公开模拟"
+            subtitle = (
+                "最新发布的 MiroShark 模拟——智能体群体、信念漂移与预测结果,"
+                "可分叉到你自己的场景中。"
+            )
+        else:
+            title = "MiroShark · Public Simulations"
+            subtitle = (
+                "Newest published MiroShark simulations — agent populations, "
+                "belief drift, and prediction outcomes you can fork into your "
+                "own scenarios."
+            )
 
     fmt_norm = (fmt or "").strip().lower()
     if fmt_norm == "rss":
@@ -526,6 +548,7 @@ def render_feed(
             title=title,
             subtitle=subtitle,
             verified_only=verified_only,
+            locale=locale,
         )
         mime = "application/rss+xml; charset=utf-8"
     else:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,7 @@
 # HTTP API Reference
 
+<sup>English · [中文](API.zh-CN.md)</sup>
+
 Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless otherwise noted.
 
 > **Interactive docs:** the running backend serves Swagger UI at `/api/docs` and the OpenAPI 3.1 spec at `/api/openapi.yaml` (or `/api/openapi.json`). Point [`openapi-generator`](https://openapi-generator.tech/) at the spec to produce a Python / TypeScript / Go SDK in one command.

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -1,0 +1,134 @@
+<sup>[English](API.md) · 中文</sup>
+
+# HTTP API 参考
+
+开发环境的 base URL 是 `http://localhost:5001`。除非另有说明,每个端点都返回 JSON。
+
+> **交互式文档:** 运行中的后端会在 `/api/docs` 暴露 Swagger UI,在 `/api/openapi.yaml`(或 `/api/openapi.json`)暴露 OpenAPI 3.1 规范。把 [`openapi-generator`](https://openapi-generator.tech/) 指向这份规范,一行命令就能生成 Python / TypeScript / Go SDK。
+
+## 配置与发现
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `POST` | `/api/simulation/suggest-scenarios` | 从文档预览生成情景自动建议(看涨 / 看跌 / 中立) |
+| `GET` | `/api/simulation/trending` | 拉取 RSS/Atom 条目,用于"热门"面板 |
+| `POST` | `/api/simulation/ask` | 直接提问 — 从一个问题合成种子简报 |
+| `POST` | `/api/graph/fetch-url` | 从 URL 抓取并抽取文本 |
+| `GET` | `/api/templates/list` | 预设模板 |
+| `GET` | `/api/templates/<id>?enrich=true` | 模板 + FeedOracle 实时增强 |
+
+## 图谱构建(步骤 1)
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `POST` | `/api/graph/ontology/generate` | NER + 本体抽取 |
+| `POST` | `/api/graph/build` | 根据本体构建 Neo4j 图谱 |
+| `GET` | `/api/graph/task/<task_id>` | 轮询异步任务状态 |
+| `GET` | `/api/graph/data/<graph_id>` | 分页的图节点 + 边 |
+| `GET` | `/api/simulation/entities/<graph_id>` | 浏览实体 |
+| `GET` | `/api/simulation/entities/<graph_id>/<uuid>` | 单个实体 + 邻域 |
+
+## 模拟生命周期
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `POST` | `/api/simulation/create` | 根据种子 + 提示词创建模拟 |
+| `POST` | `/api/simulation/prepare` | 启动画像生成(步骤 2) |
+| `POST` | `/api/simulation/prepare/status` | 轮询步骤 2 |
+| `POST` | `/api/simulation/start` | 启动 Wonderwall 子进程(步骤 3) |
+| `POST` | `/api/simulation/stop` | 终止 |
+| `POST` | `/api/simulation/branch-counterfactual` | 注入反事实并分叉 |
+| `POST` | `/api/simulation/fork` | 复制配置 |
+| `POST` | `/api/simulation/<id>/director/inject` | 导演模式 — 实时事件注入 |
+| `GET` | `/api/simulation/<id>/director/events` | 列出导演事件 |
+
+## 实时状态与数据
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/api/simulation/<id>/run-status` | 当前轮次 / 总数 |
+| `GET` | `/api/simulation/<id>/run-status/detail` | 各平台进度 |
+| `GET` | `/api/simulation/<id>/frame/<round>` | 单轮的紧凑快照 |
+| `GET` | `/api/simulation/<id>/timeline` | 逐轮总结 |
+| `GET` | `/api/simulation/<id>/actions` | 原始智能体动作日志 |
+| `GET` | `/api/simulation/<id>/posts` | 分页帖子(Twitter + Reddit) |
+| `GET` | `/api/simulation/<id>/profiles` | 智能体人设 |
+| `GET` | `/api/simulation/<id>/profiles/realtime` | 实时信念更新 |
+| `GET` | `/api/simulation/<id>/polymarket/markets` | 市场 + 当前价格 |
+| `GET` | `/api/simulation/<id>/polymarket/market/<mid>/prices` | 价格历史 |
+
+## 分析
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/api/simulation/<id>/belief-drift` | 每个话题每轮的立场漂移 |
+| `GET` | `/api/simulation/<id>/counterfactual` | 原始 vs 分支对比 |
+| `GET` | `/api/simulation/<id>/agent-stats` | 单智能体的参与度 + 发帖 |
+| `GET` | `/api/simulation/<id>/influence` | 影响力排行榜 |
+| `GET` | `/api/simulation/<id>/interaction-network` | 智能体之间的交互图 |
+| `GET` | `/api/simulation/<id>/demographics` | 原型分布 |
+| `GET` | `/api/simulation/<id>/quality` | 运行健康诊断 |
+| `POST` | `/api/simulation/compare` | 信念并排对比 |
+
+## 交互
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `POST` | `/api/simulation/interview` | 与单个智能体对话 |
+| `POST` | `/api/simulation/interview/batch` | 并行向一组智能体提问 |
+| `POST` | `/api/simulation/<id>/agents/<name>/trace-interview` | 带完整推理链的对话 |
+| `GET` | `/api/simulation/<id>/interviews/<name>` | 与某个智能体的历史对话 |
+
+## 发布 / 嵌入 / 导出
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `POST` | `/api/simulation/<id>/publish` | 切换 `is_public` |
+| `GET` | `/api/simulation/<id>/embed-summary` | 嵌入载荷(仅公开模拟) |
+| `POST` | `/api/simulation/<id>/article` | 生成 Substack 风格的报道 |
+| `GET` | `/api/simulation/<id>/export` | 完整 JSON 导出 |
+| `GET` | `/api/simulation/list` | 列出模拟 |
+| `GET` | `/api/simulation/history` | 模拟历史 / 差异 |
+
+## 报告智能体
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `POST` | `/api/report/generate` | 启动 ReACT 报告智能体 |
+| `POST` | `/api/report/generate/status` | 轮询生成进度 |
+| `GET` | `/api/report/<id>` | 完整报告 |
+| `GET` | `/api/report/by-simulation/<sim_id>` | 某次模拟对应的报告 |
+| `GET` | `/api/report/<id>/download` | PDF 导出 |
+| `POST` | `/api/report/chat` | 与报告智能体对话(会重新查询图谱) |
+| `GET` | `/api/report/<id>/agent-log` | 完整 ReACT 轨迹 |
+| `GET` | `/api/report/<id>/agent-log/stream` | SSE 流 |
+| `GET` | `/api/report/<id>/console-log` | 原始 LLM 调用日志 |
+
+## 可观测性
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/api/observability/events/stream` | SSE 推送 |
+| `GET` | `/api/observability/events` | 事件日志(分页) |
+| `GET` | `/api/observability/stats` | 聚合统计 |
+| `GET` | `/api/observability/llm-calls` | LLM 调用历史 |
+
+## 设置与推送
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` / `POST` | `/api/settings` | 运行时设置(密钥已脱敏) |
+| `POST` | `/api/settings/test-llm` | Ping 已配置的 LLM |
+| `GET` | `/api/simulation/push/vapid-public-key` | Web Push 用的 VAPID key |
+| `POST` | `/api/simulation/push/subscribe` | 注册一个浏览器订阅 |
+| `POST` | `/api/simulation/push/test` | 触发一条测试通知 |
+
+## 交互式文档
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/api/docs` | 基于本规范渲染的 Swagger UI — 启用 try-it-out |
+| `GET` | `/api/openapi.yaml` | OpenAPI 3.1 规范,YAML 格式(基准) |
+| `GET` | `/api/openapi.json` | 同一份规范,JSON 格式(便于 `openapi-generator`) |
+
+规范本身已提交到仓库的 `backend/openapi.yaml`。一个单元测试(`backend/tests/test_unit_openapi.py`)会在每次 push 时遍历所有 Flask 路由,如果规范和实现出现漂移就让 CI 失败。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture
 
+<sup>English · [中文](ARCHITECTURE.zh-CN.md)</sup>
+
 ## Pipeline overview
 
 1. **Graph build** — Extracts entities and relationships from your document into a Neo4j knowledge graph. NER uses few-shot examples and rejection rules to filter garbage entities. Chunk processing is parallelized with batched Neo4j writes (UNWIND).

--- a/docs/ARCHITECTURE.zh-CN.md
+++ b/docs/ARCHITECTURE.zh-CN.md
@@ -1,0 +1,127 @@
+<sup>[English](ARCHITECTURE.md) · 中文</sup>
+
+# 架构
+
+## 流水线总览
+
+1. **图谱构建** — 把你文档中的实体和关系抽取到一个 Neo4j 知识图谱里。NER 使用少样本示例和拒绝规则来过滤垃圾实体。分块处理通过批量 Neo4j 写入(UNWIND)做了并行。
+
+2. **智能体配置** — 基于知识图谱生成人设。每个实体获得 5 层上下文:图谱属性、关系、语义检索、相邻节点,以及 LLM 驱动的网络调研(在涉及公众人物或图谱上下文不足时自动触发)。个体 vs 机构人设通过关键词匹配自动检测。
+
+3. **模拟** — 三个平台(Twitter、Reddit、Polymarket)通过 `asyncio.gather` 同时运行。一个由 LLM 生成、初始价格非 50/50 的预测市场驱动 Polymarket 交易。智能体能看到跨平台上下文:交易者读 Twitter/Reddit 帖子,社交媒体智能体能看到市场价格。一个滑动窗口式的轮次记忆通过后台 LLM 调用压缩旧轮次。信念状态记录每个智能体的立场、置信度和信任度,每轮都用启发式更新。
+
+4. **报告** — 一个 ReACT 智能体使用 `simulation_feed`(真实的帖子/评论/交易)、`market_state`(价格/盈亏)、图谱搜索、信念轨迹、纳什均衡等工具来撰写分析报告。报告会引用智能体真实的发言和市场实际的走势。
+
+5. **交互** — 通过人设对话直接和任意智能体聊天,向群组提问,或者在任意轮次给模拟分叉一个反事实事件,以并排对比"如果"情景。点击任意智能体可以查看其完整画像和模拟历史。
+
+## 跨平台模拟引擎
+
+每一轮三个平台同时执行。数据在它们之间流动:
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │         Round Memory (sliding window)    │
+                    │  Old rounds: LLM-compacted summaries     │
+                    │  Previous round: full action detail       │
+                    │  Current round: live (partial)            │
+                    └──────┬──────────┬──────────┬────────────┘
+                           │          │          │
+                    ┌──────▼───┐ ┌────▼─────┐ ┌─▼────────────┐
+                    │ Twitter  │ │  Reddit  │ │  Polymarket   │
+                    │          │ │          │ │               │
+                    │ Posts    │ │ Comments │ │ Trades (AMM)  │
+                    │ Likes    │ │ Upvotes  │ │ Single market │
+                    │ Reposts  │ │ Threads  │ │ Buy/Sell/Wait │
+                    └──────┬───┘ └────┬─────┘ └─┬────────────┘
+                           │          │          │
+                    ┌──────▼──────────▼──────────▼────────────┐
+                    │         Market-Media Bridge              │
+                    │  Social sentiment → trader prompts       │
+                    │  Market prices → social media prompts    │
+                    │  Social posts → trader observation       │
+                    └──────┬──────────┬──────────┬────────────┘
+                           │          │          │
+                    ┌──────▼──────────▼──────────▼────────────┐
+                    │         Belief State (per agent)         │
+                    │  Positions: topic → stance (-1 to +1)    │
+                    │  Confidence: topic → certainty (0 to 1)  │
+                    │  Trust: agent → trust level (0 to 1)     │
+                    └─────────────────────────────────────────┘
+```
+
+## Polymarket 集成
+
+模拟配置创建期间,LLM 会生成单个预测市场,围绕该模拟的核心问题量身定制。市场标题生成走 **Smart** 槽位(见 [Models](MODELS.zh-CN.md)),让措辞精准、有时间界限、可结算 — 这是定义整场模拟的提示词,值得用更强的模型。AMM 使用恒定乘积定价,初始价格依据 LLM 的概率估计而非 50/50。交易者在他们的观察提示里能看到 Twitter/Reddit 上真实的帖子,以及自己的投资组合和市场数据。
+
+## 性能
+
+| 优化项 | 优化前 | 优化后 |
+|---|---|---|
+| Neo4j 写入 | 每个实体一个事务 | 批量 UNWIND(快 10 倍) |
+| 分块处理 | 顺序 | 并行 ThreadPoolExecutor(快 3 倍) |
+| 配置生成 | 顺序批量 | 并行批量(快 3 倍) |
+| 平台执行 | Twitter+Reddit 并行,Polymarket 顺序 | 三者全并行 |
+| 记忆压缩 | 阻塞 | 后台线程 |
+
+## Web 增强
+
+在为公众人物(政治家、CEO、创始人)生成画像时,或当图谱上下文太薄(<150 字符)时,系统会发起一次 LLM 调研调用,用真实世界数据丰富画像。在 `.env` 中设置 `WEB_SEARCH_MODEL=perplexity/sonar-pro`,通过 OpenRouter 进行接地的网络搜索。
+
+## 单轮帧 API
+
+`GET /api/simulation/<id>/frame/<round>` 返回某一轮的紧凑快照 — 动作、活跃智能体计数、当轮市场价格和信念状态 — 适合大型模拟的 scrub UI。这是不必通过 `/run-status/detail` 一次性加载全部 N × M 动作的替代方案。查询参数:`platforms=twitter,reddit,polymarket`、`include_belief`、`include_market`。被 **ReplayView** 用于时间轴拖动,也被 CLI(`miroshark-cli frame <id> <round>`)使用。
+
+## 记忆与检索流水线
+
+除了模拟引擎,MiroShark 还自带一个研究级的图谱记忆栈,灵感来自 Hindsight、Graphiti、Letta 和 HippoRAG。每个被摄入的文档和模拟动作都流过下面的过程:
+
+### 摄入
+
+```
+text → NER (with ontology)
+     → batch embed (OpenRouter text-embedding-3-large or local Ollama)
+     → Entity resolution (fuzzy + vector + LLM reflection — dedups "NeuralCoin"/"Neural Coin"/"NC")
+     → MERGE entities into Neo4j with canonical UUIDs
+     → Contradiction detection (LLM adjudicates same-endpoint pairs → invalidate old)
+     → CREATE RELATION edges with {valid_at, invalid_at, kind, source_type, source_id}
+```
+
+### 检索(`storage.search(...)`)
+
+```
+query
+  ├─ vector edge search (Neo4j HNSW)   ─┐
+  ├─ BM25 edge search (Neo4j fulltext) ─┼─ temporal + kind filters → fused candidates (top 30)
+  └─ BFS traversal from seed entities  ─┘
+                                        ↓
+                           BGE-reranker-v2-m3 cross-encoder (Apple MPS / CUDA / CPU)
+                                        ↓
+                         top `limit` with _sources tag ("v" / "k" / "g" / combos)
+```
+
+### 缩放层(`storage.build_communities(...)`)
+
+- 在实体图上做 Leiden 社区检测(通过 igraph)
+- 每个簇由 LLM 生成标题 + 2 句话摘要
+- 持久化为带有 `MEMBER_OF` 边的 `:Community` 节点
+- 通过 `browse_clusters` 智能体工具对簇摘要做语义检索
+
+### 推理记忆
+
+每次报告生成都会把完整的 ReACT 轨迹持久化为可遍历子图:
+
+```
+(:Report)-[:HAS_SECTION]->(:ReportSection)-[:HAS_STEP]->(:ReasoningStep)
+```
+
+步骤类别有 `thought | tool_call | observation | conclusion`。可以用 `storage.get_reasoning_trace(section_uuid)` 查询历史报告的推理过程。
+
+### 这些能给你什么
+
+- 多跳查询能用上(图遍历能抓到只有连接关系匹配的事实)
+- 时间维度查询能用上(`as_of="2026-04-10T14:00Z"` 返回那一刻所知的世界)
+- 认识论过滤(`kinds=["belief"]` 只返回智能体观点,不返回事实)
+- 报告可以被反复查询("为什么这个智能体得出 X 结论?")
+- 首次召回足够高,所以报告智能体那 5 次工具调用预算能用得更远
+
+11 个特性默认全部开启,都可以通过 `.env` 开关单独关闭 — 见 [Configuration](CONFIGURATION.zh-CN.md#特性开关汇总)。

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,5 +1,7 @@
 # CLI
 
+<sup>English · [中文](CLI.zh-CN.md)</sup>
+
 A dependency-light HTTP client for a running MiroShark backend.
 
 ## Install

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -1,0 +1,33 @@
+<sup>[English](CLI.md) · 中文</sup>
+
+# CLI
+
+为运行中的 MiroShark 后端提供一个依赖极少的 HTTP 客户端。
+
+## 安装
+
+```bash
+# From a checkout with the backend installed:
+pip install -e backend/
+miroshark-cli ask "Will the EU AI Act survive trilogue?"
+
+# Or run directly — no install, no third-party deps:
+python backend/cli.py --help
+```
+
+设置 `MIROSHARK_API_URL` 即可指向远程部署。
+
+## 命令
+
+| 命令 | 作用 |
+|---|---|
+| `ask "<question>"` | 从一个问题合成种子简报 |
+| `list` | 列出模拟 / 项目 |
+| `status <sim_id>` | runner 状态 + 当前轮次/总数 |
+| `frame <sim_id> <round>` | 单轮的紧凑快照 |
+| `publish <sim_id> [--unpublish]` | 切换嵌入公开标志 |
+| `report <sim_id>` | 渲染分析报告 |
+| `trending` | 拉取 RSS/Atom 热门条目 |
+| `health` | Ping `/health` |
+
+所有命令都接受 `--json` 以便脚本化使用。

--- a/docs/CONFIGURATION.zh-CN.md
+++ b/docs/CONFIGURATION.zh-CN.md
@@ -1,10 +1,10 @@
-# Configuration
+<sup>[English](CONFIGURATION.md) · 中文</sup>
 
-<sup>English · [中文](CONFIGURATION.zh-CN.md)</sup>
+# 配置
 
-All settings live in `.env` (copy from `.env.example`). The full reference below is organized by concern. For model selection (which model for which slot, benchmarks, Ollama context overrides) see [Models](MODELS.md).
+所有设置都在 `.env`(从 `.env.example` 拷贝)。下面这份完整参考按关注点分组。模型选择(哪个槽位用哪个模型、基准、Ollama 上下文覆盖)请见 [Models](MODELS.zh-CN.md)。
 
-## Minimum required
+## 最低必填项
 
 ```bash
 # LLM
@@ -24,22 +24,22 @@ EMBEDDING_API_KEY=your-api-key
 EMBEDDING_DIMENSIONS=768
 ```
 
-## Model slots
+## 模型槽位
 
-MiroShark routes different workflows to different models. Four independent slots:
+MiroShark 把不同的工作流路由到不同的模型。共有四个相互独立的槽位:
 
-| Slot | Env var | What it does | Volume |
+| 槽位 | 环境变量 | 作用 | 调用量 |
 |---|---|---|---|
-| **Default** | `LLM_MODEL_NAME` | Profiles, sim config, memory compaction | ~75–126 calls |
-| **Smart** | `SMART_MODEL_NAME` | Reports, ontology, graph reasoning | ~19 calls |
-| **NER** | `NER_MODEL_NAME` | Entity extraction (structured JSON) | ~85–250 calls |
-| **Wonderwall** | `WONDERWALL_MODEL_NAME` | Agent decisions in simulation loop | ~850–1650 calls |
+| **Default** | `LLM_MODEL_NAME` | 画像、模拟配置、记忆压缩 | ~75–126 次调用 |
+| **Smart** | `SMART_MODEL_NAME` | 报告、本体、图谱推理 | ~19 次调用 |
+| **NER** | `NER_MODEL_NAME` | 实体抽取(结构化 JSON) | ~85–250 次调用 |
+| **Wonderwall** | `WONDERWALL_MODEL_NAME` | 模拟循环中的智能体决策 | ~850–1650 次调用 |
 
-When a slot is not set it falls back to the Default model. If only `SMART_MODEL_NAME` is set (without `SMART_PROVIDER`/`SMART_BASE_URL`/`SMART_API_KEY`), the smart model inherits the default provider settings. The same applies to `WONDERWALL_MODEL_NAME` — set `WONDERWALL_BASE_URL` and/or `WONDERWALL_API_KEY` to point Wonderwall at a different OpenAI-compatible endpoint (e.g. a self-hosted vLLM/Modal deployment) without touching the other slots.
+未设置的槽位会回退到 Default 模型。如果只设置了 `SMART_MODEL_NAME`(没有设 `SMART_PROVIDER`/`SMART_BASE_URL`/`SMART_API_KEY`),smart 模型会继承 default 的提供商设置。`WONDERWALL_MODEL_NAME` 也是同样的逻辑 — 设置 `WONDERWALL_BASE_URL` 和/或 `WONDERWALL_API_KEY` 就能把 Wonderwall 指向另一个 OpenAI 兼容端点(例如自部署的 vLLM/Modal 部署),而不影响其他槽位。
 
-See [Models](MODELS.md) for benchmarked recommendations per slot.
+每个槽位经过基准测试的推荐配置见 [Models](MODELS.zh-CN.md)。
 
-## Full `.env` reference
+## 完整 `.env` 参考
 
 ```bash
 # ─── LLM (default — profiles, sim config, memory compaction) ───
@@ -161,50 +161,38 @@ OPENAI_API_BASE_URL=http://localhost:11434/v1
 # MIROSHARK_ADMIN_TOKEN=
 ```
 
-## Admin auth (mutation endpoints)
+## 管理员认证(写操作端点)
 
-Three endpoints write to a simulation's on-disk state and are gated on
-a shared operator secret:
+有三个端点会写入某个模拟的本地状态,它们都受同一把运维者密钥保护:
 
-- `POST /api/simulation/<id>/publish` — toggles `is_public`
-- `POST /api/simulation/<id>/resolve` — records the actual outcome
-- `POST /api/simulation/<id>/outcome` — verified-prediction annotation
+- `POST /api/simulation/<id>/publish` — 切换 `is_public`
+- `POST /api/simulation/<id>/resolve` — 记录真实结果
+- `POST /api/simulation/<id>/outcome` — 已验证预测的注解
 
-Send the secret as `Authorization: Bearer $MIROSHARK_ADMIN_TOKEN`. The
-server compares it with `hmac.compare_digest` so the comparison is
-constant-time. Read endpoints (including `GET /outcome`, the public
-gallery, and the embed widget) stay unauthenticated.
+请把密钥以 `Authorization: Bearer $MIROSHARK_ADMIN_TOKEN` 的形式发送。服务端使用 `hmac.compare_digest` 进行恒定时间比较。读端点(包括 `GET /outcome`、公开画廊、嵌入小部件)依然不需要鉴权。
 
-**Fail-closed.** If `MIROSHARK_ADMIN_TOKEN` is unset or empty in the
-backend's process environment, the gated endpoints return
-`503 — admin auth not configured` rather than silently allowing the
-mutation. There is no implicit "no auth required" fallback. An operator
-who forgot to set the secret would otherwise ship an open mutation
-surface with no warning — the 503 makes the misconfig loud.
+**默认拒绝。** 如果 `MIROSHARK_ADMIN_TOKEN` 在后端进程环境中未设置或为空,这些受控端点会返回 `503 — admin auth not configured`,而不是悄悄放行写入。这里没有"无需鉴权"的隐式回退。否则,一个忘记设置密钥的运维者会在毫无警告的情况下上线一个开放的写入接口 — 这个 503 把配置错误变得显眼。
 
-Generate a token with `openssl rand -hex 32` (or any sufficiently long
-random string), set it in `.env`, and restart the backend. The token is
-read at request time so a process restart after rotation is enough — no
-code reload required.
+用 `openssl rand -hex 32`(或者任意足够长的随机字符串)生成 token,把它写入 `.env`,然后重启后端。token 在请求时读取,所以轮换之后只需要重启进程即可 — 无需重新加载代码。
 
-## Feature flags summary
+## 特性开关汇总
 
-All retrieval and memory features are on by default. Disable individually:
+所有检索与记忆特性默认开启。可以分别关闭:
 
-| Flag | Default | What flipping off means |
+| 开关 | 默认值 | 关闭意味着什么 |
 |---|---|---|
-| `RERANKER_ENABLED` | `true` | No cross-encoder rerank; top-N comes straight from hybrid fusion |
-| `GRAPH_SEARCH_ENABLED` | `true` | No BFS traversal from seed entities — vector + BM25 only |
-| `ENTITY_RESOLUTION_ENABLED` | `true` | Duplicates like "NeuralCoin" / "Neural Coin" / "NC" stay separate |
-| `ENTITY_RESOLUTION_USE_LLM` | `true` | Fuzzy + vector only; no LLM reflection step |
-| `CONTRADICTION_DETECTION_ENABLED` | `true` | Conflicting edges both remain valid |
-| `REASONING_TRACE_ENABLED` | `true` | Report reasoning isn't persisted to the graph |
-| `WEB_ENRICHMENT_ENABLED` | `true` | Personas grounded only in the document |
-| `LLM_PROMPT_CACHING_ENABLED` | `true` | No Anthropic prompt caching on system messages |
-| `LLM_DISABLE_REASONING` | `true` | OpenRouter reasoning models emit CoT (~3× higher latency on Qwen3/Grok) |
-| `ORACLE_SEED_ENABLED` | `false` | Templates ignore `oracle_tools` |
-| `MCP_AGENT_TOOLS_ENABLED` | `false` | `tools_enabled` personas can't invoke MCP |
+| `RERANKER_ENABLED` | `true` | 没有 cross-encoder 重排;top-N 直接来自混合融合 |
+| `GRAPH_SEARCH_ENABLED` | `true` | 不再从种子实体做 BFS 遍历 — 仅向量 + BM25 |
+| `ENTITY_RESOLUTION_ENABLED` | `true` | "NeuralCoin" / "Neural Coin" / "NC" 这类重复项会保持独立 |
+| `ENTITY_RESOLUTION_USE_LLM` | `true` | 仅模糊匹配 + 向量;没有 LLM 反思步骤 |
+| `CONTRADICTION_DETECTION_ENABLED` | `true` | 互相冲突的边都保持有效 |
+| `REASONING_TRACE_ENABLED` | `true` | 报告推理过程不会持久化到图谱 |
+| `WEB_ENRICHMENT_ENABLED` | `true` | 画像只基于文档本身 |
+| `LLM_PROMPT_CACHING_ENABLED` | `true` | 系统消息上不再启用 Anthropic 提示词缓存 |
+| `LLM_DISABLE_REASONING` | `true` | OpenRouter 推理模型会输出 CoT(在 Qwen3/Grok 上延迟约高 3 倍) |
+| `ORACLE_SEED_ENABLED` | `false` | 模板会忽略 `oracle_tools` |
+| `MCP_AGENT_TOOLS_ENABLED` | `false` | 标记了 `tools_enabled` 的人设无法调用 MCP |
 
-## Observability
+## 可观测性
 
-See [Observability](OBSERVABILITY.md) for the debug panel (Ctrl+Shift+D) and event stream details.
+调试面板(Ctrl+Shift+D)与事件流细节请见 [Observability](OBSERVABILITY.zh-CN.md)。

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,5 +1,7 @@
 # Features
 
+<sup>English · [中文](FEATURES.zh-CN.md)</sup>
+
 Deep dive on every feature. One heading per feature, ordered roughly by when you'd hit it in a typical run.
 
 ## Smart Setup (Scenario Auto-Suggest)

--- a/docs/FEATURES.zh-CN.md
+++ b/docs/FEATURES.zh-CN.md
@@ -1,0 +1,199 @@
+<sup>[English](FEATURES.md) · 中文</sup>
+
+# 特性
+
+每个特性的深入介绍。一个特性一个标题,大致按你在一次典型运行中遇到它们的顺序排列。
+
+## 智能配置(情景自动建议)
+
+模拟提示词输入框是上传文档与开始模拟之间唯一的"白纸难题"。智能配置把它移除:你刚把一个 `.md`/`.txt` 文件拖进来或者贴上一个 URL,MiroShark 就会把抽取出来的文本短预览(约 2K 字符)发给已配置的 LLM,大约 2 秒后返回三张预测市场风格的情景卡片 — 一张 **看涨**、一张 **看跌**、一张 **中立** 框架,每张都带一个具体的 YES/NO 问题、一个合理的初始概率区间,以及一句基于文档的简短理由。
+
+点击任一卡片上的 **使用此项 →** 就能填进模拟提示词字段,或者忽略它们自己输入。建议会按文档缓存(预览的 SHA-256),所以离开页面再回来不会再一次调用 LLM。如果 LLM 调用失败或超时,这个面板会静默不显示 — 你输入的情景仍然完全可用。
+
+- **端点:** `POST /api/simulation/suggest-scenarios`
+
+## 热门(自动发现)
+
+智能配置照顾的是带着文档来的用户。"热门"照顾的是另一半 — 想模拟点和 AI、加密、或地缘相关的*某事*,但手头没有具体文章的人。该面板位于 URL 导入框下方,展示一份可配置的公共 RSS/Atom 源中最新的 5 条目(默认:Reuters tech、The Verge、Hacker News、CoinDesk)。
+
+点击任意卡片,MiroShark 会预填 URL 字段、抓取文章,并立刻基于抓取到的文本触发情景自动建议 — 一键就能从白纸到三张情景卡。运维者可以用 `TRENDING_FEEDS` 环境变量(逗号分隔的 URL)覆盖默认订阅列表。服务端缓存保留结果 15 分钟;如果所有源都报错,该面板会静默消失。
+
+- **端点:** `GET /api/simulation/trending`
+
+## 直接提问(纯问题模式)
+
+没有文档,也没有特定文章在脑子里?在主页输入一个问题("欧盟 AI 法案的生物特征条款会在最终三方会谈中存活吗?"),MiroShark 会让 Smart 模型调研这一话题,并合成一段 1500–3000 字符的简报 — 中立、按 上下文 / 关键角色 / 近期事件 / 待解问题 结构组织。该简报作为 `miroshark://ask/...` 的种子文档进入 URL 列表并预填模拟提示词,这样下游流水线(本体 → 图谱 → 画像 → 模拟)按原样跑。每个问题缓存以便快速重跑。
+
+- **端点:** `POST /api/simulation/ask`
+
+## 反事实分支
+
+跑完一次模拟,暂停查看,然后问:"如果 CEO 在第 24 轮辞职会怎样?" — 在模拟工作区点击 **⤷ 分支**,输入触发轮次和一段突发新闻注入,MiroShark 就会把模拟分叉一份,带着父级的全部智能体人群。当 runner 到达触发轮次时,该注入会被提升为一次导演事件,并以 BREAKING 区块的形式预置到每个智能体的观察提示词。可以用现有的 **对比** 视图把分支与原始版本并排比较。
+
+预设模板可以声明 `counterfactual_branches`(例如 `ceo_resigns`、`class_action`、`rug_pull`、`sec_notice`),这样分支对话框会提供一键情景。
+
+- **端点:** `POST /api/simulation/branch-counterfactual`
+
+## 导演模式(实时事件注入)
+
+分支会分叉出新的时间线;导演模式则编辑*当前*这一条。模拟运行期间,可以注入一条突发新闻事件,会落到每个智能体下一次观察提示词中 — 不分叉、不重启。适合在不消耗一次完整分支的算力下,对一个情景做压力测试("竞争对手开源了他们的模型"、"SEC 刚刚立案调查")。
+
+每次模拟最多 10 条事件,每条最多 500 字符。UI 控件就在 run-status 头部旁边。事件随模拟状态一同持久化,并在单轮帧 API 中回放,所以它们也会出现在导出和嵌入中。
+
+- **端点:** `POST /api/simulation/<id>/director/inject`、`GET /api/simulation/<id>/director/events`
+
+## 预设模板
+
+`backend/app/preset_templates/` 中自带六个经过基准的情景模板 — 一键起步点,会预填种子文档、模拟提示词、智能体组成,以及(可选的)`counterfactual_branches` 与 `oracle_tools`:
+
+| 模板 | 这次运行的形态 |
+|---|---|
+| `crypto_launch` | 代币 / 协议发布 — 分析师、散户、KOL、交易者对 TGE 的反应 |
+| `corporate_crisis` | 企业事件(数据泄露、产品故障、高管丑闻),媒体 + 市场参与 |
+| `political_debate` | 政策 / 选举议题,意识形态光谱与媒体回路 |
+| `product_announcement` | 主题演讲 / 功能发布 — 评测周期、开发者反馈、消费者上手 |
+| `campus_controversy` | 学生 / 教职 / 行政围绕一起争议事件的互动 |
+| `historical_whatif` | 反事实历史 — "如果事件 X 没有发生会怎样?" |
+
+可以在配置页面的 **Templates** 画廊中浏览,或者调用 `GET /api/templates/list`。用 `GET /api/templates/<id>` 获取单个模板;附加 `?enrich=true` 会在返回前对所有声明的 `oracle_tools` 实时求值 FeedOracle。
+
+## 实时 Oracle 数据(FeedOracle MCP)
+
+可选启用 [FeedOracle MCP server](https://mcp.feedoracle.io/mcp) 提供的接地种子数据(484 个工具,覆盖 MiCA 合规、DORA 评估、宏观/FRED 数据、DEX 流动性、制裁、碳市场等)。模板声明它们想用的工具:
+
+```json
+"oracle_tools": [
+  {"server": "feedoracle_core", "tool": "peg_deviation", "args": {"token_symbol": "USDT"}},
+  {"server": "feedoracle_core", "tool": "macro_risk",    "args": {}}
+]
+```
+
+把 `.env` 里的 `ORACLE_SEED_ENABLED=true`,在任意模板卡上勾选 **使用实时 oracle 数据**,MiroShark 就会派发这些调用,并在摄入前把结果以一个 markdown "Oracle Evidence" 区块附加到种子文档。禁用或调用失败时静默 no-op — 静态种子仍然能用。
+
+## 单智能体 MCP 工具
+
+可选启用,OpenMiro 风格:挑选出来的人设(记者、分析师、交易者)可以在模拟期间调用真实的 MCP 工具。在人设的 profile JSON 中标记 `"tools_enabled": true`,在 `config/mcp_servers.yaml` 配置服务器,并设置 `MCP_AGENT_TOOLS_ENABLED=true`。
+
+每一轮 runner 会:
+
+1. **注入**工具目录到智能体的系统消息(用标记分隔,这样每轮会刷新)。
+2. **解析**智能体帖子里类似 `<mcp_call server="web_search" tool="search" args='{"q":"..."}' />` 的自闭合标签(每回合最多 2 次调用)。
+3. 通过每个 server 一个的池化 stdio 子进程**派发**它们(每次模拟一个进程,反复复用)。
+4. **把结果注入**回智能体的下一轮系统消息。
+
+调用失败会变成 `{"_error": "..."}` 形式的 payload,而不是抛异常 — 智能体提示词保持良好结构。这座桥每次调用有 30 秒的超时(`MCP_CALL_TIMEOUT_SEC`),并在模拟结束时(或异常退出时通过 `atexit`)拆掉子进程。
+
+## 自定义 Wonderwall 端点
+
+模拟循环是 MiroShark 中最重的模型消费者 — 每次运行 850–1650 次调用,7M+ tokens,全部走 CAMEL-AI 单智能体动作循环。Wonderwall 槽位有自己独立的 `WONDERWALL_BASE_URL` + `WONDERWALL_API_KEY` 环境变量(以及 **设置 → 高级 → Wonderwall** 中对应的输入),所以你可以把这些高频调用路由到任意 OpenAI 兼容端点,而不用动 Default/Smart/NER 槽位 — 把图谱构建、报告和实体抽取留在 OpenRouter/Anthropic,智能体那边则可以指向自部署的 vLLM、Modal/Replicate 部署、另一块 GPU 上的 Ollama 实例,或者你自己训的微调。
+
+两个字段都可以独立省略。`WONDERWALL_BASE_URL` 留空就继承 `LLM_BASE_URL`;`WONDERWALL_API_KEY` 留空就继承 `LLM_API_KEY`。开放式端点(无鉴权)只要传一个非空占位符例如 `not-checked` 即可。
+
+```bash
+WONDERWALL_BASE_URL=https://your-endpoint.example.com/v1
+WONDERWALL_API_KEY=not-checked
+WONDERWALL_MODEL_NAME=your-model-id
+```
+
+接线在三个地方:(1) `backend/scripts/run_parallel_simulation.py`(以及 twitter / reddit 变体)在子进程启动读取环境时,会优先选 `WONDERWALL_*` 而非 `LLM_*`。(2) `backend/app/services/simulation_runner.py` 在 spawn 子进程时把 `Config.WONDERWALL_*` 转发到子进程 `env`,所以设置 UI 的更新无需重启 Flask 就能在下一次运行生效。(3) Settings API(`POST /api/settings`)以及 `SettingsPanel.vue` 中对应的部分接受这三个字段。
+
+适用场景:
+- Wonderwall 角色/人设提示词在你自己训过的微调上效果更好。
+- 你想把成本绑定到一台固定费率的自部署 GPU,而不是按 token 计费。
+- 你想通过保持除 Wonderwall 之外所有槽位不变的两次匹配模拟,来对比一个自定义小模型的信念漂移 / 连贯性 与一个托管基线之间的差异。
+
+## 发布以供嵌入
+
+`EmbedDialog` 上有一个 `公开 / 私有` 切换,背后由模拟状态上的 `is_public` 支撑。未发布的模拟在嵌入 URL 上返回 `403` — 把切换打开(或调用 `POST /api/simulation/<id>/publish`)就能让它们公开嵌入。默认私有,这样不会影响已有模拟。
+
+## 预测准确度账本(已验证预测)
+
+每个公开模拟都可以被打上它所做出预测的真实结果注解。从嵌入对话框选择 **预测正确 / 部分正确 / 预测错误**,粘贴证实结果的文章 / 推文 / dashboard URL,加一句话总结(≤280 字符)然后提交。该注解落到 `<sim_dir>/outcome.json`,并立即体现在以下位置:
+
+- 画廊卡片上的 **📍 已验证** / **⚠ 预测错误** / **◑ 部分正确** 标签(若提供了 outcome URL,标签会直接跳到该链接)。
+- 卡片左缘的彩色装饰条,这样在快速翻看时已验证墙能一眼读出来。
+- `/explore` 上的 **仅看已验证** 过滤芯片,会把列表切到这套精选集合。
+- 一个专门的 **`/verified`** URL — 与 `/explore` 同一组件但预过滤为准确预测墙。把这个链接丢进推文串里就有一页可以证明模拟是有效的。
+
+这个注解故意做成开放式的 — 与二元的 `/resolve` 端点不同,后者是 YES/NO,且与 Polymarket 共识绑定。一次模拟可以两者都有:二元结算驱动现有的 accuracy_score,outcome 注解驱动画廊上的可信度展示面。
+
+- **端点:** `POST /api/simulation/<id>/outcome`(受发布控制)、`GET /api/simulation/<id>/outcome`(只读,无控制)、`GET /api/simulation/public?verified=1`(过滤后的画廊)。
+- **UI:** 嵌入对话框内的"标记结果"面板;`/explore` 上的 **仅看已验证** 过滤芯片 + 📍 标签;专门的 `/verified` 路由。
+
+## 社交分享卡
+
+模拟一旦发布,嵌入对话框还会暴露一张 **社交卡片**,可以被 Twitter/X、Discord、Slack、LinkedIn 以及任何支持 Open-Graph 的客户端自动展开。它由两个端点支撑:
+
+- `GET /api/simulation/<id>/share-card.png` — 服务端渲染的 1200×630 PNG(Pillow)。展示情景标题、状态标签、可选的质量徽章 + 结算、智能体 / 轮次 指标,以及最终 看涨/中立/看跌 分布的堆叠条。与嵌入小部件相同的 `is_public` 控制。按内容哈希在磁盘上缓存,这样反复 unfurl 不会重复渲染。
+- `GET /share/<id>` — 一张携带正确 `og:image` / `twitter:image` 元标签的公开落地页。爬虫读标签渲染卡片;真实浏览器跳转到 SPA 模拟视图(JS 优先,带 `<meta http-equiv="refresh">` 兜底)。
+
+把 `/share/<id>` URL 贴到任何地方 — 帖子会以一张精致的卡片展开,而不是通用预览。
+
+## 信念回放动图(GIF)
+
+与分享卡同一画布(1200×630),但每轮一帧 — 看涨 / 中立 / 看跌 三条柱在每轮的分布之间滑动,配一个轮次计数器和进度条。Discord 和 Slack 会从直接文件 URL 自动播放 GIF,所以把链接丢进频道就能内联渲染动画。
+
+- `GET /api/simulation/<id>/replay.gif` — 服务端渲染的动画 GIF(Pillow,无需 FFmpeg)。每帧持续 600 ms,最后一帧持续 3 倍长度,这样静止的共识就像点睛之笔。超过 60 轮的轨迹在整段运行上均匀子采样,且一定保留最后一帧。与分享卡相同的 `is_public` 控制。按内容哈希在磁盘上缓存。
+
+嵌入对话框会渲染一张暂停的缩略图,带"点击播放"的提示(这样打开对话框时不会让每个观看者都拉一份 GIF),并暴露一个可复制的 URL 加上一个"下载 GIF"按钮,放在分享卡那行下方。
+
+## 模拟轨迹导出
+
+它是分享卡(预览)和回放 GIF(动态)的文本同伴 — 把同一次模拟做成一份可引用的逐轮智能体轨迹,这样研究论文、Substack 帖子、Discord 串可以直接引用智能体说过的话,而不必截图。
+
+两个端点,同一份载荷,不同编码:
+
+- `GET /api/simulation/<id>/transcript.md` — 带 YAML 前言区块(`sim_id`、`scenario`、`agent_count`、`total_rounds`、`consensus_label`、`quality_health`、`outcome_label`)的 Markdown。Notion、Obsidian、Bear、Substack 会把它当成页面元数据来读;正文按已记录的轮次,每个轮次一个 `## Round N` 段,每个智能体的帖子作为一段引用块,并用智能体的立场打标。超过约 80 轮的轨迹在 Markdown 渲染中省略中间轮次(并附一条注释指向 JSON 形式以获取完整序列),让文档保持可读。
+- `GET /api/simulation/<id>/transcript.json` — 同一份载荷的结构化 JSON 文档,美化输出(`indent=2`),这样 `curl` 到一个文件就能立刻可读。面向 SDK 用户和下游流水线(LLM-as-judge 评测框架、Python 客户端 SDK 等)。
+
+两个端点共享分享卡的发布控制(`is_public=true`)。每个智能体的立场标签使用与其他界面一致的 ±0.2 阈值 — 画廊上的"看涨"智能体在轨迹里也会打同样的 tag。嵌入对话框在回放 GIF 那行下方暴露"下载 .md" + "下载 .json"组合。
+
+## 公开画廊订阅(RSS / Atom)
+
+`/explore` 渲染的同一批卡片,以聚合订阅的形式提供出来,让已经在用 Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS 的研究者和工具,可以在他们已有的工具链里订阅 — 无需登录,无需 MiroShark 账户。每个新发布的模拟,以与 AI 通讯或 Substack 文章相同的方式落入他们的阅读器。
+
+两个端点,同一份载荷,不同 XML 格式:
+
+- `GET /api/feed.atom` — Atom 1.0(首选 — 现代阅读器 + 浏览器自动发现的默认目标)。
+- `GET /api/feed.rss` — RSS 2.0(为更老的自部署聚合器和学术 RSS 流水线保留)。
+
+每个条目把情景作为标题(超过 100 字符以省略号截断),把 看涨 / 中立 / 看跌 共识分布作为摘要行,把分享卡 PNG 作为 `<media:thumbnail>` + `<media:content>`(这样 River-view 聚合器会显示预览图),把回放 GIF 作为第二个 `<media:content>`(这样 Feedly 的杂志布局会显示动画)。Outcome 与 quality 暴露为 `<category>` 元素,订阅者可以在自己的阅读器里据此过滤。
+
+- **仅已验证订阅:** 附加 `?verified=1` 即可获取那些被运维者标记过真实结果的精选流 — 是 `/verified` 的聚合订阅镜像。
+- **挑选规则:** 与 `GET /api/simulation/public` 完全一致 — 最近 20 个已发布运行,按 `created_at` 降序,受发布控制。
+- **自动发现:** SPA 的 `index.html` 声明了 `<link rel="alternate" type="application/atom+xml">`(以及 RSS 变体),所以浏览器会通过地址栏地球图标暴露这个订阅源。
+- **缓存:** `Cache-Control: public, max-age=300` — 五分钟够短,新发布的模拟能在下一次聚合器轮询时出现;够长,可以承住激进轮询而不拖累画廊查询。
+- **实现:** 纯标准库(`xml.etree.ElementTree` + `html`)。无新增依赖;立场阈值与其他界面一样是 ±0.2,所以"62% 看涨"字符串与画廊卡片字节对字节一致。
+
+嵌入对话框有一条"通过 RSS 关注画廊"的提示,带 Atom 订阅、RSS 2.0 订阅、仅已验证 Atom 订阅的一键订阅链接。/explore 头部有一个"📡 通过 RSS 订阅"芯片,会镜像当前激活过滤(开启已验证过滤时也会跟随)。
+
+## 文章生成
+
+模拟结束后,点击 **Write Article**,MiroShark 会让 Smart 模型写一篇 400–600 字的 Substack 风格报道,基于真实发生的事件 — 关键发现、市场动态、信念变化和影响。文章会缓存到 `generated_article.json`,这样重新打开不会再消耗 token;传 `force_regenerate=true` 可以刷新。
+
+- **端点:** `POST /api/simulation/<id>/article`
+
+## 交互网络与人口分布
+
+两个不需要 LLM 调用的事后分析:
+
+- **交互网络**(`GET /api/simulation/<id>/interaction-network`) — 从点赞/转发/回复/提及构建一张智能体之间的图,带度中心性、桥接得分和回声室指标。缓存到 `network.json`。在 **InteractionNetwork** 面板上以力导向图渲染。
+- **人口分布**(`GET /api/simulation/<id>/demographics`) — 把智能体聚类成原型(分析师、KOL、散户、观察者……)并报告每个桶的分布 + 参与度。适合定位是哪个原型在主导某个叙事。
+
+## 模拟质量诊断
+
+每次运行都会在 `GET /api/simulation/<id>/quality` 拿到一个健康分数 — 参与度密度、信念连贯性、智能体多样性、动作方差。展示这次运行是跑到了距离还是塌成了噪声/沉默。如果连贯性低,报告大概率单薄。
+
+## 历史数据库
+
+**HistoryDatabase** 面板(从任意视图通过数据库图标进入)是一个面向所有本地模拟的功能完备浏览器 — 按提示词/文档/标签搜索、按状态过滤、克隆现有运行连同其智能体人群、导出为 JSON,或删除。背后由 `GET /api/simulation/list`、`GET /api/simulation/history`、`GET /api/simulation/<id>/export` 与 `POST /api/simulation/fork` 支撑。
+
+## 轨迹访谈(调试)
+
+普通的人设对话只显示智能体回复。轨迹访谈则展示整条链 — 观察提示词、LLM 思考、解析后的动作、有调用就连工具调用一起 — 针对某个智能体在某个时间点。当一次访谈回答看起来不对劲时,这对解释*为什么*智能体说了它说的话非常宝贵。
+
+- **端点:** `POST /api/simulation/<id>/agents/<agent_name>/trace-interview`、`GET /api/simulation/<id>/interviews/<agent_name>`
+
+## 推送通知(PWA)
+
+前端注册了一个 Service Worker,在长时间运行的工作完成时(图谱构建完成、模拟结束、报告就绪)可以触发 web-push 提醒。在被提示时授予通知权限即可启用;后端在 `GET /api/simulation/push/vapid-public-key` 提供 VAPID key,在 `POST /api/simulation/push/subscribe` 接受订阅。用 `POST /api/simulation/push/test` 测试。如果你不需要可以放心忽略 — 不主动启用就是静默 no-op。

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,5 +1,7 @@
 # Install
 
+<sup>English · [中文](INSTALL.zh-CN.md)</sup>
+
 Pick one of the paths below.
 
 | Path | GPU? | Best for |

--- a/docs/INSTALL.zh-CN.md
+++ b/docs/INSTALL.zh-CN.md
@@ -1,0 +1,332 @@
+<sup>[English](INSTALL.md) · 中文</sup>
+
+# 安装
+
+从下面的几条路径中任选其一。
+
+| 路径 | 需要 GPU? | 适用场景 |
+|---|---|---|
+| [Railway / Render](#一键云部署) | 否 | 最快上线的部署路径 |
+| [`./miroshark`(OpenRouter)](#快速开始-miroshark-启动器) | 可选 | 本地开发,阻力最小 |
+| [云端 API — OpenRouter](#方案-a1openrouter) | 否 | 一把密钥覆盖所有槽位与嵌入 |
+| [云端 API — OpenAI](#方案-a2openai) | 否 | 已有 OpenAI 密钥 |
+| [云端 API — Anthropic](#方案-a3anthropic) | 否 | 已有 Anthropic 密钥 |
+| [Docker + Ollama](#方案-bdocker--本地-ollama) | 是 | 完全自部署,一行命令 |
+| [手动 + Ollama](#方案-c手动--本地-ollama) | 是 | 完全自部署,手动控制 |
+| [Claude Code CLI](#方案-dclaude-code无需-api-密钥) | 否 | 使用你的 Claude Pro/Max 订阅 |
+
+## 前置依赖
+
+- 一把 OpenAI 兼容 API 密钥(OpenRouter、OpenAI、Anthropic 等),用于本地推理的 Ollama,**或者** Claude Code CLI
+- Python 3.11+、Node.js 18+、Neo4j 5.15+
+
+**安装 Neo4j**(`./miroshark` 启动器会替你启动它 — 你只需要装好这个软件包):
+
+- **macOS** — `brew install neo4j`
+- **Linux** — `sudo apt install neo4j` *(或对应发行版的等价命令)*
+- **Windows** — 安装 [Neo4j Desktop](https://neo4j.com/download/)(图形界面 — 在那里启动数据库,然后从 WSL2 或 Git Bash 运行启动器),或者把整套技术栈跑在 [WSL2](https://learn.microsoft.com/windows/wsl/install) 里并按 Linux 步骤操作
+- **零安装** — 创建一个免费 [Neo4j Aura](https://neo4j.com/cloud/aura-free/) 云实例,把 `NEO4J_URI` / `NEO4J_PASSWORD` 设到 `.env`
+
+> `./miroshark` 启动器是一个 bash 脚本 — 在 Windows 上需要 WSL2 或 Git Bash。
+
+在 macOS/Linux 原生安装上设置一次密码 — MiroShark 默认使用 `miroshark`,与 `.env.example` 保持一致:
+
+```bash
+neo4j-admin dbms set-initial-password miroshark
+```
+
+## 硬件
+
+**本地(Ollama):**
+
+| | 最低 | 推荐 |
+|---|---|---|
+| 内存 | 16 GB | 32 GB |
+| 显存 | 10 GB | 24 GB |
+| 磁盘 | 20 GB | 50 GB |
+
+**云端模式:** 不需要 GPU — 只要 Neo4j 和一把 API 密钥。任意 4 GB 内存的机器都能跑。
+
+---
+
+## 一键云部署
+
+3 分钟内部署到云端 — 无需任何本地搭建。
+
+**部署前先创建:**
+
+1. 一个免费 [Neo4j Aura](https://neo4j.com/cloud/aura-free/) 实例 — 拿到 `NEO4J_URI`(以 `neo4j+s://` 开头)和密码。
+2. 一把 [OpenRouter](https://openrouter.ai/) API 密钥 — 用于 LLM 调用与嵌入。
+
+### Railway(推荐 — 持久化存储,免费试用)
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/new/template?template=https://github.com/aaronjmars/MiroShark)
+
+点击之后,在 Railway 控制台中设置以下环境变量:
+
+| 变量 | 值 |
+|---|---|
+| `LLM_API_KEY` | 你的 OpenRouter 密钥(`sk-or-v1-...`) |
+| `NEO4J_URI` | 你的 Aura URI(`neo4j+s://...`) |
+| `NEO4J_PASSWORD` | 你的 Aura 密码 |
+| `EMBEDDING_API_KEY` | 同一把 OpenRouter 密钥 |
+| `OPENAI_API_KEY` | 同一把 OpenRouter 密钥 |
+
+### Render(免费套餐 — 750 小时/月,闲置 15 分钟后会自动停机)
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/aaronjmars/MiroShark)
+
+Render 会自动读取 `render.yaml`。提示时设置上面相同的环境变量即可。
+
+> 云端部署使用 OpenRouter 处理所有 LLM 调用 — 此模式下不可用 Ollama。两个平台都会以一个公开 HTTPS URL 暴露 MiroShark,无需端口转发。
+
+---
+
+## 快速开始: `./miroshark` 启动器
+
+**推荐路径** — 一把 [OpenRouter](https://openrouter.ai/) 密钥加上启动器。
+
+**前置依赖** — Python 3.11+、Node 18+、Neo4j(`brew install neo4j` / `sudo apt install neo4j`),以及一把 OpenRouter 密钥。
+
+```bash
+git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
+cp .env.example .env
+```
+
+`.env.example` 出厂自带云端预设(Mimo V2 Flash + Grok-4.1 Fast)作为默认配置。打开 `.env`,把你的 OpenRouter 密钥粘贴进五行空白的 `*_API_KEY=`(`LLM_`、`SMART_`、`NER_`、`OPENAI_`、`EMBEDDING_` — 五行用同一把密钥)。除非你想换一套不同的模型组合,否则不需要修改任何模型字段。
+
+然后启动:
+
+```bash
+./miroshark
+```
+
+启动器会做这些事:
+
+1. 检查 Python 3.11+、Node 18+、uv、Neo4j/Docker
+2. 如果 Neo4j 未运行就启动它(Docker 或原生)
+3. 缺失则安装前后端依赖
+4. 杀掉占用 3000/5001 端口的僵尸进程
+5. 启动 Vite 开发服务器(`:3000`)和 Flask API(`:5001`)
+6. Ctrl+C 全部停止
+
+打开 `http://localhost:3000`。第一次模拟约 10 分钟、约 1 美元。完整预设说明见 [Models](MODELS.zh-CN.md)。
+
+> 想完全本地运行?跳到下面的 [方案 B(Docker + Ollama)](#方案-bdocker--本地-ollama) 或 [方案 C(手动 Ollama)](#方案-c手动--本地-ollama)。
+
+---
+
+## 方案 A: 云端 API(无需 GPU)
+
+只有 Neo4j 跑在本地。LLM 与嵌入都走云端提供商。下面三个口味 — 选一个匹配你已有密钥的。
+
+```bash
+# 三个口味通用的准备步骤
+brew install neo4j       # macOS  (Linux: sudo apt install neo4j)
+cp .env.example .env
+```
+
+### 方案 A.1:OpenRouter
+
+一把密钥覆盖所有槽位,包括嵌入。配置最简单,也是 [Models](MODELS.zh-CN.md) 中跑过基准的那条路径。
+
+```bash
+LLM_API_KEY=sk-or-v1-YOUR_KEY
+LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_MODEL_NAME=xiaomi/mimo-v2-flash
+
+SMART_PROVIDER=openai
+SMART_API_KEY=sk-or-v1-YOUR_KEY
+SMART_BASE_URL=https://openrouter.ai/api/v1
+SMART_MODEL_NAME=x-ai/grok-4.1-fast
+
+NER_MODEL_NAME=x-ai/grok-4.1-fast
+NER_BASE_URL=https://openrouter.ai/api/v1
+NER_API_KEY=sk-or-v1-YOUR_KEY
+
+WONDERWALL_MODEL_NAME=xiaomi/mimo-v2-flash
+WEB_SEARCH_MODEL=x-ai/grok-4.1-fast:online
+
+OPENAI_API_KEY=sk-or-v1-YOUR_KEY
+OPENAI_API_BASE_URL=https://openrouter.ai/api/v1
+
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=openai/text-embedding-3-large
+EMBEDDING_BASE_URL=https://openrouter.ai/api
+EMBEDDING_API_KEY=sk-or-v1-YOUR_KEY
+EMBEDDING_DIMENSIONS=768
+```
+
+### 方案 A.2:OpenAI
+
+直接使用你的 OpenAI Platform 密钥。
+
+```bash
+LLM_API_KEY=sk-proj-YOUR_KEY
+LLM_BASE_URL=https://api.openai.com/v1
+LLM_MODEL_NAME=gpt-4o-mini
+
+SMART_PROVIDER=openai
+SMART_API_KEY=sk-proj-YOUR_KEY
+SMART_BASE_URL=https://api.openai.com/v1
+SMART_MODEL_NAME=gpt-4o                   # or gpt-4.1 for stronger reports
+
+NER_MODEL_NAME=gpt-4o-mini
+NER_BASE_URL=https://api.openai.com/v1
+NER_API_KEY=sk-proj-YOUR_KEY
+
+WONDERWALL_MODEL_NAME=gpt-4o-mini
+
+OPENAI_API_KEY=sk-proj-YOUR_KEY
+OPENAI_API_BASE_URL=https://api.openai.com/v1
+
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_BASE_URL=https://api.openai.com/v1
+EMBEDDING_API_KEY=sk-proj-YOUR_KEY
+EMBEDDING_DIMENSIONS=768                  # OpenAI truncates to this via the dimensions param
+```
+
+### 方案 A.3:Anthropic
+
+通过 OpenAI 兼容端点使用你的 Anthropic Console 密钥。**Anthropic 不提供嵌入** — 把 `EMBEDDING_*` 指向 Ollama(`nomic-embed-text`,见 [方案 C](#方案-c手动--本地-ollama)),或者只用一把 OpenAI/OpenRouter 密钥来做嵌入。
+
+```bash
+LLM_API_KEY=sk-ant-YOUR_KEY
+LLM_BASE_URL=https://api.anthropic.com/v1/
+LLM_MODEL_NAME=claude-haiku-4-5
+
+SMART_PROVIDER=openai
+SMART_API_KEY=sk-ant-YOUR_KEY
+SMART_BASE_URL=https://api.anthropic.com/v1/
+SMART_MODEL_NAME=claude-sonnet-4-6
+
+NER_MODEL_NAME=claude-haiku-4-5
+NER_BASE_URL=https://api.anthropic.com/v1/
+NER_API_KEY=sk-ant-YOUR_KEY
+
+WONDERWALL_MODEL_NAME=claude-haiku-4-5
+
+OPENAI_API_KEY=sk-ant-YOUR_KEY
+OPENAI_API_BASE_URL=https://api.anthropic.com/v1/
+
+# Embeddings: Anthropic doesn't provide any — use local Ollama
+EMBEDDING_PROVIDER=ollama
+EMBEDDING_MODEL=nomic-embed-text
+EMBEDDING_BASE_URL=http://localhost:11434
+EMBEDDING_DIMENSIONS=768
+```
+
+> 提示词缓存(`LLM_PROMPT_CACHING_ENABLED=true`)在这条路径上收益最大 — ReACT 报告循环会在多轮迭代之间复用同一个系统提示词,所以缓存能显著降低 Sonnet 账单。
+
+### 方案 A.4:为 Wonderwall 配置自定义端点
+
+Wonderwall 槽位(每个智能体的模拟循环,每次运行约 850–1650 次调用)允许独立的端点覆盖,这样你可以把高频调用路由到自部署的 vLLM、Modal/Replicate 部署、微调模型,或另一台主机上的 Ollama —— 同时把图谱构建、报告和 NER 留在托管提供商上。
+
+把这几行加到上面任何一种配置里:
+
+```bash
+WONDERWALL_BASE_URL=https://your-endpoint.example.com/v1
+WONDERWALL_API_KEY=not-checked            # any string for open endpoints
+WONDERWALL_MODEL_NAME=your-model-id
+```
+
+任意一个字段都可以留空。`WONDERWALL_BASE_URL` 留空则复用 `LLM_BASE_URL`,`WONDERWALL_API_KEY` 留空则复用 `LLM_API_KEY`。UI 中的 设置 → 高级 → Wonderwall 暴露相同的三个字段,改动会在下次开始模拟时生效(无需重启 Flask)。完整模式见 [docs/MODELS.md#custom-endpoint-for-wonderwall](MODELS.zh-CN.md#为-wonderwall-配置自定义端点)。
+
+---
+
+`.env` 配置完后,启动:
+
+```bash
+./miroshark
+# 或手动: npm run setup:all && npm run dev
+```
+
+打开 `http://localhost:3000`。后端 API 在 `http://localhost:5001`。
+
+---
+
+## 方案 B: Docker — 本地 Ollama
+
+```bash
+git clone https://github.com/aaronjmars/MiroShark.git
+cd MiroShark
+docker compose up -d
+
+# Pull models into Ollama
+docker exec miroshark-ollama ollama pull qwen2.5:32b
+docker exec miroshark-ollama ollama pull nomic-embed-text
+```
+
+打开 `http://localhost:3000`。
+
+---
+
+## 方案 C: 手动 — 本地 Ollama
+
+```bash
+# 1. Start Neo4j (macOS; for Linux: sudo apt install neo4j)
+brew install neo4j && brew services start neo4j
+
+# 2. Start Ollama & pull models
+ollama serve &
+ollama pull qwen2.5:32b
+ollama pull nomic-embed-text
+
+# 3. Configure & run
+cp .env.example .env
+npm run setup:all
+npm run dev
+```
+
+Ollama 上下文窗口的覆盖配置(很重要 — 默认只有 4096 tokens,而 MiroShark 需要 10–30k)请见 [Models](MODELS.zh-CN.md)。
+
+---
+
+## 方案 D: Claude Code(无需 API 密钥)
+
+通过本地 `claude` CLI 把你的 Claude Pro/Max 订阅当作 LLM 后端。无需 API 密钥或 GPU — 只要本地有一份已登录的安装。
+
+```bash
+# 1. Install Claude Code (if not already)
+npm install -g @anthropic-ai/claude-code
+
+# 2. Log in (opens browser)
+claude
+
+# 3. Start Neo4j (macOS; for Linux: sudo apt install neo4j)
+brew install neo4j && brew services start neo4j
+
+# 4. Configure
+cp .env.example .env
+```
+
+编辑 `.env`:
+
+```bash
+LLM_PROVIDER=claude-code
+# Optional: pick a specific model (default uses your Claude Code default)
+# CLAUDE_CODE_MODEL=claude-sonnet-4-20250514
+```
+
+你仍然需要嵌入(Claude Code 不支持嵌入)以及一个独立的 LLM 给 CAMEL-AI 模拟轮次用。两者都可以选择 Ollama 或一个云端 API。
+
+```bash
+npm run setup:all && npm run dev
+```
+
+### Claude Code 覆盖哪些组件
+
+当 `LLM_PROVIDER=claude-code` 时,MiroShark 的服务会通过 Claude Code 路由。唯一例外是 CAMEL-AI 模拟引擎本身,它在内部管理自己的 LLM 连接。
+
+| 组件 | Claude Code | 需要独立 LLM |
+|---|---|---|
+| 图谱构建(本体 + NER) | 是 | — |
+| 智能体画像生成 | 是 | — |
+| 模拟配置生成 | 是 | — |
+| 报告生成 | 是 | — |
+| 人设对话 | 是 | — |
+| CAMEL-AI 模拟轮次 | — | 是(Ollama 或云端) |
+| 嵌入 | — | 是(Ollama 或云端) |
+
+> **性能提示:** 每次 LLM 调用都会派生一个 `claude -p` 子进程(开销约 2–5 秒)。最适合小模拟或混合模式 — 高频模拟轮次用 Ollama/云端,其他都交给 Claude Code。

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,5 +1,7 @@
 # MCP
 
+<sup>English · [中文](MCP.zh-CN.md)</sup>
+
 MiroShark ships two MCP surfaces: a **standalone MCP server** so you can query your knowledge graphs from Claude Desktop, Cursor, Windsurf, or Continue, and a set of **report agent tools** used internally by the ReACT report agent.
 
 > **Tip:** open MiroShark → **Settings → AI Integration · MCP** for an auto-generated, copy-paste-ready config snippet for each client. The Settings panel reads `GET /api/mcp/status` and stamps the snippet with the absolute paths on your machine.

--- a/docs/MCP.zh-CN.md
+++ b/docs/MCP.zh-CN.md
@@ -1,0 +1,183 @@
+<sup>[English](MCP.md) · 中文</sup>
+
+# MCP
+
+MiroShark 提供两套 MCP 表面:一个**独立 MCP server**,让你可以在 Claude Desktop、Cursor、Windsurf 或 Continue 里查询自己的知识图谱;还有一组**报告智能体工具**,被 ReACT 报告智能体内部使用。
+
+> **提示:** 打开 MiroShark → **设置 → AI Integration · MCP**,可以为每个客户端拿到自动生成的、可直接复制粘贴的配置片段。设置面板会调用 `GET /api/mcp/status`,并把你机器上的绝对路径打进片段里。
+
+## 暴露了什么
+
+`backend/mcp_server.py` 跑在 **stdio** 上(无需开端口、无需常驻守护进程 — 你的 MCP 客户端按需启动它),并使用你已有的 `.env` 中的 Neo4j + LLM 凭据。
+
+| 工具 | 作用 |
+|---|---|
+| `list_graphs` | 浏览图谱 + 实体/边数量 |
+| `search_graph` | 完整的混合 + 重排流水线,带 `kinds` / `as_of` 过滤 |
+| `browse_clusters` | 社区缩放(首次调用时自动构建) |
+| `search_communities` | 直接在簇摘要上做语义检索 |
+| `get_community` | 展开一个簇及其成员 |
+| `list_reports` | 某个图谱上生成过的报告 |
+| `list_report_sections` | 一份报告的各个章节 |
+| `get_reasoning_trace` | 一个章节的完整 ReACT 决策链 |
+
+**示例提示词:** *"列出我的 MiroShark 图谱,在最大的那个上 browse clusters 找任何与 oracle 漏洞相关的内容,然后给我看那个图谱上最近一份报告的推理链。"*
+
+---
+
+## Claude Desktop
+
+打开 **Claude Desktop → Settings → Developer → Edit Config**。文件位置:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux:** `~/.config/Claude/claude_desktop_config.json`
+
+把下面这块加进 `mcpServers`(或合并进去) — 把 `/absolute/path/to/MiroShark/backend` 替换成你机器上的路径:
+
+```json
+{
+  "mcpServers": {
+    "miroshark": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/MiroShark/backend",
+        "python",
+        "mcp_server.py"
+      ]
+    }
+  }
+}
+```
+
+重启 Claude Desktop。`miroshark` 工具会出现在锤子 / 🛠️ 菜单里。
+
+> **没有 `uv`?** 直接用 Python 解释器:
+> ```json
+> "command": "/absolute/path/to/MiroShark/backend/.venv/bin/python",
+> "args": ["/absolute/path/to/MiroShark/backend/mcp_server.py"]
+> ```
+
+---
+
+## Cursor
+
+Cursor 从下面任意一处读 `mcpServers`:
+
+- 工作区配置:你正在工作的仓库里 `.cursor/mcp.json`,**或者**
+- 全局配置:`~/.cursor/mcp.json`
+
+加上:
+
+```json
+{
+  "mcpServers": {
+    "miroshark": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/MiroShark/backend",
+        "python",
+        "mcp_server.py"
+      ]
+    }
+  }
+}
+```
+
+重新加载 Cursor 窗口(`Cmd/Ctrl+Shift+P → Reload Window`)。当你在聊天里 `@mention` MCP 时,miroshark 工具就会出现。
+
+---
+
+## Windsurf
+
+Windsurf 从 `~/.codeium/windsurf/mcp_config.json` 读 MCP 服务器:
+
+```json
+{
+  "mcpServers": {
+    "miroshark": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/MiroShark/backend",
+        "python",
+        "mcp_server.py"
+      ]
+    }
+  }
+}
+```
+
+然后打开 **Cascade → MCP Servers → Refresh**。miroshark 工具就可以从 Cascade 对话中调用了。
+
+---
+
+## Continue(VS Code / JetBrains)
+
+Continue ≥ 0.9.x 通过 `~/.continue/config.json` 支持 MCP:
+
+```json
+{
+  "experimental": {
+    "modelContextProtocolServers": [
+      {
+        "transport": {
+          "type": "stdio",
+          "command": "uv",
+          "args": [
+            "run",
+            "--directory",
+            "/absolute/path/to/MiroShark/backend",
+            "python",
+            "mcp_server.py"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+保存后重新加载你的编辑器。
+
+---
+
+## 验证它能跑
+
+1. 启动你的 MCP 客户端。几秒内它应该会以子进程方式启动 `mcp_server.py`。
+2. 提问:*"用 `list_graphs` 工具列出我的 MiroShark 图谱。"* — 助手应当返回每个图谱一行,以及实体/边数量。如果返回为空(`No graphs found.`),先在 MiroShark UI 中至少构建一个图谱(步骤 1:图谱构建)。
+3. MiroShark UI 中 **设置 → AI Integration · MCP** 面板暴露了相同的 Neo4j 健康探测 — 如果面板说 *Neo4j down*,MCP 工具会以同样的方式失败。
+
+## 故障排查
+
+| 现象 | 可能原因 | 修复 |
+|---|---|---|
+| 客户端 MCP 日志中出现 `uv: command not found` | `uv` 不在客户端继承的 PATH 上 | 切换到 **没有 uv?** 那段(直接解释器路径),或者全局安装 `uv`。 |
+| `list_graphs` 返回 `No graphs found.` | Neo4j 是空的 | 在 MiroShark UI 跑一次模拟,至少写入一个图谱。 |
+| `Neo.ClientError.Security.Unauthorized` | `.env` 中的 `NEO4J_PASSWORD` 已过期 | 更新 `.env` 并重启任何已经派发过该 server 的客户端。 |
+| Server 启动后立刻退出 | 缺少 `mcp` Python 包 | MCP SDK 在 `pyproject.toml` 中 — 确认 `uv sync`(或 `pip install -e backend/`)正常完成。 |
+| 设置面板上片段显示 `mcp_script: missing` | 你正在跑后端的 checkout 与含 `mcp_server.py` 的 checkout 不是同一个 | 重新克隆或 `git pull`,确保 `backend/mcp_server.py` 存在。 |
+
+## 报告智能体工具
+
+ReACT 报告智能体在内部暴露这些工具(通过 `REPORT_AGENT_MAX_TOOL_CALLS` 配置):
+
+| 工具 | 用途 |
+|---|---|
+| `insight_forge` | 围绕一个具体问题做多轮深度分析 |
+| `panorama_search` | 混合 vector + BM25 + 图谱检索 |
+| `quick_search` | 轻量关键词检索 |
+| `interview_agents` | 与模拟智能体实时对话 |
+| `analyze_trajectory` | 信念漂移 — 收敛、极化、转折点 |
+| `analyze_equilibrium` | 在拟合到最终信念分布的 2 人立场博弈上求纳什均衡 — 揭示观察到的结果是否与自利博弈一致(需要 `nashpy`) |
+| `analyze_graph_structure` | 中心性 / 社区 / 桥接分析 |
+| `find_causal_path` | 两个实体之间的图谱遍历 |
+| `detect_contradictions` | 图中互相冲突的边 |
+| `simulation_feed` | 原始动作日志,按平台 / 查询 / 轮次过滤 |
+| `market_state` | Polymarket 价格、交易、组合 |
+| `browse_clusters` | 社区缩放(用于全局定位) |

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,5 +1,7 @@
 # Models
 
+<sup>English · [中文](MODELS.zh-CN.md)</sup>
+
 Four independent model slots (see [Configuration](CONFIGURATION.md#model-slots) for the env vars). This doc covers which models to put in which slot.
 
 ## Cloud preset (OpenRouter)

--- a/docs/MODELS.zh-CN.md
+++ b/docs/MODELS.zh-CN.md
@@ -1,0 +1,82 @@
+<sup>[English](MODELS.md) · 中文</sup>
+
+# 模型
+
+四个相互独立的模型槽位(对应的环境变量见 [Configuration](CONFIGURATION.zh-CN.md#模型槽位))。本篇讲哪些模型应该填到哪个槽位。
+
+## 云端预设(OpenRouter)
+
+`.env.example` 出厂自带一套经过基准测试的预设。复制一份,填上你的 API 密钥即可。
+
+每个槽位控制不同的质量轴:
+
+| 槽位 | 控制的内容 | 关键发现 |
+|---|---|---|
+| **Default** | 人设丰富度、模拟密度 | Mimo V2 Flash 在 flash 价位上能给出辨识度高的人物声音 |
+| **Smart** | 报告质量(头号杠杆) | Grok-4.1 Fast 在关闭 reasoning 的 ReACT 报告循环中表现稳定 |
+| **NER** | 抽取可靠性 | 需要确定性的 JSON — 选一个不会暗中输出 CoT 的模型 |
+| **Wonderwall** | 成本(最大消费方) | 850+ 次调用、7M+ tokens。冗长程度比 $/M 更重要 |
+
+### 云端模式 — 约 1 美元/次,约 10 分钟
+
+Mimo V2 Flash 做人设 + Grok-4.1 Fast 做 smart/NER。每个槽位都关闭了 reasoning(`LLM_DISABLE_REASONING=true` 会在 `extra_body` 里发送 `reasoning: {enabled: false}`),这就是一次场景建议从约 45 秒变成约 3 秒的差别。
+
+| 槽位 | 模型 | 备注 |
+|---|---|---|
+| Default | `xiaomi/mimo-v2-flash` | 画像生成、模拟配置、记忆压缩 |
+| Smart | `x-ai/grok-4.1-fast` | 报告 ReACT 循环 — 每次运行只有约 19 次调用 |
+| NER | `x-ai/grok-4.1-fast` | 关闭 reasoning 后输出稳定 JSON |
+| Wonderwall | `xiaomi/mimo-v2-flash` | 每次运行 850+ 次智能体动作调用;保持低冗长度 |
+
+嵌入用 `openai/text-embedding-3-large`(通过 Matryoshka 截断到 768 维)。Web 增强用 `x-ai/grok-4.1-fast:online`。
+
+> **延迟提示** — 每次 OpenRouter 调用都会经过 `LLMClient`,默认会在 `extra_body` 中注入 `reasoning: {enabled: false}`。仅当某个具体槽位从思维链中收益时才用 `LLM_DISABLE_REASONING=false` 关掉这个默认行为(对 MiroShark 的结构化提示词来说很罕见)。
+
+### 为 Wonderwall 配置自定义端点
+
+Wonderwall 槽位接受按槽位的端点覆盖,可以让你在 OpenRouter 支撑的 Default/Smart/NER 槽位旁边运行一个自部署或微调过的模型:
+
+```bash
+WONDERWALL_BASE_URL=https://your-endpoint.example.com/v1
+WONDERWALL_API_KEY=not-checked          # any string for open endpoints
+WONDERWALL_MODEL_NAME=your-model-id
+```
+
+任意一个字段都可以省略 — `WONDERWALL_BASE_URL` 留空则复用 `LLM_BASE_URL`,`WONDERWALL_API_KEY` 留空则复用 `LLM_API_KEY`。适合把每次运行 850+ 次智能体动作调用路由到 vLLM / Modal / 服务器上的 Ollama 部署,同时把报告和图谱构建槽位留在托管提供商上。
+
+## 本地模式(Ollama)
+
+> **必须覆盖上下文长度。** Ollama 默认是 4096 tokens,但 MiroShark 的提示词需要 10–30k。创建一个自定义 Modelfile:
+>
+> ```bash
+> printf 'FROM qwen3:14b\nPARAMETER num_ctx 32768' > Modelfile
+> ollama create mirosharkai -f Modelfile
+> ```
+
+| 模型 | 显存 | 速度 | 备注 |
+|---|---|---|---|
+| `qwen2.5:32b` | 20GB+ | ~40 t/s | `.env.example` 中的默认 — 全能型 |
+| `qwen3:30b-a3b` *(MoE)* | 18GB | ~110 t/s | 最快 — MoE 每个 token 只激活 3B 参数 |
+| `qwen3:14b` | 12GB | ~60 t/s | 中端 GPU 的均衡选择 |
+| `qwen3:8b` | 8GB | ~42 t/s | 最低可用;上下文紧时减少 Wonderwall 轮次 |
+
+### 硬件快速选型
+
+| 配置 | 模型 |
+|---|---|
+| RTX 3090/4090 或 M2 Pro 32GB+ | `qwen2.5:32b` |
+| RTX 4080 / M2 Pro 16GB | `qwen3:30b-a3b` |
+| RTX 4070 / M1 Pro | `qwen3:14b` |
+| 8GB 显存 / 笔记本 | `qwen3:8b` |
+
+**本地嵌入:** `ollama pull nomic-embed-text` — 768 维,与 Neo4j 默认一致。
+
+## 混合模式
+
+大多数用户自然落到这里:本地跑高频模拟轮次,把报告路由到 Claude。
+
+```bash
+LLM_MODEL_NAME=qwen2.5:32b
+SMART_PROVIDER=claude-code
+SMART_MODEL_NAME=claude-sonnet-4-20250514
+```

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,5 +1,7 @@
 # Observability & Debugging
 
+<sup>English · [中文](OBSERVABILITY.zh-CN.md)</sup>
+
 MiroShark includes a built-in observability system with real-time visibility into every LLM call, agent decision, graph build step, and simulation round.
 
 ## Debug panel

--- a/docs/OBSERVABILITY.zh-CN.md
+++ b/docs/OBSERVABILITY.zh-CN.md
@@ -1,0 +1,59 @@
+<sup>[English](OBSERVABILITY.md) · 中文</sup>
+
+# 可观测性与调试
+
+MiroShark 内置了一套可观测性系统,可实时观察每一次 LLM 调用、智能体决策、图谱构建步骤和模拟轮次。
+
+## 调试面板
+
+在 UI 任意位置按 **Ctrl+Shift+D** 打开调试面板。共四个标签:
+
+| 标签 | 显示什么 |
+|---|---|
+| **Live Feed** | 实时 SSE 事件流 — 每次 LLM 调用、智能体动作、轮次边界、图谱构建步骤和错误。带颜色编码,可按平台/智能体/文本过滤,可展开查看完整细节。 |
+| **LLM Calls** | 所有 LLM 调用的列表,显示调用方、模型、输入/输出 tokens、延迟。点击可展开完整提示词和响应(当 `MIROSHARK_LOG_PROMPTS=true` 时)。顶部有聚合统计。 |
+| **Agent Trace** | 单智能体的决策时间线 — 智能体看到了什么、LLM 回复了什么、解析出了什么动作、成功/失败。 |
+| **Errors** | 过滤后的错误视图,带堆栈跟踪。 |
+
+## 事件流
+
+所有事件都以追加模式的 JSONL 写入:
+
+- `backend/logs/events.jsonl` — 全局(所有 Flask 进程的事件)
+- `uploads/simulations/{id}/events.jsonl` — 每个模拟一份(包含子进程事件)
+
+### SSE 端点
+
+```
+GET /api/observability/events/stream?simulation_id=sim_xxx&event_types=llm_call,error
+```
+
+返回 `text/event-stream` 格式的实时事件。调试面板自动使用这个端点。
+
+### REST 端点
+
+```
+GET /api/observability/events?simulation_id=sim_xxx&from_line=0&limit=200
+GET /api/observability/stats?simulation_id=sim_xxx
+GET /api/observability/llm-calls?simulation_id=sim_xxx&caller=ner_extractor
+```
+
+## 事件类型
+
+| 类型 | 由谁发出 | 数据 |
+|---|---|---|
+| `llm_call` | 每一次 LLM 调用(NER、本体、画像、配置、报告) | model、tokens、latency、caller、响应预览 |
+| `agent_decision` | 模拟期间的 agent `perform_action_by_llm()` | 环境观察、LLM 响应、解析后的动作、工具调用 |
+| `round_boundary` | 模拟循环(每轮开始/结束) | 模拟时刻、活跃智能体、动作数量、耗时 |
+| `graph_build` | 图谱构建器生命周期 | phase、节点/边数量、分块进度 |
+| `error` | 任意被捕获的异常并带 traceback | 错误类、消息、traceback、上下文 |
+
+## 配置
+
+```bash
+# .env
+MIROSHARK_LOG_PROMPTS=true    # Log full LLM prompts/responses (large files, debug only)
+MIROSHARK_LOG_LEVEL=info      # debug|info|warn — controls event verbosity
+```
+
+默认只记录响应预览(200 字符)。把 `MIROSHARK_LOG_PROMPTS=true` 打开,即可在深度调试时捕获完整提示词与响应。

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -1,5 +1,7 @@
 # Webhooks
 
+<sup>English · [中文](WEBHOOKS.zh-CN.md)</sup>
+
 MiroShark fires an outbound HTTP **POST** to a URL of your choosing the moment a simulation reaches a terminal state — `completed` or `failed`. The payload includes the scenario, final consensus, quality assessment, and a public share-card URL so consumers like Slack and Discord auto-unfurl with a rich preview.
 
 > **Tip:** open MiroShark → **Settings → Integrations · Webhook** to paste your URL and fire a test event without leaving the app. The same URL is read by the runner for live runs.

--- a/docs/WEBHOOKS.zh-CN.md
+++ b/docs/WEBHOOKS.zh-CN.md
@@ -1,0 +1,183 @@
+<sup>[English](WEBHOOKS.md) · 中文</sup>
+
+# Webhook
+
+MiroShark 会在某次模拟到达终态(`completed` 或 `failed`)的瞬间,向你指定的 URL 发起一次出站 HTTP **POST**。载荷包含情景、最终共识、质量评估,以及一个公开的分享卡 URL — 这样 Slack 和 Discord 等消费方能自动展开成富预览。
+
+> **提示:** 打开 MiroShark → **设置 → Integrations · Webhook**,即可在不离开应用的情况下粘贴你的 URL 并触发一次测试事件。同一个 URL 也会被 runner 在真实运行时读取。
+
+---
+
+## 为什么要有 webhook
+
+完成回调 webhook 是 MiroShark 之外一切外部世界的集成面:
+
+- **Slack / Discord / Teams** — 粘贴一个 Incoming Webhook URL;每次长时间模拟一结束,聊天频道就会亮起来,并自带分享卡片图。
+- **Zapier / Make / n8n / IFTTT** — 把 Zap/Scenario/Workflow 指向 MiroShark,然后从那里发散开:邮件摘要、Notion 行、Airtable 记录、Google 表格更新、自定义仪表板。
+- **自定义应用** — 你自己的 Cloud Run / Lambda / Express 端点收到 JSON;之后随便你怎么处理(启动下游分析、追加到队列、写 BigQuery 等)。
+
+无 bot、无 OAuth、无托管基础设施。只要一个 URL 字段。
+
+---
+
+## 配置
+
+要么在启动 MiroShark 之前设置环境变量:
+
+```bash
+WEBHOOK_URL=https://hooks.slack.com/services/T0XXX/B0YYY/abcSECRETxyz
+PUBLIC_BASE_URL=https://miroshark.app           # optional, see below
+```
+
+……要么打开 **设置 → Integrations · Webhook** 在那里粘贴 URL。设置改动会在运行时生效 — 无需重启。
+
+`PUBLIC_BASE_URL` 是你 MiroShark 部署对外公开可达的根地址(例如 `https://miroshark.app`)。设置之后,载荷会包含绝对路径的 `share_url` 与 `share_card_url` 字段,让 Slack / Discord 自动展开模拟卡片。如果你只需要相对路径并且消费方能自己拼绝对 URL,留空即可。
+
+---
+
+## 载荷结构
+
+```json
+{
+  "event": "simulation.completed",
+  "sim_id": "sim_abc123def456",
+  "scenario": "Will the SEC approve a spot Solana ETF before Q3 2026?",
+  "status": "completed",
+  "current_round": 20,
+  "total_rounds": 20,
+  "agent_count": 248,
+  "quality_health": "Excellent",
+  "final_consensus": {
+    "bullish": 62.0,
+    "neutral": 13.0,
+    "bearish": 25.0
+  },
+  "resolution_outcome": "YES",
+  "share_path": "/share/sim_abc123def456",
+  "share_card_path": "/api/simulation/sim_abc123def456/share-card.png",
+  "share_url": "https://miroshark.app/share/sim_abc123def456",
+  "share_card_url": "https://miroshark.app/api/simulation/sim_abc123def456/share-card.png",
+  "created_at": "2026-04-26T10:12:34",
+  "completed_at": "2026-04-26T10:35:11",
+  "parent_simulation_id": null,
+  "fired_at": "2026-04-26T10:35:11.842113+00:00"
+}
+```
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `event` | string | `simulation.completed`、`simulation.failed` 或 `simulation.test` |
+| `sim_id` | string | 稳定标识符 — 同时也在 `X-MiroShark-Sim-Id` 头部里 |
+| `scenario` | string | 截断到 280 字符,带 Unicode 省略号 |
+| `status` | string | `completed`、`failed` 或 `test` |
+| `current_round` | int | 完成时已结束的最后一轮 |
+| `total_rounds` | int | 配置的总轮数 — 未知时为 `0` |
+| `agent_count` | int | 智能体画像数量 |
+| `quality_health` | string \| null | `Excellent` / `Good` / `Fair` / `Poor`,跳过评估时为 `null` |
+| `final_consensus` | object \| null | 最后一份信念快照中的 看涨 / 中立 / 看跌 百分比 |
+| `resolution_outcome` | string \| null | 当本次运行有 polymarket 结算时存在(`YES` / `NO`) |
+| `share_path` | string | 永远是相对路径;打日志安全 |
+| `share_card_path` | string | 永远是相对路径 |
+| `share_url` | string \| absent | 仅在设置了 `PUBLIC_BASE_URL` 时存在 |
+| `share_card_url` | string \| absent | 仅在设置了 `PUBLIC_BASE_URL` 时存在 |
+| `created_at` | string \| null | ISO 8601,模拟创建时间 |
+| `completed_at` | string \| null | ISO 8601,达到终态的时间 |
+| `parent_simulation_id` | string \| null | 当此次运行是从其他运行分叉而来时存在 |
+| `fired_at` | string | 带时区的 ISO 8601,webhook 离开 MiroShark 的时间 |
+| `error` | string \| absent | 仅在 `simulation.failed` 上 — 截断到 1000 字符 |
+| `test` | bool \| absent | 仅在 `simulation.test` 事件上为 `true` |
+
+### HTTP 头
+
+| 头 | 值 |
+|---|---|
+| `Content-Type` | `application/json; charset=utf-8` |
+| `User-Agent` | `MiroShark-Webhook/1.0` |
+| `X-MiroShark-Event` | 与 `event` 相同的值 |
+| `X-MiroShark-Sim-Id` | 与 `sim_id` 相同的值 |
+
+---
+
+## 投递语义
+
+- **发了就忘** — POST 跑在守护线程上,所以慢的接收端永远不会拖慢模拟 runner。
+- **尽力而为,不重试** — 单次尝试,5 秒超时。需要可靠送达的消费方应该把 webhook 接进队列,并尽快用 HTTP 2xx 应答。
+- **进程内去重** — runner 会通过两条路径检测完成(进程退出码 + 各平台的 `simulation_end` 事件)。两者都会调进 webhook 服务;每个 `(sim_id, status)` 只有第一次会真的发出。
+- **只送 `completed` 与 `failed`** — 暂停 / 恢复 / running 事件*不*下发。
+- **2xx 即成功** — 其他都会被记录为投递失败,但永远不会抛出。
+
+---
+
+## 示例
+
+### Slack
+
+```bash
+WEBHOOK_URL=https://hooks.slack.com/services/T0XXX/B0YYY/abcSECRETxyz
+PUBLIC_BASE_URL=https://miroshark.example.com
+```
+
+Slack 消息会自动把 `share_url` 展开成 `GET /api/simulation/<id>/share-card.png` 生成的 OG 卡(1200×630 PNG,带情景、共识分布、质量徽章)。无需额外格式化。
+
+### Discord
+
+```bash
+WEBHOOK_URL=https://discord.com/api/webhooks/123456789/abcSECRETxyz
+PUBLIC_BASE_URL=https://miroshark.example.com
+```
+
+Discord 频道 webhook 接受同一份 JSON body。`share_url` 会在频道里展开。
+
+### Zapier / Make / n8n
+
+创建一个"Webhook by Zapier" / "Webhooks · Custom webhook" / "Webhook" 触发节点,把它的 URL 复制到 `WEBHOOK_URL`。每次模拟完成都会成为一次新的触发事件,带上面完整的载荷 — 然后扇出到邮件、Notion、表格,或者它们提供的 5,000+ 集成中的任何一个。
+
+### 自定义监听端(Python)
+
+```python
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+@app.post("/miroshark-webhook")
+async def receive(req: Request):
+    payload = await req.json()
+    if payload["event"] == "simulation.completed":
+        print(f"{payload['sim_id']}: {payload['scenario']!r} → {payload['final_consensus']}")
+    return {"ok": True}
+```
+
+---
+
+## 测试你的端点
+
+最快的路径是 **设置 → Integrations · Webhook** 中的 **发送测试事件** 按钮 — 它会以同一份结构 POST `event: "simulation.test"` 与 `test: true`,并就地显示响应状态 / 延迟。
+
+同样的调用也以 `POST /api/settings/test-webhook` 的形式暴露,便于脚本化:
+
+```bash
+curl -s -X POST http://localhost:5000/api/settings/test-webhook \
+     -H 'Content-Type: application/json' \
+     -d '{"url": "https://example.com/hook"}'
+```
+
+响应:
+
+```json
+{
+  "success": true,
+  "message": "HTTP 200",
+  "latency_ms": 142,
+  "url_masked": "https://example.com/***"
+}
+```
+
+省略 body 即可测试当前已保存的 `WEBHOOK_URL`。
+
+---
+
+## 安全说明
+
+- 完整的 webhook URL 被视为密钥 — `GET /api/settings` 只返回脱敏形式(`https://hooks.slack.com/***`)。路径永远不会被回显。
+- Webhook 调用直接从你的 MiroShark 实例打到你的端点 — 不经过 Anthropic 或任何第三方中转。
+- 校验会拒绝任何不以 `http://` 或 `https://` 开头的 URL。JavaScript / file / FTP URL 在 API 层就被拦掉。


### PR DESCRIPTION
## Summary
Polish pass on top of the initial zh-CN ship (#61). Two visible changes:

**(a) Backend error messages + RSS feed channel title** — 138 user-facing API error sites now go through `_t(en, zh, locale)`:
- `graph.py` (15), `simulation.py` (~58 distinct), `report.py` (22), `share.py` (1), `feed.py` (channel metadata + RSS `<language>`)
- `services/feed.py`'s `render_feed()` accepts a `locale` kwarg so `/api/feed.atom?lang=zh-CN` serves a Chinese channel title + description (`MiroShark · 公开模拟` / `MiroShark · 已验证预言`)
- Logger / programmatic error codes / exception bubble-ups stay English (developer-facing)

**(b) All docs translated** — 10 `docs/*.md` files + root `CONTRIBUTING.md` now have `*.zh-CN.md` siblings. Each English source gained a `<sup>English · [中文](*.zh-CN.md)</sup>` switcher under its H1; each Chinese sibling opens with the reverse switcher. `INSTALL.zh-CN.md` and `CONFIGURATION.zh-CN.md` got an extra-careful pass since they're the real Chinese onboarding path. Cross-doc links inside the Chinese set rewritten to keep the localized doc graph self-consistent. README's Chinese docs index points to `*.zh-CN.md` siblings.

## Test plan
- [ ] All 214 backend unit tests pass (verified locally)
- [ ] `npm run build` clean (verified locally)
- [ ] `curl /api/feed.atom?lang=zh-CN` shows `<title>MiroShark · 公开模拟</title>`
- [ ] `curl -H 'Accept-Language: zh-CN' /api/simulation/<bad-id>` returns Chinese error
- [ ] Click any docs link from the Chinese README section → land on a Chinese doc
- [ ] Click the `English · 中文` switcher at the top of any doc → swap languages without context loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)