### PR TITLE
feat: belief trajectory CSV / JSONL export

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Social Share Card** | 1200×630 PNG that auto-unfurls scenario, status, quality, and belief split on Twitter/X, Discord, Slack, LinkedIn |
 | **Animated Belief Replay** | 1200×630 GIF — one frame per round, belief bars sliding to each round's distribution. Discord and Slack auto-play GIFs from the direct URL |
 | **Transcript Export** | Per-round agent posts + stance labels as Markdown (YAML front matter for Notion / Obsidian / Substack) or structured JSON (for SDKs and LLM-as-judge pipelines) |
+| **Trajectory Export** | One row per round as RFC 4180 CSV or JSONL — `pandas.read_csv("…/trajectory.csv")` lands ready for Pandas / Excel / Tableau / R / Observable. Same ±0.2 stance threshold as every other surface |
 | **Public Gallery** | `/explore` browses every published simulation as a card grid — preview the share card, consensus split, and quality health; click to open or one-click fork |
 | **Verified Predictions** | Annotate any public sim with the real-world outcome (called it / partial / called wrong + URL). `/verified` is the dedicated hall of calls that landed |
 | **RSS / Atom Feeds** | `/api/feed.atom` + `/api/feed.rss` — every newly published simulation lands in Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS without anyone curating it. `?verified=1` for the verified-only stream |

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -5116,6 +5116,99 @@ def get_transcript_json(simulation_id: str):
     return _serve_transcript(simulation_id, "json")
 
 
