### PR TITLE
feat: webhook delivery log + manual retry endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Trace Interview** | See the full reasoning chain behind an agent's reply, not just the reply |
 | **Push Notifications** | Web-push alerts when long-running graph / sim / report jobs finish |
 | **Completion Webhook** | POST a JSON summary the moment a sim finishes — wires Slack, Discord, Zapier, Make, n8n, or any custom endpoint with one URL field |
+| **Webhook Delivery Log** | Per-sim `webhook-log.jsonl` records every dispatch attempt (status code, latency, error). Inspect from the EmbedDialog and re-fire any failed delivery with a "Retry" button — closes the operational blindspot every Zapier / n8n integration eventually hits |
 | **Surface Usage Analytics** | `GET /api/simulation/<id>/surface-stats` — per-share-surface request counters (share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS) with a synthetic `total`. Inbound observability for the distribution loop the webhook log tracks on the outbound side |
 
 Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
@@ -234,6 +235,7 @@ cp .env.example .env
 | **轨迹访谈** | 查看智能体回复背后的完整推理链,而不止是回复本身 |
 | **推送通知** | 长耗时图谱 / 模拟 / 报告任务完成时的浏览器推送提醒 |
 | **完成 Webhook** | 模拟一结束即 POST 一份 JSON 摘要 — 一个 URL 字段即可连通 Slack、Discord、Zapier、Make、n8n 或任意自定义端点 |
+| **Webhook 投递日志** | 每个模拟在 `webhook-log.jsonl` 记录每次投递尝试(HTTP 状态码、延迟、错误)。可在 EmbedDialog 中查看,并通过「重试」按钮重发任何失败的投递 — 弥补每个 Zapier / n8n 集成最终都会遇到的运维盲点 |
 | **分发统计(分享面使用分析)** | `GET /api/simulation/<id>/surface-stats` — 每个分享面的请求计数器(分享卡 / 回放 GIF / 转录 / 轨迹 / 推文串 / 观看页 / Atom / RSS),以及合成的 `total`。Webhook 日志在出站侧跟踪分发回路,本面则负责入站可观测性 |
 
 每项功能详见 **[docs/FEATURES.zh-CN.md](docs/FEATURES.zh-CN.md)**。

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -5446,6 +5446,7 @@ def get_webhook_log(simulation_id: str):
     """
     locale = get_locale(request)
     try:
+        validate_simulation_id(simulation_id)
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
         if not state:
@@ -5493,6 +5494,7 @@ def retry_webhook(simulation_id: str):
     """
     locale = get_locale(request)
     try:
+        validate_simulation_id(simulation_id)
         manager = SimulationManager()
         state = manager.get_simulation(simulation_id)
         if not state:
@@ -5505,7 +5507,23 @@ def retry_webhook(simulation_id: str):
         from ..services.webhook_service import (
             retry_webhook_for_simulation,
             _resolve_webhook_url,
+            claim_retry_slot,
+            RETRY_COOLDOWN_SEC,
         )
+
+        cooldown_remaining = claim_retry_slot(simulation_id)
+        if cooldown_remaining is not None:
+            wait_s = max(1, int(round(cooldown_remaining)))
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    f"Retry rate-limited — wait {wait_s}s before retrying this simulation again "
+                    f"(cooldown: {RETRY_COOLDOWN_SEC:g}s).",
+                    f"重试限速 — 请等待 {wait_s} 秒后再次重试该模拟(冷却时间:{RETRY_COOLDOWN_SEC:g} 秒)。",
+                    locale,
+                ),
+                "retry_after_seconds": wait_s,
+            }), 429
 
         if not _resolve_webhook_url():
             return jsonify({

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -5415,6 +5415,174 @@ def get_surface_stats(simulation_id: str):
         }), 500
 
 
