### PR TITLE
docs(readme): put English section above Chinese

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,115 +21,6 @@
 
 ---
 
-<a id="中文"></a>
-
-## 中文
-
-> **一切皆可模拟,只需 $1、不到 10 分钟 — 通用群体智能引擎**
-> 投入任何素材 — 新闻稿、头条、政策草案、一个无解的问题、一段历史假设 — MiroShark 都会派出数百个智能体,每小时一轮地做出反应:发帖、辩论、交易、改变想法。
-
-### 它做什么
-
-- 你提供一个情景,MiroShark 围绕它构建世界。
-- 数百个有据可依的智能体在 Twitter、Reddit 与预测市场上每小时一轮地反应。
-- 与任意智能体对话。在运行中投入突发新闻。派生出反事实分支。
-- 生成一份引用真实发帖与交易的复盘报告。
-
-### 快速开始
-
-推荐路径:**一个 [OpenRouter](https://openrouter.ai/) 密钥 + `./miroshark` 启动器**。首次模拟约 10 分钟、约 $1。
-
-**前置条件** — Python 3.11+、Node 18+、Neo4j,以及 [OpenRouter 密钥](https://openrouter.ai/)。
-
-安装 Neo4j(启动器会自动启动它):
-
-- **macOS** — `brew install neo4j`
-- **Linux** — `sudo apt install neo4j` *(或所在发行版对应的命令)*
-- **Windows** — 安装 [Neo4j Desktop](https://neo4j.com/download/) *(原生 GUI,先在其中启动数据库,然后通过 WSL2 或 Git Bash 运行启动器)*,或在 [WSL2](https://learn.microsoft.com/windows/wsl/install) 内运行整套环境并按 Linux 步骤操作
-- **零安装** — 创建免费的 [Neo4j Aura](https://neo4j.com/cloud/aura-free/) 云实例,在 `.env` 中将 `NEO4J_URI` / `NEO4J_PASSWORD` 指向它
-
-然后:
-
-```bash
-git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
-cp .env.example .env
-# 将你的 OpenRouter 密钥粘贴到 LLM_API_KEY / SMART_API_KEY /
-# NER_API_KEY / OPENAI_API_KEY / EMBEDDING_API_KEY 五个字段
-# (同一个密钥,粘 5 处)。默认组合是 Mimo V2 Flash + Grok-4.1 Fast。
-./miroshark
-```
-
-启动器会检查依赖、启动 Neo4j、安装前后端,并在 `:3000` + `:5001` 提供服务。Ctrl+C 停止。打开 `http://localhost:3000` 投入文档即可。
-
-**界面语言** — 启动后,在导航栏右上角点击「中 / EN」按钮即可切换中英文。语言选择会保存在浏览器中,下次访问时自动应用。模板画廊与公开模拟列表的卡片标题/描述也会随之切换。
-
-**其他部署路径** — [一键 Railway / Render](docs/INSTALL.zh-CN.md)、[Docker + Ollama](docs/INSTALL.zh-CN.md)、[手动 Ollama](docs/INSTALL.zh-CN.md)、[Claude Code CLI](docs/INSTALL.zh-CN.md) — 详见 **[docs/INSTALL.zh-CN.md](docs/INSTALL.zh-CN.md)**。
-
-### 主要功能
-
-| 功能 | 说明 |
-|---|---|
-| **智能配置** | 投入文档 → 约 2 秒生成三套自动情景(看涨/看跌/中立) |
-| **热门追踪** | 从 RSS 中挑选实时新闻,一键预填情景 |
-| **直接提问** | 不用文档,直接打字提问 — MiroShark 自行调研并撰写种子简报 |
-| **反事实分支** | 在运行中的模拟里派生分支并注入事件(「如果 24 轮时 CEO 辞职会怎样?」) |
-| **导演模式** | 在当前时间线中投入突发新闻,无需派生分支 |
-| **预设模板** | 6 套基准情景:加密代币发布、企业危机、政治辩论、产品发布、校园风波、历史假设 |
-| **现实预言机** | 可选地从 [FeedOracle](https://mcp.feedoracle.io/mcp) MCP 中拉取实时数据(484 个工具) |
-| **每个智能体的 MCP 工具** | 人设可在模拟过程中调用真实 MCP 工具(网页搜索、API 等) |
-| **自定义 Wonderwall 端点** | 将模拟主循环指向任意 OpenAI 兼容端点(自部署 vLLM、Modal、微调模型……),不影响 Default/Smart/NER。设置 `WONDERWALL_BASE_URL` + `WONDERWALL_API_KEY` |
-| **嵌入与发布** | 公开/私有切换 + 嵌入 URL,便于分享已完成的运行 |
-| **社交分享卡片** | 1200×630 PNG,自动展开情景、状态、质量与信念分布,适配 Twitter/X、Discord、Slack、LinkedIn |
-| **信念回放动图** | 1200×630 GIF,每轮一帧,信念条动态滑向各轮分布。Discord 与 Slack 在直接 URL 上自动播放 |
-| **转录导出** | 每轮智能体发帖与立场标签,导出为 Markdown(YAML 头,适配 Notion / Obsidian / Substack)或结构化 JSON(适配 SDK 与 LLM 评审管线) |
-| **公开图库** | `/explore` 以卡片网格浏览所有公开模拟 — 预览分享卡、共识分布与质量指标;一键打开或派生 |
-| **已验证预言** | 为公开模拟标注真实结果(命中 / 部分 / 失误 + 链接)。`/verified` 是命中预言专属展厅 |
-| **RSS / Atom 订阅源** | `/api/feed.atom` + `/api/feed.rss` — 每个新发布的模拟无需任何整理就会进入 Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS。`?verified=1` 只看已验证内容 |
-| **文章生成** | Substack 风格的复盘文章,基于真实发帖与交易数据 |
-| **互动网络** | 力导向智能体关系图,带回声室指标 |
-| **人口分布** | 原型聚类(分析师 / 影响者 / 散户 / 旁观者……) |
-| **质量诊断** | 单次运行的健康评分 — 参与度、连贯性、多样性、方差 |
-| **历史数据库** | 搜索、克隆、导出或删除任一过往模拟 |
-| **轨迹访谈** | 查看智能体回复背后的完整推理链,而不止是回复本身 |
-| **推送通知** | 长耗时图谱 / 模拟 / 报告任务完成时的浏览器推送提醒 |
-| **完成 Webhook** | 模拟一结束即 POST 一份 JSON 摘要 — 一个 URL 字段即可连通 Slack、Discord、Zapier、Make、n8n 或任意自定义端点 |
-
-每项功能详见 **[docs/FEATURES.zh-CN.md](docs/FEATURES.zh-CN.md)**。
-
-### 应用场景
-
-- **公关危机演练** — 在新闻稿发布前模拟舆论反应
-- **市场反应** — 喂入财经新闻,观察模拟交易者与投资者情绪
-- **广告测试** — 在投放前用模拟受众检验文案、标题或卖点
-- **政策分析** — 用模拟公众检验法规草案
-- **人生抉择** — 把个人决定(换工作、搬家、上线时机)作为情景,看多元人设辩论
-- **历史假设** — 改写一段历史事件,看一群人设如何重写后续叙事
-- **创意实验** — 喂入失去结尾的小说,智能体续写出叙事自洽的结局
-
-### 文档
-
-| | |
-|---|---|
-| [安装](docs/INSTALL.zh-CN.md) | 全部部署路径:云端、Docker、Ollama、Claude Code |
-| [配置](docs/CONFIGURATION.zh-CN.md) | 环境变量、模型路由、特性开关 |
-| [模型](docs/MODELS.zh-CN.md) | 云端预设、本地 Ollama 模型、基准发现 |
-| [架构](docs/ARCHITECTURE.zh-CN.md) | 模拟引擎、记忆管线、图谱检索 |
-| [功能](docs/FEATURES.zh-CN.md) | 上述功能表的深入解析 |
-| [HTTP API](docs/API.zh-CN.md) | 全部端点,按关注点分组 — 含 `/api/docs` 交互式 Swagger UI 与 `/api/openapi.yaml` 规范 |
-| [CLI](docs/CLI.zh-CN.md) | `miroshark-cli` 参考 |
-| [MCP](docs/MCP.zh-CN.md) | Claude Desktop / Cursor / Windsurf / Continue 集成 + 报告智能体工具(可在「设置 → AI 集成」中获取自动生成的片段) |
-| [Webhook](docs/WEBHOOKS.zh-CN.md) | 完成 Webhook 载荷、头部、投递语义、Slack/Discord/Zapier/n8n 食谱 |
-| [可观测性](docs/OBSERVABILITY.zh-CN.md) | 调试面板、事件流、日志 |
-| [贡献](CONTRIBUTING.zh-CN.md) | 测试与开发 |
-
-### 许可证
-
-AGPL-3.0,详见 [LICENSE](./LICENSE)。
-
-支持本项目:`0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3`
-
----
-
 <a id="english"></a>
 
 ## English
@@ -265,3 +156,113 @@ Support the project: `0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3`
 ### Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=aaronjmars/miroshark&type=Date)](https://www.star-history.com/#aaronjmars/miroshark&Date)
+
+---
+
+<a id="中文"></a>
+
+## 中文
+
+> **一切皆可模拟,只需 $1、不到 10 分钟 — 通用群体智能引擎**
+> 投入任何素材 — 新闻稿、头条、政策草案、一个无解的问题、一段历史假设 — MiroShark 都会派出数百个智能体,每小时一轮地做出反应:发帖、辩论、交易、改变想法。
+
+### 它做什么
+
+- 你提供一个情景,MiroShark 围绕它构建世界。
+- 数百个有据可依的智能体在 Twitter、Reddit 与预测市场上每小时一轮地反应。
+- 与任意智能体对话。在运行中投入突发新闻。派生出反事实分支。
+- 生成一份引用真实发帖与交易的复盘报告。
+
+### 快速开始
+
+推荐路径:**一个 [OpenRouter](https://openrouter.ai/) 密钥 + `./miroshark` 启动器**。首次模拟约 10 分钟、约 $1。
+
+**前置条件** — Python 3.11+、Node 18+、Neo4j,以及 [OpenRouter 密钥](https://openrouter.ai/)。
+
+安装 Neo4j(启动器会自动启动它):
+
+- **macOS** — `brew install neo4j`
+- **Linux** — `sudo apt install neo4j` *(或所在发行版对应的命令)*
+- **Windows** — 安装 [Neo4j Desktop](https://neo4j.com/download/) *(原生 GUI,先在其中启动数据库,然后通过 WSL2 或 Git Bash 运行启动器)*,或在 [WSL2](https://learn.microsoft.com/windows/wsl/install) 内运行整套环境并按 Linux 步骤操作
+- **零安装** — 创建免费的 [Neo4j Aura](https://neo4j.com/cloud/aura-free/) 云实例,在 `.env` 中将 `NEO4J_URI` / `NEO4J_PASSWORD` 指向它
+
+然后:
+
+```bash
+git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
+cp .env.example .env
+# 将你的 OpenRouter 密钥粘贴到 LLM_API_KEY / SMART_API_KEY /
+# NER_API_KEY / OPENAI_API_KEY / EMBEDDING_API_KEY 五个字段
+# (同一个密钥,粘 5 处)。默认组合是 Mimo V2 Flash + Grok-4.1 Fast。
+./miroshark
+```
+
+启动器会检查依赖、启动 Neo4j、安装前后端,并在 `:3000` + `:5001` 提供服务。Ctrl+C 停止。打开 `http://localhost:3000` 投入文档即可。
+
+**界面语言** — 启动后,在导航栏右上角点击「中 / EN」按钮即可切换中英文。语言选择会保存在浏览器中,下次访问时自动应用。模板画廊与公开模拟列表的卡片标题/描述也会随之切换。
+
+**其他部署路径** — [一键 Railway / Render](docs/INSTALL.zh-CN.md)、[Docker + Ollama](docs/INSTALL.zh-CN.md)、[手动 Ollama](docs/INSTALL.zh-CN.md)、[Claude Code CLI](docs/INSTALL.zh-CN.md) — 详见 **[docs/INSTALL.zh-CN.md](docs/INSTALL.zh-CN.md)**。
+
+### 主要功能
+
+| 功能 | 说明 |
+|---|---|
+| **智能配置** | 投入文档 → 约 2 秒生成三套自动情景(看涨/看跌/中立) |
+| **热门追踪** | 从 RSS 中挑选实时新闻,一键预填情景 |
+| **直接提问** | 不用文档,直接打字提问 — MiroShark 自行调研并撰写种子简报 |
+| **反事实分支** | 在运行中的模拟里派生分支并注入事件(「如果 24 轮时 CEO 辞职会怎样?」) |
+| **导演模式** | 在当前时间线中投入突发新闻,无需派生分支 |
+| **预设模板** | 6 套基准情景:加密代币发布、企业危机、政治辩论、产品发布、校园风波、历史假设 |
+| **现实预言机** | 可选地从 [FeedOracle](https://mcp.feedoracle.io/mcp) MCP 中拉取实时数据(484 个工具) |
+| **每个智能体的 MCP 工具** | 人设可在模拟过程中调用真实 MCP 工具(网页搜索、API 等) |
+| **自定义 Wonderwall 端点** | 将模拟主循环指向任意 OpenAI 兼容端点(自部署 vLLM、Modal、微调模型……),不影响 Default/Smart/NER。设置 `WONDERWALL_BASE_URL` + `WONDERWALL_API_KEY` |
+| **嵌入与发布** | 公开/私有切换 + 嵌入 URL,便于分享已完成的运行 |
+| **社交分享卡片** | 1200×630 PNG,自动展开情景、状态、质量与信念分布,适配 Twitter/X、Discord、Slack、LinkedIn |
+| **信念回放动图** | 1200×630 GIF,每轮一帧,信念条动态滑向各轮分布。Discord 与 Slack 在直接 URL 上自动播放 |
+| **转录导出** | 每轮智能体发帖与立场标签,导出为 Markdown(YAML 头,适配 Notion / Obsidian / Substack)或结构化 JSON(适配 SDK 与 LLM 评审管线) |
+| **公开图库** | `/explore` 以卡片网格浏览所有公开模拟 — 预览分享卡、共识分布与质量指标;一键打开或派生 |
+| **已验证预言** | 为公开模拟标注真实结果(命中 / 部分 / 失误 + 链接)。`/verified` 是命中预言专属展厅 |
+| **RSS / Atom 订阅源** | `/api/feed.atom` + `/api/feed.rss` — 每个新发布的模拟无需任何整理就会进入 Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS。`?verified=1` 只看已验证内容 |
+| **文章生成** | Substack 风格的复盘文章,基于真实发帖与交易数据 |
+| **互动网络** | 力导向智能体关系图,带回声室指标 |
+| **人口分布** | 原型聚类(分析师 / 影响者 / 散户 / 旁观者……) |
+| **质量诊断** | 单次运行的健康评分 — 参与度、连贯性、多样性、方差 |
+| **历史数据库** | 搜索、克隆、导出或删除任一过往模拟 |
+| **轨迹访谈** | 查看智能体回复背后的完整推理链,而不止是回复本身 |
+| **推送通知** | 长耗时图谱 / 模拟 / 报告任务完成时的浏览器推送提醒 |
+| **完成 Webhook** | 模拟一结束即 POST 一份 JSON 摘要 — 一个 URL 字段即可连通 Slack、Discord、Zapier、Make、n8n 或任意自定义端点 |
+
+每项功能详见 **[docs/FEATURES.zh-CN.md](docs/FEATURES.zh-CN.md)**。
+
+### 应用场景
+
+- **公关危机演练** — 在新闻稿发布前模拟舆论反应
+- **市场反应** — 喂入财经新闻,观察模拟交易者与投资者情绪
+- **广告测试** — 在投放前用模拟受众检验文案、标题或卖点
+- **政策分析** — 用模拟公众检验法规草案
+- **人生抉择** — 把个人决定(换工作、搬家、上线时机)作为情景,看多元人设辩论
+- **历史假设** — 改写一段历史事件,看一群人设如何重写后续叙事
+- **创意实验** — 喂入失去结尾的小说,智能体续写出叙事自洽的结局
+
+### 文档
+
+| | |
+|---|---|
+| [安装](docs/INSTALL.zh-CN.md) | 全部部署路径:云端、Docker、Ollama、Claude Code |
+| [配置](docs/CONFIGURATION.zh-CN.md) | 环境变量、模型路由、特性开关 |
+| [模型](docs/MODELS.zh-CN.md) | 云端预设、本地 Ollama 模型、基准发现 |
+| [架构](docs/ARCHITECTURE.zh-CN.md) | 模拟引擎、记忆管线、图谱检索 |
+| [功能](docs/FEATURES.zh-CN.md) | 上述功能表的深入解析 |
+| [HTTP API](docs/API.zh-CN.md) | 全部端点,按关注点分组 — 含 `/api/docs` 交互式 Swagger UI 与 `/api/openapi.yaml` 规范 |
+| [CLI](docs/CLI.zh-CN.md) | `miroshark-cli` 参考 |
+| [MCP](docs/MCP.zh-CN.md) | Claude Desktop / Cursor / Windsurf / Continue 集成 + 报告智能体工具(可在「设置 → AI 集成」中获取自动生成的片段) |
+| [Webhook](docs/WEBHOOKS.zh-CN.md) | 完成 Webhook 载荷、头部、投递语义、Slack/Discord/Zapier/n8n 食谱 |
+| [可观测性](docs/OBSERVABILITY.zh-CN.md) | 调试面板、事件流、日志 |
+| [贡献](CONTRIBUTING.zh-CN.md) | 测试与开发 |
+
+### 许可证
+
+AGPL-3.0,详见 [LICENSE](./LICENSE)。
+
+支持本项目:`0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3`
+


### PR DESCRIPTION
## Summary
Mechanical reorder — the top-of-page `English · 中文` switcher and both anchor IDs (`#english`, `#中文`) are unchanged, so existing deep links still resolve.

## Test plan
- [x] `#english` and `#中文` anchors still scroll to their sections
- [x] Top switcher links unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)