+def _serve_trajectory(simulation_id: str, fmt: str):
+    """Shared body for the trajectory.csv / trajectory.jsonl routes.
+
+    Both endpoints share the same publish gate, the same row assembly
+    (``trajectory_export.build_rows``), and only diverge in the encoding
+    step. Extracted so the two route handlers stay one-line wrappers —
+    the decorator presence is what the OpenAPI drift test scans for,
+    but the actual logic lives here.
+    """
+    from ..services import trajectory_export
+    from flask import Response
+
+    locale = get_locale(request)
+    try:
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                    "该模拟未发布,请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
+            }), 403
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        rows = trajectory_export.build_rows(sim_dir)
+
+        if fmt == "jsonl":
+            payload = trajectory_export.render_jsonl(rows)
+            mimetype = "application/jsonl; charset=utf-8"
+            filename = f"miroshark-{simulation_id[:12]}-trajectory.jsonl"
+        else:
+            payload = trajectory_export.render_csv(rows)
+            mimetype = "text/csv; charset=utf-8"
+            filename = f"miroshark-{simulation_id[:12]}-trajectory.csv"
+
+        response = Response(payload, mimetype=mimetype)
+        # Short cache — the trajectory grows by one row per round on a
+        # live run; 60s matches transcript + embed-summary so an
+        # analyst polling for completion sees fresh data quickly while
+        # bot crawlers don't hammer disk reads.
+        response.headers["Cache-Control"] = "public, max-age=60"
+        # ``attachment`` so a click from the embed dialog triggers a
+        # save-as without an explicit ``download`` attribute on the
+        # anchor — analysts paste the URL into ``pandas.read_csv()``,
+        # they don't render the bytes in-tab.
+        response.headers["Content-Disposition"] = (
+            f'attachment; filename="{filename}"'
+        )
+        return response
+
+    except Exception as e:
+        logger.error(f"trajectory: failed for {simulation_id}: {e}\n{traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500
+
+
+@simulation_bp.route('/<simulation_id>/trajectory.csv', methods=['GET'])
+def get_trajectory_csv(simulation_id: str):
+    """Per-round belief trajectory as RFC 4180 CSV.
+
+    One row per recorded round with the bullish/neutral/bearish split
+    (using the same ±0.2 stance threshold as the gallery, share card,
+    replay GIF, transcript, webhook, and feed surfaces), participating
+    agents, post + engagement counts, and the overall quality health.
+    Intended for ``pandas.read_csv()`` / Excel / Tableau / R / Observable
+    consumers — the analyst's default toolkit. Same publish gate as the
+    transcript and share card.
+    """
+    return _serve_trajectory(simulation_id, "csv")
+
+
+@simulation_bp.route('/<simulation_id>/trajectory.jsonl', methods=['GET'])
+def get_trajectory_jsonl(simulation_id: str):
+    """Same per-round belief trajectory as ``trajectory.csv`` but as
+    newline-delimited JSON.
+
+    One JSON object per line — the format ``pandas.read_json(lines=True)``,
+    DuckDB ``read_json_auto``, and most stream-processing pipelines
+    consume natively without a separate CSV-to-DataFrame conversion.
+    Intended for SDK / pipeline consumers that need the same numbers
+    the CSV carries but in a structured shape.
+    """
+    return _serve_trajectory(simulation_id, "jsonl")
+
+
 # ============== Public Gallery ==============
 
 

--- a/backend/app/services/trajectory_export.py
+++ b/backend/app/services/trajectory_export.py
@@ -1,0 +1,297 @@
+"""Belief trajectory export — CSV + JSONL renderers.
+
+Turns ``trajectory.json`` (one snapshot per round, with per-agent
+``belief_positions`` + per-round counters) into the analyst's default
+serialization formats: a CSV that ``pandas.read_csv()`` / Excel /
+Tableau / R / Observable consume directly, and a JSON-lines stream for
+pipeline ingest.
+
+Pairs with the share card (preview / PNG), the replay GIF (motion),
+and the transcript (Markdown + JSON prose) as the **fifth** export
+surface — the previous four cover the *qualitative* read of a
+simulation; this one covers the *quantitative* one. ``transcript.json``
+is what the LLM-as-judge pipelines parse for reasoning quality;
+``trajectory.csv`` is what a quant researcher loads into a notebook to
+compute variance, autocorrelation, or compare across runs.
+
+Pure stdlib (``csv`` + ``io`` + ``json``). Reads the same on-disk
+artifacts the embed-summary, share-card, replay-GIF, gallery card,
+webhook, transcript, and Atom/RSS feeds already share — same ±0.2
+stance threshold, so a "bullish" percentage in the trajectory matches
+a "bullish" percentage on every other surface for the same round.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+from typing import Any, Optional
+
+
+# Same threshold the embed-summary, share card, replay GIF, gallery
+# card, webhook, transcript, and feed renderers all use. Per-round
+# bullish/neutral/bearish percentages here MUST stay consistent with
+# what those surfaces report for the same simulation, otherwise an
+# analyst comparing the CSV to the share card would see drift.
+STANCE_THRESHOLD = 0.2
+
+
+# Field order for the CSV header + JSONL key order. Locked because
+# ``pandas.read_csv()`` consumers index by column name and downstream
+# pipelines key on the JSONL field names — adding a new column at the
+# end is fine, reordering breaks consumers.
+CSV_COLUMNS: tuple[str, ...] = (
+    "round",
+    "round_timestamp",
+    "bullish_pct",
+    "neutral_pct",
+    "bearish_pct",
+    "participating_agents",
+    "total_posts",
+    "total_engagements",
+    "quality_health",
+    "participation_rate",
+)
+
+
+# ── On-disk readers ────────────────────────────────────────────────────────
+
+
+def _safe_load_json(path: str) -> Any:
+    """Read JSON, returning ``None`` on missing / corrupt input.
+
+    Never raises — the route handler must produce a (possibly empty)
+    feed rather than a 500 when an artifact is malformed on disk.
+    """
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+# ── Stance computation ────────────────────────────────────────────────────
+
+
+def _avg_position(positions: dict | None) -> Optional[float]:
+    """Mean of an agent's per-topic belief positions for one round.
+
+    The per-topic dict can be empty or contain non-numeric values when
+    a snapshot is mid-write; we filter those out and return ``None`` if
+    no usable values remain.
+    """
+    if not positions:
+        return None
+    values = [
+        float(v)
+        for v in positions.values()
+        if isinstance(v, (int, float)) and not isinstance(v, bool)
+    ]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def compute_stance_split(
+    belief_positions: dict | None,
+    threshold: float = STANCE_THRESHOLD,
+) -> dict[str, float]:
+    """Bucket per-agent belief positions into bullish/neutral/bearish %.
+
+    ``belief_positions`` is the snapshot field: ``{agent_id: {topic: float}}``.
+    Each agent's per-topic positions are averaged into a single scalar,
+    then bucketed against ``±threshold``.
+
+    Returns ``{"bullish": pct, "neutral": pct, "bearish": pct}`` with
+    each percentage rounded to one decimal place. Empty input returns
+    all zeros so the row can still be emitted (downstream consumers
+    expect a constant column count).
+    """
+    if not belief_positions:
+        return {"bullish": 0.0, "neutral": 0.0, "bearish": 0.0}
+
+    stances: list[float] = []
+    for agent_positions in belief_positions.values():
+        avg = _avg_position(agent_positions)
+        if avg is not None:
+            stances.append(avg)
+
+    total = len(stances)
+    if total == 0:
+        return {"bullish": 0.0, "neutral": 0.0, "bearish": 0.0}
+
+    n_bull = sum(1 for s in stances if s > threshold)
+    n_bear = sum(1 for s in stances if s < -threshold)
+    n_neut = total - n_bull - n_bear
+    return {
+        "bullish": round(n_bull / total * 100, 1),
+        "neutral": round(n_neut / total * 100, 1),
+        "bearish": round(n_bear / total * 100, 1),
+    }
+
+
+# ── Row assembly ───────────────────────────────────────────────────────────
+
+
+def _participating_agents(snapshot: dict) -> int:
+    """Count agents that posted at least once in this round.
+
+    ``active_agent_count`` is the runner's recorded headline number;
+    we prefer the ``viral_posts`` set count when both are present and
+    diverge, since the post set is what an analyst would reproduce
+    from the same trajectory file.
+    """
+    posts = snapshot.get("viral_posts") or []
+    posters: set[int] = set()
+    if isinstance(posts, list):
+        for vp in posts:
+            if not isinstance(vp, dict):
+                continue
+            try:
+                posters.add(int(vp.get("user_id")))
+            except (TypeError, ValueError):
+                continue
+    if posters:
+        return len(posters)
+    # Fall back to the snapshot's recorded active_agent_count when
+    # viral_posts is empty — a "no posts" round still has agents
+    # holding positions.
+    try:
+        return int(snapshot.get("active_agent_count") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _row_from_snapshot(
+    snapshot: dict,
+    quality_health: str,
+    participation_rate: Optional[float],
+) -> Optional[dict[str, Any]]:
+    """Project one trajectory snapshot into one CSV / JSONL row.
+
+    Returns ``None`` for snapshots that aren't usable as analyst rows
+    (missing round number, no belief data); the route handler skips
+    those so the resulting file has only well-formed rows.
+    """
+    if not isinstance(snapshot, dict):
+        return None
+
+    raw_round = snapshot.get("round_num")
+    try:
+        round_num = int(raw_round)
+    except (TypeError, ValueError):
+        return None
+
+    split = compute_stance_split(snapshot.get("belief_positions"))
+
+    timestamp = (snapshot.get("timestamp") or "").strip()
+
+    try:
+        total_posts = int(snapshot.get("total_posts_created") or 0)
+    except (TypeError, ValueError):
+        total_posts = 0
+    try:
+        total_engagements = int(snapshot.get("total_engagements") or 0)
+    except (TypeError, ValueError):
+        total_engagements = 0
+
+    return {
+        "round": round_num,
+        "round_timestamp": timestamp,
+        "bullish_pct": split["bullish"],
+        "neutral_pct": split["neutral"],
+        "bearish_pct": split["bearish"],
+        "participating_agents": _participating_agents(snapshot),
+        "total_posts": total_posts,
+        "total_engagements": total_engagements,
+        "quality_health": quality_health,
+        "participation_rate": (
+            round(participation_rate, 4)
+            if isinstance(participation_rate, (int, float))
+            else ""
+        ),
+    }
+
+
+def build_rows(sim_dir: str) -> list[dict[str, Any]]:
+    """Read sim_dir on-disk artifacts and return the analyst row list.
+
+    Reads ``trajectory.json`` (required — empty list when missing) and
+    ``quality.json`` (optional; the ``health`` + ``participation_rate``
+    fields are repeated on every row so a single row from the CSV is
+    self-describing without a separate join).
+    """
+    quality = _safe_load_json(os.path.join(sim_dir, "quality.json")) or {}
+    quality_health = (quality.get("health") or "").strip() if isinstance(quality, dict) else ""
+    pr_raw = quality.get("participation_rate") if isinstance(quality, dict) else None
+    if isinstance(pr_raw, (int, float)):
+        participation_rate: Optional[float] = float(pr_raw)
+    else:
+        participation_rate = None
+
+    trajectory = _safe_load_json(os.path.join(sim_dir, "trajectory.json")) or {}
+    snapshots = trajectory.get("snapshots") if isinstance(trajectory, dict) else None
+    if not isinstance(snapshots, list):
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for snap in snapshots:
+        row = _row_from_snapshot(snap, quality_health, participation_rate)
+        if row is not None:
+            rows.append(row)
+
+    # Chronological order (snapshots are appended in round order on
+    # disk; we re-sort defensively in case a runner ever writes them
+    # out of order — the analyst pulling df.iloc[-1] expects the
+    # final round at the bottom of the file).
+    rows.sort(key=lambda r: r["round"])
+    return rows
+
+
+# ── Renderers ──────────────────────────────────────────────────────────────
+
+
+def render_csv(rows: list[dict[str, Any]]) -> bytes:
+    """Render the row list as RFC 4180 CSV with the locked header.
+
+    Uses ``csv.DictWriter`` with ``QUOTE_MINIMAL`` so numeric columns
+    stay unquoted (``pd.read_csv()`` infers dtype correctly without a
+    converters argument). Empty trajectories still emit the header row
+    so downstream consumers don't have to special-case them.
+    """
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf,
+        fieldnames=list(CSV_COLUMNS),
+        lineterminator="\n",
+        quoting=csv.QUOTE_MINIMAL,
+        extrasaction="ignore",
+    )
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buf.getvalue().encode("utf-8")
+
+
+def render_jsonl(rows: list[dict[str, Any]]) -> bytes:
+    """Render the row list as JSON-lines (newline-delimited JSON).
+
+    One JSON object per line — the format ``pandas.read_json(lines=True)``,
+    DuckDB ``read_json_auto``, and most stream-processing pipelines
+    consume natively. Empty input yields zero bytes; the route handler
+    still serves the right content type so a curl into a file produces
+    an empty but well-formed JSONL document.
+    """
+    buf = io.StringIO()
+    for row in rows:
+        # Filter to the canonical column list so an upstream change to
+        # ``_row_from_snapshot`` can't accidentally leak unstable keys
+        # into the JSONL stream.
+        ordered = {col: row.get(col, "") for col in CSV_COLUMNS}
+        buf.write(json.dumps(ordered, ensure_ascii=False))
+        buf.write("\n")
+    return buf.getvalue().encode("utf-8")

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1217,6 +1217,70 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/simulation/{simulation_id}/trajectory.csv:
+    get:
+      tags: [Publish & Embed]
+      summary: Per-round belief trajectory as RFC 4180 CSV.
+      description: |
+        One row per recorded round with the bullish / neutral / bearish
+        split (using the same ±0.2 stance threshold as the gallery,
+        share card, replay GIF, transcript, webhook, and feed surfaces),
+        participating agents, post + engagement counts, and the overall
+        quality health. Intended for `pandas.read_csv()` / Excel /
+        Tableau / R / Observable — the analyst's default toolkit.
+
+        Pairs with `share-card.png` (preview), `replay.gif` (motion),
+        and `transcript.{md,json}` (prose) as the **fifth** export
+        surface — the previous four cover the qualitative read of a
+        simulation; this one covers the quantitative one.
+
+        Same publish gate as the transcript. The CSV header row is
+        emitted even when the trajectory is empty so downstream
+        consumers don't have to special-case zero-row files.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: "CSV with `Content-Type: text/csv; charset=utf-8` + `Cache-Control: public, max-age=60`."
+          content:
+            text/csv:
+              schema:
+                type: string
+                description: |
+                  RFC 4180 CSV. Column order is locked to:
+                  `round,round_timestamp,bullish_pct,neutral_pct,bearish_pct,participating_agents,total_posts,total_engagements,quality_health,participation_rate`.
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/simulation/{simulation_id}/trajectory.jsonl:
+    get:
+      tags: [Publish & Embed]
+      summary: Per-round belief trajectory as newline-delimited JSON.
+      description: |
+        Same row shape as `trajectory.csv` but as JSON Lines — one
+        object per line. The format `pandas.read_json(lines=True)`,
+        DuckDB `read_json_auto`, and most stream-processing pipelines
+        consume natively without a separate CSV-to-DataFrame
+        conversion.
+
+        Same publish gate as the CSV form. Empty trajectories yield
+        zero bytes (no rows, no header — JSONL has no header concept)
+        so a curl into a file produces an empty but well-formed JSONL
+        document.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: "JSONL with `Content-Type: application/jsonl; charset=utf-8` + `Cache-Control: public, max-age=60`."
+          content:
+            application/jsonl:
+              schema:
+                type: string
+                description: |
+                  One `SimulationTrajectoryRow` JSON object per line.
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /share/{simulation_id}:
     get:
       tags: [Publish & Embed]
@@ -2323,6 +2387,49 @@ components:
         submitted_at:
           type: string
           format: date-time
+
+    SimulationTrajectoryRow:
+      type: object
+      description: |
+        One row of the per-round belief trajectory export. The CSV
+        endpoint emits a fixed column order; the JSONL endpoint emits
+        the same fields per object, one object per line. The bullish /
+        neutral / bearish percentages use the same ±0.2 stance
+        threshold as every other surface so the numbers in this row
+        match what the gallery + share card report for the same round.
+      properties:
+        round:
+          type: integer
+          description: Zero- or one-indexed round number, per the runner.
+        round_timestamp:
+          type: string
+          description: ISO-8601 timestamp the snapshot was committed (may be empty for older runs).
+        bullish_pct:
+          type: number
+          description: Percentage of agents whose mean position > +0.2 this round.
+        neutral_pct:
+          type: number
+          description: Percentage of agents whose mean position is in [-0.2, +0.2].
+        bearish_pct:
+          type: number
+          description: Percentage of agents whose mean position < -0.2 this round.
+        participating_agents:
+          type: integer
+          description: Distinct agents that posted in this round (falls back to active_agent_count on rounds with no viral_posts).
+        total_posts:
+          type: integer
+          description: Posts created during the round.
+        total_engagements:
+          type: integer
+          description: Likes + dislikes + replies recorded during the round.
+        quality_health:
+          type: string
+          description: Overall run health (`excellent` / `good` / `degraded` / `poor`); repeated on every row.
+        participation_rate:
+          oneOf:
+            - { type: number }
+            - { type: string }
+          description: Overall participation rate ∈ [0,1] from quality.json; empty string when the run has not produced quality.json yet.
 
     SettingsUpdate:
       type: object

--- a/backend/tests/test_unit_trajectory.py
+++ b/backend/tests/test_unit_trajectory.py
@@ -1,0 +1,402 @@
+"""Unit tests for the belief trajectory CSV / JSONL export service.
+
+Pure offline — no Flask, no network, no simulation runner, no
+on-disk state outside ``tmp_path``. Cover the seven properties the
+``trajectory.csv`` + ``trajectory.jsonl`` endpoints depend on:
+
+  1. ``compute_stance_split`` uses the same ±0.2 threshold every other
+     surface (gallery, share card, replay GIF, transcript, webhook,
+     feed) uses — so a "bullish" pct in the CSV matches the same
+     round's "bullish" pct on every other surface.
+  2. ``build_rows`` produces well-formed analyst rows from the same
+     on-disk artifacts the transcript / share card / replay GIF
+     consume, and degrades gracefully when files are missing or
+     malformed (the route handler must never 500 on the assembly step).
+  3. The CSV header column order is locked — column-name-keyed
+     consumers (``pandas.read_csv()`` on a notebook) break if a future
+     edit reorders fields.
+  4. The CSV body is RFC 4180 / ``QUOTE_MINIMAL`` so numeric columns
+     stay unquoted (``pd.read_csv()`` infers dtype correctly without a
+     converters argument).
+  5. The JSONL form emits one JSON object per line in the same field
+     order, and an empty trajectory yields zero bytes (no header, no
+     spurious newline).
+  6. ``participating_agents`` is computed from distinct ``viral_posts``
+     posters when present, falling back to ``active_agent_count`` so
+     a "no posts" round still has a sensible row.
+  7. The route decorators exist in ``app/api/simulation.py`` — the
+     OpenAPI drift test will validate spec ↔ route equality, but this
+     guards against an accidental decorator removal that the spec test
+     wouldn't catch in isolation.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def populated_sim_dir(tmp_path: Path) -> Path:
+    """Sim directory with the artifacts the trajectory export reads:
+    trajectory (3 snapshots, viral_posts on each) + quality.
+
+    The belief positions are picked so each round has a distinct
+    stance split that the tests can assert exactly on:
+      - round 1: 1 bullish, 1 bearish, 1 neutral
+      - round 2: 0 bullish, 3 bearish, 0 neutral
+      - round 3: 0 bullish, 4 bearish, 0 neutral
+    """
+    (tmp_path / "quality.json").write_text(json.dumps({
+        "health": "excellent",
+        "participation_rate": 0.91,
+    }), encoding="utf-8")
+    (tmp_path / "trajectory.json").write_text(json.dumps({
+        "snapshots": [
+            {
+                "round_num": 1,
+                "timestamp": "2026-04-29T10:00:00Z",
+                "total_posts_created": 4,
+                "total_engagements": 12,
+                "active_agent_count": 3,
+                "belief_positions": {
+                    "1": {"topic_a": 0.0,  "topic_b": -0.1},   # neutral (avg -0.05)
+                    "2": {"topic_a": -0.5, "topic_b": -0.4},   # bearish (avg -0.45)
+                    "3": {"topic_a": 0.3,  "topic_b": 0.4},    # bullish (avg 0.35)
+                },
+                "viral_posts": [
+                    {"post_id": 11, "user_id": 1, "content": "post one", "num_likes": 4, "num_dislikes": 1},
+                    {"post_id": 12, "user_id": 2, "content": "post two", "num_likes": 6, "num_dislikes": 0},
+                ],
+            },
+            {
+                "round_num": 2,
+                "timestamp": "2026-04-29T10:01:00Z",
+                "total_posts_created": 5,
+                "total_engagements": 18,
+                "active_agent_count": 3,
+                "belief_positions": {
+                    "1": {"topic_a": -0.4, "topic_b": -0.5},   # bearish
+                    "2": {"topic_a": -0.7, "topic_b": -0.6},   # bearish
+                    "3": {"topic_a": -0.3, "topic_b": -0.2},   # bearish (avg -0.25)
+                },
+                "viral_posts": [
+                    {"post_id": 21, "user_id": 3, "content": "post three", "num_likes": 9, "num_dislikes": 0},
+                ],
+            },
+            {
+                "round_num": 3,
+                "timestamp": "2026-04-29T10:02:00Z",
+                "total_posts_created": 3,
+                "total_engagements": 22,
+                "active_agent_count": 4,
+                "belief_positions": {
+                    "1": {"topic_a": -0.6},
+                    "2": {"topic_a": -0.8},
+                    "3": {"topic_a": -0.5},
+                    "4": {"topic_a": -0.7},
+                },
+                "viral_posts": [
+                    {"post_id": 31, "user_id": 4, "content": "post four", "num_likes": 11, "num_dislikes": 1},
+                ],
+            },
+        ],
+    }), encoding="utf-8")
+    return tmp_path
+
+
+# ── Stance threshold (property 1) ──────────────────────────────────────────
+
+
+def test_stance_threshold_matches_every_other_surface():
+    from app.services.trajectory_export import STANCE_THRESHOLD
+
+    assert STANCE_THRESHOLD == 0.2
+
+
+def test_compute_stance_split_buckets_at_plus_minus_threshold():
+    from app.services.trajectory_export import compute_stance_split
+
+    # Three agents, one above +0.2, one below -0.2, one at exactly 0.0.
+    split = compute_stance_split({
+        "1": {"t": 0.5},
+        "2": {"t": -0.5},
+        "3": {"t": 0.0},
+    })
+    # 1 bullish, 1 neutral, 1 bearish ⇒ 33.3% each.
+    assert split["bullish"] == pytest.approx(33.3, abs=0.1)
+    assert split["bearish"] == pytest.approx(33.3, abs=0.1)
+    assert split["neutral"] == pytest.approx(33.3, abs=0.1)
+
+
+def test_compute_stance_split_threshold_is_strict_inequality():
+    """Exactly ±0.2 must bucket as neutral — same convention every
+    other surface uses (``> 0.2`` and ``< -0.2``)."""
+    from app.services.trajectory_export import compute_stance_split
+
+    split = compute_stance_split({
+        "1": {"t": 0.2},   # ≤ +threshold ⇒ neutral
+        "2": {"t": -0.2},  # ≥ -threshold ⇒ neutral
+    })
+    assert split["bullish"] == 0.0
+    assert split["bearish"] == 0.0
+    assert split["neutral"] == 100.0
+
+
+def test_compute_stance_split_empty_or_missing_input_yields_zeros():
+    """Empty / missing input must still return a complete split — the
+    CSV row needs a constant column count even on a no-data round."""
+    from app.services.trajectory_export import compute_stance_split
+
+    assert compute_stance_split({}) == {"bullish": 0.0, "neutral": 0.0, "bearish": 0.0}
+    assert compute_stance_split(None) == {"bullish": 0.0, "neutral": 0.0, "bearish": 0.0}
+    # Agent positions are non-numeric → drop them, return all zeros
+    # rather than 500-ing.
+    assert compute_stance_split({"1": {"t": "not-a-number"}}) == {
+        "bullish": 0.0, "neutral": 0.0, "bearish": 0.0,
+    }
+
+
+# ── build_rows pipeline (property 2) ───────────────────────────────────────
+
+
+def test_build_rows_full_pipeline(populated_sim_dir):
+    from app.services.trajectory_export import build_rows
+
+    rows = build_rows(str(populated_sim_dir))
+    assert len(rows) == 3
+
+    # Round 1: 1 bullish (agent 3), 1 bearish (agent 2), 1 neutral (agent 1).
+    r1 = rows[0]
+    assert r1["round"] == 1
+    assert r1["round_timestamp"] == "2026-04-29T10:00:00Z"
+    assert r1["bullish_pct"] == pytest.approx(33.3, abs=0.1)
+    assert r1["bearish_pct"] == pytest.approx(33.3, abs=0.1)
+    assert r1["neutral_pct"] == pytest.approx(33.3, abs=0.1)
+    # 2 distinct viral_posts posters (user 1, user 2).
+    assert r1["participating_agents"] == 2
+    assert r1["total_posts"] == 4
+    assert r1["total_engagements"] == 12
+    assert r1["quality_health"] == "excellent"
+    assert r1["participation_rate"] == 0.91
+
+    # Round 2: all three agents bearish.
+    r2 = rows[1]
+    assert r2["bullish_pct"] == 0.0
+    assert r2["bearish_pct"] == 100.0
+    assert r2["neutral_pct"] == 0.0
+
+    # Round 3: all four agents bearish (4 distinct posters? only 1 posted).
+    r3 = rows[2]
+    assert r3["bullish_pct"] == 0.0
+    assert r3["bearish_pct"] == 100.0
+    # Only user 4 posted in viral_posts ⇒ 1 participating poster.
+    assert r3["participating_agents"] == 1
+
+
+def test_build_rows_rounds_emit_in_chronological_order(tmp_path):
+    """Snapshots written out-of-order on disk must still emit
+    chronologically — analysts rely on ``df.iloc[-1]`` for the
+    final-round value."""
+    from app.services.trajectory_export import build_rows
+
+    (tmp_path / "trajectory.json").write_text(json.dumps({
+        "snapshots": [
+            {"round_num": 3, "belief_positions": {"1": {"t": 0.5}}, "viral_posts": []},
+            {"round_num": 1, "belief_positions": {"1": {"t": 0.5}}, "viral_posts": []},
+            {"round_num": 2, "belief_positions": {"1": {"t": 0.5}}, "viral_posts": []},
+        ],
+    }), encoding="utf-8")
+    rows = build_rows(str(tmp_path))
+    assert [r["round"] for r in rows] == [1, 2, 3]
+
+
+def test_build_rows_missing_trajectory_returns_empty_list(tmp_path):
+    """Brand-new published sim with no trajectory.json yet must return
+    an empty list (the CSV will be header-only, the JSONL empty)."""
+    from app.services.trajectory_export import build_rows
+
+    assert build_rows(str(tmp_path)) == []
+
+
+def test_build_rows_corrupt_trajectory_degrades_to_empty(tmp_path):
+    """A truncated / corrupt trajectory.json must not raise — the
+    route handler can't 500 on a bad on-disk artifact."""
+    from app.services.trajectory_export import build_rows
+
+    (tmp_path / "trajectory.json").write_text("{not valid json", encoding="utf-8")
+    assert build_rows(str(tmp_path)) == []
+
+
+def test_build_rows_skips_snapshots_with_unparseable_round_num(tmp_path):
+    from app.services.trajectory_export import build_rows
+
+    (tmp_path / "trajectory.json").write_text(json.dumps({
+        "snapshots": [
+            # Missing round_num ⇒ skipped.
+            {"belief_positions": {"1": {"t": 0.5}}},
+            # Non-numeric round_num ⇒ skipped.
+            {"round_num": "round-zero", "belief_positions": {"1": {"t": 0.5}}},
+            # Valid.
+            {"round_num": 5, "belief_positions": {"1": {"t": 0.5}}, "viral_posts": []},
+        ],
+    }), encoding="utf-8")
+    rows = build_rows(str(tmp_path))
+    assert len(rows) == 1
+    assert rows[0]["round"] == 5
+
+
+def test_build_rows_handles_missing_quality_json(tmp_path):
+    """quality.json is optional. Without it ``quality_health`` must be
+    an empty string (CSV-friendly) and ``participation_rate`` must be
+    an empty string (so the column count stays constant)."""
+    from app.services.trajectory_export import build_rows
+
+    (tmp_path / "trajectory.json").write_text(json.dumps({
+        "snapshots": [
+            {"round_num": 1, "belief_positions": {"1": {"t": 0.0}}, "viral_posts": []},
+        ],
+    }), encoding="utf-8")
+    rows = build_rows(str(tmp_path))
+    assert rows[0]["quality_health"] == ""
+    assert rows[0]["participation_rate"] == ""
+
+
+# ── participating_agents fallback (property 6) ─────────────────────────────
+
+
+def test_participating_agents_falls_back_to_active_agent_count(tmp_path):
+    """When viral_posts is empty (a quiet round) we fall back to
+    ``active_agent_count`` so the row still carries a meaningful
+    agent count."""
+    from app.services.trajectory_export import build_rows
+
+    (tmp_path / "trajectory.json").write_text(json.dumps({
+        "snapshots": [
+            {
+                "round_num": 1,
+                "belief_positions": {"1": {"t": 0.5}},
+                "viral_posts": [],            # empty
+                "active_agent_count": 12,
+            },
+        ],
+    }), encoding="utf-8")
+    rows = build_rows(str(tmp_path))
+    assert rows[0]["participating_agents"] == 12
+
+
+# ── CSV renderer (properties 3 + 4) ────────────────────────────────────────
+
+
+def test_render_csv_header_column_order_is_locked():
+    """Column-name-keyed consumers ((``df["bullish_pct"]`` etc) break
+    if a future edit reorders fields. Lock the header explicitly."""
+    from app.services.trajectory_export import render_csv
+
+    payload = render_csv([])
+    text = payload.decode("utf-8")
+    header = text.splitlines()[0].split(",")
+    assert header == [
+        "round",
+        "round_timestamp",
+        "bullish_pct",
+        "neutral_pct",
+        "bearish_pct",
+        "participating_agents",
+        "total_posts",
+        "total_engagements",
+        "quality_health",
+        "participation_rate",
+    ]
+
+
+def test_render_csv_emits_header_even_on_empty_input():
+    """Empty trajectories still emit the header row so downstream
+    consumers don't have to special-case zero-row files."""
+    from app.services.trajectory_export import render_csv
+
+    text = render_csv([]).decode("utf-8")
+    assert text.startswith("round,round_timestamp,")
+    assert text.count("\n") == 1   # one header line, no body rows
+
+
+def test_render_csv_round_trips_through_python_csv_reader(populated_sim_dir):
+    """The CSV emitted by ``render_csv`` must parse cleanly back through
+    ``csv.DictReader`` — same path ``pandas.read_csv`` uses."""
+    from app.services.trajectory_export import build_rows, render_csv
+
+    rows = build_rows(str(populated_sim_dir))
+    payload = render_csv(rows).decode("utf-8")
+
+    reader = csv.DictReader(io.StringIO(payload))
+    parsed = list(reader)
+    assert len(parsed) == 3
+    assert parsed[0]["round"] == "1"
+    assert parsed[2]["bearish_pct"] == "100.0"
+    # Numeric columns are unquoted (QUOTE_MINIMAL) — the underlying
+    # field has no commas/quotes/newlines so they round-trip as
+    # bare strings, which is exactly what pandas dtype inference wants.
+    assert '"' not in payload.splitlines()[1]
+
+
+# ── JSONL renderer (property 5) ────────────────────────────────────────────
+
+
+def test_render_jsonl_one_object_per_line(populated_sim_dir):
+    from app.services.trajectory_export import build_rows, render_jsonl
+
+    rows = build_rows(str(populated_sim_dir))
+    payload = render_jsonl(rows).decode("utf-8")
+    lines = payload.splitlines()
+    assert len(lines) == 3
+    parsed = [json.loads(line) for line in lines]
+    assert parsed[0]["round"] == 1
+    assert parsed[2]["bearish_pct"] == 100.0
+    # Field set must match the locked CSV column list — same shape on
+    # both surfaces so a consumer can switch formats without rewiring.
+    from app.services.trajectory_export import CSV_COLUMNS
+    for row in parsed:
+        assert tuple(row.keys()) == CSV_COLUMNS
+
+
+def test_render_jsonl_empty_input_yields_zero_bytes():
+    """JSONL has no header concept, so empty input must produce an
+    empty document — not a stray newline that would parse as an empty
+    object somewhere downstream."""
+    from app.services.trajectory_export import render_jsonl
+
+    assert render_jsonl([]) == b""
+
+
+# ── Route decorator presence (property 7) ──────────────────────────────────
+
+
+def test_simulation_routes_have_trajectory_decorators():
+    """Guard against an accidental decorator removal that the OpenAPI
+    drift test wouldn't catch in isolation (drift compares spec ↔
+    Flask routes — both need to exist)."""
+    sim_py = (_BACKEND / "app" / "api" / "simulation.py").read_text(encoding="utf-8")
+    assert re.search(
+        r"@simulation_bp\.route\(\s*['\"]/<simulation_id>/trajectory\.csv['\"]",
+        sim_py,
+    ), "trajectory.csv route decorator missing"
+    assert re.search(
+        r"@simulation_bp\.route\(\s*['\"]/<simulation_id>/trajectory\.jsonl['\"]",
+        sim_py,
+    ), "trajectory.jsonl route decorator missing"
+    # Shared body presence — the wrappers should delegate to it.
+    assert "_serve_trajectory" in sim_py

--- a/docs/API.md
+++ b/docs/API.md
@@ -85,10 +85,39 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 |---|---|---|
 | `POST` | `/api/simulation/<id>/publish` | Toggle `is_public` |
 | `GET` | `/api/simulation/<id>/embed-summary` | Embed payload (public sims only) |
+| `GET` | `/api/simulation/<id>/share-card.png` | 1200×630 OG image (auto-unfurls) |
+| `GET` | `/api/simulation/<id>/replay.gif` | Animated belief-bar replay |
+| `GET` | `/api/simulation/<id>/transcript.md` | Markdown transcript (Notion / Obsidian / Substack) |
+| `GET` | `/api/simulation/<id>/transcript.json` | Structured JSON transcript (SDKs / LLM-as-judge) |
+| `GET` | `/api/simulation/<id>/trajectory.csv` | Per-round belief CSV (`pandas.read_csv()` / Excel / Tableau / R) |
+| `GET` | `/api/simulation/<id>/trajectory.jsonl` | Per-round belief JSONL (DuckDB / pipelines) |
 | `POST` | `/api/simulation/<id>/article` | Generate a Substack-style write-up |
 | `GET` | `/api/simulation/<id>/export` | Full JSON export |
 | `GET` | `/api/simulation/list` | List simulations |
 | `GET` | `/api/simulation/history` | Simulation history / diffs |
+
+### Analyst quickstart
+
+Pull a simulation's per-round belief trajectory straight into Pandas:
+
+```python
+import pandas as pd
+df = pd.read_csv("https://your-host/api/simulation/<id>/trajectory.csv")
+print(df.describe())
+df[["round", "bullish_pct", "bearish_pct"]].plot(x="round")
+```
+
+Or via DuckDB / JSONL for streaming pipelines:
+
+```python
+import duckdb
+duckdb.sql("""
+  SELECT round, bullish_pct
+  FROM read_json_auto('https://your-host/api/simulation/<id>/trajectory.jsonl')
+""").df()
+```
+
+The CSV column order is locked: `round, round_timestamp, bullish_pct, neutral_pct, bearish_pct, participating_agents, total_posts, total_engagements, quality_health, participation_rate`. The bullish / neutral / bearish percentages use the same ±0.2 stance threshold as the gallery, share card, transcript, webhook, and feed surfaces, so the numbers in the DataFrame match what every other surface reports for the same round.
 
 ## Report Agent
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -148,6 +148,17 @@ Two endpoints, same payload, different encoding:
 
 Both endpoints share the share-card publish gate (`is_public=true`). Per-agent stance labels use the same ±0.2 threshold as every other surface — a "bullish" agent on the gallery is the same agent's tag in the transcript. The Embed dialog exposes a "Download .md" + "Download .json" pair beneath the replay-GIF row.
 
+## Belief Trajectory Export (CSV / JSONL)
+
+The fifth surface alongside the share card (preview), replay GIF (motion), transcript Markdown (prose), and transcript JSON (SDKs). The previous four cover the *qualitative* read of a simulation; trajectory CSV / JSONL covers the *quantitative* one — the row-per-round table a quant researcher pastes into a notebook to compute variance, autocorrelation, or compare across replicates.
+
+Two endpoints, same row schema, different serialization:
+
+- `GET /api/simulation/<id>/trajectory.csv` — RFC 4180 CSV, one row per recorded round. Locked column order: `round, round_timestamp, bullish_pct, neutral_pct, bearish_pct, participating_agents, total_posts, total_engagements, quality_health, participation_rate`. `pandas.read_csv("…/trajectory.csv")`, Excel "Get Data → From Web", Tableau Web Data Connector, R `read.csv()`, and Observable `d3.csv()` consume it natively. The CSV header row is emitted even for empty trajectories so downstream consumers don't have to special-case zero-row files.
+- `GET /api/simulation/<id>/trajectory.jsonl` — JSON Lines (newline-delimited JSON), one object per line with the same field shape as the CSV row. The format `pandas.read_json(lines=True)`, DuckDB `read_json_auto`, and stream-processing pipelines (Kafka, Beam, Materialize) consume natively without a CSV-to-DataFrame conversion. Empty input yields zero bytes — well-formed JSONL has no header concept.
+
+Same publish gate as the share card and transcript (`is_public=true`). The bullish / neutral / bearish percentages use the same ±0.2 stance threshold as every other surface, so a number in the CSV matches what the gallery, share card, replay GIF, transcript, webhook, and feed report for the same round. The Embed dialog exposes a "Download .csv" + "Download .jsonl" pair beneath the transcript row, plus a copyable CSV URL and a `pd.read_csv("<url>")` quickstart snippet.
+
 ## Public Gallery Feeds (RSS / Atom)
 
 The same cards `/explore` renders, served as a syndication feed so researchers and tooling already on Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS subscribe in their existing toolchain — no login, no MiroShark account. Every newly published simulation lands in their reader the same way an AI newsletter or Substack post does.

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -473,6 +473,41 @@ export const getTranscriptJsonUrl = (simulationId, origin) => {
 }
 
 /**
+ * Build the absolute URL of the per-round belief trajectory CSV
+ * export. One row per recorded round with bullish / neutral / bearish
+ * percent (same ±0.2 stance threshold as every other surface),
+ * participating agents, post + engagement counts, and quality health.
+ *
+ * Intended for `pandas.read_csv()` / Excel / Tableau / R / Observable
+ * — the analyst's default toolkit. Same publish gate as the share
+ * card and transcript.
+ *
+ * @param {string} simulationId
+ * @param {string} [origin]
+ * @returns {string}
+ */
+export const getTrajectoryCsvUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/api/simulation/${simulationId}/trajectory.csv`
+}
+
+/**
+ * Build the absolute URL of the per-round belief trajectory JSONL
+ * (newline-delimited JSON) export — same row shape as the CSV form
+ * but as one JSON object per line. The format `pandas.read_json(lines=true)`,
+ * DuckDB `read_json_auto`, and stream-processing pipelines consume
+ * natively without a CSV-to-DataFrame conversion.
+ *
+ * @param {string} simulationId
+ * @param {string} [origin]
+ * @returns {string}
+ */
+export const getTrajectoryJsonlUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/api/simulation/${simulationId}/trajectory.jsonl`
+}
+
+/**
  * Build the absolute URL of the public share landing page for a
  * simulation. The page exposes Open Graph + Twitter Card meta tags so
  * pasting the URL into Twitter/X / Discord / Slack / LinkedIn unfurls

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -274,6 +274,63 @@
               </div>
             </div>
 
+            <!-- Belief trajectory data export — pairs with the share
+                 card / replay GIF / transcript as the fifth share
+                 surface. The previous four cover the qualitative read
+                 of a simulation; this one gives Pandas / Excel /
+                 Tableau / R / Observable users the raw numbers. -->
+            <div class="transcript-section trajectory-section">
+              <div class="transcript-head">
+                <span class="transcript-icon">📊</span>
+                <div class="transcript-head-body">
+                  <div class="transcript-title">{{ $tr('Export trajectory data', '导出轨迹数据') }}</div>
+                  <div class="transcript-sub">
+                    {{ $tr('One row per round — bullish / neutral / bearish %, participating agents, post + engagement counts. Pandas, Excel, Tableau, R, and Observable consume CSV natively.', '每轮一行 — 看涨 / 中性 / 看跌 %、参与的智能体、帖子和互动数。Pandas、Excel、Tableau、R 和 Observable 原生消费 CSV。') }}
+                  </div>
+                </div>
+              </div>
+
+              <div class="transcript-actions">
+                <a
+                  v-if="isPublic && trajectoryCsvUrl"
+                  class="transcript-download-btn"
+                  :href="trajectoryCsvUrl"
+                  :download="`miroshark-${simulationId.slice(0, 12)}-trajectory.csv`"
+                >
+                  ↓ {{ $tr('Download .csv', '下载 .csv') }}
+                </a>
+                <a
+                  v-if="isPublic && trajectoryJsonlUrl"
+                  class="transcript-download-btn transcript-download-btn-secondary"
+                  :href="trajectoryJsonlUrl"
+                  :download="`miroshark-${simulationId.slice(0, 12)}-trajectory.jsonl`"
+                >
+                  ↓ {{ $tr('Download .jsonl', '下载 .jsonl') }}
+                </a>
+                <span v-if="!isPublic" class="transcript-empty">
+                  {{ $tr('Publish the simulation to enable the trajectory export.', '发布模拟以启用轨迹数据导出。') }}
+                </span>
+              </div>
+
+              <div class="snippet-block transcript-snippet">
+                <div class="snippet-head">
+                  <span class="snippet-label">{{ $tr('CSV URL (paste into pandas.read_csv())', 'CSV URL(粘贴至 pandas.read_csv())') }}</span>
+                  <button
+                    class="snippet-copy-btn"
+                    @click="copy('trajectoryCsv')"
+                    :disabled="!isPublic"
+                  >
+                    {{ copied === 'trajectoryCsv' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy URL', '复制 URL') }}
+                  </button>
+                </div>
+                <pre class="snippet-code"><code>{{ trajectoryCsvUrl || '—' }}</code></pre>
+              </div>
+
+              <p class="trajectory-quickstart">
+                <code>pd.read_csv("{{ trajectoryCsvUrl || 'https://your-host/api/simulation/&lt;id&gt;/trajectory.csv' }}")</code>
+              </p>
+            </div>
+
             <!-- Verified-prediction annotation — lets operators turn a
                  published simulation into a "called it" record on the
                  /verified gallery page. Only meaningful once the run is
@@ -465,6 +522,8 @@ import {
   getShareLandingUrl,
   getTranscriptMarkdownUrl,
   getTranscriptJsonUrl,
+  getTrajectoryCsvUrl,
+  getTrajectoryJsonlUrl,
   getFeedUrl,
   getSimulationOutcome,
   submitSimulationOutcome,
@@ -581,6 +640,16 @@ const transcriptJsonUrl = computed(() => {
   return getTranscriptJsonUrl(props.simulationId, origin.value)
 })
 
+const trajectoryCsvUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  return getTrajectoryCsvUrl(props.simulationId, origin.value)
+})
+
+const trajectoryJsonlUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  return getTrajectoryJsonlUrl(props.simulationId, origin.value)
+})
+
 // Public-gallery syndication URLs — independent of `simulationId` (the
 // feed lists everyone's published runs), but kept on the embed dialog
 // so an operator who just toggled their sim public can subscribe to the
@@ -644,6 +713,7 @@ const copy = async (which) => {
   else if (which === 'card') text = shareCardUrl.value
   else if (which === 'replay') text = replayGifUrl.value
   else if (which === 'transcriptMd') text = transcriptMarkdownUrl.value
+  else if (which === 'trajectoryCsv') text = trajectoryCsvUrl.value
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)
@@ -1379,6 +1449,28 @@ watch(isPublic, () => {
 
 .transcript-snippet {
   margin: 0;
+}
+
+.trajectory-section {
+  margin-top: 14px;
+}
+
+.trajectory-quickstart {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: #555;
+  background: #f5f5f5;
+  border: 1px solid rgba(10, 10, 10, 0.08);
+  border-radius: 6px;
+  padding: 8px 10px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.trajectory-quickstart code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: #2a2a2a;
 }
 
 .outcome-section {


### PR DESCRIPTION
## What

Two new export endpoints over the existing on-disk simulation artifacts so analysts can pull a per-round belief trajectory directly into Pandas / Excel / Tableau / R / Observable without an intermediate conversion step.

- `GET /api/simulation/<id>/trajectory.csv` — RFC 4180 CSV, locked column order: `round, round_timestamp, bullish_pct, neutral_pct, bearish_pct, participating_agents, total_posts, total_engagements, quality_health, participation_rate`. Header row is emitted even on empty trajectories so consumers don't have to special-case zero-row files.
- `GET /api/simulation/<id>/trajectory.jsonl` — newline-delimited JSON, one object per line, same field shape and order as the CSV row. Empty input yields zero bytes (no header — well-formed JSONL has no header concept).

Both share the existing transcript / share-card publish gate (`is_public=true`), `Cache-Control: public, max-age=60`, and the same ±0.2 stance threshold every other surface uses, so a `bullish_pct` in the CSV matches the gallery / share card / replay GIF / transcript / webhook / feed for the same round.

## Why

The fifth share / export surface alongside `share-card.png` (preview), `replay.gif` (motion), `transcript.md` (prose), and `transcript.json` (SDKs). The previous four cover the *qualitative* read of a simulation; trajectory CSV / JSONL covers the *quantitative* one — the row-per-round table a quant researcher pastes into a notebook to compute variance, autocorrelation, or compare across replicates.

Pandas, Excel, Tableau, R, and Observable — the analyst's default toolkit — consume CSV natively. `transcript.json` covers reasoning prose; `trajectory.csv` covers the numbers. The quant audience evaluating MiroShark as a research data source can now run `pd.read_csv(url)` as their first action and get a typed DataFrame back in <10 seconds.

Source idea: `repo-actions-2026-04-30.md` #4 (Belief Trajectory CSV / JSONL Export).

## Changes

- **NEW** `backend/app/services/trajectory_export.py` (297 lines) — pure stdlib (`csv` + `io` + `json`). `compute_stance_split()` helper, `build_rows()` reader, `render_csv` + `render_jsonl` emitters. `participating_agents` is derived from distinct `viral_posts` user_ids and falls back to `active_agent_count` when a quiet round has no posts.
- `backend/app/api/simulation.py` — `_serve_trajectory()` shared body + two route decorators, mirroring the existing `_serve_transcript` pattern (PR #57). `Content-Disposition: attachment` so a click triggers save-as without an explicit `download` attribute on the anchor.
- `backend/openapi.yaml` — both paths under **Publish & Embed** tag + new `SimulationTrajectoryRow` schema. The OpenAPI drift-detection test (PR #45) passes against the new routes.
- **NEW** `backend/tests/test_unit_trajectory.py` (402 lines, 17 offline unit tests): stance-threshold parity, strict-inequality boundary bucketing, full pipeline, chronological ordering, missing / corrupt trajectory degradation, unparseable round_num skipped, missing quality.json fallback, participating_agents fallback, locked CSV header order, csv.DictReader round-trip, QUOTE_MINIMAL preserves dtype inference, JSONL one-object-per-line + field-key order matches CSV_COLUMNS, empty-trajectory zero-byte JSONL contract, route-decorator presence guard.
- `frontend/src/api/simulation.js` — `getTrajectoryCsvUrl` + `getTrajectoryJsonlUrl` helpers, mirroring the existing transcript URL pattern.
- `frontend/src/components/EmbedDialog.vue` — "📊 Export trajectory data" section beneath the transcript row: Download `.csv` + Download `.jsonl` buttons (publish-gated), copyable CSV URL with a Copy URL button, and a `pd.read_csv("<url>")` quickstart snippet.
- `README.md` — Features row.
- `docs/FEATURES.md` — dedicated "Belief Trajectory Export (CSV / JSONL)" section.
- `docs/API.md` — `trajectory.csv` + `trajectory.jsonl` rows in the Publish / Embed / Export table + new "Analyst quickstart" with `pandas.read_csv()` and DuckDB `read_json_auto()` snippets.

Zero new dependencies; pure stdlib end-to-end.

---
*Built autonomously by Aeon*