### PR TITLE
docs(readme): move License + Star History below the Chinese section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,16 +147,6 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 | [Observability](docs/OBSERVABILITY.md) | Debug panel, event stream, logging |
 | [Contributing](CONTRIBUTING.md) | Tests and development |
 
-### License
-
-AGPL-3.0. See [LICENSE](./LICENSE).
-
-Support the project: `0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3`
-
-### Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=aaronjmars/miroshark&type=Date)](https://www.star-history.com/#aaronjmars/miroshark&Date)
-
 ---
 
 <a id="中文"></a>
@@ -260,9 +250,15 @@ cp .env.example .env
 | [可观测性](docs/OBSERVABILITY.zh-CN.md) | 调试面板、事件流、日志 |
 | [贡献](CONTRIBUTING.zh-CN.md) | 测试与开发 |
 
-### 许可证
+---
 
+## License · 许可证
+
+AGPL-3.0. See [LICENSE](./LICENSE).
 AGPL-3.0,详见 [LICENSE](./LICENSE)。
 
-支持本项目:`0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3`
+Support the project · 支持本项目:`0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3`
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=aaronjmars/miroshark&type=Date)](https://www.star-history.com/#aaronjmars/miroshark&Date)


### PR DESCRIPTION
## Summary
License + Star History belong to the project as a whole, not to either language section. They were sitting at the bottom of the English block (which made them invisible to readers who jumped straight to `#中文` and read past the bottom). Now they live once, at the very end of the README, under a single bilingual header (`License · 许可证`).

## Test plan
- [x] `#english` and `#中文` anchors still resolve
- [x] No duplicate license/star-history blocks
- [x] Both languages share the same trailing footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)