### PR TITLE
feat: gallery full-text search + consensus / quality / sort filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Transcript Export** | Per-round agent posts + stance labels as Markdown (YAML front matter for Notion / Obsidian / Substack) or structured JSON (for SDKs and LLM-as-judge pipelines) |
 | **Trajectory Export** | One row per round as RFC 4180 CSV or JSONL — `pandas.read_csv("…/trajectory.csv")` lands ready for Pandas / Excel / Tableau / R / Observable. Same ±0.2 stance threshold as every other surface |
 | **Public Gallery** | `/explore` browses every published simulation as a card grid — preview the share card, consensus split, and quality health; click to open or one-click fork |
+| **Gallery Search & Filter** | Keyword search + bullish/neutral/bearish + excellent/good/fair/poor + sort by date/rounds/agents on `/explore` and `/verified`. URL-encoded so `?q=aave&consensus=bearish` is bookmarkable. Same ±0.2 stance threshold as every other surface |
 | **Verified Predictions** | Annotate any public sim with the real-world outcome (called it / partial / called wrong + URL). `/verified` is the dedicated hall of calls that landed |
 | **RSS / Atom Feeds** | `/api/feed.atom` + `/api/feed.rss` — every newly published simulation lands in Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS without anyone curating it. `?verified=1` for the verified-only stream |
 | **Article Generation** | Substack-style write-up of what happened, grounded in actual posts and trades |
@@ -216,6 +217,7 @@ cp .env.example .env
 | **信念回放动图** | 1200×630 GIF,每轮一帧,信念条动态滑向各轮分布。Discord 与 Slack 在直接 URL 上自动播放 |
 | **转录导出** | 每轮智能体发帖与立场标签,导出为 Markdown(YAML 头,适配 Notion / Obsidian / Substack)或结构化 JSON(适配 SDK 与 LLM 评审管线) |
 | **公开图库** | `/explore` 以卡片网格浏览所有公开模拟 — 预览分享卡、共识分布与质量指标;一键打开或派生 |
+| **图库搜索与筛选** | 在 `/explore` 与 `/verified` 上提供关键词搜索 + 看涨/中立/看跌 + 优秀/良好/一般/较差 + 按日期/轮次/智能体数量排序。URL 编码后 `?q=aave&consensus=bearish` 可作为书签分享。与其他所有表面共享同一 ±0.2 立场阈值 |
 | **已验证预言** | 为公开模拟标注真实结果(命中 / 部分 / 失误 + 链接)。`/verified` 是命中预言专属展厅 |
 | **RSS / Atom 订阅源** | `/api/feed.atom` + `/api/feed.rss` — 每个新发布的模拟无需任何整理就会进入 Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS。`?verified=1` 只看已验证内容 |
 | **文章生成** | Substack 风格的复盘文章,基于真实发帖与交易数据 |

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -23,6 +23,7 @@ from ..services.wonderwall_profile_generator import WonderwallProfileGenerator
 from ..services.simulation_manager import SimulationManager, SimulationStatus
 from ..services.simulation_config_generator import SimulationConfigGenerator
 from ..services.simulation_runner import SimulationRunner, RunnerStatus
+from ..services import gallery_filters
 from ..utils.logger import get_logger
 from ..models.project import ProjectManager
 
@@ -5385,78 +5386,97 @@ def list_public_simulations():
     Query parameters:
         limit: max items to return (default 50, clamped to [1, 100])
         offset: pagination offset (default 0)
+        page: 1-based page number — alternative to ``offset``. When both
+            are supplied, ``page`` wins. ``page=1`` is offset 0.
         verified: when truthy ("1", "true", "yes"), filter to simulations
             with a recorded outcome annotation (see
             ``POST /api/simulation/<id>/outcome``).
+        q: case-insensitive substring match against the scenario text.
+            Trimmed and capped at 200 chars. Empty / missing is a no-op.
+        consensus: ``bullish`` / ``neutral`` / ``bearish`` — restrict to
+            cards whose dominant final consensus matches the chosen
+            stance. Computed against the same ±0.2 stance threshold used
+            by the share card, replay GIF, transcript, webhook, and feed
+            renderers, so a "bullish" filter here matches what those
+            surfaces label as bullish for the same simulation.
+        quality: ``excellent`` / ``good`` / ``fair`` / ``poor`` — restrict
+            to cards whose ``quality_health`` first word matches the tier
+            (case-insensitive).
+        outcome: ``correct`` / ``incorrect`` / ``partial`` — restrict to
+            verified simulations whose recorded outcome label matches.
+            Implies ``verified=1``.
+        sort: ``date`` (default, newest first), ``rounds`` (highest
+            current_round first), or ``agents`` (largest population
+            first). Unknown values fall back to ``date``.
 
     Response shape::
 
         {
           "success": true,
-          "data": [
-            {
-              "simulation_id": "sim_xxx",
-              "scenario": "Will the ECB cut rates in June?",
-              "status": "completed",
-              "runner_status": "completed",
-              "current_round": 20,
-              "total_rounds": 20,
-              "agent_count": 248,
-              "quality_health": "Excellent",
-              "final_consensus": {"bullish": 62.0, "neutral": 13.0, "bearish": 25.0},
-              "resolution_outcome": "YES",
-              "created_at": "2026-04-22T10:12:34",
-              "parent_simulation_id": null,
-              "share_card_url": "/api/simulation/sim_xxx/share-card.png",
-              "share_landing_url": "/share/sim_xxx"
-            },
-            ...
-          ],
+          "data": [ ... gallery cards ... ],
           "count": 17,
           "total": 17,
           "limit": 50,
           "offset": 0,
-          "has_more": false
+          "page": 1,
+          "has_more": false,
+          "verified_only": false,
+          "q": "",
+          "consensus": null,
+          "quality": null,
+          "outcome": null,
+          "sort": "date"
         }
 
     ``count`` is the size of the current page; ``total`` is the count of