+# ============== Webhook Delivery Log ==============
+#
+# PR #46 shipped the outbound completion webhook. This pair of routes
+# closes the operational gap: every Zapier / Make / n8n / Slack /
+# Discord integration built on top of that webhook needs a way to ask
+# "did it fire? what did the endpoint return? how long did it take?".
+# Without a delivery log the operator finds out about a 5xx from their
+# downstream system only by reading server logs manually.
+#
+# Both routes are admin-token gated — these endpoints leak nothing
+# secret (the URL is masked, no payload bodies persist), but the retry
+# is a side-effect-producing mutation and the log itself can include
+# error strings from the downstream service that an operator wouldn't
+# want a public probe to fingerprint.
+
+
+@simulation_bp.route('/<simulation_id>/webhook-log', methods=['GET'])
+@require_admin_token
+def get_webhook_log(simulation_id: str):
+    """Return the recent webhook delivery attempts for a simulation.
+
+    Reads ``<sim_dir>/webhook-log.jsonl`` — one line per attempt,
+    bounded to the last ``WEBHOOK_LOG_MAX_LINES`` deliveries by the
+    dispatcher itself. The response slice is the last 10 entries
+    newest-first; ``total_attempts`` is the all-time monotonic counter
+    so the dialog can show "showing last 10 of N".
+
+    Auth: requires ``Authorization: Bearer $MIROSHARK_ADMIN_TOKEN``.
+    """
+    locale = get_locale(request)
+    try:
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
+
+        from ..services.webhook_service import (
+            read_webhook_log,
+            WEBHOOK_LOG_RETURN_LIMIT,
+        )
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        data = read_webhook_log(sim_dir, limit=WEBHOOK_LOG_RETURN_LIMIT)
+        return jsonify({"success": True, "data": data})
+
+    except Exception as e:
+        logger.error(f"webhook-log: failed for {simulation_id}: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@simulation_bp.route('/<simulation_id>/webhook-retry', methods=['POST'])
+@require_admin_token
+def retry_webhook(simulation_id: str):
+    """Re-fire the completion webhook for an already-finished simulation.
+
+    Useful when the original delivery hit a transient 5xx, the operator
+    pointed the URL at the wrong endpoint, or the consuming integration
+    was down at the time. The resulting attempt appends a fresh entry
+    to the delivery log with ``trigger:"retry"`` so a future log read
+    can tell auto-fired vs operator-fired deliveries apart.
+
+    Body (optional): ``{"status": "completed" | "failed"}`` — defaults
+    to the simulation's current runner status. The retry payload
+    carries an extra top-level ``retry: true`` so downstream consumers
+    can dedupe / handle replays differently if they care.
+
+    Returns 400 when no webhook URL is configured (configure one in
+    Settings or via the ``WEBHOOK_URL`` env var first), 409 when the
+    simulation has not reached a terminal state.
+
+    Auth: requires ``Authorization: Bearer $MIROSHARK_ADMIN_TOKEN``.
+    """
+    locale = get_locale(request)
+    try:
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({"success": False, "error": _t(
+                f"Simulation not found: {simulation_id}",
+                f"未找到模拟:{simulation_id}",
+                locale,
+            )}), 404
+
+        from ..services.webhook_service import (
+            retry_webhook_for_simulation,
+            _resolve_webhook_url,
+        )
+
+        if not _resolve_webhook_url():
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "No webhook URL configured. Set WEBHOOK_URL in Settings "
+                    "or via the env var, then retry.",
+                    "未配置 webhook URL,请在设置或环境变量中设置 WEBHOOK_URL,然后重试。",
+                    locale,
+                ),
+            }), 400
+
+        run_state = SimulationRunner.get_run_state(simulation_id)
+        runner_status_str = ""
+        if run_state and hasattr(run_state, "runner_status"):
+            rs = run_state.runner_status
+            runner_status_str = (rs.value if hasattr(rs, "value") else str(rs)).lower()
+
+        body = request.get_json(silent=True) or {}
+        requested_status = (body.get("status") or "").strip().lower()
+        if requested_status:
+            if requested_status not in ("completed", "failed"):
+                return jsonify({
+                    "success": False,
+                    "error": _t(
+                        "status must be 'completed' or 'failed'",
+                        "status 必须为 'completed' 或 'failed'",
+                        locale,
+                    ),
+                }), 400
+            status = requested_status
+        else:
+            sim_status = (state.status.value if hasattr(state.status, "value") else str(state.status)).lower()
+            if runner_status_str in ("completed", "failed"):
+                status = runner_status_str
+            elif sim_status in ("completed", "failed"):
+                status = sim_status
+            else:
+                return jsonify({
+                    "success": False,
+                    "error": _t(
+                        "Simulation has not reached a terminal state yet "
+                        "(current: " + (runner_status_str or sim_status or "unknown") + "). "
+                        "Wait for completion or pass status explicitly.",
+                        "模拟尚未达到终止状态(当前:" + (runner_status_str or sim_status or "unknown") + "),请等待完成或显式传入 status。",
+                        locale,
+                    ),
+                }), 409
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        completed_at = getattr(run_state, "completed_at", None) if run_state else None
+        result = retry_webhook_for_simulation(
+            simulation_id,
+            status,
+            sim_dir=sim_dir,
+            state=run_state,
+            completed_at=completed_at,
+            base_url=_resolve_share_base_url(),
+        )
+
+        if not result.get("queued"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Could not queue retry: " + str(result.get("error", "unknown")),
+                    "无法排队重试:" + str(result.get("error", "unknown")),
+                    locale,
+                ),
+            }), 400
+
+        return jsonify({"success": True, "data": result})
+
+    except Exception as e:
+        logger.error(f"webhook-retry: failed for {simulation_id}: {e}\n{traceback.format_exc()}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
 # ============== Public Gallery ==============
 
 

--- a/backend/app/services/webhook_service.py
+++ b/backend/app/services/webhook_service.py
@@ -91,6 +91,50 @@ _FIRED: set[Tuple[str, str]] = set()
 _FIRED_LOCK = threading.Lock()
 _FIRED_MAX = 4096
 
+# Serializes the read-modify-rename in `_append_log_entry`. Without it,
+# two concurrent dispatches (auto-fire racing a manual retry, or two
+# retries clicked back-to-back) both read `existing` and both
+# `os.replace`, silently dropping the loser's entry — exactly the
+# visibility failure this log is meant to surface.
+_LOG_WRITE_LOCK = threading.Lock()
+
+# Per-(sim_id) retry cooldown for the manual retry endpoint. Caps any
+# single sim to one queued retry per ``RETRY_COOLDOWN_SEC`` window so a
+# leaked admin token can't be weaponized as a low-volume amplifier
+# against the configured Slack/Discord/n8n endpoint.
+RETRY_COOLDOWN_SEC = 5.0
+_LAST_RETRY_AT: Dict[str, float] = {}
+_RETRY_LOCK = threading.Lock()
+
+
+def claim_retry_slot(simulation_id: str, now: Optional[float] = None) -> Optional[float]:
+    """Reserve a retry slot for ``simulation_id``.
+
+    Returns ``None`` if the call is allowed (caller may proceed); returns
+    the number of seconds remaining in the cooldown window if rate-limited.
+    """
+    import time
+    ts = now if now is not None else time.monotonic()
+    with _RETRY_LOCK:
+        last = _LAST_RETRY_AT.get(simulation_id, 0.0)
+        elapsed = ts - last
+        if elapsed < RETRY_COOLDOWN_SEC:
+            return RETRY_COOLDOWN_SEC - elapsed
+        _LAST_RETRY_AT[simulation_id] = ts
+        # Bound dict growth — drop one arbitrary expired entry per claim.
+        if len(_LAST_RETRY_AT) > 4096:
+            for sid, last_ts in list(_LAST_RETRY_AT.items()):
+                if ts - last_ts >= RETRY_COOLDOWN_SEC:
+                    _LAST_RETRY_AT.pop(sid, None)
+                    break
+        return None
+
+
+def reset_retry_cooldown_for_tests() -> None:
+    """Clear the per-sim retry cooldown table. Test-only convenience."""
+    with _RETRY_LOCK:
+        _LAST_RETRY_AT.clear()
+
 
 def _mark_fired(sim_id: str, status: str) -> bool:
     """Record (sim_id, status) and return True if this is the first time."""
@@ -207,27 +251,30 @@ def _append_log_entry(sim_dir: str, entry: Dict[str, Any]) -> None:
         logger.warning(f"webhook-log: refusing unserializable entry for {sim_dir}: {exc}")
         return
 
-    try:
-        existing = _read_log_lines(sim_dir)
-        if len(existing) >= WEBHOOK_LOG_MAX_LINES:
-            keep = existing[-(WEBHOOK_LOG_MAX_LINES - 1):]
-            tmp_path = path + ".tmp"
-            try:
-                with open(tmp_path, 'w', encoding='utf-8') as f:
-                    f.writelines(keep)
+    # Lock the read-modify-rename window so concurrent dispatches don't
+    # both read the same `existing` and clobber each other's entries.
+    with _LOG_WRITE_LOCK:
+        try:
+            existing = _read_log_lines(sim_dir)
+            if len(existing) >= WEBHOOK_LOG_MAX_LINES:
+                keep = existing[-(WEBHOOK_LOG_MAX_LINES - 1):]
+                tmp_path = path + ".tmp"
+                try:
+                    with open(tmp_path, 'w', encoding='utf-8') as f:
+                        f.writelines(keep)
+                        f.write(serialized)
+                    os.replace(tmp_path, path)
+                finally:
+                    if os.path.exists(tmp_path):
+                        try:
+                            os.remove(tmp_path)
+                        except OSError:
+                            pass
+            else:
+                with open(path, 'a', encoding='utf-8') as f:
                     f.write(serialized)
-                os.replace(tmp_path, path)
-            finally:
-                if os.path.exists(tmp_path):
-                    try:
-                        os.remove(tmp_path)
-                    except OSError:
-                        pass
-        else:
-            with open(path, 'a', encoding='utf-8') as f:
-                f.write(serialized)
-    except OSError as exc:
-        logger.warning(f"webhook-log: write failed for {sim_dir}: {exc}")
+        except OSError as exc:
+            logger.warning(f"webhook-log: write failed for {sim_dir}: {exc}")
 
 
 def _parse_status_code_from_message(msg: Optional[str]) -> Optional[int]:

--- a/backend/app/services/webhook_service.py
+++ b/backend/app/services/webhook_service.py
@@ -53,10 +53,11 @@ from __future__ import annotations
 import json
 import os
 import threading
+import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..utils.logger import get_logger
 
@@ -66,6 +67,20 @@ logger = get_logger('miroshark.webhook')
 WEBHOOK_USER_AGENT = "MiroShark-Webhook/1.0"
 WEBHOOK_TIMEOUT_SECONDS = 5.0
 WEBHOOK_MAX_SCENARIO_CHARS = 280
+
+# ---- Delivery log (per-simulation) -------------------------------------
+#
+# Every dispatch attempt — auto-fired from the runner OR manually
+# replayed from the ``/webhook-retry`` endpoint — appends one JSON line
+# to ``<sim_dir>/webhook-log.jsonl``. The log gives operators a feedback
+# loop they didn't have before PR #46 shipped: "did the webhook fire?",
+# "what status did the endpoint return?", "how long did it take?",
+# "should I retry?". A 50-line cap with read-modify-write trim keeps
+# disk usage bounded — operators can always retry past failures from a
+# clean state.
+WEBHOOK_LOG_FILENAME = "webhook-log.jsonl"
+WEBHOOK_LOG_MAX_LINES = 50
+WEBHOOK_LOG_RETURN_LIMIT = 10
 
 
 # Per-process dedup. The runner's exit-code path and the ``simulation_end``
@@ -115,6 +130,183 @@ def mask_url(url: str) -> str:
         return f"{parts.scheme}://{parts.netloc}/***"
     except Exception:
         return '***'
+
+
+def webhook_log_path(sim_dir: str) -> str:
+    """Absolute path to the per-sim webhook delivery log."""
+    return os.path.join(sim_dir, WEBHOOK_LOG_FILENAME)
+
+
+def _read_log_lines(sim_dir: str) -> List[str]:
+    """Return the raw, non-empty lines of the log (preserving order).
+
+    Never raises — a missing or unreadable log is treated as empty so
+    the dispatch path stays fire-and-forget.
+    """
+    path = webhook_log_path(sim_dir)
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return [line for line in f.readlines() if line.strip()]
+    except OSError:
+        return []
+
+
+def _parse_log_entries(lines: List[str]) -> List[Dict[str, Any]]:
+    """Parse JSONL lines, silently skipping anything malformed."""
+    entries: List[Dict[str, Any]] = []
+    for line in lines:
+        text = line.strip()
+        if not text:
+            continue
+        try:
+            obj = json.loads(text)
+        except Exception:
+            continue
+        if isinstance(obj, dict):
+            entries.append(obj)
+    return entries
+
+
+def _next_attempt_number(sim_dir: str) -> int:
+    """1-based attempt counter — picks ``max(attempt) + 1`` from disk.
+
+    Returns 1 when the log is missing or empty. Used so the GET endpoint
+    can show ``attempt #N`` on each delivery without callers needing to
+    pre-compute it.
+    """
+    entries = _parse_log_entries(_read_log_lines(sim_dir))
+    last = 0
+    for rec in entries:
+        attempt = rec.get('attempt')
+        if isinstance(attempt, int) and attempt > last:
+            last = attempt
+    return last + 1
+
+
+def _append_log_entry(sim_dir: str, entry: Dict[str, Any]) -> None:
+    """Append ``entry`` as a JSON line; trim to ``WEBHOOK_LOG_MAX_LINES``.
+
+    Never raises — log writes are best-effort. If the log already has
+    ``WEBHOOK_LOG_MAX_LINES`` rows, the oldest get dropped via a
+    read-modify-rename so the new entry always lands.
+    """
+    if not sim_dir:
+        return
+    try:
+        os.makedirs(sim_dir, exist_ok=True)
+    except OSError as exc:
+        logger.warning(f"webhook-log: could not ensure sim_dir for {sim_dir}: {exc}")
+        return
+
+    path = webhook_log_path(sim_dir)
+    try:
+        serialized = json.dumps(entry, ensure_ascii=False) + "\n"
+    except Exception as exc:
+        logger.warning(f"webhook-log: refusing unserializable entry for {sim_dir}: {exc}")
+        return
+
+    try:
+        existing = _read_log_lines(sim_dir)
+        if len(existing) >= WEBHOOK_LOG_MAX_LINES:
+            keep = existing[-(WEBHOOK_LOG_MAX_LINES - 1):]
+            tmp_path = path + ".tmp"
+            try:
+                with open(tmp_path, 'w', encoding='utf-8') as f:
+                    f.writelines(keep)
+                    f.write(serialized)
+                os.replace(tmp_path, path)
+            finally:
+                if os.path.exists(tmp_path):
+                    try:
+                        os.remove(tmp_path)
+                    except OSError:
+                        pass
+        else:
+            with open(path, 'a', encoding='utf-8') as f:
+                f.write(serialized)
+    except OSError as exc:
+        logger.warning(f"webhook-log: write failed for {sim_dir}: {exc}")
+
+
+def _parse_status_code_from_message(msg: Optional[str]) -> Optional[int]:
+    """Extract the integer HTTP status from an ``HTTP <N>`` message.
+
+    Returns ``None`` for network errors / serialization failures /
+    anything that isn't a numeric HTTP response — those cases land in
+    the log with ``status_code: null`` so consumers can distinguish
+    them from a real 5xx.
+    """
+    if not isinstance(msg, str):
+        return None
+    if msg.startswith("HTTP "):
+        try:
+            return int(msg.split(" ", 1)[1].strip())
+        except (ValueError, IndexError):
+            return None
+    return None
+
+
+def read_webhook_log(
+    sim_dir: str,
+    *,
+    limit: int = WEBHOOK_LOG_RETURN_LIMIT,
+) -> Dict[str, Any]:
+    """Public read API for ``GET /webhook-log``.
+
+    Returns the most recent ``limit`` entries newest-first plus the
+    total attempt count. ``max_retained`` is exposed so the EmbedDialog
+    can show "showing last N of M (max retained K)".
+    """
+    entries = _parse_log_entries(_read_log_lines(sim_dir))
+    total_attempts = 0
+    for rec in entries:
+        attempt = rec.get('attempt')
+        if isinstance(attempt, int) and attempt > total_attempts:
+            total_attempts = attempt
+    sliced = entries[-max(limit, 0):] if limit > 0 else entries
+    sliced.reverse()  # newest first
+    return {
+        "entries": sliced,
+        "total_attempts": total_attempts,
+        "max_retained": WEBHOOK_LOG_MAX_LINES,
+    }
+
+
+def _record_delivery(
+    *,
+    sim_dir: Optional[str],
+    url: str,
+    payload: Dict[str, Any],
+    ok: bool,
+    message: str,
+    latency_ms: int,
+    trigger: str,
+) -> None:
+    """Persist a single delivery attempt to ``webhook-log.jsonl``.
+
+    ``trigger`` is ``"auto"`` for the runner-fired path and ``"retry"``
+    for the manual replay endpoint — useful when an operator scans the
+    log to tell automatic vs manual deliveries apart.
+    """
+    if not sim_dir:
+        return
+    status_code = _parse_status_code_from_message(message)
+    error = None if ok else message
+    entry: Dict[str, Any] = {
+        "attempt": _next_attempt_number(sim_dir),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "url_masked": mask_url(url),
+        "event": payload.get("event"),
+        "status": payload.get("status"),
+        "status_code": status_code,
+        "ok": bool(ok),
+        "latency_ms": int(latency_ms) if latency_ms is not None else None,
+        "error": error,
+        "trigger": trigger,
+    }
+    _append_log_entry(sim_dir, entry)
 
 
 def validate_url(url: str) -> Optional[str]:
@@ -395,18 +587,140 @@ def fire_webhook_for_simulation(
         error=error,
     )
 
+    _start_dispatch_thread(
+        url=url,
+        payload=payload,
+        sim_dir=sim_dir,
+        trigger="auto",
+        thread_name=f'webhook-{simulation_id}',
+    )
+
+
+def _start_dispatch_thread(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    sim_dir: Optional[str],
+    trigger: str,
+    thread_name: str,
+) -> None:
+    """Launch the daemon thread that POSTs ``payload`` and records a log
+    entry on the way out.
+
+    Shared between the automatic ``fire_webhook_for_simulation`` path
+    and the manual ``retry_webhook_for_simulation`` path so the timing,
+    masking, and log shape stay identical.
+    """
+    sim_id = payload.get("sim_id", "")
+    status = payload.get("status", "")
+
     def _send() -> None:
+        started = time.monotonic()
         ok, msg = _post_json(url, payload, WEBHOOK_TIMEOUT_SECONDS)
+        latency_ms = int((time.monotonic() - started) * 1000)
+
+        masked = mask_url(url)
         if ok:
-            logger.info(f"Webhook fired for {simulation_id} ({status}) → {mask_url(url)} [{msg}]")
+            logger.info(
+                f"Webhook fired for {sim_id} ({status}) → {masked} "
+                f"[{msg} · {latency_ms}ms · {trigger}]"
+            )
         else:
-            logger.warning(f"Webhook delivery failed for {simulation_id} ({status}) → {mask_url(url)}: {msg}")
+            logger.warning(
+                f"Webhook delivery failed for {sim_id} ({status}) → {masked}: "
+                f"{msg} ({latency_ms}ms · {trigger})"
+            )
+
+        try:
+            _record_delivery(
+                sim_dir=sim_dir,
+                url=url,
+                payload=payload,
+                ok=ok,
+                message=msg,
+                latency_ms=latency_ms,
+                trigger=trigger,
+            )
+        except Exception as exc:
+            # Never let a logging failure take the dispatch thread down.
+            logger.warning(f"webhook-log: record_delivery failed for {sim_id}: {exc}")
 
     threading.Thread(
         target=_send,
         daemon=True,
-        name=f'webhook-{simulation_id}',
+        name=thread_name,
     ).start()
+
+
+def retry_webhook_for_simulation(
+    simulation_id: str,
+    status: str,
+    *,
+    sim_dir: Optional[str] = None,
+    state: Optional[Any] = None,
+    completed_at: Optional[str] = None,
+    error: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Manually re-dispatch the completion webhook for a finished sim.
+
+    Mirrors :func:`fire_webhook_for_simulation` but **bypasses the
+    per-process ``(sim_id, status)`` dedup set** — operators retry
+    precisely when the original auto-fire failed (or hit the wrong
+    endpoint), so blocking the second attempt would defeat the
+    purpose. Dedup exists only to prevent the runner's two terminal
+    code paths from double-firing automatically.
+
+    Returns ``{queued, attempt_will_be, sim_id, status, url_masked,
+    error?}``. Returns ``{queued: False}`` when no webhook URL is
+    configured — the caller should surface a clear "configure your
+    webhook URL first" error.
+    """
+    if status not in {"completed", "failed"}:
+        return {"queued": False, "error": f"unsupported status: {status}"}
+
+    url = _resolve_webhook_url()
+    if not url:
+        return {"queued": False, "error": "no webhook URL configured"}
+
+    if sim_dir is None:
+        try:
+            from ..config import Config
+            sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        except Exception:
+            sim_dir = simulation_id
+
+    if base_url is None:
+        base_url = _resolve_base_url()
+
+    payload = build_payload(
+        simulation_id,
+        status,
+        sim_dir,
+        state=state,
+        base_url=base_url,
+        completed_at=completed_at,
+        error=error,
+    )
+    payload["retry"] = True
+
+    attempt_will_be = _next_attempt_number(sim_dir)
+
+    _start_dispatch_thread(
+        url=url,
+        payload=payload,
+        sim_dir=sim_dir,
+        trigger="retry",
+        thread_name=f'webhook-retry-{simulation_id}',
+    )
+
+    return {
+        "queued": True,
+        "attempt_will_be": attempt_will_be,
+        "sim_id": simulation_id,
+        "status": status,
+        "url_masked": mask_url(url),
+    }
 
 
 def send_test_webhook(url: str, base_url: Optional[str] = None) -> Dict[str, Any]:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1796,6 +1796,117 @@ paths:
         "404": { $ref: "#/components/responses/NotFound" }
         "503": { $ref: "#/components/responses/AdminAuthNotConfigured" }
 
+  /api/simulation/{simulation_id}/webhook-log:
+    get:
+      tags: [Publish & Embed]
+      summary: Recent webhook delivery attempts for a simulation.
+      description: |
+        Returns the last 10 entries from `<sim_dir>/webhook-log.jsonl`
+        newest-first plus the all-time `total_attempts` counter.
+
+        Each line is one attempt by the outbound completion webhook
+        (PR #46) — auto-fired at simulation end, or manually replayed
+        via `POST /webhook-retry`. Operators use this surface to
+        verify the webhook fired, see HTTP status / latency, and decide
+        whether to retry. The dispatcher truncates the on-disk log to
+        the last 50 attempts; `total_attempts` keeps climbing past
+        that bound.
+
+        URLs are masked (`scheme://host/***`) before persisting so the
+        Slack / Discord secret in the path never round-trips through
+        the read endpoint.
+      security:
+        - AdminToken: []
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Delivery log slice.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data: { $ref: "#/components/schemas/WebhookDeliveryLog" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "503": { $ref: "#/components/responses/AdminAuthNotConfigured" }
+
+  /api/simulation/{simulation_id}/webhook-retry:
+    post:
+      tags: [Publish & Embed]
+      summary: Re-fire the completion webhook for a finished simulation.
+      description: |
+        Manually replays the outbound completion webhook for a sim
+        already in a terminal state. Useful when the original delivery
+        hit a transient 5xx, the URL was misconfigured at the time, or
+        the consuming integration was down.
+
+        The retry payload carries an extra top-level `retry: true` so
+        downstream consumers can dedupe / handle replays differently.
+        The replay appends a new entry to `webhook-log.jsonl` with
+        `trigger: "retry"` so a subsequent log read can tell automatic
+        and operator-fired deliveries apart.
+
+        Bypasses the per-process `(sim_id, status)` dedup gate the
+        auto-fire path uses — that gate exists only to prevent the
+        runner's two terminal code paths from double-firing
+        automatically; an explicit retry should always go through.
+
+        Returns 400 when no webhook URL is configured (set
+        `WEBHOOK_URL` in Settings or as an env var first), 409 when
+        the simulation has not reached a terminal state.
+      security:
+        - AdminToken: []
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum: [completed, failed]
+                  description: |
+                    Optional. Defaults to the simulation's current
+                    runner status when omitted; pass explicitly to
+                    replay either side of a recent state transition.
+            example:
+              status: completed
+      responses:
+        "200":
+          description: Retry queued — the delivery happens in a daemon thread.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [queued, sim_id, status]
+                        properties:
+                          queued: { type: boolean, enum: [true] }
+                          attempt_will_be:
+                            type: integer
+                            description: Optimistic next attempt number — the actual log entry is written after the POST returns.
+                          sim_id: { type: string }
+                          status: { type: string, enum: [completed, failed] }
+                          url_masked: { type: string }
+        "400":
+          description: No webhook URL configured (or unsupported status passed).
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409":
+          description: Simulation has not reached a terminal state yet.
+        "503": { $ref: "#/components/responses/AdminAuthNotConfigured" }
+
   # ────────────────────────────────────────────────────────────────────
   # Report Agent
   # ────────────────────────────────────────────────────────────────────
@@ -2624,6 +2735,78 @@ components:
         submitted_at:
           type: string
           format: date-time
+
+    WebhookDeliveryEntry:
+      type: object
+      description: |
+        One row of the per-simulation webhook delivery log. Written by
+        the dispatcher after each POST attempt completes — successful
+        or otherwise. Failure rows carry the upstream message in
+        `error`; success rows have `error: null`.
+      required: [attempt, timestamp, ok, url_masked, trigger]
+      properties:
+        attempt:
+          type: integer
+          description: Monotonically increasing 1-based counter; survives log truncation.
+        timestamp:
+          type: string
+          format: date-time
+          description: UTC ISO-8601 timestamp of when the dispatch completed.
+        url_masked:
+          type: string
+          description: |
+            `scheme://host/***` mask of the configured webhook URL —
+            the path of a Slack / Discord webhook URL is the secret
+            and is never echoed to disk or to the API consumer.
+        event:
+          type: string
+          description: The `event` field from the dispatched payload (e.g. `simulation.completed`).
+        status:
+          type: string
+          enum: [completed, failed]
+          description: Terminal status the simulation reached when this delivery fired.
+        status_code:
+          oneOf:
+            - { type: integer }
+            - { type: "null" }
+          description: HTTP status returned by the downstream endpoint, or `null` for network errors / timeouts.
+        ok:
+          type: boolean
+          description: True for a 2xx response; false for any other outcome.
+        latency_ms:
+          type: integer
+          description: Wall-clock time of the HTTP call, in milliseconds.
+        error:
+          oneOf:
+            - { type: string }
+            - { type: "null" }
+          description: Human-readable upstream error string on failure; `null` on success.
+        trigger:
+          type: string
+          enum: [auto, retry]
+          description: |
+            `auto` for the runner-fired path (simulation completion),
+            `retry` for an operator-driven replay via `/webhook-retry`.
+
+    WebhookDeliveryLog:
+      type: object
+      description: |
+        Recent webhook delivery attempts for one simulation. Returned
+        from `GET /webhook-log` — newest-first slice plus the all-time
+        attempt counter and the on-disk retention bound.
+      required: [entries, total_attempts, max_retained]
+      properties:
+        entries:
+          type: array
+          description: Last `WEBHOOK_LOG_RETURN_LIMIT` entries, newest first.
+          items:
+            $ref: "#/components/schemas/WebhookDeliveryEntry"
+        total_attempts:
+          type: integer
+          description: All-time attempt counter — keeps climbing past the on-disk truncation bound.
+        max_retained:
+          type: integer
+          description: Maximum number of entries the dispatcher persists on disk before rolling oldest off.
 
     SimulationTrajectoryRow:
       type: object

--- a/backend/tests/test_unit_webhook_log.py
+++ b/backend/tests/test_unit_webhook_log.py
@@ -378,3 +378,66 @@ def test_retry_rejects_unknown_status(tmp_path: Path):
         )
     assert result["queued"] is False
     assert "unsupported status" in (result.get("error") or "")
+
+
+def test_concurrent_appends_do_not_drop_entries(tmp_path: Path):
+    """Two threads writing concurrently must both land in the log.
+
+    Without the module-level write lock, both threads could read the
+    same `existing` lines, both rename their tmp file over the target,
+    and one entry would be silently lost — exactly the visibility gap
+    this log is supposed to close.
+    """
+    from app.services import webhook_service
+
+    N = 32
+    barrier = threading.Barrier(N)
+    errors: list[BaseException] = []
+
+    def write(i: int) -> None:
+        try:
+            barrier.wait(timeout=2.0)
+            webhook_service._append_log_entry(
+                str(tmp_path),
+                {"attempt": i, "trigger": "test", "status": "completed"},
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=write, args=(i,)) for i in range(N)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5.0)
+
+    assert not errors, f"thread errors: {errors!r}"
+    log = tmp_path / "webhook-log.jsonl"
+    assert log.exists()
+    lines = [ln for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    # All N writes must be persisted (or capped at WEBHOOK_LOG_MAX_LINES).
+    expected = min(N, webhook_service.WEBHOOK_LOG_MAX_LINES)
+    assert len(lines) == expected
+    parsed = [json.loads(ln) for ln in lines]
+    attempts = {e["attempt"] for e in parsed}
+    assert len(attempts) == expected, f"duplicates / drops: {attempts}"
+
+
+def test_retry_cooldown_rate_limits_per_simulation(tmp_path: Path):
+    """`claim_retry_slot` rejects a second call inside the cooldown window
+    for the same sim_id, but allows other sims through."""
+    from app.services import webhook_service
+
+    webhook_service.reset_retry_cooldown_for_tests()
+
+    # First claim succeeds.
+    assert webhook_service.claim_retry_slot("sim_a", now=100.0) is None
+    # Same sim, half a second later → blocked, returns remaining seconds.
+    remaining = webhook_service.claim_retry_slot("sim_a", now=100.5)
+    assert remaining is not None
+    assert 0.0 < remaining <= webhook_service.RETRY_COOLDOWN_SEC
+    # Different sim is unaffected.
+    assert webhook_service.claim_retry_slot("sim_b", now=100.5) is None
+    # After cooldown elapses, the original sim is allowed again.
+    assert webhook_service.claim_retry_slot(
+        "sim_a", now=100.0 + webhook_service.RETRY_COOLDOWN_SEC + 0.01
+    ) is None

--- a/backend/tests/test_unit_webhook_log.py
+++ b/backend/tests/test_unit_webhook_log.py
@@ -1,0 +1,380 @@
+"""Unit tests for the per-simulation webhook delivery log.
+
+Covers the operational visibility layer that PR #46 (the outbound
+completion webhook) shipped without: every dispatch attempt should
+land in ``<sim_dir>/webhook-log.jsonl`` so an operator can verify
+deliveries, see latency / status codes, and replay failures.
+
+Pure offline tests — no Flask app, no real HTTP, no Neo4j. We patch
+``_post_json`` so the dispatch path runs end-to-end (including the
+log write inside the daemon thread) without network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _wait_for_log_lines(sim_dir: Path, expected: int, timeout: float = 3.0) -> int:
+    """Poll for the log to reach ``expected`` lines (the daemon thread
+    writes on its own schedule). Returns the actual line count."""
+    deadline = time.monotonic() + timeout
+    log = sim_dir / "webhook-log.jsonl"
+    last = 0
+    while time.monotonic() < deadline:
+        if log.exists():
+            try:
+                last = sum(1 for line in log.read_text().splitlines() if line.strip())
+            except OSError:
+                last = 0
+            if last >= expected:
+                return last
+        time.sleep(0.02)
+    return last
+
+
+def _read_log(sim_dir: Path) -> list[dict]:
+    log = sim_dir / "webhook-log.jsonl"
+    if not log.exists():
+        return []
+    out = []
+    for line in log.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        out.append(json.loads(line))
+    return out
+
+
+# ── Direct helper tests ──────────────────────────────────────────────────
+
+
+def test_log_path_uses_filename_constant(tmp_path: Path):
+    from app.services.webhook_service import (
+        webhook_log_path,
+        WEBHOOK_LOG_FILENAME,
+    )
+    assert webhook_log_path(str(tmp_path)) == str(tmp_path / WEBHOOK_LOG_FILENAME)
+
+
+def test_read_webhook_log_empty_when_no_file(tmp_path: Path):
+    from app.services.webhook_service import (
+        read_webhook_log,
+        WEBHOOK_LOG_MAX_LINES,
+    )
+    result = read_webhook_log(str(tmp_path))
+    assert result == {
+        "entries": [],
+        "total_attempts": 0,
+        "max_retained": WEBHOOK_LOG_MAX_LINES,
+    }
+
+
+def test_append_and_read_round_trip(tmp_path: Path):
+    """A series of appends should produce monotonic ``attempt`` numbers
+    and the GET-style read returns them newest-first."""
+    from app.services import webhook_service
+
+    payload = {"event": "simulation.completed", "sim_id": "sim_a", "status": "completed"}
+    for i in range(3):
+        webhook_service._record_delivery(
+            sim_dir=str(tmp_path),
+            url="https://hooks.slack.com/services/T0/B0/abc",
+            payload=payload,
+            ok=(i % 2 == 0),
+            message=("HTTP 200" if i % 2 == 0 else "HTTP 503"),
+            latency_ms=120 + i,
+            trigger="auto",
+        )
+
+    result = webhook_service.read_webhook_log(str(tmp_path))
+    assert result["total_attempts"] == 3
+    assert len(result["entries"]) == 3
+    # newest-first
+    assert [e["attempt"] for e in result["entries"]] == [3, 2, 1]
+    # masking persists to disk
+    assert all(e["url_masked"] == "https://hooks.slack.com/***" for e in result["entries"])
+    assert "abc" not in (tmp_path / "webhook-log.jsonl").read_text()
+
+
+def test_status_code_parsed_from_http_messages(tmp_path: Path):
+    """``HTTP 503`` → ``status_code == 503``; network errors → null."""
+    from app.services import webhook_service
+
+    payload = {"event": "simulation.completed", "sim_id": "sim_x", "status": "completed"}
+    webhook_service._record_delivery(
+        sim_dir=str(tmp_path), url="https://example.com/hook",
+        payload=payload, ok=True, message="HTTP 200", latency_ms=10, trigger="auto",
+    )
+    webhook_service._record_delivery(
+        sim_dir=str(tmp_path), url="https://example.com/hook",
+        payload=payload, ok=False, message="HTTP 503", latency_ms=20, trigger="auto",
+    )
+    webhook_service._record_delivery(
+        sim_dir=str(tmp_path), url="https://example.com/hook",
+        payload=payload, ok=False, message="URL error: timeout", latency_ms=5000, trigger="auto",
+    )
+
+    entries = _read_log(tmp_path)
+    codes = {e["attempt"]: e["status_code"] for e in entries}
+    assert codes[1] == 200
+    assert codes[2] == 503
+    assert codes[3] is None
+    # Failure rows carry the upstream message; success rows have ``error: None``.
+    err_by_attempt = {e["attempt"]: e["error"] for e in entries}
+    assert err_by_attempt[1] is None
+    assert err_by_attempt[2] == "HTTP 503"
+    assert err_by_attempt[3] == "URL error: timeout"
+
+
+def test_log_truncates_to_max_lines(tmp_path: Path):
+    """Once the log hits ``WEBHOOK_LOG_MAX_LINES``, the oldest entry
+    rolls off so the new attempt always lands."""
+    from app.services import webhook_service
+    from app.services.webhook_service import WEBHOOK_LOG_MAX_LINES
+
+    payload = {"event": "simulation.completed", "sim_id": "sim_trunc", "status": "completed"}
+    overshoot = WEBHOOK_LOG_MAX_LINES + 5
+    for _ in range(overshoot):
+        webhook_service._record_delivery(
+            sim_dir=str(tmp_path), url="https://example.com/hook",
+            payload=payload, ok=True, message="HTTP 204", latency_ms=15, trigger="auto",
+        )
+
+    log = tmp_path / "webhook-log.jsonl"
+    line_count = sum(1 for line in log.read_text().splitlines() if line.strip())
+    assert line_count == WEBHOOK_LOG_MAX_LINES
+
+    # The all-time attempt counter keeps climbing even though older
+    # rows have rolled off the disk file.
+    result = webhook_service.read_webhook_log(str(tmp_path))
+    assert result["total_attempts"] == overshoot
+    # The slice is bounded by WEBHOOK_LOG_RETURN_LIMIT (default 10).
+    assert len(result["entries"]) == 10
+    # Newest first — the very first entry in the slice is the final
+    # write (attempt = overshoot).
+    assert result["entries"][0]["attempt"] == overshoot
+
+
+def test_read_webhook_log_caps_slice_to_limit(tmp_path: Path):
+    """The default GET slice is the last 10 entries even when more
+    survived the truncation pass."""
+    from app.services import webhook_service
+
+    payload = {"event": "simulation.completed", "sim_id": "sim_cap", "status": "completed"}
+    for _ in range(15):
+        webhook_service._record_delivery(
+            sim_dir=str(tmp_path), url="https://example.com/hook",
+            payload=payload, ok=True, message="HTTP 200", latency_ms=8, trigger="auto",
+        )
+
+    result = webhook_service.read_webhook_log(str(tmp_path))
+    assert len(result["entries"]) == 10
+    assert result["total_attempts"] == 15
+    # First entry of the slice is the most recent attempt (15th).
+    assert result["entries"][0]["attempt"] == 15
+    # Slice is contiguous: 15, 14, 13, ... 6.
+    assert [e["attempt"] for e in result["entries"]] == list(range(15, 5, -1))
+
+
+def test_append_skips_unwritable_sim_dir(tmp_path: Path):
+    """Empty / falsy ``sim_dir`` must be a silent no-op — never raise."""
+    from app.services import webhook_service
+
+    # Should not raise.
+    webhook_service._record_delivery(
+        sim_dir="", url="https://example.com/hook",
+        payload={"event": "x", "sim_id": "y", "status": "completed"},
+        ok=True, message="HTTP 200", latency_ms=10, trigger="auto",
+    )
+    webhook_service._record_delivery(
+        sim_dir=None, url="https://example.com/hook",
+        payload={"event": "x", "sim_id": "y", "status": "completed"},
+        ok=True, message="HTTP 200", latency_ms=10, trigger="auto",
+    )
+
+
+def test_corrupt_log_lines_are_skipped(tmp_path: Path):
+    """A garbage line in the middle of the log must not blank the read."""
+    from app.services import webhook_service
+
+    log = tmp_path / "webhook-log.jsonl"
+    log.write_text(
+        json.dumps({"attempt": 1, "ok": True, "url_masked": "x"}) + "\n"
+        + "this is not json\n"
+        + json.dumps({"attempt": 2, "ok": False, "url_masked": "y"}) + "\n"
+    )
+    result = webhook_service.read_webhook_log(str(tmp_path))
+    # Two valid, one skipped — total_attempts reflects the highest seen.
+    assert result["total_attempts"] == 2
+    assert len(result["entries"]) == 2
+    assert {e["attempt"] for e in result["entries"]} == {1, 2}
+
+
+# ── End-to-end dispatch + log integration ────────────────────────────────
+
+
+def test_fire_webhook_appends_log_entry(tmp_path: Path):
+    """A successful auto-fire writes a single ``trigger:"auto"`` row."""
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    finished = threading.Event()
+
+    def fake_post(url, payload, timeout):
+        # Tiny sleep so the elapsed time is measurable but bounded.
+        time.sleep(0.01)
+        finished.set()
+        return True, "HTTP 200"
+
+    with patch.object(webhook_service, '_resolve_webhook_url',
+                      return_value='https://hooks.slack.com/services/T0/B0/abc'), \
+         patch.object(webhook_service, '_post_json', side_effect=fake_post):
+        webhook_service.fire_webhook_for_simulation(
+            "sim_log_auto",
+            "completed",
+            sim_dir=str(tmp_path),
+        )
+        assert finished.wait(timeout=2.0)
+        # Wait for the log write that happens after _post_json returns.
+        assert _wait_for_log_lines(tmp_path, expected=1) == 1
+
+    entries = _read_log(tmp_path)
+    assert len(entries) == 1
+    rec = entries[0]
+    assert rec["attempt"] == 1
+    assert rec["ok"] is True
+    assert rec["status_code"] == 200
+    assert rec["error"] is None
+    assert rec["trigger"] == "auto"
+    assert rec["url_masked"] == "https://hooks.slack.com/***"
+    assert rec["event"] == "simulation.completed"
+    assert rec["status"] == "completed"
+    assert isinstance(rec["latency_ms"], int) and rec["latency_ms"] >= 0
+    assert "T" in rec["timestamp"]  # ISO 8601
+
+
+def test_fire_webhook_logs_failure_on_5xx(tmp_path: Path):
+    """A 5xx from the downstream endpoint lands in the log as ok:false
+    with a parsed status code and an upstream-error string."""
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    finished = threading.Event()
+
+    def fake_post(url, payload, timeout):
+        finished.set()
+        return False, "HTTP 503"
+
+    with patch.object(webhook_service, '_resolve_webhook_url',
+                      return_value='https://example.com/hook'), \
+         patch.object(webhook_service, '_post_json', side_effect=fake_post):
+        webhook_service.fire_webhook_for_simulation(
+            "sim_log_5xx",
+            "failed",
+            sim_dir=str(tmp_path),
+            error="exit code 1",
+        )
+        assert finished.wait(timeout=2.0)
+        assert _wait_for_log_lines(tmp_path, expected=1) == 1
+
+    entries = _read_log(tmp_path)
+    rec = entries[0]
+    assert rec["ok"] is False
+    assert rec["status_code"] == 503
+    assert rec["error"] == "HTTP 503"
+    assert rec["status"] == "failed"
+    assert rec["event"] == "simulation.failed"
+
+
+def test_retry_bypasses_dedup_and_uses_retry_trigger(tmp_path: Path):
+    """``retry_webhook_for_simulation`` must ignore the ``(sim_id, status)``
+    dedup gate that ``fire_webhook_for_simulation`` honours, and tag the
+    log entry with ``trigger:"retry"``."""
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    started = threading.Event()
+    counter = {'n': 0}
+    last_payload: dict = {}
+
+    def fake_post(url, payload, timeout):
+        counter['n'] += 1
+        last_payload.clear()
+        last_payload.update(payload)
+        started.set()
+        return True, "HTTP 200"
+
+    with patch.object(webhook_service, '_resolve_webhook_url',
+                      return_value='https://example.com/hook'), \
+         patch.object(webhook_service, '_post_json', side_effect=fake_post):
+        # First, the auto-fire path: takes the (sim_id, "completed") slot.
+        webhook_service.fire_webhook_for_simulation(
+            "sim_replay", "completed", sim_dir=str(tmp_path),
+        )
+        assert _wait_for_log_lines(tmp_path, expected=1) == 1
+
+        # A second auto-fire is deduped — never reaches _post_json.
+        webhook_service.fire_webhook_for_simulation(
+            "sim_replay", "completed", sim_dir=str(tmp_path),
+        )
+        # Operator-driven retry must NOT be deduped.
+        result = webhook_service.retry_webhook_for_simulation(
+            "sim_replay", "completed", sim_dir=str(tmp_path),
+        )
+        assert result["queued"] is True
+        assert result["attempt_will_be"] == 2
+        assert _wait_for_log_lines(tmp_path, expected=2) == 2
+
+    entries = _read_log(tmp_path)
+    triggers = {e["attempt"]: e["trigger"] for e in entries}
+    assert triggers == {1: "auto", 2: "retry"}
+    # Retry payload carries the explicit replay marker.
+    assert last_payload.get("retry") is True
+
+
+def test_retry_returns_error_when_no_url_configured(tmp_path: Path):
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    with patch.object(webhook_service, '_resolve_webhook_url', return_value=''):
+        result = webhook_service.retry_webhook_for_simulation(
+            "sim_no_url", "completed", sim_dir=str(tmp_path),
+        )
+    assert result["queued"] is False
+    assert "no webhook URL" in (result.get("error") or "")
+    # No log file should have been created — nothing was dispatched.
+    assert not (tmp_path / "webhook-log.jsonl").exists()
+
+
+def test_retry_rejects_unknown_status(tmp_path: Path):
+    from app.services import webhook_service
+
+    webhook_service.reset_dedup_for_tests()
+
+    with patch.object(webhook_service, '_resolve_webhook_url',
+                      return_value='https://example.com/hook'):
+        result = webhook_service.retry_webhook_for_simulation(
+            "sim_running", "running", sim_dir=str(tmp_path),
+        )
+    assert result["queued"] is False
+    assert "unsupported status" in (result.get("error") or "")

--- a/docs/API.md
+++ b/docs/API.md
@@ -94,6 +94,8 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `GET` | `/api/simulation/<id>/thread.txt` | Auto-formatted X / Twitter tweet thread (one tweet per belief inflection point, ≤280 chars each) |
 | `GET` | `/api/simulation/<id>/thread.json` | Same tweet thread as `thread.txt` but as `{tweets, total, inflections_recorded, truncated}` for programmatic consumers |
 | `GET` | `/api/simulation/<id>/surface-stats` | Per-share-surface request counters — share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS, plus a synthetic `total` |
+| `GET` | `/api/simulation/<id>/webhook-log` | Recent outbound-webhook delivery attempts (last 10 + total count). Admin-token gated |
+| `POST` | `/api/simulation/<id>/webhook-retry` | Re-fire the completion webhook for a finished sim. Admin-token gated |
 | `GET` | `/share/<id>` | Public OG-tag landing page (auto-redirects to SPA) |
 | `GET` | `/watch/<id>` | Live spectator-watch page — minimal full-viewport broadcast view, polls every 15 s, OG / Twitter-card unfurl |
 | `POST` | `/api/simulation/<id>/article` | Generate a Substack-style write-up |

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -87,7 +87,9 @@
 | `GET` | `/api/simulation/<id>/embed-summary` | 嵌入载荷(仅公开模拟) |
 | `GET` | `/api/simulation/<id>/thread.txt` | 自动生成的 X / Twitter 推文串(每个信念转折点一条推文,每条 ≤280 字符) |
 | `GET` | `/api/simulation/<id>/thread.json` | 同样的推文串内容,以 `{tweets, total, inflections_recorded, truncated}` 形式返回,供程序消费 |
-| `GET` | `/api/simulation/<id>/surface-stats` | 每个分享面的请求计数器 — 分享卡 / 回放 GIF / 转录 / 轨迹 / 推文串 / 观看页 / Atom / RSS,以及合成的 `total` |
+| `GET` | `/api/simulation/<id>/surface-stats` | 每个分享面的请求计数器 — 分享卡 / 回放 GIF / 转录 / 推文串 / 观看页 / Atom / RSS,以及合成的 `total` |
+| `GET` | `/api/simulation/<id>/webhook-log` | 最近的出站 webhook 投递记录(最近 10 条 + 总次数)。需管理员 token |
+| `POST` | `/api/simulation/<id>/webhook-retry` | 重发已完成模拟的完成 webhook。需管理员 token |
 | `POST` | `/api/simulation/<id>/article` | 生成 Substack 风格的报道 |
 | `GET` | `/api/simulation/<id>/export` | 完整 JSON 导出 |
 | `GET` | `/api/simulation/list` | 列出模拟 |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -279,6 +279,31 @@ Implementation:
 
 The Embed dialog has a "📊 Distribution" panel (collapsed by default, click the chevron to expand) — a sorted two-column table (surface · count, ranked by count desc), a `Total serves: N` row, and a `↻ Refresh` button. The panel is publish-gated; private sims see "Publish the simulation to see distribution stats." instead. Same publish gate as every other share surface (`is_public=true`).
 
+## Webhook Delivery Log
+
+Every dispatch attempt of the outbound completion webhook (the one configured in **Settings → Integrations → Webhook**, see [WEBHOOKS.md](WEBHOOKS.md)) appends a JSON line to `<sim_dir>/webhook-log.jsonl`. Each row records:
+
+- **`attempt`** — monotonically increasing 1-based counter (survives the on-disk truncation at 50 rows).
+- **`timestamp`** — UTC ISO-8601 of when the dispatch completed.
+- **`url_masked`** — `scheme://host/***`. The path of a Slack / Discord webhook URL is the secret and is *never* persisted to disk.
+- **`event`** / **`status`** — the `event` field from the dispatched payload (`simulation.completed` / `simulation.failed`) and the terminal status the run reached.
+- **`status_code`** — HTTP status returned by the downstream endpoint, or `null` for network errors / timeouts (so a real 5xx is distinguishable from a TCP reset).
+- **`ok`** — `true` for a 2xx response; `false` for any other outcome.
+- **`latency_ms`** — wall-clock time of the HTTP call in milliseconds.
+- **`error`** — human-readable upstream error string on failure (e.g. `HTTP 503`, `URL error: timeout`); `null` on success.
+- **`trigger`** — `auto` for the runner-fired path, `retry` for an operator-driven replay.
+
+Two endpoints surface the log:
+
+- **`GET /api/simulation/<id>/webhook-log`** — admin-token gated. Returns the last 10 entries newest-first plus the all-time `total_attempts` counter and the on-disk retention bound (`max_retained: 50`). Operators use this to verify the webhook fired, see the HTTP status / latency, and decide whether to retry.
+- **`POST /api/simulation/<id>/webhook-retry`** — admin-token gated. Re-fires the completion webhook for a sim already in a terminal state (useful when the original delivery hit a transient 5xx, the URL was misconfigured at the time, or the consuming integration was down). The retry payload carries `retry: true` so downstream consumers can dedupe replays. Bypasses the per-process `(sim_id, status)` dedup gate the auto-fire path uses (that gate exists only to prevent the runner's two terminal code paths from double-firing automatically; an explicit retry should always go through). Returns 400 when no webhook URL is configured, 409 when the simulation has not reached a terminal state.
+
+The Embed dialog has a **📡 Webhook delivery history** panel beneath the outcome row (admin-token gated, collapsed by default to keep the dialog compact for users who don't have a webhook configured). Each delivery renders as a status chip (✓ green for 2xx, ✗ red for 4xx/5xx, ⏱ amber for timeouts) with the HTTP code, latency, trigger label, and timestamp. **Refresh** re-pulls the log; **Retry delivery** re-fires the webhook and refreshes after a short delay so the new attempt shows up automatically.
+
+The dispatcher writes to disk only after the POST returns (or times out) so the dispatch path stays fire-and-forget — the log write never blocks the simulation runner. Log writes use a read-modify-rename pattern (atomic via `os.replace`) so the log can never be corrupted by a partial write. URL masking happens before serialization, so the secret in a Slack / Discord URL is gone the moment it lands on disk.
+
+Implementation: helpers in `app/services/webhook_service.py` (`_record_delivery`, `_append_log_entry`, `read_webhook_log`, `retry_webhook_for_simulation`) + `_start_dispatch_thread` shared between auto-fire and retry paths. Zero new dependencies (pure stdlib `json` + `os` + `time` + `threading`). Bounded to 50 lines on disk; older deliveries roll off so the log never grows unbounded.
+
 ## Article Generation
 
 After a simulation finishes, click **Write Article** and MiroShark asks the Smart model to produce a 400–600-word Substack-style write-up grounded in what actually happened — key findings, market dynamics, belief shifts, and implications. The article is cached at `generated_article.json` so it doesn't re-spend tokens on reopen; pass `force_regenerate=true` to refresh.

--- a/docs/FEATURES.zh-CN.md
+++ b/docs/FEATURES.zh-CN.md
@@ -253,6 +253,31 @@ WONDERWALL_MODEL_NAME=your-model-id
 
 嵌入对话框有一条"通过 RSS 关注画廊"的提示,带 Atom 订阅、RSS 2.0 订阅、仅已验证 Atom 订阅的一键订阅链接。/explore 头部有一个"📡 通过 RSS 订阅"芯片,会镜像当前激活过滤(开启已验证过滤时也会跟随)。
 
+## Webhook 投递日志
+
+每一次 Webhook 投递尝试(在 **设置 → 集成 → Webhook** 中配置,详见 [WEBHOOKS.zh-CN.md](WEBHOOKS.zh-CN.md))都会在 `<sim_dir>/webhook-log.jsonl` 追加一行 JSON。每行记录:
+
+- **`attempt`** — 1 起单调递增计数器(磁盘截断到 50 行后仍持续递增)。
+- **`timestamp`** — 投递完成的 UTC ISO-8601 时间。
+- **`url_masked`** — `scheme://host/***`。Slack / Discord webhook URL 路径中的密钥**绝不**写入磁盘。
+- **`event`** / **`status`** — 投递载荷的 `event` 字段(`simulation.completed` / `simulation.failed`)与运行到达的终止状态。
+- **`status_code`** — 下游端点返回的 HTTP 状态码,对网络错误 / 超时为 `null`(便于把真实 5xx 与 TCP 重置区分开)。
+- **`ok`** — 2xx 响应为 `true`,其他情况为 `false`。
+- **`latency_ms`** — HTTP 调用的实测耗时(毫秒)。
+- **`error`** — 失败时的可读上游错误字符串(例如 `HTTP 503`、`URL error: timeout`);成功时为 `null`。
+- **`trigger`** — runner 自动触发为 `auto`,运维者通过重试端点驱动为 `retry`。
+
+两个端点暴露日志:
+
+- **`GET /api/simulation/<id>/webhook-log`** — 需管理员 token。返回最近 10 条记录(从新到旧)+ 全程 `total_attempts` 计数器 + 磁盘留存上限(`max_retained: 50`)。运维者据此核对 webhook 是否触发、看 HTTP 状态 / 延迟,以及决定是否重试。
+- **`POST /api/simulation/<id>/webhook-retry`** — 需管理员 token。重发已经处于终止状态的模拟的完成 webhook(原投递偶发 5xx、URL 当时配错、消费集成当时宕机时有用)。重发载荷带 `retry: true`,下游消费者可据此对重放去重。绕过自动触发路径使用的进程内 `(sim_id, status)` 去重门(那道门只防止 runner 的两条终止代码路径自动双发;运维者显式重试理应总能通过)。未配置 webhook URL 时返回 400,模拟尚未到达终止状态时返回 409。
+
+嵌入对话框在 outcome 行下方有一个 **📡 Webhook 投递历史** 面板(需管理员 token,默认折叠以保持对话框紧凑,适配未配置 webhook 的用户)。每次投递渲染为状态 chip(✓ 绿色对应 2xx,✗ 红色对应 4xx/5xx,⏱ 琥珀色对应超时),含 HTTP 状态码、延迟、触发标签和时间戳。**刷新** 重新拉取日志;**重试投递** 重发 webhook 并在短暂延迟后刷新,以便新一次投递自动出现。
+
+调度器在 POST 返回(或超时)之后才写盘,所以投递路径仍是 fire-and-forget — 日志写入永远不会阻塞模拟 runner。日志写入采用读-改-重命名模式(通过 `os.replace` 原子化),日志永远不会因部分写入而损坏。URL 在序列化前就掩码,所以 Slack / Discord URL 中的密钥落盘那刻便已不存在。
+
+实现:`app/services/webhook_service.py` 中的辅助(`_record_delivery`、`_append_log_entry`、`read_webhook_log`、`retry_webhook_for_simulation`)+ `_start_dispatch_thread` 在自动触发与重试路径间共享。零新增依赖(纯标准库 `json` + `os` + `time` + `threading`)。磁盘上限 50 行;旧投递自动滚出,日志永不无界增长。
+
 ## 文章生成
 
 模拟结束后,点击 **Write Article**,MiroShark 会让 Smart 模型写一篇 400–600 字的 Substack 风格报道,基于真实发生的事件 — 关键发现、市场动态、信念变化和影响。文章会缓存到 `generated_article.json`,这样重新打开不会再消耗 token;传 `force_regenerate=true` 可以刷新。

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -105,6 +105,8 @@ PUBLIC_BASE_URL=https://miroshark.app           # optional, see below
 - **Deduped per process** — the runner can detect completion via two paths (process exit code + per-platform `simulation_end` events). Both call into the webhook service; only the first fire per `(sim_id, status)` actually sends.
 - **`completed` and `failed` only** — pause / resume / running events are *not* delivered.
 - **2xx = success** — anything else is logged as a delivery failure but never raised.
+- **Delivery log** — every dispatch attempt (auto-fired *or* manually replayed) appends one JSON line to `<sim_dir>/webhook-log.jsonl` with timestamp, masked URL, HTTP status code, latency, and trigger label. Bounded to 50 rows on disk; `GET /api/simulation/<id>/webhook-log` (admin-token gated) returns the last 10 entries newest-first plus the all-time `total_attempts` counter.
+- **Manual retry** — `POST /api/simulation/<id>/webhook-retry` (admin-token gated) re-fires the completion webhook for a sim already in a terminal state. Useful when the original delivery hit a transient 5xx, the URL was misconfigured at the time, or the consuming integration was down. The retry payload carries an extra top-level `retry: true` so downstream consumers can dedupe replays. The replay bypasses the per-process `(sim_id, status)` dedup gate that auto-fires honour (that gate exists only to prevent the runner's two terminal code paths from double-firing automatically; an explicit retry should always go through). Returns 400 when no webhook URL is configured, 409 when the simulation has not reached a terminal state.
 
 ---
 

--- a/docs/WEBHOOKS.zh-CN.md
+++ b/docs/WEBHOOKS.zh-CN.md
@@ -105,6 +105,8 @@ PUBLIC_BASE_URL=https://miroshark.app           # optional, see below
 - **进程内去重** — runner 会通过两条路径检测完成(进程退出码 + 各平台的 `simulation_end` 事件)。两者都会调进 webhook 服务;每个 `(sim_id, status)` 只有第一次会真的发出。
 - **只送 `completed` 与 `failed`** — 暂停 / 恢复 / running 事件*不*下发。
 - **2xx 即成功** — 其他都会被记录为投递失败,但永远不会抛出。
+- **投递日志** — 每次投递尝试(自动触发*或*手动重发)都会在 `<sim_dir>/webhook-log.jsonl` 追加一行 JSON,包含时间戳、掩码 URL、HTTP 状态码、延迟和触发标签。磁盘上限 50 行;`GET /api/simulation/<id>/webhook-log`(需管理员 token)返回最近 10 条记录(从新到旧)以及全程 `total_attempts` 计数器。
+- **手动重试** — `POST /api/simulation/<id>/webhook-retry`(需管理员 token)重发已经处于终止状态的模拟的完成 webhook。原投递偶发 5xx、URL 当时配错、消费集成当时宕机时有用。重发载荷带 `retry: true`,下游消费者可据此对重放去重。重发会绕过自动触发使用的进程内 `(sim_id, status)` 去重门(那道门只防止 runner 的两条终止代码路径自动双发;运维者显式重试理应总能通过)。未配置 webhook URL 时返回 400,模拟尚未到达终止状态时返回 409。
 
 ---
 

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -828,6 +828,40 @@ export const submitSimulationOutcome = (simulationId, data) => {
 }
 
 /**
+ * Fetch the recent webhook delivery attempts for a simulation.
+ *
+ * Reads `<sim_dir>/webhook-log.jsonl` server-side and returns the
+ * newest 10 entries plus the all-time `total_attempts` count. Useful
+ * for the EmbedDialog "Delivery history" panel — operators can verify
+ * that the outbound webhook fired, what the downstream endpoint
+ * returned, and how long the round trip took.
+ *
+ * Admin-token gated server-side. The SPA does not attach the token —
+ * deployments behind a reverse proxy that adds the bearer header
+ * automatically work; localhost dev installs without a configured
+ * token will see a 503 and the panel renders a "configure first" hint.
+ *
+ * @param {string} simulationId
+ */
+export const getWebhookLog = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/webhook-log`)
+}
+
+/**
+ * Re-fire the completion webhook for an already-finished simulation.
+ *
+ * Intended for the "Retry delivery" button in the EmbedDialog
+ * Delivery history panel. The retry payload carries an extra
+ * `retry: true` so downstream consumers can dedupe or surface replays.
+ *
+ * @param {string} simulationId
+ * @param {Object} [data] - { status?: 'completed' | 'failed' }
+ */
+export const retryWebhookDelivery = (simulationId, data = {}) => {
+  return service.post(`/api/simulation/${simulationId}/webhook-retry`, data)
+}
+
+/**
  * List all Polymarket prediction markets for a simulation.
  * @param {string} simulationId
  */

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -633,6 +633,96 @@
               </div>
             </div>
 
+            <!-- Webhook delivery history — every Zapier / Make / n8n /
+                 Slack / Discord integration built on top of the outbound
+                 completion webhook (PR #46) needs a feedback loop so the
+                 operator can verify it fired. Reads the last 10 entries
+                 from <sim_dir>/webhook-log.jsonl. Admin-token gated
+                 server-side; the panel shows a "configure first" hint
+                 instead of a hard error when the token is unset. -->
+            <div class="webhook-log-section">
+              <div class="webhook-log-head">
+                <span class="webhook-log-icon">📡</span>
+                <div class="webhook-log-head-body">
+                  <div class="webhook-log-title">
+                    {{ $tr('Webhook delivery history', 'Webhook 投递历史') }}
+                    <span v-if="webhookLogTotal > 0" class="webhook-log-count">
+                      {{ webhookLogTotal }} {{ webhookLogTotal === 1 ? $tr('attempt', '次') : $tr('attempts', '次') }}
+                    </span>
+                  </div>
+                  <div class="webhook-log-sub">
+                    {{ $tr('Auto-fires on simulation completion. Records the last 50 attempts on disk so a delivery failure is visible without checking server logs.', '在模拟完成时自动触发。最多在磁盘上保留 50 次投递记录,无需查看服务器日志即可发现失败。') }}
+                  </div>
+                </div>
+                <button
+                  class="webhook-log-toggle"
+                  @click="toggleWebhookLog"
+                  :title="webhookLogExpanded ? $tr('Hide history', '隐藏历史') : $tr('Show history', '显示历史')"
+                >
+                  {{ webhookLogExpanded ? '▾' : '▸' }}
+                </button>
+              </div>
+
+              <div v-if="webhookLogExpanded" class="webhook-log-body">
+                <div v-if="webhookLogLoading" class="webhook-log-loading">
+                  {{ $tr('Loading delivery history…', '正在加载投递历史…') }}
+                </div>
+
+                <div v-else-if="webhookLogConfigError" class="webhook-log-config-hint">
+                  {{ $tr('Admin authentication is not configured on this deployment. Set MIROSHARK_ADMIN_TOKEN to enable the delivery log.', '此部署未配置管理员身份验证。设置 MIROSHARK_ADMIN_TOKEN 以启用投递日志。') }}
+                </div>
+
+                <div v-else-if="webhookLogError" class="webhook-log-error">
+                  {{ webhookLogError }}
+                </div>
+
+                <div v-else-if="webhookLogEntries.length === 0" class="webhook-log-empty">
+                  {{ $tr('No deliveries recorded yet. The webhook fires automatically on simulation completion.', '暂无投递记录。Webhook 会在模拟完成时自动触发。') }}
+                </div>
+
+                <ul v-else class="webhook-log-list">
+                  <li
+                    v-for="entry in webhookLogEntries"
+                    :key="entry.attempt"
+                    class="webhook-log-row"
+                    :class="webhookEntryClass(entry)"
+                  >
+                    <span class="webhook-log-row-icon">{{ webhookEntryIcon(entry) }}</span>
+                    <span class="webhook-log-row-attempt">#{{ entry.attempt }}</span>
+                    <span class="webhook-log-row-code">{{ webhookEntryCode(entry) }}</span>
+                    <span class="webhook-log-row-latency">{{ formatLatency(entry.latency_ms) }}</span>
+                    <span class="webhook-log-row-trigger">{{ entry.trigger || '—' }}</span>
+                    <span class="webhook-log-row-time" :title="entry.timestamp || ''">
+                      {{ formatLogTime(entry.timestamp) }}
+                    </span>
+                  </li>
+                </ul>
+
+                <div class="webhook-log-actions">
+                  <button
+                    class="webhook-log-refresh"
+                    @click="loadWebhookLog"
+                    :disabled="webhookLogLoading"
+                  >
+                    {{ $tr('Refresh', '刷新') }}
+                  </button>
+                  <button
+                    class="webhook-log-retry"
+                    @click="retryWebhook"
+                    :disabled="webhookRetrying || !canRetryWebhook"
+                    :title="canRetryWebhook ? $tr('Re-fire the webhook with the same payload', '使用相同 payload 重发 webhook') : $tr('Retry available after the simulation reaches a terminal state', '模拟到达终止状态后可重试')"
+                  >
+                    <span v-if="webhookRetrying">{{ $tr('Queueing…', '排队中…') }}</span>
+                    <span v-else>{{ $tr('Retry delivery', '重试投递') }}</span>
+                  </button>
+                </div>
+
+                <div v-if="webhookRetryMessage" class="webhook-log-message" :class="webhookRetryMessageClass">
+                  {{ webhookRetryMessage }}
+                </div>
+              </div>
+            </div>
+
             <!-- Gallery callout — appears once the simulation is public so the
                  operator knows their run is visible on /explore, and offers a
                  one-click jump to see it in situ alongside other public runs. -->
@@ -746,6 +836,8 @@ import {
   getFeedUrl,
   getSimulationOutcome,
   submitSimulationOutcome,
+  getWebhookLog,
+  retryWebhookDelivery,
 } from '../api/simulation'
 import { tr } from '../i18n'
 
@@ -1219,6 +1311,174 @@ const submitOutcome = async () => {
   }
 }
 
+// ── Webhook delivery log ───────────────────────────────────────────────
+// Operators get no feedback today on whether the outbound completion
+// webhook actually fired — this panel reads ``<sim_dir>/webhook-log.jsonl``
+// (admin-token gated server-side) so a 5xx from Zapier / n8n / Slack /
+// Discord doesn't disappear into server logs.
+const webhookLogExpanded = ref(false)
+const webhookLogLoading = ref(false)
+const webhookLogEntries = ref([])
+const webhookLogTotal = ref(0)
+const webhookLogError = ref('')
+const webhookLogConfigError = ref(false)
+const webhookRetrying = ref(false)
+const webhookRetryMessage = ref('')
+const webhookRetryMessageClass = ref('')
+const runnerStatus = ref('')
+
+const canRetryWebhook = computed(() => {
+  // Retry only meaningful once the run has reached a terminal state —
+  // before then there's no completion event to replay.
+  const s = (runnerStatus.value || '').toLowerCase()
+  return s === 'completed' || s === 'failed'
+})
+
+const formatLatency = (ms) => {
+  if (typeof ms !== 'number' || Number.isNaN(ms)) return '—'
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+const formatLogTime = (iso) => {
+  if (!iso || typeof iso !== 'string') return '—'
+  try {
+    const d = new Date(iso)
+    if (Number.isNaN(d.getTime())) return iso
+    // Compact time-only label so the row stays one line on narrow screens.
+    return d.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+const webhookEntryClass = (entry) => {
+  if (!entry) return ''
+  if (entry.ok) return 'webhook-row-ok'
+  if (entry.status_code === null && (entry.error || '').toLowerCase().includes('timeout')) {
+    return 'webhook-row-timeout'
+  }
+  return 'webhook-row-fail'
+}
+
+const webhookEntryIcon = (entry) => {
+  if (!entry) return ''
+  if (entry.ok) return '✓'
+  if (entry.status_code === null && (entry.error || '').toLowerCase().includes('timeout')) {
+    return '⏱'
+  }
+  return '✗'
+}
+
+const webhookEntryCode = (entry) => {
+  if (!entry) return '—'
+  if (typeof entry.status_code === 'number') return `HTTP ${entry.status_code}`
+  if (entry.error) {
+    const text = String(entry.error)
+    return text.length > 40 ? `${text.slice(0, 39)}…` : text
+  }
+  return '—'
+}
+
+const loadWebhookLog = async () => {
+  if (!props.simulationId) return
+  webhookLogLoading.value = true
+  webhookLogError.value = ''
+  webhookLogConfigError.value = false
+  try {
+    const res = await getWebhookLog(props.simulationId)
+    const data = res?.data || {}
+    webhookLogEntries.value = Array.isArray(data.entries) ? data.entries : []
+    webhookLogTotal.value = Number(data.total_attempts || 0)
+  } catch (err) {
+    const status = err?.response?.status
+    if (status === 503) {
+      webhookLogConfigError.value = true
+    } else if (status === 401) {
+      webhookLogError.value = tr(
+        'Admin token does not match — set Authorization: Bearer $MIROSHARK_ADMIN_TOKEN at your reverse proxy to view the log.',
+        '管理员 token 不匹配 — 请在反向代理处设置 Authorization: Bearer $MIROSHARK_ADMIN_TOKEN 以查看日志。',
+      )
+    } else {
+      webhookLogError.value =
+        err?.response?.data?.error || err?.message || tr('Could not load delivery history.', '无法加载投递历史。')
+    }
+    webhookLogEntries.value = []
+    webhookLogTotal.value = 0
+  } finally {
+    webhookLogLoading.value = false
+  }
+}
+
+const toggleWebhookLog = () => {
+  webhookLogExpanded.value = !webhookLogExpanded.value
+  if (webhookLogExpanded.value && webhookLogEntries.value.length === 0 && !webhookLogError.value) {
+    loadWebhookLog()
+  }
+}
+
+const retryWebhook = async () => {
+  if (!canRetryWebhook.value || webhookRetrying.value) return
+  webhookRetrying.value = true
+  webhookRetryMessage.value = ''
+  webhookRetryMessageClass.value = ''
+  try {
+    const res = await retryWebhookDelivery(props.simulationId, {})
+    if (res?.success && res.data?.queued) {
+      webhookRetryMessage.value = tr(
+        'Queued — refresh in a moment to see the new attempt.',
+        '已排队 — 稍后刷新查看新一次投递。',
+      )
+      webhookRetryMessageClass.value = 'webhook-log-message-ok'
+      // Pull fresh entries after a short delay so the daemon thread has
+      // time to log its result. 1.2s comfortably covers a healthy
+      // round-trip; a slow downstream still surfaces on the next manual
+      // Refresh click.
+      setTimeout(() => loadWebhookLog(), 1200)
+    } else {
+      webhookRetryMessage.value =
+        res?.error || tr('Could not queue retry.', '无法排队重试。')
+      webhookRetryMessageClass.value = 'webhook-log-message-error'
+    }
+  } catch (err) {
+    const status = err?.response?.status
+    if (status === 400) {
+      webhookRetryMessage.value = err?.response?.data?.error
+        || tr('No webhook URL configured.', '未配置 webhook URL。')
+    } else if (status === 409) {
+      webhookRetryMessage.value = err?.response?.data?.error
+        || tr('Simulation has not finished yet.', '模拟尚未完成。')
+    } else if (status === 503) {
+      webhookRetryMessage.value = tr(
+        'Admin authentication not configured.',
+        '未配置管理员身份验证。',
+      )
+    } else {
+      webhookRetryMessage.value =
+        err?.response?.data?.error || err?.message || tr('Could not queue retry.', '无法排队重试。')
+    }
+    webhookRetryMessageClass.value = 'webhook-log-message-error'
+  } finally {
+    webhookRetrying.value = false
+  }
+}
+
+const _resetWebhookLogState = () => {
+  webhookLogExpanded.value = false
+  webhookLogEntries.value = []
+  webhookLogTotal.value = 0
+  webhookLogError.value = ''
+  webhookLogConfigError.value = false
+  webhookRetryMessage.value = ''
+  webhookRetryMessageClass.value = ''
+  runnerStatus.value = ''
+}
+
 watch(() => props.open, async (val) => {
   if (!val) return
   copied.value = ''
@@ -1228,10 +1488,15 @@ watch(() => props.open, async (val) => {
   replayPlay.value = false
   replayLoaded.value = false
   _resetOutcomeForm()
+  _resetWebhookLogState()
   // Refresh public state when reopened — reflects external flips.
   try {
     const res = await getEmbedSummary(props.simulationId)
     if (typeof res?.data?.is_public === 'boolean') isPublic.value = res.data.is_public
+    // Capture the runner status so the Retry button knows whether the
+    // sim has reached a terminal state — auto-fire only triggers on
+    // completed/failed, so retry semantics need the same gate.
+    runnerStatus.value = res?.data?.runner_status || res?.data?.status || ''
   } catch (err) {
     if (err?.response?.status === 403) isPublic.value = false
   }
@@ -2631,6 +2896,240 @@ watch(isPublic, () => {
 .snippet-copy-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+/* Webhook delivery history — collapsed by default to keep the dialog
+   compact for users who don't have a webhook configured. Expands to a
+   compact tabular row layout that reads like a tail of a delivery log
+   (one row per attempt, status colour, latency, trigger, time). */
+.webhook-log-section {
+  margin-top: 12px;
+  padding: 14px 16px;
+  background: #fafafa;
+  border: 1px solid rgba(10, 10, 10, 0.08);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.webhook-log-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.webhook-log-icon {
+  font-size: 20px;
+  line-height: 1;
+  padding-top: 2px;
+}
+
+.webhook-log-head-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.webhook-log-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0a0a0a;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.webhook-log-count {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: #4a4a4a;
+  padding: 2px 7px;
+  background: rgba(10, 10, 10, 0.06);
+  border-radius: 999px;
+}
+
+.webhook-log-sub {
+  font-size: 12px;
+  line-height: 1.5;
+  color: #4a4a4a;
+  margin-top: 4px;
+}
+
+.webhook-log-toggle {
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid rgba(10, 10, 10, 0.18);
+  color: #0a0a0a;
+  font-size: 13px;
+  font-weight: 600;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.webhook-log-toggle:hover {
+  background: rgba(10, 10, 10, 0.05);
+}
+
+.webhook-log-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.webhook-log-loading,
+.webhook-log-empty,
+.webhook-log-config-hint,
+.webhook-log-error {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: #4a4a4a;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(10, 10, 10, 0.04);
+}
+
+.webhook-log-config-hint {
+  background: rgba(255, 178, 0, 0.12);
+  color: #7a4a00;
+}
+
+.webhook-log-error {
+  background: rgba(255, 68, 68, 0.10);
+  color: #b22020;
+}
+
+.webhook-log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+  font-variant-numeric: tabular-nums;
+}
+
+.webhook-log-row {
+  display: grid;
+  grid-template-columns: auto auto auto 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.4;
+  background: #fff;
+  border: 1px solid rgba(10, 10, 10, 0.06);
+}
+
+.webhook-log-row-icon {
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.webhook-log-row-attempt {
+  color: #4a4a4a;
+  font-size: 11px;
+}
+
+.webhook-log-row-code {
+  font-weight: 600;
+  color: #0a0a0a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.webhook-log-row-latency {
+  color: #4a4a4a;
+}
+
+.webhook-log-row-trigger {
+  color: #6a6a6a;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.webhook-log-row-time {
+  color: #6a6a6a;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.webhook-row-ok .webhook-log-row-icon { color: #2e7d32; }
+.webhook-row-fail .webhook-log-row-icon { color: #b22020; }
+.webhook-row-timeout .webhook-log-row-icon { color: #b97000; }
+
+.webhook-row-ok { border-left: 3px solid #2e7d32; }
+.webhook-row-fail { border-left: 3px solid #b22020; }
+.webhook-row-timeout { border-left: 3px solid #b97000; }
+
+.webhook-log-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.webhook-log-refresh,
+.webhook-log-retry {
+  padding: 6px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 6px;
+  border: 1px solid rgba(10, 10, 10, 0.18);
+  background: #fff;
+  color: #0a0a0a;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.webhook-log-refresh:hover,
+.webhook-log-retry:hover {
+  background: #0a0a0a;
+  color: #fff;
+  border-color: #0a0a0a;
+}
+
+.webhook-log-refresh:disabled,
+.webhook-log-retry:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.webhook-log-message {
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+
+.webhook-log-message-ok {
+  background: rgba(67, 193, 101, 0.12);
+  color: #1f6b35;
+}
+
+.webhook-log-message-error {
+  background: rgba(255, 68, 68, 0.12);
+  color: #b22020;
+}
+
+@media (max-width: 600px) {
+  .webhook-log-row {
+    grid-template-columns: auto auto 1fr;
+    grid-template-rows: auto auto;
+    grid-row-gap: 2px;
+  }
+  .webhook-log-row-trigger,
+  .webhook-log-row-time { grid-column: 1 / -1; }
 }
 
 /* Transition */


### PR DESCRIPTION
## What

Adds the operational visibility layer the outbound completion webhook (PR #46) was missing.

- **`<sim_dir>/webhook-log.jsonl`** — one JSON line per dispatch attempt (auto-fired or manually replayed). Records `attempt`, `timestamp`, `url_masked`, `event`, `status`, `status_code`, `ok`, `latency_ms`, `error`, `trigger`. Bounded to 50 lines on disk via atomic read-modify-rename so the log can never corrupt or grow unbounded.
- **`GET /api/simulation/<id>/webhook-log`** — admin-token gated. Returns the last 10 entries newest-first plus the all-time `total_attempts` counter and the on-disk retention bound (`max_retained: 50`).
- **`POST /api/simulation/<id>/webhook-retry`** — admin-token gated. Re-fires the completion webhook for a sim already in a terminal state. Bypasses the per-process `(sim_id, status)` dedup gate (that gate exists only to prevent the runner's two terminal code paths from double-firing automatically; an explicit retry should always go through). Replay payload carries `retry: true` so downstream consumers can dedupe. Returns 400 when no webhook URL configured, 409 when the sim has not reached a terminal state.
- **EmbedDialog "📡 Webhook delivery history" panel** — admin-token gated, collapsed by default. Status chips (✓ green for 2xx, ✗ red for 4xx/5xx, ⏱ amber for timeouts) per delivery with HTTP code, latency, trigger label, and timestamp. **Refresh** + **Retry delivery** buttons.

## Why

PR #46 shipped the outbound completion webhook but every Zapier / Make / n8n / Slack / Discord integration built on top has been flying blind on delivery status. A 5xx from the downstream endpoint disappeared into server logs and the operator had no way to verify the dispatch fired, see HTTP status / latency, or re-fire a failed attempt. Pivot from May 4 repo-actions idea #2 — the cleanest small-effort autonomous pick (pure stdlib, follows existing patterns, zero new deps).

## How it works

- The dispatch path now routes through a shared `_start_dispatch_thread` helper between auto-fire and retry. After the POST returns (or times out / raises), `_record_delivery` writes one JSON line to `<sim_dir>/webhook-log.jsonl`. URL masking happens before serialization, so the secret in a Slack / Discord webhook URL is gone the moment it lands on disk.
- `_append_log_entry` reads the existing file, trims to `WEBHOOK_LOG_MAX_LINES - 1` rows when the file already has 50 entries, writes to a `.tmp` file, then atomically `os.replace`s it onto the canonical path — so a partial write can never leave a half-flushed line.
- The `attempt` counter is computed from `max(attempt) + 1` over the parsed log, so it survives the on-disk truncation and the all-time `total_attempts` keeps climbing past the retention bound.
- Status code is parsed from the existing `_post_json` 2-tuple message format (`HTTP <N>` → integer, network errors → `null`) so the test surface for the original webhook stays untouched — no breaking changes to `test_unit_webhook.py`.

## Changes

- `backend/app/services/webhook_service.py`: log helpers (`webhook_log_path`, `_read_log_lines`, `_parse_log_entries`, `_next_attempt_number`, `_append_log_entry`, `_parse_status_code_from_message`, `read_webhook_log`, `_record_delivery`) + `_start_dispatch_thread` shared between auto-fire and retry + `retry_webhook_for_simulation` + extended `_send` body to capture latency and write the log.
- `backend/app/api/simulation.py`: `GET /<id>/webhook-log` + `POST /<id>/webhook-retry` route handlers, both admin-token gated, between the thread routes and the public-gallery section.
- `backend/openapi.yaml`: both new paths under Publish & Embed + `WebhookDeliveryEntry` and `WebhookDeliveryLog` schemas. Drift-detection test passes.
- `backend/tests/test_unit_webhook_log.py`: 13 offline unit tests — log append + read, status-code parsing, 50-line truncation, newest-first slice cap, falsy sim_dir no-op, corrupt-line resilience, end-to-end auto-fire log integration, 5xx logging, retry bypassing dedup, retry without URL, and unknown-status rejection.
- `frontend/src/api/simulation.js`: `getWebhookLog` + `retryWebhookDelivery` helpers.
- `frontend/src/components/EmbedDialog.vue`: Delivery history panel with status chips, refresh + retry actions, dark-mode friendly CSS, narrow-viewport responsive layout.
- `README.md` (en + zh-CN), `docs/FEATURES.md` + `docs/FEATURES.zh-CN.md`, `docs/API.md` + `docs/API.zh-CN.md`, `docs/WEBHOOKS.md` + `docs/WEBHOOKS.zh-CN.md`: feature row + full docs section + delivery-semantics callouts.

Pure stdlib (`json` + `os` + `time` + `threading`). Zero new dependencies — the streak now spans 13 consecutive PRs.

---
*Built autonomously by Aeon*