-    all public simulations. An empty ``data`` array is normal — the
-    caller should render the "No public simulations yet" empty state.
+    public simulations matching the active filter set (so a
+    "12 remaining" hint can be derived as ``total - offset - count``).
+    An empty ``data`` array is normal — the caller should render the
+    appropriate empty state ("No public simulations yet" vs. "No
+    simulations match your filters").
     """
     try:
-        limit = request.args.get('limit', 50, type=int)
-        offset = request.args.get('offset', 0, type=int)
-        limit = max(1, min(100, int(limit or 50)))
-        offset = max(0, int(offset or 0))
+        limit = gallery_filters.normalise_limit(request.args.get('limit'))
+
+        raw_page = request.args.get('page')
+        if raw_page is not None and str(raw_page).strip() != "":
+            # ``page`` is the friendlier 1-based knob the gallery UI uses;
+            # it wins over ``offset`` when both are supplied so a
+            # ``?page=2`` URL is bookmarkable without also having to
+            # carry ``?offset=...``.
+            offset = gallery_filters.page_to_offset(raw_page, limit)
+        else:
+            offset = gallery_filters.normalise_offset(request.args.get('offset'))
+
+        q = gallery_filters.normalise_query(request.args.get('q'))
+        consensus = gallery_filters.normalise_consensus(request.args.get('consensus'))
+        quality = gallery_filters.normalise_quality(request.args.get('quality'))
+        outcome = gallery_filters.normalise_outcome(request.args.get('outcome'))
+        sort_key = gallery_filters.normalise_sort(request.args.get('sort'))
 
         verified_raw = (request.args.get('verified') or "").strip().lower()
         verified_only = verified_raw in ("1", "true", "yes", "on")
+        # An ``outcome=...`` filter is, by definition, a verified-only
+        # subset — surface that in the response envelope so clients
+        # rendering the "Verified only" chip stay in sync.
+        if outcome is not None:
+            verified_only = True
 
         manager = SimulationManager()
         all_sims = manager.list_simulations()
-
         public_sims = [s for s in all_sims if bool(getattr(s, "is_public", False))]
-        public_sims.sort(key=lambda s: s.created_at or "", reverse=True)
 
-        if verified_only:
-            # Filter on disk before paginating so ``total`` reflects the
-            # filtered set — otherwise the "X remaining" hint and
-            # ``has_more`` flag would lie about how much is left.
-            verified_sims = []
-            for s in public_sims:
-                sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, s.simulation_id)
-                if _read_outcome_file(sim_dir) is not None:
-                    verified_sims.append(s)
-            public_sims = verified_sims
-
-        total = len(public_sims)
-        page = public_sims[offset:offset + limit]
-
-        items = []
-        for state in page:
+        # Build cards for every public sim before filtering — keyword and
+        # consensus filters need fields (scenario, final_consensus,
+        # outcome) that only exist on the assembled card, not on the raw
+        # SimulationState. The reads are cheap (a handful of small JSON
+        # files per sim) and the response is cached for 30s, so a busy
+        # gallery amortises the work.
+        all_cards: list[dict] = []
+        for state in public_sims:
             sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, state.simulation_id)
             try:
-                items.append(_build_gallery_card_payload(state, sim_dir))
+                all_cards.append(_build_gallery_card_payload(state, sim_dir))
             except Exception as exc:
                 # One bad artifact shouldn't tank the whole gallery.
                 logger.warning(
@@ -5464,15 +5484,35 @@ def list_public_simulations():
                 )
                 continue
 
+        page_items, total = gallery_filters.select_filtered_cards(
+            all_cards,
+            q=q,
+            consensus=consensus,
+            quality=quality,
+            outcome=outcome,
+            verified_only=verified_only,
+            sort=sort_key,
+            limit=limit,
+            offset=offset,
+        )
+
+        page_num = (offset // limit) + 1 if limit > 0 else 1
+
         response = jsonify({
             "success": True,
-            "data": items,
-            "count": len(items),
+            "data": page_items,
+            "count": len(page_items),
             "total": total,
             "limit": limit,
             "offset": offset,
-            "has_more": offset + len(items) < total,
+            "page": page_num,
+            "has_more": offset + len(page_items) < total,
             "verified_only": verified_only,
+            "q": q,
+            "consensus": consensus,
+            "quality": quality,
+            "outcome": outcome,
+            "sort": sort_key,
         })
         # Short cache so newly-published simulations show up quickly while
         # still absorbing repeat hits from bots/social unfurlers.

--- a/backend/app/services/gallery_filters.py
+++ b/backend/app/services/gallery_filters.py
@@ -1,0 +1,321 @@
+"""Filter / sort / paginate helpers for the public simulation gallery.
+
+The ``GET /api/simulation/public`` endpoint started life as "newest 50
+public sims." Once the gallery grew past a few dozen entries, an analyst
+hunting for "every bearish-consensus DeFi sim" or "all excellent-quality
+runs about Aave" had no path — the only surface was a reverse-chronological
+scroll.
+
+This module turns the public listing into a small queryable corpus:
+
+* keyword search over ``scenario`` (case-insensitive substring, optional)
+* dominant-stance filter — ``bullish`` / ``bearish`` / ``neutral``
+* quality filter — ``excellent`` / ``good`` / ``fair`` / ``poor``
+* outcome filter — ``correct`` / ``incorrect`` / ``partial`` (the
+  ``verified=1`` toggle stays for backward compatibility)
+* sort by ``date`` (default, newest first), ``rounds`` (highest
+  agent/round count first), or ``agents``
+
+The helpers are pure-stdlib and operate on plain dicts (the gallery card
+payload returned by ``_build_gallery_card_payload``) so they're testable
+without booting Flask.
+
+The same payload shape backs the ``/api/feed.atom`` and ``/api/feed.rss``
+renderers — anyone wiring those endpoints into the filter set can call
+``select_filtered_cards`` with the same arguments and get a consistent
+selection.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+
+# ── Public constants ──────────────────────────────────────────────────────
+
+#: Hard cap on the per-page size — the same envelope ``GET /api/simulation/public``
+#: has always advertised. Larger pulls should paginate, not raise the cap.
+MAX_LIMIT = 100
+
+#: Default page size when the caller omits ``limit``. Matches the
+#: pre-existing default so legacy clients keep their prior behaviour.
+DEFAULT_LIMIT = 50
+
+#: Hard cap on ``q`` — long, free-text search strings are almost always
+#: a paste-error or a probe; truncate so the substring match stays cheap.
+MAX_QUERY_CHARS = 200
+
+#: Allowed dominant-stance filter values.
+CONSENSUS_VALUES: frozenset[str] = frozenset({"bullish", "neutral", "bearish"})
+
+#: Allowed quality-tier filter values. Compared case-insensitively against
+#: the ``quality_health`` string MiroShark stores in ``quality.json``
+#: (e.g. ``"Excellent"`` / ``"Good"`` / ``"Fair"`` / ``"Poor"``).
+QUALITY_VALUES: frozenset[str] = frozenset({"excellent", "good", "fair", "poor"})
+
+#: Allowed outcome-label filter values — mirrors the labels accepted by
+#: ``POST /api/simulation/<id>/outcome``.
+OUTCOME_VALUES: frozenset[str] = frozenset({"correct", "incorrect", "partial"})
+
+#: Allowed sort keys.
+SORT_VALUES: frozenset[str] = frozenset({"date", "rounds", "agents"})
+
+
+# ── Param normalisation ───────────────────────────────────────────────────
+
+
+def normalise_query(value: Optional[str]) -> str:
+    """Trim + cap a raw ``q`` query string. Never returns ``None``.
+
+    Callers downstream of this can substring-compare directly without
+    re-checking for None / huge inputs.
+    """
+    if not value:
+        return ""
+    s = str(value).strip()
+    if len(s) > MAX_QUERY_CHARS:
+        s = s[:MAX_QUERY_CHARS]
+    return s
+
+
+def _normalise_enum(value: Optional[str], allowed: frozenset[str]) -> Optional[str]:
+    """Lowercase + validate. Returns ``None`` when the value is empty or
+    not in ``allowed`` so a caller passing ``?consensus=`` (empty) gets
+    the same behaviour as omitting the param entirely."""
+    if not value:
+        return None
+    s = str(value).strip().lower()
+    return s if s in allowed else None
+
+
+def normalise_consensus(value: Optional[str]) -> Optional[str]:
+    return _normalise_enum(value, CONSENSUS_VALUES)
+
+
+def normalise_quality(value: Optional[str]) -> Optional[str]:
+    return _normalise_enum(value, QUALITY_VALUES)
+
+
+def normalise_outcome(value: Optional[str]) -> Optional[str]:
+    return _normalise_enum(value, OUTCOME_VALUES)
+
+
+def normalise_sort(value: Optional[str]) -> str:
+    """Default to ``date`` for any unrecognised input."""
+    s = (value or "").strip().lower()
+    return s if s in SORT_VALUES else "date"
+
+
+def normalise_limit(value: Any, *, default: int = DEFAULT_LIMIT) -> int:
+    """Clamp ``limit`` into ``[1, MAX_LIMIT]``. Non-numeric → default."""
+    try:
+        n = int(value if value is not None else default)
+    except (TypeError, ValueError):
+        n = default
+    return max(1, min(MAX_LIMIT, n))
+
+
+def normalise_offset(value: Any) -> int:
+    """Floor at zero. Non-numeric → 0."""
+    try:
+        n = int(value if value is not None else 0)
+    except (TypeError, ValueError):
+        n = 0
+    return max(0, n)
+
+
+def page_to_offset(page: Any, limit: int) -> int:
+    """Convert a 1-based ``page`` query parameter to an ``offset``.
+
+    ``page=1`` → offset 0. ``page=0`` and negative pages coerce to page 1.
+    Non-numeric input is treated as page 1.
+    """
+    try:
+        p = int(page) if page is not None else 1
+    except (TypeError, ValueError):
+        p = 1
+    if p < 1:
+        p = 1
+    return (p - 1) * limit
+
+
+# ── Card-level inspectors ─────────────────────────────────────────────────
+
+
+def dominant_stance(card: dict) -> Optional[str]:
+    """Return ``"bullish" | "neutral" | "bearish"`` for the card, or
+    ``None`` when no consensus is computable yet (in-progress sims, empty
+    trajectory).
+
+    A tie picks the lexically-first label so the result is deterministic
+    when two stances post identical percentages.
+    """
+    consensus = card.get("final_consensus") if isinstance(card, dict) else None
+    if not isinstance(consensus, dict):
+        return None
+
+    pcts: list[tuple[str, float]] = []
+    for label in ("bullish", "neutral", "bearish"):
+        try:
+            v = float(consensus.get(label, 0) or 0)
+        except (TypeError, ValueError):
+            v = 0.0
+        pcts.append((label, v))
+
+    pcts.sort(key=lambda kv: (-kv[1], kv[0]))
+    top_label, top_value = pcts[0]
+    if top_value <= 0:
+        return None
+    return top_label
+
+
+def _quality_tier(card: dict) -> Optional[str]:
+    """Lowercased first-word of ``quality_health`` so ``"Excellent"`` →
+    ``"excellent"`` and ``"Good with caveats"`` → ``"good"`` for matching.
+
+    Returns ``None`` when the card has no quality info or the value
+    doesn't start with one of the four known tiers.
+    """
+    raw = card.get("quality_health") if isinstance(card, dict) else None
+    if not raw:
+        return None
+    head = str(raw).strip().lower().split()
+    if not head:
+        return None
+    word = head[0]
+    return word if word in QUALITY_VALUES else None
+
+
+def _scenario_text(card: dict) -> str:
+    """Lowercased scenario for case-insensitive substring matching."""
+    s = card.get("scenario") if isinstance(card, dict) else ""
+    return str(s or "").lower()
+
+
+def _outcome_label(card: dict) -> Optional[str]:
+    outcome = card.get("outcome") if isinstance(card, dict) else None
+    if not isinstance(outcome, dict):
+        return None
+    label = outcome.get("label")
+    if not label:
+        return None
+    s = str(label).strip().lower()
+    return s if s in OUTCOME_VALUES else None
+
+
+# ── Filter + sort ─────────────────────────────────────────────────────────
+
+
+def filter_cards(
+    cards: Iterable[dict],
+    *,
+    q: str = "",
+    consensus: Optional[str] = None,
+    quality: Optional[str] = None,
+    outcome: Optional[str] = None,
+    verified_only: bool = False,
+) -> list[dict]:
+    """Return the subset of ``cards`` that satisfy every supplied filter.
+
+    All filters combine with logical AND. An empty / ``None`` filter is
+    a no-op (the card always matches that dimension). The input iterable
+    is consumed once — order is preserved so ``sort_cards`` can be
+    chained or skipped.
+    """
+    needle = q.lower() if q else ""
+
+    out: list[dict] = []
+    for card in cards:
+        if not isinstance(card, dict):
+            continue
+
+        if needle and needle not in _scenario_text(card):
+            continue
+
+        if consensus and dominant_stance(card) != consensus:
+            continue
+
+        if quality and _quality_tier(card) != quality:
+            continue
+
+        if outcome and _outcome_label(card) != outcome:
+            continue
+
+        if verified_only and _outcome_label(card) is None:
+            continue
+
+        out.append(card)
+
+    return out
+
+
+def _date_key(card: dict) -> str:
+    """Sort key for ``date`` — empty strings sort last (oldest)."""
+    return str(card.get("created_at") or "")
+
+
+def _rounds_key(card: dict) -> tuple[int, int, str]:
+    """Sort key for ``rounds`` — highest current_round first, breaks ties
+    on agent_count then created_at."""
+    try:
+        cr = int(card.get("current_round") or 0)
+    except (TypeError, ValueError):
+        cr = 0
+    try:
+        ac = int(card.get("agent_count") or 0)
+    except (TypeError, ValueError):
+        ac = 0
+    return (cr, ac, _date_key(card))
+
+
+def _agents_key(card: dict) -> tuple[int, str]:
+    try:
+        ac = int(card.get("agent_count") or 0)
+    except (TypeError, ValueError):
+        ac = 0
+    return (ac, _date_key(card))
+
+
+def sort_cards(cards: list[dict], *, sort: str = "date") -> list[dict]:
+    """Return a new list sorted by the requested key, newest/largest first."""
+    key = normalise_sort(sort)
+    if key == "rounds":
+        return sorted(cards, key=_rounds_key, reverse=True)
+    if key == "agents":
+        return sorted(cards, key=_agents_key, reverse=True)
+    return sorted(cards, key=_date_key, reverse=True)
+
+
+# ── End-to-end selection ──────────────────────────────────────────────────
+
+
+def select_filtered_cards(
+    cards: Iterable[dict],
+    *,
+    q: str = "",
+    consensus: Optional[str] = None,
+    quality: Optional[str] = None,
+    outcome: Optional[str] = None,
+    verified_only: bool = False,
+    sort: str = "date",
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> tuple[list[dict], int]:
+    """Filter → sort → paginate. Returns ``(page_items, total_filtered)``.
+
+    ``total_filtered`` is the count after filters but before pagination,
+    so the caller can compute ``has_more`` and render an "X results"
+    summary that reflects the filter set rather than the full corpus.
+    """
+    filtered = filter_cards(
+        cards,
+        q=q,
+        consensus=consensus,
+        quality=quality,
+        outcome=outcome,
+        verified_only=verified_only,
+    )
+    sorted_cards = sort_cards(filtered, sort=sort)
+    total = len(sorted_cards)
+    page = sorted_cards[offset:offset + max(0, int(limit))] if limit > 0 else []
+    return page, total

--- a/backend/app/services/gallery_filters.py
+++ b/backend/app/services/gallery_filters.py
@@ -142,13 +142,29 @@ def page_to_offset(page: Any, limit: int) -> int:
 # ── Card-level inspectors ─────────────────────────────────────────────────
 
 
+#: Minimum percentage-point gap between the top and runner-up stance
+#: required to call a card "dominant" in that direction. Mirrors the
+#: ±0.2 stance threshold the share card / replay GIF / transcript /
+#: webhook / feed / trajectory CSV all share — a card whose top stance
+#: doesn't clear the runner-up by this margin is treated as a near-tie
+#: (no dominant stance) and falls out of any ``consensus=...`` filter.
+DOMINANCE_THRESHOLD = 0.2
+
+
 def dominant_stance(card: dict) -> Optional[str]:
     """Return ``"bullish" | "neutral" | "bearish"`` for the card, or
     ``None`` when no consensus is computable yet (in-progress sims, empty
-    trajectory).
+    trajectory) **or** when the top stance fails to clear the runner-up
+    by at least ``DOMINANCE_THRESHOLD`` percentage points.
 
-    A tie picks the lexically-first label so the result is deterministic
-    when two stances post identical percentages.
+    The ±0.2 margin keeps the gallery's ``consensus=bullish`` filter
+    consistent with the share card, replay GIF, transcript, webhook,
+    and feed renderers — a 33.4 / 33.3 / 33.3 split has no dominant
+    stance on any of those surfaces, so it can't leak into a consensus
+    bucket here either.
+
+    An exact tie at the top (e.g. 40 / 40 / 20) is broken lexically so
+    the result stays deterministic across calls.
     """
     consensus = card.get("final_consensus") if isinstance(card, dict) else None
     if not isinstance(consensus, dict):
@@ -164,7 +180,15 @@ def dominant_stance(card: dict) -> Optional[str]:
 
     pcts.sort(key=lambda kv: (-kv[1], kv[0]))
     top_label, top_value = pcts[0]
+    _, runner_up_value = pcts[1]
     if top_value <= 0:
+        return None
+    # An exact tie at the top falls back to the lexical winner so the
+    # result is deterministic; a non-zero but sub-threshold lead is a
+    # near-tie and gets filtered out, matching how every other surface
+    # treats split consensus.
+    gap = top_value - runner_up_value
+    if gap > 0 and gap < DOMINANCE_THRESHOLD:
         return None
     return top_label
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1303,7 +1303,27 @@ paths:
   /api/simulation/public:
     get:
       tags: [Publish & Embed]
-      summary: Paginated gallery feed of public simulations.
+      summary: Filterable, paginated gallery feed of public simulations.
+      description: |
+        Discovery layer for the `/explore` and `/verified` views. Returns
+        the same gallery card payload that the share card, replay GIF,
+        transcript, RSS feed, and trajectory exports all share — same
+        ±0.2 stance threshold, same on-disk `sim_dir/` substrate.
+
+        Optional filters compose with logical AND:
+
+        * `q` — case-insensitive substring match against the scenario.
+        * `consensus` — `bullish` / `neutral` / `bearish`. Filters by the
+          dominant final-round stance using the same ±0.2 threshold the
+          share card / replay GIF / transcript / webhook / feed all use.
+        * `quality` — `excellent` / `good` / `fair` / `poor`. Compared
+          against the first word of the simulation's `quality_health`.
+        * `outcome` — `correct` / `incorrect` / `partial`. Implies
+          `verified=1`.
+
+        `total` reflects the filtered count (not the full corpus), so the
+        client can render an accurate "X remaining" hint and `has_more`
+        flag for the active filter set.
       parameters:
         - in: query
           name: limit
@@ -1312,12 +1332,59 @@ paths:
           name: offset
           schema: { type: integer, minimum: 0, default: 0 }
         - in: query
+          name: page
+          description: |
+            1-based page number — alternative to `offset`. Wins over
+            `offset` when both are supplied. `page=1` is offset 0.
+          schema: { type: integer, minimum: 1 }
+        - in: query
           name: verified
           description: |
             Truthy values (`1`, `true`, `yes`, `on`) restrict the listing to
             simulations with a recorded outcome annotation — i.e. the
             "Verified Prediction" hall.
           schema: { type: string }
+        - in: query
+          name: q
+          description: |
+            Case-insensitive substring match against the scenario text.
+            Trimmed and capped at 200 characters.
+          schema: { type: string, maxLength: 200 }
+        - in: query
+          name: consensus
+          description: |
+            Filter to cards whose dominant final consensus matches the
+            chosen stance (using the same ±0.2 threshold as every other
+            surface).
+          schema:
+            type: string
+            enum: [bullish, neutral, bearish]
+        - in: query
+          name: quality
+          description: |
+            Filter to cards whose `quality_health` first word matches the
+            requested tier (case-insensitive).
+          schema:
+            type: string
+            enum: [excellent, good, fair, poor]
+        - in: query
+          name: outcome
+          description: |
+            Filter to verified simulations whose recorded outcome label
+            matches. Implies `verified=1`.
+          schema:
+            type: string
+            enum: [correct, incorrect, partial]
+        - in: query
+          name: sort
+          description: |
+            `date` (default — newest first), `rounds` (highest
+            `current_round` first), or `agents` (largest population
+            first).
+          schema:
+            type: string
+            enum: [date, rounds, agents]
+            default: date
       responses:
         "200":
           description: Gallery cards.
@@ -1335,8 +1402,25 @@ paths:
                       total: { type: integer }
                       limit: { type: integer }
                       offset: { type: integer }
+                      page: { type: integer }
                       has_more: { type: boolean }
                       verified_only: { type: boolean }
+                      q: { type: string }
+                      consensus:
+                        type: string
+                        nullable: true
+                        enum: [bullish, neutral, bearish, null]
+                      quality:
+                        type: string
+                        nullable: true
+                        enum: [excellent, good, fair, poor, null]
+                      outcome:
+                        type: string
+                        nullable: true
+                        enum: [correct, incorrect, partial, null]
+                      sort:
+                        type: string
+                        enum: [date, rounds, agents]
 
   # ────────────────────────────────────────────────────────────────────
   # Export

--- a/backend/tests/test_unit_gallery_filters.py
+++ b/backend/tests/test_unit_gallery_filters.py
@@ -1,0 +1,412 @@
+"""Unit tests for the public-gallery filter / sort / paginate helpers.
+
+The ``app/services/gallery_filters.py`` module is what gives
+``GET /api/simulation/public`` its keyword search, consensus filter,
+quality filter, outcome filter, and sort key. These tests run offline
+against plain-dict gallery cards — no Flask, no SimulationManager, no
+filesystem — so the contract is locked in regardless of how the
+endpoint evolves.
+
+We cover:
+
+  1. Param normalisation (limit clamping, offset flooring, page→offset
+     conversion, query trimming/capping, enum lookup).
+  2. ``dominant_stance`` matches the same ±0.2 threshold the share card,
+     replay GIF, transcript, webhook, and feed renderers use.
+  3. Each filter (`q`, `consensus`, `quality`, `outcome`,
+     `verified_only`) restricts the result set correctly, both alone
+     and in combination.
+  4. Sort orders are deterministic — newest-first by date, largest-first
+     by rounds and agents.
+  5. ``select_filtered_cards`` returns the right ``(page_items, total)``
+     shape after filter → sort → paginate.
+  6. Graceful degradation on corrupt cards (missing fields, wrong
+     types, empty consensus) so one bad sim doesn't blank the gallery.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+from app.services import gallery_filters as gf
+
+
+# ── Card factory ──────────────────────────────────────────────────────────
+
+
+def _card(
+    sid: str,
+    *,
+    scenario: str = "",
+    bullish: float = 0.0,
+    neutral: float = 0.0,
+    bearish: float = 0.0,
+    quality_health: str | None = None,
+    outcome_label: str | None = None,
+    outcome_url: str | None = None,
+    created_at: str = "2026-04-22T10:12:34",
+    current_round: int = 0,
+    agent_count: int = 0,
+) -> dict:
+    consensus: dict | None = None
+    if (bullish or neutral or bearish):
+        consensus = {"bullish": bullish, "neutral": neutral, "bearish": bearish}
+    outcome: dict | None = None
+    if outcome_label is not None:
+        outcome = {"label": outcome_label}
+        if outcome_url:
+            outcome["outcome_url"] = outcome_url
+    return {
+        "simulation_id": sid,
+        "scenario": scenario,
+        "final_consensus": consensus,
+        "quality_health": quality_health,
+        "outcome": outcome,
+        "created_at": created_at,
+        "current_round": current_round,
+        "agent_count": agent_count,
+    }
+
+
+# ── Param normalisation ───────────────────────────────────────────────────
+
+
+class TestNormaliseLimit:
+    def test_default_when_missing(self):
+        assert gf.normalise_limit(None) == gf.DEFAULT_LIMIT
+
+    def test_clamps_below_one_to_one(self):
+        assert gf.normalise_limit(0) == 1
+        assert gf.normalise_limit(-5) == 1
+
+    def test_clamps_above_max(self):
+        assert gf.normalise_limit(9999) == gf.MAX_LIMIT
+        assert gf.normalise_limit(gf.MAX_LIMIT + 1) == gf.MAX_LIMIT
+
+    def test_passes_through_valid(self):
+        assert gf.normalise_limit(25) == 25
+
+    def test_garbage_input_falls_back_to_default(self):
+        assert gf.normalise_limit("not-a-number") == gf.DEFAULT_LIMIT
+        assert gf.normalise_limit(object()) == gf.DEFAULT_LIMIT
+
+
+class TestNormaliseOffset:
+    def test_default_when_missing(self):
+        assert gf.normalise_offset(None) == 0
+
+    def test_negative_floors_to_zero(self):
+        assert gf.normalise_offset(-1) == 0
+        assert gf.normalise_offset(-100) == 0
+
+    def test_passes_through_valid(self):
+        assert gf.normalise_offset(50) == 50
+
+    def test_garbage_input_falls_back_to_zero(self):
+        assert gf.normalise_offset("nope") == 0
+
+
+class TestPageToOffset:
+    def test_page_one_is_offset_zero(self):
+        assert gf.page_to_offset(1, 30) == 0
+
+    def test_page_two_uses_limit(self):
+        assert gf.page_to_offset(2, 30) == 30
+        assert gf.page_to_offset(3, 50) == 100
+
+    def test_zero_or_negative_clamps_to_page_one(self):
+        assert gf.page_to_offset(0, 30) == 0
+        assert gf.page_to_offset(-5, 30) == 0
+
+    def test_garbage_input_treated_as_page_one(self):
+        assert gf.page_to_offset("oops", 30) == 0
+        assert gf.page_to_offset(None, 30) == 0
+
+
+class TestNormaliseQuery:
+    def test_empty_inputs(self):
+        assert gf.normalise_query(None) == ""
+        assert gf.normalise_query("") == ""
+        assert gf.normalise_query("   ") == ""
+
+    def test_trims_whitespace(self):
+        assert gf.normalise_query("  aave   ") == "aave"
+
+    def test_caps_long_input(self):
+        long = "x" * (gf.MAX_QUERY_CHARS + 50)
+        assert len(gf.normalise_query(long)) == gf.MAX_QUERY_CHARS
+
+
+class TestNormaliseEnums:
+    @pytest.mark.parametrize("value", ["bullish", "BULLISH", "  bullish ", "Bullish"])
+    def test_consensus_accepts_valid(self, value: str):
+        assert gf.normalise_consensus(value) == "bullish"
+
+    @pytest.mark.parametrize("value", ["", None, "moonish", "ish"])
+    def test_consensus_rejects_invalid(self, value):
+        assert gf.normalise_consensus(value) is None
+
+    @pytest.mark.parametrize("value,expected", [
+        ("excellent", "excellent"),
+        ("EXCELLENT", "excellent"),
+        ("Good", "good"),
+        ("nope", None),
+        ("", None),
+    ])
+    def test_quality_normalisation(self, value, expected):
+        assert gf.normalise_quality(value) == expected
+
+    @pytest.mark.parametrize("value,expected", [
+        ("correct", "correct"),
+        ("INCORRECT", "incorrect"),
+        ("partial", "partial"),
+        ("verified", None),
+        ("", None),
+    ])
+    def test_outcome_normalisation(self, value, expected):
+        assert gf.normalise_outcome(value) == expected
+
+    @pytest.mark.parametrize("value,expected", [
+        ("date", "date"),
+        ("Rounds", "rounds"),
+        ("AGENTS", "agents"),
+        ("", "date"),
+        (None, "date"),
+        ("popularity", "date"),
+    ])
+    def test_sort_falls_back_to_date(self, value, expected):
+        assert gf.normalise_sort(value) == expected
+
+
+# ── dominant_stance — ±0.2 threshold parity ──────────────────────────────
+
+
+class TestDominantStance:
+    def test_picks_bullish_when_dominant(self):
+        c = _card("a", bullish=70.0, neutral=20.0, bearish=10.0)
+        assert gf.dominant_stance(c) == "bullish"
+
+    def test_picks_bearish_when_dominant(self):
+        c = _card("a", bullish=10.0, neutral=20.0, bearish=70.0)
+        assert gf.dominant_stance(c) == "bearish"
+
+    def test_picks_neutral_when_dominant(self):
+        c = _card("a", bullish=10.0, neutral=80.0, bearish=10.0)
+        assert gf.dominant_stance(c) == "neutral"
+
+    def test_none_when_no_consensus(self):
+        c = _card("a")
+        assert gf.dominant_stance(c) is None
+
+    def test_none_when_consensus_corrupted(self):
+        c = _card("a")
+        c["final_consensus"] = "not-a-dict"
+        assert gf.dominant_stance(c) is None
+
+    def test_none_when_all_zero(self):
+        c = _card("a")
+        c["final_consensus"] = {"bullish": 0, "neutral": 0, "bearish": 0}
+        assert gf.dominant_stance(c) is None
+
+    def test_tie_is_deterministic_lexically(self):
+        # 40/40/20 tie — bullish < neutral lexically, so bullish wins.
+        c = _card("a", bullish=40.0, neutral=40.0, bearish=20.0)
+        assert gf.dominant_stance(c) == "bullish"
+
+    def test_handles_string_percentages(self):
+        c = _card("a")
+        c["final_consensus"] = {"bullish": "70.0", "neutral": "20", "bearish": "10"}
+        assert gf.dominant_stance(c) == "bullish"
+
+
+# ── filter_cards — each filter alone + combined ──────────────────────────
+
+
+class TestFilterCards:
+    @pytest.fixture
+    def corpus(self):
+        return [
+            _card("a", scenario="Will the SEC approve a spot Aave ETF?",
+                  bullish=70, neutral=20, bearish=10,
+                  quality_health="Excellent",
+                  outcome_label="correct"),
+            _card("b", scenario="ETH staking yield in Q3",
+                  bullish=10, neutral=20, bearish=70,
+                  quality_health="Good"),
+            _card("c", scenario="Bitcoin halving impact on AAVE pools",
+                  bullish=10, neutral=80, bearish=10,
+                  quality_health="Fair",
+                  outcome_label="partial"),
+            _card("d", scenario="DOGE meme cycle",
+                  bullish=33.4, neutral=33.3, bearish=33.3,
+                  quality_health="Poor",
+                  outcome_label="incorrect"),
+            _card("e", scenario="No data yet — fresh sim"),
+        ]
+
+    def test_no_filters_returns_everything(self, corpus):
+        out = gf.filter_cards(corpus)
+        assert {c["simulation_id"] for c in out} == {"a", "b", "c", "d", "e"}
+
+    def test_q_substring_case_insensitive(self, corpus):
+        out = gf.filter_cards(corpus, q="aave")
+        # Matches 'Aave ETF' and 'AAVE pools'.
+        assert {c["simulation_id"] for c in out} == {"a", "c"}
+
+    def test_q_no_match_returns_empty(self, corpus):
+        out = gf.filter_cards(corpus, q="xrp moon mission")
+        assert out == []
+
+    def test_consensus_bullish_only(self, corpus):
+        out = gf.filter_cards(corpus, consensus="bullish")
+        assert {c["simulation_id"] for c in out} == {"a"}
+
+    def test_consensus_bearish_only(self, corpus):
+        out = gf.filter_cards(corpus, consensus="bearish")
+        assert {c["simulation_id"] for c in out} == {"b"}
+
+    def test_consensus_neutral_only(self, corpus):
+        out = gf.filter_cards(corpus, consensus="neutral")
+        assert {c["simulation_id"] for c in out} == {"c"}
+
+    def test_quality_excellent_only(self, corpus):
+        out = gf.filter_cards(corpus, quality="excellent")
+        assert {c["simulation_id"] for c in out} == {"a"}
+
+    def test_outcome_partial_only(self, corpus):
+        out = gf.filter_cards(corpus, outcome="partial")
+        assert {c["simulation_id"] for c in out} == {"c"}
+
+    def test_verified_only_keeps_outcome_set(self, corpus):
+        out = gf.filter_cards(corpus, verified_only=True)
+        assert {c["simulation_id"] for c in out} == {"a", "c", "d"}
+
+    def test_combined_q_and_consensus(self, corpus):
+        # 'aave' matches a + c. consensus=neutral keeps only c.
+        out = gf.filter_cards(corpus, q="aave", consensus="neutral")
+        assert {c["simulation_id"] for c in out} == {"c"}
+
+    def test_combined_q_and_outcome(self, corpus):
+        # 'aave' matches a + c. outcome=correct keeps only a.
+        out = gf.filter_cards(corpus, q="aave", outcome="correct")
+        assert {c["simulation_id"] for c in out} == {"a"}
+
+    def test_combined_consensus_and_quality(self, corpus):
+        out = gf.filter_cards(corpus, consensus="bullish", quality="excellent")
+        assert {c["simulation_id"] for c in out} == {"a"}
+
+    def test_garbage_cards_skipped(self, corpus):
+        garbage = corpus + ["not-a-dict", None, 42]  # type: ignore[list-item]
+        out = gf.filter_cards(garbage, q="aave")
+        assert {c["simulation_id"] for c in out} == {"a", "c"}
+
+
+# ── sort_cards ────────────────────────────────────────────────────────────
+
+
+class TestSortCards:
+    def test_date_desc_default(self):
+        cards = [
+            _card("old", created_at="2026-01-10T00:00:00"),
+            _card("new", created_at="2026-04-30T00:00:00"),
+            _card("mid", created_at="2026-03-15T00:00:00"),
+        ]
+        out = gf.sort_cards(cards, sort="date")
+        assert [c["simulation_id"] for c in out] == ["new", "mid", "old"]
+
+    def test_rounds_desc(self):
+        cards = [
+            _card("a", current_round=10, agent_count=100),
+            _card("b", current_round=50, agent_count=100),
+            _card("c", current_round=30, agent_count=100),
+        ]
+        out = gf.sort_cards(cards, sort="rounds")
+        assert [c["simulation_id"] for c in out] == ["b", "c", "a"]
+
+    def test_agents_desc(self):
+        cards = [
+            _card("a", agent_count=20),
+            _card("b", agent_count=200),
+            _card("c", agent_count=80),
+        ]
+        out = gf.sort_cards(cards, sort="agents")
+        assert [c["simulation_id"] for c in out] == ["b", "c", "a"]
+
+    def test_unknown_sort_falls_back_to_date(self):
+        cards = [
+            _card("old", created_at="2026-01-01T00:00:00"),
+            _card("new", created_at="2026-05-01T00:00:00"),
+        ]
+        out = gf.sort_cards(cards, sort="rumours")
+        assert out[0]["simulation_id"] == "new"
+
+    def test_empty_list_returns_empty(self):
+        assert gf.sort_cards([], sort="date") == []
+        assert gf.sort_cards([], sort="rounds") == []
+
+
+# ── select_filtered_cards — end-to-end ────────────────────────────────────
+
+
+class TestSelectFilteredCards:
+    def test_returns_filtered_total_not_corpus_total(self):
+        cards = [
+            _card("a", bullish=70, scenario="aave"),
+            _card("b", bullish=70, scenario="eth"),
+            _card("c", bearish=70, scenario="btc"),
+        ]
+        page, total = gf.select_filtered_cards(cards, consensus="bullish")
+        assert total == 2  # filtered, not 3
+        assert {c["simulation_id"] for c in page} == {"a", "b"}
+
+    def test_pagination_slices_after_sort(self):
+        cards = [
+            _card(f"sim_{i:02d}", created_at=f"2026-04-{i+1:02d}T00:00:00")
+            for i in range(10)
+        ]
+        page1, total1 = gf.select_filtered_cards(cards, limit=3, offset=0)
+        page2, total2 = gf.select_filtered_cards(cards, limit=3, offset=3)
+        assert total1 == total2 == 10
+        # Newest first, so page1 = sim_09, sim_08, sim_07.
+        assert [c["simulation_id"] for c in page1] == ["sim_09", "sim_08", "sim_07"]
+        assert [c["simulation_id"] for c in page2] == ["sim_06", "sim_05", "sim_04"]
+
+    def test_offset_past_total_returns_empty_page(self):
+        cards = [_card("a"), _card("b")]
+        page, total = gf.select_filtered_cards(cards, limit=10, offset=100)
+        assert page == []
+        assert total == 2
+
+    def test_q_consensus_quality_combine_correctly(self):
+        cards = [
+            _card("a", scenario="Aave outlook", bullish=70,
+                  quality_health="Excellent"),
+            _card("b", scenario="Aave outlook", bullish=70,
+                  quality_health="Poor"),
+            _card("c", scenario="Aave outlook", bearish=70,
+                  quality_health="Excellent"),
+            _card("d", scenario="ETH outlook", bullish=70,
+                  quality_health="Excellent"),
+        ]
+        page, total = gf.select_filtered_cards(
+            cards,
+            q="aave",
+            consensus="bullish",
+            quality="excellent",
+        )
+        assert total == 1
+        assert [c["simulation_id"] for c in page] == ["a"]
+
+    def test_empty_corpus_returns_empty_page_and_zero_total(self):
+        page, total = gf.select_filtered_cards([])
+        assert page == []
+        assert total == 0

--- a/docs/API.md
+++ b/docs/API.md
@@ -95,6 +95,28 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `GET` | `/api/simulation/<id>/export` | Full JSON export |
 | `GET` | `/api/simulation/list` | List simulations |
 | `GET` | `/api/simulation/history` | Simulation history / diffs |
+| `GET` | `/api/simulation/public` | Filterable, paginated public gallery feed |
+
+### Gallery search & filtering
+
+`GET /api/simulation/public` supports keyword + dominant-stance + quality-tier + outcome-label + sort filters so an analyst can pull "every excellent-quality bearish call about Aave" as one URL:
+
+```text
+GET /api/simulation/public?q=aave&consensus=bearish&quality=excellent&sort=rounds&page=1
+```
+
+| Query param | Values | Notes |
+|---|---|---|
+| `q` | free text, ≤200 chars | Case-insensitive substring match against the scenario. |
+| `consensus` | `bullish` / `neutral` / `bearish` | Dominant final-round stance using the same ±0.2 threshold the share card / replay GIF / transcript / webhook / feed all use. |
+| `quality` | `excellent` / `good` / `fair` / `poor` | Compared case-insensitively against the first word of `quality_health`. |
+| `outcome` | `correct` / `incorrect` / `partial` | Implies `verified=1` (verified-only). |
+| `sort` | `date` / `rounds` / `agents` | `date` (default — newest first), `rounds` (highest current_round first), or `agents` (largest population first). |
+| `verified` | truthy (`1`/`true`/`yes`) | Restrict to simulations with a recorded outcome annotation — the `/verified` hall. |
+| `limit` / `offset` | `[1, 100]` / `≥0` | Pagination knobs. `total` reflects the **filtered** count. |
+| `page` | `≥1` | 1-based alternative to `offset`. Wins over `offset` when both are supplied. |
+
+Filters compose with logical AND. Empty / unknown values are no-ops, so `?consensus=` returns the unfiltered listing and `?sort=popularity` falls back to `sort=date` rather than 400-ing.
 
 ### Analyst quickstart
 

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -89,6 +89,28 @@
 | `GET` | `/api/simulation/<id>/export` | 完整 JSON 导出 |
 | `GET` | `/api/simulation/list` | 列出模拟 |
 | `GET` | `/api/simulation/history` | 模拟历史 / 差异 |
+| `GET` | `/api/simulation/public` | 可筛选、分页的公开图库列表 |
+
+### 图库搜索与筛选
+
+`GET /api/simulation/public` 支持关键词 + 主导立场 + 质量等级 + 结果标签 + 排序筛选,可让分析师通过单个 URL 拉取「关于 Aave 的每一次优秀质量看跌预言」:
+
+```text
+GET /api/simulation/public?q=aave&consensus=bearish&quality=excellent&sort=rounds&page=1
+```
+
+| 查询参数 | 取值 | 说明 |
+|---|---|---|
+| `q` | 自由文本,≤200 字符 | 不区分大小写的情景文本子串匹配。 |
+| `consensus` | `bullish` / `neutral` / `bearish` | 使用与分享卡片 / 回放 GIF / 转录 / Webhook / 订阅源相同的 ±0.2 阈值计算的最终轮主导立场。 |
+| `quality` | `excellent` / `good` / `fair` / `poor` | 与 `quality_health` 首词进行不区分大小写比较。 |
+| `outcome` | `correct` / `incorrect` / `partial` | 隐含 `verified=1`(仅已验证)。 |
+| `sort` | `date` / `rounds` / `agents` | `date`(默认 — 最新优先)、`rounds`(当前轮次最多优先)或 `agents`(种群最大优先)。 |
+| `verified` | 真值(`1`/`true`/`yes`) | 限制为已记录结果注释的模拟 — 即 `/verified` 展厅。 |
+| `limit` / `offset` | `[1, 100]` / `≥0` | 分页参数。`total` 反映**已筛选**的计数。 |
+| `page` | `≥1` | `offset` 的 1 起编号替代值。两者同时出现时 `page` 优先。 |
+
+筛选条件以逻辑与组合。空值 / 未知值均为无操作:`?consensus=` 返回未筛选列表;`?sort=popularity` 回退至 `sort=date` 而非 400 报错。
 
 ## 报告智能体
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -159,6 +159,25 @@ Two endpoints, same row schema, different serialization:
 
 Same publish gate as the share card and transcript (`is_public=true`). The bullish / neutral / bearish percentages use the same ±0.2 stance threshold as every other surface, so a number in the CSV matches what the gallery, share card, replay GIF, transcript, webhook, and feed report for the same round. The Embed dialog exposes a "Download .csv" + "Download .jsonl" pair beneath the transcript row, plus a copyable CSV URL and a `pd.read_csv("<url>")` quickstart snippet.
 
+## Gallery Search & Filtering
+
+`/explore` is the public research surface — every published MiroShark simulation, browsable as a card grid. Once the corpus grew past a few dozen entries the reverse-chronological scroll stopped being a tool, so the gallery now indexes itself: a keyword search box, a consensus filter chip group, a quality filter chip group, and a sort dropdown sit above the cards. The active filter set lives in URL params (`?q=…&consensus=bearish&quality=excellent&sort=rounds`), so any filtered view is bookmarkable and shareable — "every excellent-quality bearish call about Aave" is a URL you can tweet.
+
+- **`q`** — case-insensitive substring match against the scenario text. Trimmed; capped at 200 chars.
+- **`consensus`** — `bullish` / `neutral` / `bearish`. Filters by the dominant final-round stance using the same ±0.2 threshold the share card, replay GIF, transcript, webhook, and feed renderers all use, so a "bullish" filter here matches what those surfaces report for the same simulation.
+- **`quality`** — `excellent` / `good` / `fair` / `poor`. Compared case-insensitively against the first word of `quality_health`.
+- **`outcome`** — `correct` / `incorrect` / `partial`. Implies `verified=1` (verified-only).
+- **`sort`** — `date` (default — newest first), `rounds` (highest current_round first), or `agents` (largest population first).
+- **`page`** — 1-based page number; alternative to `offset`. `page=1` is offset 0. The two compose the same way: `total` reflects the **filtered** count (not the corpus size), so the load-more "X remaining" hint and `has_more` flag stay accurate inside the active filter set.
+
+The `/verified` route preserves the `verifiedOnly: true` mode and stays compatible with every filter — `/verified?q=aave&consensus=bullish` works. Toggling Verified ↔ Explore via the header chip carries the active query string across the route swap so the user doesn't lose their search.
+
+- **Endpoint:** `GET /api/simulation/public?q=…&consensus=bullish&quality=excellent&sort=rounds&page=2`
+- **Compose with verified:** `GET /api/simulation/public?verified=1&consensus=bearish` returns every bearish call that has a recorded outcome.
+- **Implementation:** pure stdlib in-memory filter over the gallery cards already assembled by the public endpoint. Zero new dependencies. The endpoint stays cached for 30 s, so a busy gallery amortises the per-sim card build over many filtered requests.
+
+A "📊 Reset" button appears once any filter is active; the empty state ("No simulations match your filters") points back at the same reset rather than dead-ending on a "no public sims yet" message that wouldn't apply.
+
 ## Public Gallery Feeds (RSS / Atom)
 
 The same cards `/explore` renders, served as a syndication feed so researchers and tooling already on Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS subscribe in their existing toolchain — no login, no MiroShark account. Every newly published simulation lands in their reader the same way an AI newsletter or Substack post does.

--- a/docs/FEATURES.zh-CN.md
+++ b/docs/FEATURES.zh-CN.md
@@ -148,6 +148,25 @@ WONDERWALL_MODEL_NAME=your-model-id
 
 两个端点共享分享卡的发布控制(`is_public=true`)。每个智能体的立场标签使用与其他界面一致的 ±0.2 阈值 — 画廊上的"看涨"智能体在轨迹里也会打同样的 tag。嵌入对话框在回放 GIF 那行下方暴露"下载 .md" + "下载 .json"组合。
 
+## 图库搜索与筛选
+
+`/explore` 是公开研究界面 — 每一次发布的 MiroShark 模拟,都以卡片网格浏览。当语料库突破几十条后,反向时间序列的滚动列表就不再是工具,因此图库现在自带索引:卡片之上有一个关键词搜索框、一组共识筛选芯片、一组质量筛选芯片以及一个排序下拉。激活的筛选集合保存在 URL 参数中(`?q=…&consensus=bearish&quality=excellent&sort=rounds`),因此任意筛选视图都可作为书签分享 — "每一次关于 Aave 的优秀质量看跌预言"成了一个可发推文的 URL。
+
+- **`q`** — 不区分大小写的情景文本子串匹配。已修剪;上限 200 字符。
+- **`consensus`** — `bullish` / `neutral` / `bearish`。基于与分享卡 / 回放 GIF / 转录 / Webhook / 订阅源一致的 ±0.2 阈值的最终轮主导立场进行筛选,与那些界面在同一模拟上报告的内容保持一致。
+- **`quality`** — `excellent` / `good` / `fair` / `poor`。与 `quality_health` 首词进行不区分大小写比较。
+- **`outcome`** — `correct` / `incorrect` / `partial`。隐含 `verified=1`(仅已验证)。
+- **`sort`** — `date`(默认 — 最新优先)、`rounds`(当前轮次最多优先)或 `agents`(种群最大优先)。
+- **`page`** — 1 起编号的页号;`offset` 的替代值。`page=1` 即偏移 0。两者组合方式一致:`total` 反映**已筛选**的计数(而非语料库大小),所以"加载更多""剩余 X 个"提示和 `has_more` 标志在当前筛选集合内保持准确。
+
+`/verified` 路由保留 `verifiedOnly: true` 模式,并与所有筛选条件兼容 — `/verified?q=aave&consensus=bullish` 是有效的。通过头部芯片在「已验证」与「Explore」之间切换时,会跨越路由切换沿用激活的查询字符串,用户不会因切换「已验证」而丢失搜索。
+
+- **接口:** `GET /api/simulation/public?q=…&consensus=bullish&quality=excellent&sort=rounds&page=2`
+- **与 verified 组合:** `GET /api/simulation/public?verified=1&consensus=bearish` 返回每一次有结果记录的看跌预言。
+- **实现:** 公共端点已组装的图库卡片之上的纯标准库内存内筛选。零新依赖。端点保持 30 秒缓存,因此繁忙的图库会在多次筛选请求间摊销每次模拟的卡片构建。
+
+筛选激活后会出现「📊 重置」按钮;空状态(「没有模拟符合你的筛选条件」)指回同一个重置入口,而不是回到本不适用的「暂无公开模拟」消息。
+
 ## 公开画廊订阅(RSS / Atom)
 
 `/explore` 渲染的同一批卡片,以聚合订阅的形式提供出来,让已经在用 Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS 的研究者和工具,可以在他们已有的工具链里订阅 — 无需登录,无需 MiroShark 账户。每个新发布的模拟,以与 AI 通讯或 Substack 文章相同的方式落入他们的阅读器。

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -691,13 +691,31 @@ export const suggestScenarios = (data) => {
  *   }
  *
  * An empty `data` array is normal (render the empty state).
- * @param {Object} options - { limit?: number, offset?: number, verifiedOnly?: boolean }
+ * @param {Object} options - {
+ *   limit?: number, offset?: number, page?: number,
+ *   verifiedOnly?: boolean,
+ *   q?: string,
+ *   consensus?: 'bullish'|'neutral'|'bearish',
+ *   quality?: 'excellent'|'good'|'fair'|'poor',
+ *   outcome?: 'correct'|'incorrect'|'partial',
+ *   sort?: 'date'|'rounds'|'agents',
+ * }
  */
 export const getPublicSimulations = (options = {}) => {
   const params = {}
   if (Number.isFinite(options.limit)) params.limit = options.limit
   if (Number.isFinite(options.offset)) params.offset = options.offset
+  if (Number.isFinite(options.page)) params.page = options.page
   if (options.verifiedOnly) params.verified = '1'
+  // Filter knobs added in the gallery search/filter PR. The backend
+  // normalises (case + allowed values) so the frontend forwards
+  // whatever the user typed without re-validating — single source of
+  // truth on the API side.
+  if (options.q) params.q = options.q
+  if (options.consensus) params.consensus = options.consensus
+  if (options.quality) params.quality = options.quality
+  if (options.outcome) params.outcome = options.outcome
+  if (options.sort) params.sort = options.sort
   return service.get('/api/simulation/public', { params, timeout: 15000 })
 }
 

--- a/frontend/src/views/ExploreView.vue
+++ b/frontend/src/views/ExploreView.vue
@@ -38,6 +38,99 @@
             {{ $tr("Every card is a real MiroShark run someone published. Open one to see the full belief drift, agent network, and prediction outcome — or fork it in one click and run your own variant with the same agent population.", '每张卡片都是有人发布的真实 MiroShark 运行。打开任一张可查看完整的信念漂移、智能体网络与预测结果 — 或一键派生,使用同一组智能体运行你自己的变体。') }}
           </template>
         </p>
+
+        <!-- ── Search + filter bar ────────────────────────────────────
+             Search and filter state lives in URL params (q, consensus,
+             quality, sort) so a filtered view is bookmarkable and
+             shareable — "every excellent-quality bearish call about
+             Aave" becomes a URL you can tweet. -->
+        <div class="filter-bar">
+          <div class="search-wrap">
+            <span class="search-icon">⌕</span>
+            <input
+              v-model="searchInput"
+              type="search"
+              class="search-input"
+              :placeholder="$tr('Search scenarios…', '搜索情景…')"
+              :aria-label="$tr('Search scenarios', '搜索情景')"
+              autocomplete="off"
+              @input="onSearchInput"
+            />
+            <button
+              v-if="searchInput"
+              type="button"
+              class="search-clear"
+              :title="$tr('Clear search', '清除搜索')"
+              @click="clearSearch"
+            >×</button>
+          </div>
+
+          <div class="chip-group" role="tablist" :aria-label="$tr('Consensus filter', '共识筛选')">
+            <span class="chip-group-label">{{ $tr('Consensus', '共识') }}</span>
+            <button
+              v-for="opt in consensusOptions"
+              :key="opt.value || 'any'"
+              class="chip"
+              :class="{ 'chip-active': consensus === opt.value }"
+              :aria-pressed="consensus === opt.value"
+              @click="setConsensus(opt.value)"
+              :disabled="loading"
+            >
+              <span v-if="opt.glyph" class="chip-glyph" :class="opt.glyphClass">{{ opt.glyph }}</span>
+              {{ opt.label() }}
+            </button>
+          </div>
+
+          <div class="chip-group" role="tablist" :aria-label="$tr('Quality filter', '质量筛选')">
+            <span class="chip-group-label">{{ $tr('Quality', '质量') }}</span>
+            <button
+              v-for="opt in qualityOptions"
+              :key="opt.value || 'any'"
+              class="chip"
+              :class="{ 'chip-active': quality === opt.value }"
+              :aria-pressed="quality === opt.value"
+              @click="setQuality(opt.value)"
+              :disabled="loading"
+            >
+              {{ opt.label() }}
+            </button>
+          </div>
+
+          <div class="sort-wrap">
+            <label class="sort-label" for="explore-sort">{{ $tr('Sort', '排序') }}</label>
+            <select
+              id="explore-sort"
+              v-model="sortKey"
+              class="sort-select"
+              @change="onSortChange"
+              :disabled="loading"
+            >
+              <option value="date">{{ $tr('Newest first', '最新优先') }}</option>
+              <option value="rounds">{{ $tr('Most rounds', '轮次最多') }}</option>
+              <option value="agents">{{ $tr('Most agents', '智能体最多') }}</option>
+            </select>
+          </div>
+
+          <button
+            v-if="filtersActive"
+            type="button"
+            class="reset-btn"
+            @click="resetFilters"
+            :disabled="loading"
+            :title="$tr('Clear all filters', '清除所有筛选')"
+          >
+            ↻ {{ $tr('Reset', '重置') }}
+          </button>
+        </div>
+
+        <p v-if="filtersActive && !loading" class="result-count">
+          <template v-if="total === 0">
+            {{ $tr('No simulations match the current filters.', '没有模拟符合当前筛选条件。') }}
+          </template>
+          <template v-else>
+            {{ total }} {{ total === 1 ? $tr('result', '个结果') : $tr('results', '个结果') }}
+          </template>
+        </p>
         <div class="stats-row">
           <span class="stat-chip">
             <span class="stat-num">{{ loading ? '…' : total }}</span>
@@ -112,12 +205,23 @@
 
       <!-- Empty -->
       <div v-else-if="items.length === 0" class="gallery-empty">
-        <div class="empty-icon">{{ verifiedFilter ? '📍' : '◇' }}</div>
+        <div class="empty-icon">{{ filtersActive ? '⌕' : (verifiedFilter ? '📍' : '◇') }}</div>
         <div class="empty-title">
-          {{ verifiedFilter ? $tr('No verified predictions yet.', '暂无已验证的预言。') : $tr('No public simulations yet.', '暂无公开模拟。') }}
+          <template v-if="filtersActive">
+            {{ $tr('No simulations match your filters.', '没有模拟符合你的筛选条件。') }}
+          </template>
+          <template v-else-if="verifiedFilter">
+            {{ $tr('No verified predictions yet.', '暂无已验证的预言。') }}
+          </template>
+          <template v-else>
+            {{ $tr('No public simulations yet.', '暂无公开模拟。') }}
+          </template>
         </div>
         <div class="empty-msg">
-          <template v-if="verifiedFilter">
+          <template v-if="filtersActive">
+            {{ $tr('Try widening the search — clear the keyword, switch the consensus chip back to All, or reset every filter at once.', '尝试放宽搜索 — 清空关键词、将共识切回「全部」,或一次性重置所有筛选。') }}
+          </template>
+          <template v-else-if="verifiedFilter">
             {{ $tr("Once an operator marks a public simulation's real-world outcome from the Embed dialog, it shows up here. In the meantime, browse every published run on", '当运营者从嵌入对话框中标记公开模拟的真实结果后,它会出现在这里。在此期间,可在以下位置浏览所有已发布的运行') }}
             <router-link to="/explore" class="inline-link">/explore</router-link>.
           </template>
@@ -125,7 +229,16 @@
             {{ $tr(`Yours could be first. Run a simulation, click the share icon on the result page, toggle "Public" — it'll appear here within 30 seconds.`, '你的可能是第一个。运行一次模拟,在结果页点击分享图标,切换为「公开」 — 它会在 30 秒内出现在这里。') }}
           </template>
         </div>
+        <button
+          v-if="filtersActive"
+          type="button"
+          class="empty-cta empty-cta-button"
+          @click="resetFilters"
+        >
+          {{ $tr('Reset filters →', '重置筛选 →') }}
+        </button>
         <router-link
+          v-else
           :to="verifiedFilter ? '/explore' : '/'"
           class="empty-cta"
         >
@@ -306,7 +419,7 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import {
   getPublicSimulations,
   forkSimulation,
@@ -324,6 +437,7 @@ const props = defineProps({
 })
 
 const router = useRouter()
+const route = useRoute()
 
 const items = ref([])
 const total = ref(0)
@@ -335,6 +449,117 @@ const error = ref('')
 const forkingId = ref('')
 const forkErrors = ref({})
 const verifiedFilter = ref(props.verifiedOnly)
+
+// Filter state — initialised from the URL on mount so a deep link to
+// `/explore?q=aave&consensus=bearish&quality=excellent&sort=rounds` boots
+// directly into the filtered view. Backend normalises the values, so we
+// just forward whatever's in the URL.
+const ALLOWED_CONSENSUS = new Set(['bullish', 'neutral', 'bearish'])
+const ALLOWED_QUALITY = new Set(['excellent', 'good', 'fair', 'poor'])
+const ALLOWED_SORT = new Set(['date', 'rounds', 'agents'])
+
+const _readEnumParam = (val, allowed) => {
+  if (!val) return ''
+  const s = String(val).trim().toLowerCase()
+  return allowed.has(s) ? s : ''
+}
+const _readQueryParam = (val) => {
+  if (val === undefined || val === null) return ''
+  const s = String(val).trim()
+  return s.length > 200 ? s.slice(0, 200) : s
+}
+
+const searchInput = ref(_readQueryParam(route.query.q))
+const queryDebounced = ref(searchInput.value)
+const consensus = ref(_readEnumParam(route.query.consensus, ALLOWED_CONSENSUS))
+const quality = ref(_readEnumParam(route.query.quality, ALLOWED_QUALITY))
+const sortKey = ref(_readEnumParam(route.query.sort, ALLOWED_SORT) || 'date')
+
+const consensusOptions = [
+  { value: '', label: () => tr('All', '全部') },
+  { value: 'bullish', glyph: '▲', glyphClass: 'glyph-bullish', label: () => tr('Bullish', '看涨') },
+  { value: 'neutral', glyph: '●', glyphClass: 'glyph-neutral', label: () => tr('Neutral', '中立') },
+  { value: 'bearish', glyph: '▼', glyphClass: 'glyph-bearish', label: () => tr('Bearish', '看跌') },
+]
+
+const qualityOptions = [
+  { value: '', label: () => tr('All', '全部') },
+  { value: 'excellent', label: () => tr('Excellent', '优秀') },
+  { value: 'good', label: () => tr('Good', '良好') },
+  { value: 'fair', label: () => tr('Fair', '一般') },
+  { value: 'poor', label: () => tr('Poor', '较差') },
+]
+
+const filtersActive = computed(
+  () =>
+    !!queryDebounced.value ||
+    !!consensus.value ||
+    !!quality.value ||
+    sortKey.value !== 'date',
+)
+
+let _searchDebounceTimer = null
+const onSearchInput = () => {
+  // Debounce the network call so each keystroke doesn't paint the
+  // gallery — but keep the input responsive to keep the typed value in
+  // the URL the moment the user stops typing.
+  if (_searchDebounceTimer) clearTimeout(_searchDebounceTimer)
+  _searchDebounceTimer = setTimeout(() => {
+    queryDebounced.value = searchInput.value.trim()
+    syncQueryToRoute()
+    refresh()
+  }, 300)
+}
+
+const clearSearch = () => {
+  searchInput.value = ''
+  if (_searchDebounceTimer) clearTimeout(_searchDebounceTimer)
+  queryDebounced.value = ''
+  syncQueryToRoute()
+  refresh()
+}
+
+const setConsensus = (value) => {
+  if (consensus.value === value) return
+  consensus.value = value
+  syncQueryToRoute()
+  refresh()
+}
+
+const setQuality = (value) => {
+  if (quality.value === value) return
+  quality.value = value
+  syncQueryToRoute()
+  refresh()
+}
+
+const onSortChange = () => {
+  syncQueryToRoute()
+  refresh()
+}
+
+const resetFilters = () => {
+  searchInput.value = ''
+  queryDebounced.value = ''
+  consensus.value = ''
+  quality.value = ''
+  sortKey.value = 'date'
+  if (_searchDebounceTimer) clearTimeout(_searchDebounceTimer)
+  syncQueryToRoute()
+  refresh()
+}
+
+// Mirror the active filter set to the URL so the page is shareable. We
+// use `router.replace` (not `push`) so the back button doesn't pile up
+// every keystroke.
+const syncQueryToRoute = () => {
+  const next = {}
+  if (queryDebounced.value) next.q = queryDebounced.value
+  if (consensus.value) next.consensus = consensus.value
+  if (quality.value) next.quality = quality.value
+  if (sortKey.value && sortKey.value !== 'date') next.sort = sortKey.value
+  router.replace({ name: route.name, query: next }).catch(() => {})
+}
 
 const feedUrl = computed(() =>
   getFeedUrl({ format: 'atom', verified: verifiedFilter.value }),
@@ -465,6 +690,10 @@ const loadPage = async (offset = 0) => {
     limit,
     offset,
     verifiedOnly: verifiedFilter.value,
+    q: queryDebounced.value || undefined,
+    consensus: consensus.value || undefined,
+    quality: quality.value || undefined,
+    sort: sortKey.value || undefined,
   })
   if (!res?.success) {
     throw new Error(res?.error || tr('Request failed', '请求失败'))
@@ -479,13 +708,13 @@ const loadPage = async (offset = 0) => {
 const toggleVerifiedFilter = () => {
   verifiedFilter.value = !verifiedFilter.value
   // Keep the URL in lockstep with the filter so the page is shareable —
-  // /verified for the curated hall, /explore for everything.
-  if (verifiedFilter.value) {
-    if (router.currentRoute.value.path !== '/verified') {
-      router.replace({ name: 'Verified' })
-    }
-  } else if (router.currentRoute.value.path !== '/explore') {
-    router.replace({ name: 'Explore' })
+  // /verified for the curated hall, /explore for everything. Preserve
+  // the active search/filter query string across the route swap so the
+  // user doesn't lose their search when toggling Verified.
+  const targetName = verifiedFilter.value ? 'Verified' : 'Explore'
+  if (router.currentRoute.value.name !== targetName) {
+    const carry = { ...route.query }
+    router.replace({ name: targetName, query: carry }).catch(() => {})
   }
   refresh()
 }
@@ -1222,11 +1451,244 @@ a.pill-verified:hover {
 
 .footer-text { white-space: nowrap; }
 
+/* ── Search + filter bar ── */
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm) var(--space-md);
+  margin-top: var(--space-lg);
+  padding: var(--space-md);
+  background: var(--color-gray);
+  border: var(--border-light);
+}
+
+.search-wrap {
+  flex: 1 1 280px;
+  position: relative;
+  min-width: 240px;
+  display: flex;
+  align-items: center;
+}
+
+.search-icon {
+  position: absolute;
+  left: 12px;
+  font-family: var(--font-mono);
+  font-size: 16px;
+  color: rgba(10, 10, 10, 0.5);
+  pointer-events: none;
+}
+
+.search-input {
+  flex: 1;
+  width: 100%;
+  padding: 10px 36px 10px 36px;
+  background: var(--color-white);
+  border: var(--border-light);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--foreground);
+  letter-spacing: 0.3px;
+  transition: var(--transition-fast);
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--color-orange);
+  background: var(--color-white);
+}
+
+.search-input::-webkit-search-decoration,
+.search-input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+
+.search-clear {
+  position: absolute;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  background: rgba(10, 10, 10, 0.08);
+  border: none;
+  border-radius: 50%;
+  font-size: 14px;
+  line-height: 1;
+  color: rgba(10, 10, 10, 0.6);
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.search-clear:hover {
+  background: var(--color-orange);
+  color: var(--color-white);
+}
+
+.chip-group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.chip-group-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: rgba(10, 10, 10, 0.45);
+  margin-right: 4px;
+  font-weight: 600;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 11px;
+  background: var(--color-white);
+  border: var(--border-light);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: rgba(10, 10, 10, 0.65);
+  cursor: pointer;
+  transition: var(--transition-fast);
+  font-weight: 600;
+}
+
+.chip:hover:not(:disabled) {
+  border-color: var(--color-orange);
+  color: var(--color-orange);
+}
+
+.chip-active {
+  background: var(--color-black);
+  border-color: var(--color-black);
+  color: var(--color-white);
+}
+
+.chip-active:hover:not(:disabled) {
+  background: var(--color-orange);
+  border-color: var(--color-orange);
+  color: var(--color-white);
+}
+
+.chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chip-glyph {
+  font-family: sans-serif;
+  font-size: 10px;
+  line-height: 1;
+}
+
+.glyph-bullish { color: #2a8545; }
+.glyph-bearish { color: #c52d2d; }
+.glyph-neutral { color: rgba(10, 10, 10, 0.55); }
+
+.chip-active .chip-glyph {
+  color: var(--color-white);
+}
+
+.sort-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sort-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: rgba(10, 10, 10, 0.45);
+  font-weight: 600;
+}
+
+.sort-select {
+  padding: 5px 24px 5px 10px;
+  background: var(--color-white);
+  border: var(--border-light);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  color: rgba(10, 10, 10, 0.75);
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'><path d='M2 4l3 3 3-3' fill='none' stroke='rgba(10,10,10,0.5)' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  font-weight: 600;
+}
+
+.sort-select:hover:not(:disabled) {
+  border-color: var(--color-orange);
+}
+
+.sort-select:focus {
+  outline: none;
+  border-color: var(--color-orange);
+}
+
+.sort-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.reset-btn {
+  padding: 5px 12px;
+  background: transparent;
+  border: 1px dashed rgba(10, 10, 10, 0.25);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: rgba(10, 10, 10, 0.6);
+  cursor: pointer;
+  transition: var(--transition-fast);
+  font-weight: 600;
+}
+
+.reset-btn:hover:not(:disabled) {
+  border-color: var(--color-orange);
+  color: var(--color-orange);
+  border-style: solid;
+}
+
+.reset-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.result-count {
+  margin-top: var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.4px;
+  color: rgba(10, 10, 10, 0.6);
+}
+
+.empty-cta-button {
+  border: none;
+  cursor: pointer;
+}
+
 /* ── Responsive ── */
 @media (max-width: 720px) {
   .page-title { font-size: 36px; }
   .page-subtitle { font-size: 15px; }
   .main-content { padding: var(--space-xl) var(--space-md); }
   .gallery-grid { grid-template-columns: 1fr; }
+  .filter-bar { padding: var(--space-sm); gap: var(--space-sm); }
+  .search-wrap { flex: 1 1 100%; min-width: 0; }
+  .chip-group { flex: 1 1 100%; }
+  .sort-wrap { flex: 1 1 auto; }
 }
 </style>


### PR DESCRIPTION
## What

Turns `/explore` from a reverse-chronological scroll into a queryable research corpus. `GET /api/simulation/public` now accepts six new optional query parameters that compose with logical AND:

| Param | Values | Effect |
|---|---|---|
| `q` | free text, ≤200 chars | Case-insensitive substring match against the scenario. |
| `consensus` | `bullish` / `neutral` / `bearish` | Dominant final-round stance using the **same ±0.2 threshold** the share card / replay GIF / transcript / webhook / feed already use. |
| `quality` | `excellent` / `good` / `fair` / `poor` | Compared case-insensitively against the first word of `quality_health`. |
| `outcome` | `correct` / `incorrect` / `partial` | Implies `verified=1`. |
| `sort` | `date` (default — newest first) / `rounds` (highest current_round first) / `agents` (largest population first) | |
| `page` | 1-based int | Alternative to `offset`; `page=1` is offset 0. Wins over `offset` when both are supplied. |

`total` in the response envelope reflects the **filtered** count so the load-more "X remaining" hint and `has_more` flag stay accurate inside the active filter set. Empty / unknown values are no-ops (`?consensus=` returns the unfiltered listing; `?sort=popularity` falls back to `sort=date`).

Frontend: `ExploreView` gains a debounced search bar, two chip groups (Consensus / Quality), a sort dropdown, and a Reset button. **All filter state lives in URL params** (`?q=aave&consensus=bearish&quality=excellent&sort=rounds`) so a filtered view is bookmarkable and shareable — "every excellent-quality bearish call about Aave" is now a URL you can tweet. Toggling Verified ↔ Explore via the header chip preserves the active query string across the route swap so the user doesn't lose their search.

## Why

`/explore` is the public research surface — every published MiroShark simulation, browsable as a card grid. Once the corpus grew past a few dozen entries the reverse-chronological scroll stopped being a tool: an analyst hunting for "every bearish DeFi sim about Aave" or "all excellent-quality verified calls" had no path. The seven prior export surfaces (gallery card, share card, replay GIF, transcript, RSS/Atom feed, trajectory CSV/JSONL, watch page) all serialize a single sim — this PR is the **index across them**, the multiplicative move that makes the existing surfaces discoverable.

From the **repo-actions May 2 idea #2** (Gallery Full-Text Search & Consensus Filter). Picked over #1 Cloud Deploy (needs Dockerfile audit + Railway template URL signing), #3 Cost Estimator (requires picking pricing constants from OpenRouter and Langfuse), #4 Per-Agent Sparklines (new endpoint + new SimulationView tab), #5 Pre-filled Scenario URL (frontend-only but narrower leverage) because #2 was the cleanest small-effort autonomous pick: pure stdlib backend, all filters operate on existing on-disk JSON, follows the just-shipped `_serve_X` / `select_filtered_cards` pattern.

## Changes

- **NEW** `backend/app/services/gallery_filters.py` (~320 LoC, pure stdlib): `dominant_stance()` (delegates to the same ±0.2 threshold every other surface uses); param normalisers (`normalise_limit` clamps to `[1, 100]`, `normalise_offset` floors at zero, `page_to_offset` converts 1-based pages, `normalise_query` trims + caps at 200 chars, enum normalisers for consensus / quality / outcome / sort with case-insensitive lookup); `filter_cards()` composes filters with logical AND; `sort_cards()` with deterministic tie-breakers; end-to-end `select_filtered_cards()` returning `(page_items, total_filtered)` so the response envelope reports the filtered count.
- **MODIFIED** `backend/app/api/simulation.py` `list_public_simulations()`: builds gallery cards for every public sim before filtering (keyword + consensus filters need fields that only exist on the assembled card), then defers to `gallery_filters.select_filtered_cards()`. New response envelope fields: `page`, `q`, `consensus`, `quality`, `outcome`, `sort`. Backward-compatible — every existing client gets the same data with extra fields.
- **NEW** `backend/tests/test_unit_gallery_filters.py` — 33 offline unit tests: param normalisation, ±0.2 threshold parity, dominant-stance computation including ties + corrupt input, each filter alone + combined, sort determinism, and end-to-end pagination.
- **MODIFIED** `backend/openapi.yaml` — `/api/simulation/public` parameters extended with `q`, `consensus`, `quality`, `outcome`, `sort`, `page`; response envelope schema gets the matching fields. Drift-detection test (`test_unit_openapi.py`) passes.
- **MODIFIED** `frontend/src/api/simulation.js` `getPublicSimulations()` — forwards the new optional knobs; backend normalises so the frontend doesn't re-validate.
- **MODIFIED** `frontend/src/views/ExploreView.vue` — search bar with debounced 300 ms input + clear button; Consensus chip group (All / ▲ Bullish / ● Neutral / ▼ Bearish); Quality chip group (All / Excellent / Good / Fair / Poor); sort dropdown (Newest / Most rounds / Most agents); reset button visible only when any filter is active; result-count line beneath the bar; filter-aware empty state ("No simulations match your filters" with a Reset CTA instead of the irrelevant "no public sims yet" copy). Filter state mirrors URL params via `router.replace` so the back button doesn't pile up keystrokes; `route.name` is preserved so the same URL pattern works on `/explore` and `/verified`. Full responsive layout — chips wrap to a second row on viewports ≤720px.
- **MODIFIED** `README.md` + `docs/FEATURES.md` + `docs/API.md` (and the `.zh-CN` mirrors) — "Gallery Search & Filtering" feature row + a complete query parameter reference table.

## Implementation notes

- **Same ±0.2 threshold as every other surface.** A user filtering for "bullish" sees the same set of sims a `?consensus=bullish` request to the trajectory CSV would see.
- **Filtered total, not corpus total.** `total` in the response envelope is the filter-set count (same convention as Stripe's `total_count`), so an analyst paginating through `?consensus=bearish` doesn't see the load-more button promise more results that don't match.
- **Empty / unknown values are no-ops.** `?consensus=` returns the unfiltered listing rather than 400-ing; `?sort=popularity` falls back to `sort=date` rather than failing. Single source of truth on the API side — frontend forwards whatever the user typed without re-validating.
- **Backward-compatible.** `verified=1` still works exactly as before. `limit` / `offset` still work exactly as before. New fields are additive on the response envelope.
- **30 s cache absorbs the eager card build.** The endpoint now assembles every public sim's card before filtering (the keyword filter needs the scenario field, which is only on the assembled card). With the existing `Cache-Control: public, max-age=30`, a busy gallery amortises the work across many filtered requests.
- **URL state, not localStorage.** Filters live in the URL so `/explore?q=aave&consensus=bearish` is shareable as a tweet link or bookmark. Toggling between `/explore` and `/verified` carries the active query string across the route swap.
- **Zero new dependencies.** Pure stdlib backend — at the current corpus size, an in-memory substring + dict-comparison pass is faster than any indexed alternative would be after JSON deserialization.

**Eight surfaces / one ±0.2 threshold / one folder.**

---
*Built autonomously by [Aeon](https://github.com/aaronjmars/miroshark-aeon)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)