### PR TITLE
feat: surface usage analytics — per-share-surface request counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Trace Interview** | See the full reasoning chain behind an agent's reply, not just the reply |
 | **Push Notifications** | Web-push alerts when long-running graph / sim / report jobs finish |
 | **Completion Webhook** | POST a JSON summary the moment a sim finishes — wires Slack, Discord, Zapier, Make, n8n, or any custom endpoint with one URL field |
+| **Surface Usage Analytics** | `GET /api/simulation/<id>/surface-stats` — per-share-surface request counters (share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS) with a synthetic `total`. Inbound observability for the distribution loop the webhook log tracks on the outbound side |
 
 Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 
@@ -233,6 +234,7 @@ cp .env.example .env
 | **轨迹访谈** | 查看智能体回复背后的完整推理链,而不止是回复本身 |
 | **推送通知** | 长耗时图谱 / 模拟 / 报告任务完成时的浏览器推送提醒 |
 | **完成 Webhook** | 模拟一结束即 POST 一份 JSON 摘要 — 一个 URL 字段即可连通 Slack、Discord、Zapier、Make、n8n 或任意自定义端点 |
+| **分发统计(分享面使用分析)** | `GET /api/simulation/<id>/surface-stats` — 每个分享面的请求计数器(分享卡 / 回放 GIF / 转录 / 轨迹 / 推文串 / 观看页 / Atom / RSS),以及合成的 `total`。Webhook 日志在出站侧跟踪分发回路,本面则负责入站可观测性 |
 
 每项功能详见 **[docs/FEATURES.zh-CN.md](docs/FEATURES.zh-CN.md)**。
 

--- a/backend/app/api/feed.py
+++ b/backend/app/api/feed.py
@@ -33,6 +33,7 @@ from ..services.feed import (
     render_feed,
     select_public_cards,
 )
+from ..services import surface_stats
 from ..utils.i18n import get_locale
 from ..utils.logger import get_logger
 
@@ -116,6 +117,23 @@ def _serve_feed(fmt: str) -> Response:
     # simulation appears in subscribers' next poll without requiring a
     # cache bust, long enough to absorb aggressive aggregator polling.
     response.headers["Cache-Control"] = "public, max-age=300"
+
+    # Each sim that appears in this feed render gets +1 on its own
+    # ``feed_atom`` / ``feed_rss`` counter. The operator-facing question
+    # this answers is: "was my sim syndicated to RSS subscribers in the
+    # last poll cycle?" — which is the distribution signal that
+    # matters, not the global feed-fetch count.
+    surface_key = "feed_atom" if fmt == "atom" else "feed_rss"
+    for card in cards:
+        if not isinstance(card, dict):
+            continue
+        sim_id = card.get("simulation_id") or card.get("id")
+        if not sim_id:
+            continue
+        surface_stats.increment_surface_stat(
+            os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, str(sim_id)),
+            surface_key,
+        )
     return response
 
 

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -4909,6 +4909,7 @@ def get_share_card(simulation_id: str):
     unfurler hits don't re-render.
     """
     from ..services import share_card as share_card_renderer
+    from ..services import surface_stats
     from flask import Response
 
     locale = get_locale(request)
@@ -4950,6 +4951,10 @@ def get_share_card(simulation_id: str):
         response.headers["Content-Disposition"] = (
             f'inline; filename="miroshark-{simulation_id[:12]}.png"'
         )
+        surface_stats.increment_surface_stat(
+            os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id),
+            "share_card",
+        )
         return response
 
     except Exception as e:
@@ -4974,6 +4979,7 @@ def get_replay_gif(simulation_id: str):
     Cached on disk by content hash so repeat hits don't re-render.
     """
     from ..services import replay_gif as replay_renderer
+    from ..services import surface_stats
     from flask import Response
 
     locale = get_locale(request)
@@ -5016,6 +5022,10 @@ def get_replay_gif(simulation_id: str):
         response.headers["Content-Disposition"] = (
             f'inline; filename="miroshark-{simulation_id[:12]}-replay.gif"'
         )
+        surface_stats.increment_surface_stat(
+            os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id),
+            "replay_gif",
+        )
         return response
 
     except Exception as e:
@@ -5036,6 +5046,7 @@ def _serve_transcript(simulation_id: str, fmt: str):
     scans for, but the actual logic lives here.
     """
     from ..services import transcript as transcript_renderer
+    from ..services import surface_stats
     from flask import Response
 
     locale = get_locale(request)
@@ -5062,10 +5073,12 @@ def _serve_transcript(simulation_id: str, fmt: str):
             payload = transcript_renderer.render_json_bytes(data)
             mimetype = "application/json; charset=utf-8"
             filename = f"miroshark-{simulation_id[:12]}-transcript.json"
+            surface_key = "transcript_json"
         else:
             payload = transcript_renderer.render_markdown_bytes(data)
             mimetype = "text/markdown; charset=utf-8"
             filename = f"miroshark-{simulation_id[:12]}-transcript.md"
+            surface_key = "transcript_md"
 
         response = Response(payload, mimetype=mimetype)
         # Short cache — the transcript can change every round on a
@@ -5078,6 +5091,7 @@ def _serve_transcript(simulation_id: str, fmt: str):
         response.headers["Content-Disposition"] = (
             f'inline; filename="{filename}"'
         )
+        surface_stats.increment_surface_stat(sim_dir, surface_key)
         return response
 
     except Exception as e:
@@ -5127,6 +5141,7 @@ def _serve_trajectory(simulation_id: str, fmt: str):
     but the actual logic lives here.
     """
     from ..services import trajectory_export
+    from ..services import surface_stats
     from flask import Response
 
     locale = get_locale(request)
@@ -5153,10 +5168,12 @@ def _serve_trajectory(simulation_id: str, fmt: str):
             payload = trajectory_export.render_jsonl(rows)
             mimetype = "application/jsonl; charset=utf-8"
             filename = f"miroshark-{simulation_id[:12]}-trajectory.jsonl"
+            surface_key = "trajectory_jsonl"
         else:
             payload = trajectory_export.render_csv(rows)
             mimetype = "text/csv; charset=utf-8"
             filename = f"miroshark-{simulation_id[:12]}-trajectory.csv"
+            surface_key = "trajectory_csv"
 
         response = Response(payload, mimetype=mimetype)
         # Short cache — the trajectory grows by one row per round on a
@@ -5171,6 +5188,7 @@ def _serve_trajectory(simulation_id: str, fmt: str):
         response.headers["Content-Disposition"] = (
             f'attachment; filename="{filename}"'
         )
+        surface_stats.increment_surface_stat(sim_dir, surface_key)
         return response
 
     except Exception as e:
@@ -5236,6 +5254,7 @@ def _serve_thread(simulation_id: str, fmt: str):
     drift test scans for, but the actual logic lives here.
     """
     from ..services import thread_formatter
+    from ..services import surface_stats
     from flask import Response
 
     locale = get_locale(request)
@@ -5270,10 +5289,12 @@ def _serve_thread(simulation_id: str, fmt: str):
             payload = thread_formatter.render_thread_json(thread)
             mimetype = "application/json; charset=utf-8"
             filename = f"miroshark-{simulation_id[:12]}-thread.json"
+            surface_key = "thread_json"
         else:
             payload = thread_formatter.render_thread_txt(thread)
             mimetype = "text/plain; charset=utf-8"
             filename = f"miroshark-{simulation_id[:12]}-thread.txt"
+            surface_key = "thread_txt"
 
         response = Response(payload, mimetype=mimetype)
         # Short cache — the thread can change as new rounds land on a
@@ -5290,6 +5311,7 @@ def _serve_thread(simulation_id: str, fmt: str):
         response.headers["Content-Disposition"] = (
             f'inline; filename="{filename}"'
         )
+        surface_stats.increment_surface_stat(sim_dir, surface_key)
         return response
 
     except Exception as e:
@@ -5335,6 +5357,62 @@ def get_thread_json(simulation_id: str):
     Same publish gate as ``thread.txt``.
     """
     return _serve_thread(simulation_id, "json")
+
+
+@simulation_bp.route('/<simulation_id>/surface-stats', methods=['GET'])
+def get_surface_stats(simulation_id: str):
+    """Per-share-surface request counters for a published simulation.
+
+    Returns the number of times each share surface has served a
+    successful response for this simulation — share card PNG, replay
+    GIF, transcript (Markdown + JSON), trajectory (CSV + JSONL), tweet
+    thread (TXT + JSON), live watch page, and Atom / RSS feeds. Plus a
+    synthetic ``total`` summing all counters.
+
+    The first **inbound** observability surface — pairs with the
+    outbound webhook delivery log (``/<id>/webhook-log``) so an operator
+    has both directions of the distribution loop visible from the
+    EmbedDialog.
+
+    Same publish gate as the share card / transcript / trajectory /
+    thread endpoints — the counter file lives inside the sim's
+    on-disk directory and is only meaningful for sims the operator has
+    chosen to surface publicly.
+    """
+    from ..services import surface_stats
+
+    locale = get_locale(request)
+    try:
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                    "该模拟未发布,请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
+            }), 403
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        stats = surface_stats.read_surface_stats(sim_dir)
+
+        return jsonify({
+            "success": True,
+            "simulation_id": simulation_id,
+            "stats": stats,
+        })
+
+    except Exception as e:
+        logger.error(f"surface-stats: failed for {simulation_id}: {e}\n{traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500
 
 
 # ============== Public Gallery ==============

--- a/backend/app/api/watch.py
+++ b/backend/app/api/watch.py
@@ -28,6 +28,7 @@ from flask import Blueprint, Response, request
 from ..services.simulation_manager import SimulationManager
 from ..services.simulation_runner import SimulationRunner
 from ..services import watch_renderer
+from ..services import surface_stats
 from ..utils.i18n import get_locale, t as _t
 from ..utils.validation import validate_simulation_id
 
@@ -258,4 +259,15 @@ def watch_landing(simulation_id: str):
     # initial unfurl reflects the running state shortly after publish,
     # while keeping crawler load bounded.
     response.headers["Cache-Control"] = "public, max-age=60"
+
+    # Only count public sims — the generic broadcast page rendered for
+    # private / missing sims should never write to a non-existent
+    # ``sim_dir``.
+    if summary is not None and summary.get("is_public"):
+        import os
+        from ..config import Config
+        surface_stats.increment_surface_stat(
+            os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id),
+            "watch_page",
+        )
     return response

--- a/backend/app/services/surface_stats.py
+++ b/backend/app/services/surface_stats.py
@@ -1,0 +1,215 @@
+"""Per-share-surface request counters.
+
+Closes the **inbound** observability gap that paired with the outbound
+webhook delivery log (PR #73). Every public share surface
+(``share-card.png``, ``replay.gif``, ``transcript.md`` / ``.json``,
+``trajectory.csv`` / ``.jsonl``, ``thread.txt`` / ``.json``,
+``/watch/<id>``, ``/api/feed.atom`` + ``feed.rss``) increments a counter
+on disk after it serves a successful response. The counts are returned
+by ``GET /api/simulation/<id>/surface-stats`` so an operator running
+MiroShark for a DeFi fund or research group can see which surfaces
+their audience actually uses — the first operator-side feedback loop on
+distribution.
+
+Design notes
+------------
+
+* **Fire-and-forget.** Increment never raises; a corrupt counter file
+  is reset to zeros, never propagated. The serve path must always
+  succeed even if the analytics layer is broken.
+* **Atomic.** Read-modify-write goes through a tempfile + ``os.replace``
+  so two concurrent requests can't truncate the JSON to ``{`` and lose
+  every prior count.
+* **Bounded.** The counter file is a single small JSON object — only
+  the keys in ``SURFACE_KEYS`` are persisted; an unknown key from a
+  rogue caller is rejected at the API boundary, not silently written.
+* **Stdlib only.** ``json`` + ``os``, plus the standard ``tempfile``
+  module for the staging file. No new dependencies.
+
+Schema::
+
+    {
+      "share_card": 0,
+      "replay_gif": 0,
+      "transcript_md": 0,
+      "transcript_json": 0,
+      "trajectory_csv": 0,
+      "trajectory_jsonl": 0,
+      "thread_txt": 0,
+      "thread_json": 0,
+      "watch_page": 0,
+      "feed_atom": 0,
+      "feed_rss": 0
+    }
+
+The ``read_surface_stats`` helper returns the same dict with every key
+present (zero-defaulted) plus a synthetic ``total`` key, so the frontend
+doesn't have to special-case missing fields.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Dict, Optional
+
+
+SURFACE_STATS_FILENAME = "surface-stats.json"
+
+
+# Locked set of recognized surface keys. The route handlers + the
+# unit tests both read from this set, so adding a new share surface is
+# a one-line change here.
+SURFACE_KEYS: frozenset[str] = frozenset(
+    {
+        "share_card",
+        "replay_gif",
+        "transcript_md",
+        "transcript_json",
+        "trajectory_csv",
+        "trajectory_jsonl",
+        "thread_txt",
+        "thread_json",
+        "watch_page",
+        "feed_atom",
+        "feed_rss",
+    }
+)
+
+
+def surface_stats_path(sim_dir: str) -> str:
+    """Return the on-disk path to the surface-stats file for a sim.
+
+    Pure path join — never touches the filesystem. ``sim_dir`` is
+    expected to be an absolute path (the route handlers resolve it via
+    ``Config.WONDERWALL_SIMULATION_DATA_DIR / simulation_id``).
+    """
+    return os.path.join(sim_dir or "", SURFACE_STATS_FILENAME)
+
+
+def _empty_stats() -> Dict[str, int]:
+    """Return a dict with every key in ``SURFACE_KEYS`` set to zero.
+
+    The dict is fresh on every call — callers mutate the result without
+    affecting subsequent reads.
+    """
+    return {key: 0 for key in SURFACE_KEYS}
+
+
+def _load_raw(path: str) -> Dict[str, int]:
+    """Read the on-disk JSON, coerce to integer counters, drop unknown
+    keys, and silently reset on corrupt input.
+
+    Returns a dict containing only keys from ``SURFACE_KEYS`` — values
+    coerced to ``int`` (negative values are clamped to zero so a hand-
+    edited file can't produce a negative ``total``).
+    """
+    if not path or not os.path.exists(path):
+        return _empty_stats()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except Exception:
+        # Corrupt file — reset to zeros rather than 500ing the read.
+        return _empty_stats()
+
+    if not isinstance(raw, dict):
+        return _empty_stats()
+
+    stats = _empty_stats()
+    for key in SURFACE_KEYS:
+        value = raw.get(key, 0)
+        try:
+            ivalue = int(value)
+        except (TypeError, ValueError):
+            ivalue = 0
+        stats[key] = max(0, ivalue)
+    return stats
+
+
+def _atomic_write(path: str, payload: Dict[str, int]) -> None:
+    """Write ``payload`` to ``path`` atomically.
+
+    A ``tempfile.NamedTemporaryFile`` in the same directory plus
+    ``os.replace`` so the canonical file is either fully present or
+    fully absent — never half-written. Same pattern the webhook log
+    uses, kept local here so this module stays self-contained.
+    """
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".surface-stats-", suffix=".tmp", dir=parent
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, sort_keys=True, separators=(",", ":"))
+        os.replace(tmp_path, path)
+    except Exception:
+        # Best-effort cleanup of the staging file. The serve path
+        # already returned a successful response by the time we get
+        # here — failing to persist a counter must never crash.
+        try:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            pass
+
+
+def increment_surface_stat(sim_dir: Optional[str], surface_key: str) -> None:
+    """Increment the counter for ``surface_key`` in the sim's stats file.
+
+    Fire-and-forget. Never raises. No-op when:
+
+    * ``sim_dir`` is falsy (private sim, missing directory) — the route
+      handlers already short-circuit on the publish gate, but we
+      double-check here so a future caller that forgets the gate can't
+      crash on a ``None`` sim_dir.
+    * ``surface_key`` isn't in ``SURFACE_KEYS`` — protects the file
+      schema; the bad key is silently dropped.
+    * the parent directory doesn't exist and can't be created — the
+      sim might have been pruned between the publish check and the
+      increment; better to lose one count than to 500 a downloaded
+      share card.
+    """
+    if not sim_dir:
+        return
+    if surface_key not in SURFACE_KEYS:
+        return
+
+    path = surface_stats_path(sim_dir)
+
+    try:
+        if not os.path.isdir(sim_dir):
+            return
+        stats = _load_raw(path)
+        stats[surface_key] = max(0, int(stats.get(surface_key, 0))) + 1
+        _atomic_write(path, stats)
+    except Exception:
+        # Any failure (permission denied, disk full, race with a sim
+        # cleanup) is swallowed — the analytics layer is best-effort.
+        return
+
+
+def read_surface_stats(sim_dir: Optional[str]) -> Dict[str, int]:
+    """Return ``{key: count, ..., total: sum}`` for the sim's stats file.
+
+    Every key in ``SURFACE_KEYS`` is present (zero-defaulted) plus a
+    synthetic ``total`` key whose value is the sum of all surface
+    counts. This shape lets the frontend render the table without
+    special-casing missing fields, and makes ``"Total serves: N"``
+    a free read.
+
+    Falls back to all-zeros when ``sim_dir`` is falsy or the file is
+    missing / corrupt — never raises.
+    """
+    if not sim_dir:
+        result = _empty_stats()
+        result["total"] = 0
+        return result
+
+    stats = _load_raw(surface_stats_path(sim_dir))
+    total = sum(stats.values())
+    result = dict(stats)
+    result["total"] = total
+    return result

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1354,6 +1354,45 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/simulation/{simulation_id}/surface-stats:
+    get:
+      tags: [Publish & Embed]
+      summary: Per-share-surface request counters for a published simulation.
+      description: |
+        Returns the number of times each share surface has served a
+        successful response for this simulation — share card PNG,
+        replay GIF, transcript (Markdown + JSON), trajectory
+        (CSV + JSONL), tweet thread (TXT + JSON), live watch page,
+        and Atom / RSS feeds — plus a synthetic `total` summing all
+        counters.
+
+        The **inbound** observability surface — pairs with the
+        outbound webhook delivery log so an operator running MiroShark
+        for a DeFi fund or research group can see which surfaces their
+        audience actually uses. Closes the inbound side of the
+        distribution loop opened by the webhook delivery log on the
+        outbound side.
+
+        Counter file lives at `<sim_dir>/surface-stats.json`. Bounded
+        in size (one small JSON object) and atomically updated via
+        tempfile + `os.replace`, so concurrent requests can never
+        corrupt the file. A corrupt file is silently reset to zeros
+        rather than 500ing the read.
+
+        Same publish gate as every other share surface — requires the
+        simulation to be public (`is_public=true`).
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Per-surface counters + total.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimulationSurfaceStats"
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /share/{simulation_id}:
     get:
       tags: [Publish & Embed]
@@ -2666,6 +2705,92 @@ components:
             True when `inflections_recorded` exceeded the per-thread
             body budget and a bridge tweet was inserted between the
             head and tail inflections.
+
+    SimulationSurfaceStats:
+      type: object
+      description: |
+        Envelope returned by `/api/simulation/{id}/surface-stats`. Each
+        named counter is the cumulative number of times that share
+        surface has served a successful response for the simulation.
+        Every key is always present (zero-defaulted), so a frontend
+        renders the table without special-casing missing fields.
+      required: [success, simulation_id, stats]
+      properties:
+        success:
+          type: boolean
+        simulation_id:
+          type: string
+          description: Echoed simulation id.
+        stats:
+          type: object
+          required:
+            - share_card
+            - replay_gif
+            - transcript_md
+            - transcript_json
+            - trajectory_csv
+            - trajectory_jsonl
+            - thread_txt
+            - thread_json
+            - watch_page
+            - feed_atom
+            - feed_rss
+            - total
+          properties:
+            share_card:
+              type: integer
+              minimum: 0
+              description: Successful `share-card.png` serves.
+            replay_gif:
+              type: integer
+              minimum: 0
+              description: Successful `replay.gif` serves.
+            transcript_md:
+              type: integer
+              minimum: 0
+              description: Successful `transcript.md` serves.
+            transcript_json:
+              type: integer
+              minimum: 0
+              description: Successful `transcript.json` serves.
+            trajectory_csv:
+              type: integer
+              minimum: 0
+              description: Successful `trajectory.csv` serves.
+            trajectory_jsonl:
+              type: integer
+              minimum: 0
+              description: Successful `trajectory.jsonl` serves.
+            thread_txt:
+              type: integer
+              minimum: 0
+              description: Successful `thread.txt` serves.
+            thread_json:
+              type: integer
+              minimum: 0
+              description: Successful `thread.json` serves.
+            watch_page:
+              type: integer
+              minimum: 0
+              description: Successful `/watch/{id}` serves (public sims only).
+            feed_atom:
+              type: integer
+              minimum: 0
+              description: |
+                Number of times this simulation appeared in a served
+                Atom feed render (`/api/feed.atom`). Each feed render
+                increments every sim that landed in the rendered card
+                set, so this counter is best read as "syndicated to
+                Atom subscribers N times".
+            feed_rss:
+              type: integer
+              minimum: 0
+              description: |
+                Same semantics as `feed_atom` for the RSS 2.0 form.
+            total:
+              type: integer
+              minimum: 0
+              description: Sum of every per-surface counter above.
 
     SettingsUpdate:
       type: object

--- a/backend/tests/test_unit_surface_stats.py
+++ b/backend/tests/test_unit_surface_stats.py
@@ -1,0 +1,349 @@
+"""Unit tests for the per-share-surface usage counter service.
+
+Pure offline — no Flask, no network, no simulation runner, no on-disk
+state outside ``tmp_path``. Cover the properties the
+``GET /api/simulation/<id>/surface-stats`` endpoint and every
+``_serve_X`` handler depend on:
+
+  1. Increment from a fresh sim_dir creates the file with a single
+     counter at 1.
+  2. Repeated increments climb monotonically.
+  3. ``read_surface_stats`` zero-defaults every key in ``SURFACE_KEYS``
+     and exposes a synthetic ``total``.
+  4. The atomic write contract — staging file + ``os.replace`` — keeps
+     the on-disk file from ever being half-written.
+  5. Unknown surface keys are silently dropped at increment time so a
+     rogue caller can't pollute the schema.
+  6. A falsy ``sim_dir`` is a graceful no-op (private sim, missing
+     directory) — never raises.
+  7. A corrupt JSON file is silently reset to zeros rather than 500ing
+     the read.
+  8. Negative on-disk values are clamped to zero (defense-in-depth
+     against a hand-edited file producing a negative ``total``).
+  9. Two same-process increments to the same key produce a +2 net
+     change — the read-modify-write gates against losing a count under
+     normal serial load.
+ 10. The route decorator for ``GET /<id>/surface-stats`` is registered
+     in ``app/api/simulation.py`` so the OpenAPI drift test passes.
+ 11. Each ``_serve_X`` handler in ``app/api/simulation.py`` is wired
+     to the matching surface key — increment line presence guard.
+ 12. ``increment_surface_stat`` is fire-and-forget — never raises even
+     when ``os.replace`` fails partway through (we patch it to throw).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+from unittest import mock
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# Late import — keeps the suite collectable even if a future refactor
+# moves the module, the failure surfaces as a single import error
+# rather than an opaque NameError everywhere.
+from app.services import surface_stats  # noqa: E402
+
+
+# ── Module-level invariants ────────────────────────────────────────────
+
+
+def test_surface_keys_includes_every_serve_handler():
+    """The locked set of keys must cover every share surface that has a
+    ``_serve_X`` handler today. New surfaces must be added here AND in
+    the matching handler — failing this test means the analytics layer
+    silently drops a counter."""
+    expected = {
+        "share_card",
+        "replay_gif",
+        "transcript_md",
+        "transcript_json",
+        "trajectory_csv",
+        "trajectory_jsonl",
+        "thread_txt",
+        "thread_json",
+        "watch_page",
+        "feed_atom",
+        "feed_rss",
+    }
+    assert set(surface_stats.SURFACE_KEYS) == expected
+
+
+def test_surface_stats_path_is_pure_join(tmp_path: Path):
+    """Pure path join — must not touch the filesystem."""
+    path = surface_stats.surface_stats_path(str(tmp_path))
+    assert path == str(tmp_path / "surface-stats.json")
+    # And the file does NOT exist after a path lookup.
+    assert not os.path.exists(path)
+
+
+# ── Increment + read happy path ───────────────────────────────────────
+
+
+def test_increment_creates_file_at_one(tmp_path: Path):
+    surface_stats.increment_surface_stat(str(tmp_path), "share_card")
+
+    on_disk = json.loads(
+        (tmp_path / "surface-stats.json").read_text(encoding="utf-8")
+    )
+    # Only the incremented key needs to be present on disk; missing
+    # keys are zero-defaulted on read. (We don't assert exact dict
+    # equality here so adding a new SURFACE_KEY in the future doesn't
+    # break this test.)
+    assert on_disk["share_card"] == 1
+
+
+def test_repeated_increments_climb_monotonically(tmp_path: Path):
+    for _ in range(7):
+        surface_stats.increment_surface_stat(str(tmp_path), "replay_gif")
+
+    stats = surface_stats.read_surface_stats(str(tmp_path))
+    assert stats["replay_gif"] == 7
+    # Other keys remain zero.
+    assert stats["share_card"] == 0
+    assert stats["transcript_md"] == 0
+    # Total reflects only the actually-incremented surface.
+    assert stats["total"] == 7
+
+
+def test_read_zero_defaults_every_key_and_total(tmp_path: Path):
+    """A sim_dir with no stats file produces a fully-zeroed dict so the
+    frontend never has to special-case a missing field."""
+    stats = surface_stats.read_surface_stats(str(tmp_path))
+
+    for key in surface_stats.SURFACE_KEYS:
+        assert stats[key] == 0, f"key {key!r} should default to zero"
+    assert stats["total"] == 0
+    # Every documented frontend key must be present.
+    assert set(stats.keys()) >= set(surface_stats.SURFACE_KEYS) | {"total"}
+
+
+def test_increment_preserves_other_surfaces(tmp_path: Path):
+    """A new increment to one key must not zero out another key — the
+    on-disk file is read, mutated in place, then re-written."""
+    surface_stats.increment_surface_stat(str(tmp_path), "transcript_md")
+    surface_stats.increment_surface_stat(str(tmp_path), "transcript_md")
+    surface_stats.increment_surface_stat(str(tmp_path), "trajectory_csv")
+    surface_stats.increment_surface_stat(str(tmp_path), "feed_rss")
+
+    stats = surface_stats.read_surface_stats(str(tmp_path))
+    assert stats["transcript_md"] == 2
+    assert stats["trajectory_csv"] == 1
+    assert stats["feed_rss"] == 1
+    assert stats["total"] == 4
+
+
+# ── Edge cases / failure modes ────────────────────────────────────────
+
+
+def test_unknown_surface_key_is_silently_dropped(tmp_path: Path):
+    """Defense-in-depth on the schema: a rogue caller passing a key not
+    in ``SURFACE_KEYS`` must not write that key to disk."""
+    surface_stats.increment_surface_stat(str(tmp_path), "totally_made_up")
+
+    # No file written — the increment short-circuited.
+    assert not os.path.exists(tmp_path / "surface-stats.json")
+    stats = surface_stats.read_surface_stats(str(tmp_path))
+    assert "totally_made_up" not in stats
+    assert stats["total"] == 0
+
+
+def test_falsy_sim_dir_is_a_no_op():
+    """Private sim / missing dir / None — must never raise. This is the
+    posture every ``_serve_X`` handler relies on so a peripheral failure
+    can't 500 a successful share-card serve."""
+    surface_stats.increment_surface_stat(None, "share_card")
+    surface_stats.increment_surface_stat("", "share_card")
+
+    stats = surface_stats.read_surface_stats(None)
+    assert stats["total"] == 0
+    for key in surface_stats.SURFACE_KEYS:
+        assert stats[key] == 0
+
+
+def test_corrupt_json_file_resets_to_zeros(tmp_path: Path):
+    """A half-written / hand-edited / truncated stats file must read as
+    zeros rather than 500ing the GET endpoint."""
+    (tmp_path / "surface-stats.json").write_text(
+        '{"share_card": 12, "replay_gif"',  # truncated mid-key
+        encoding="utf-8",
+    )
+
+    stats = surface_stats.read_surface_stats(str(tmp_path))
+    assert stats["share_card"] == 0
+    assert stats["total"] == 0
+
+    # And a subsequent increment must succeed — the corrupt file is
+    # rewritten with a clean schema.
+    surface_stats.increment_surface_stat(str(tmp_path), "share_card")
+    stats = surface_stats.read_surface_stats(str(tmp_path))
+    assert stats["share_card"] == 1
+
+
+def test_negative_on_disk_values_clamped_to_zero(tmp_path: Path):
+    """A hand-edited file with a negative count would otherwise produce
+    a negative ``total`` — clamp at read time and on the next write."""
+    (tmp_path / "surface-stats.json").write_text(
+        json.dumps({"share_card": -5, "replay_gif": 3}),
+        encoding="utf-8",
+    )
+
+    stats = surface_stats.read_surface_stats(str(tmp_path))
+    assert stats["share_card"] == 0
+    assert stats["replay_gif"] == 3
+    assert stats["total"] == 3
+
+
+def test_atomic_write_uses_os_replace(tmp_path: Path):
+    """The write path must go through ``os.replace`` so a concurrent
+    reader either sees the old file or the new one — never a partial
+    write. We patch ``os.replace`` and assert it was invoked."""
+    with mock.patch.object(
+        surface_stats.os, "replace", wraps=surface_stats.os.replace
+    ) as replace_spy:
+        surface_stats.increment_surface_stat(str(tmp_path), "watch_page")
+
+    assert replace_spy.called, "increment must use os.replace, not a naive open()"
+    # Final state still ends up correct.
+    stats = surface_stats.read_surface_stats(str(tmp_path))
+    assert stats["watch_page"] == 1
+
+
+def test_increment_swallows_replace_failure(tmp_path: Path):
+    """A filesystem error during ``os.replace`` (read-only mount, full
+    disk, antivirus lock) must never bubble out — the analytics layer
+    is best-effort. The serve path that called us already returned a
+    successful response."""
+    with mock.patch.object(
+        surface_stats.os, "replace", side_effect=OSError("disk full")
+    ):
+        # Must not raise.
+        surface_stats.increment_surface_stat(str(tmp_path), "thread_txt")
+
+    # No partial file left behind, no count persisted.
+    assert not os.path.exists(tmp_path / "surface-stats.json")
+
+
+# ── Route + handler wiring guards ─────────────────────────────────────
+
+
+def _read_simulation_api() -> str:
+    return (_BACKEND / "app" / "api" / "simulation.py").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_surface_stats_route_decorator_registered():
+    """The ``GET /<id>/surface-stats`` route must exist in
+    simulation.py — the OpenAPI drift test will surface a missing path
+    on the spec side, but the decorator scan here catches an
+    accidental decorator removal that wouldn't show up on the spec
+    test in isolation."""
+    text = _read_simulation_api()
+    assert (
+        "@simulation_bp.route('/<simulation_id>/surface-stats', methods=['GET'])"
+        in text
+    ), "GET /<id>/surface-stats route decorator missing from simulation.py"
+    assert "def get_surface_stats" in text, (
+        "get_surface_stats handler function missing from simulation.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "surface_key",
+    [
+        "share_card",
+        "replay_gif",
+        "transcript_md",
+        "transcript_json",
+        "trajectory_csv",
+        "trajectory_jsonl",
+        "thread_txt",
+        "thread_json",
+    ],
+)
+def test_serve_handlers_increment_their_surface_key(surface_key: str):
+    """Every share-surface handler must increment its matching counter.
+    Static guard against an accidental removal of the increment line —
+    the handler itself stays green if the increment is missing, but
+    the analytics layer goes silent for that surface."""
+    text = _read_simulation_api()
+    needle = f'"{surface_key}"'
+    assert needle in text, (
+        f"surface key {surface_key!r} not referenced in simulation.py — "
+        f"the matching _serve_X handler must call "
+        f"surface_stats.increment_surface_stat(..., {needle})"
+    )
+
+
+def test_watch_handler_increments_watch_page():
+    text = (_BACKEND / "app" / "api" / "watch.py").read_text(encoding="utf-8")
+    assert '"watch_page"' in text, (
+        "watch.py must increment the watch_page counter via "
+        "surface_stats.increment_surface_stat(..., \"watch_page\")"
+    )
+    assert "surface_stats.increment_surface_stat" in text
+
+
+def test_feed_handler_increments_per_card():
+    text = (_BACKEND / "app" / "api" / "feed.py").read_text(encoding="utf-8")
+    assert "surface_stats.increment_surface_stat" in text, (
+        "feed.py must increment a feed counter for every sim that "
+        "appears in a served feed render"
+    )
+    # Both Atom and RSS surface keys must be referenced.
+    assert '"feed_atom"' in text
+    assert '"feed_rss"' in text
+
+
+def test_openapi_spec_documents_surface_stats_path():
+    """End-to-end paranoia: the YAML spec must list the new path so
+    the drift test passes. Independent from the regex scan above."""
+    spec_text = (_BACKEND / "openapi.yaml").read_text(encoding="utf-8")
+    assert "/api/simulation/{simulation_id}/surface-stats:" in spec_text, (
+        "openapi.yaml is missing the /surface-stats path entry"
+    )
+    assert "SimulationSurfaceStats:" in spec_text, (
+        "openapi.yaml is missing the SimulationSurfaceStats schema"
+    )
+
+
+# ── Composite integration-style guard ─────────────────────────────────
+
+
+def test_full_distribution_table_round_trips(tmp_path: Path):
+    """A realistic operator session: PNG served 4×, replay GIF 2×,
+    transcript Markdown 1×, trajectory CSV 3×, watch page 1×. The
+    response shape is exactly what the EmbedDialog Distribution panel
+    consumes — column order doesn't matter, but every key must be
+    present."""
+    plan: Iterable[tuple[str, int]] = [
+        ("share_card", 4),
+        ("replay_gif", 2),
+        ("transcript_md", 1),
+        ("trajectory_csv", 3),
+        ("watch_page", 1),
+    ]
+    for key, n in plan:
+        for _ in range(n):
+            surface_stats.increment_surface_stat(str(tmp_path), key)
+
+    stats = surface_stats.read_surface_stats(str(tmp_path))
+    assert stats["share_card"] == 4
+    assert stats["replay_gif"] == 2
+    assert stats["transcript_md"] == 1
+    assert stats["trajectory_csv"] == 3
+    assert stats["watch_page"] == 1
+    assert stats["total"] == 4 + 2 + 1 + 3 + 1
+    # Untouched surfaces are zero, not absent.
+    assert stats["thread_txt"] == 0
+    assert stats["feed_atom"] == 0

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,6 +93,7 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `GET` | `/api/simulation/<id>/trajectory.jsonl` | Per-round belief JSONL (DuckDB / pipelines) |
 | `GET` | `/api/simulation/<id>/thread.txt` | Auto-formatted X / Twitter tweet thread (one tweet per belief inflection point, ≤280 chars each) |
 | `GET` | `/api/simulation/<id>/thread.json` | Same tweet thread as `thread.txt` but as `{tweets, total, inflections_recorded, truncated}` for programmatic consumers |
+| `GET` | `/api/simulation/<id>/surface-stats` | Per-share-surface request counters — share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS, plus a synthetic `total` |
 | `GET` | `/share/<id>` | Public OG-tag landing page (auto-redirects to SPA) |
 | `GET` | `/watch/<id>` | Live spectator-watch page — minimal full-viewport broadcast view, polls every 15 s, OG / Twitter-card unfurl |
 | `POST` | `/api/simulation/<id>/article` | Generate a Substack-style write-up |

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -87,6 +87,7 @@
 | `GET` | `/api/simulation/<id>/embed-summary` | 嵌入载荷(仅公开模拟) |
 | `GET` | `/api/simulation/<id>/thread.txt` | 自动生成的 X / Twitter 推文串(每个信念转折点一条推文,每条 ≤280 字符) |
 | `GET` | `/api/simulation/<id>/thread.json` | 同样的推文串内容,以 `{tweets, total, inflections_recorded, truncated}` 形式返回,供程序消费 |
+| `GET` | `/api/simulation/<id>/surface-stats` | 每个分享面的请求计数器 — 分享卡 / 回放 GIF / 转录 / 轨迹 / 推文串 / 观看页 / Atom / RSS,以及合成的 `total` |
 | `POST` | `/api/simulation/<id>/article` | 生成 Substack 风格的报道 |
 | `GET` | `/api/simulation/<id>/export` | 完整 JSON 导出 |
 | `GET` | `/api/simulation/list` | 列出模拟 |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -254,6 +254,31 @@ The Embed dialog has a "🧵 Tweet thread" section beneath the trajectory row: a
 
 Implementation: `app/services/thread_formatter.py` (pure stdlib `json` + `os`, ~430 LoC) + `_serve_thread()` shared body in `app/api/simulation.py` mirroring the `_serve_transcript` / `_serve_trajectory` pattern. Zero new dependencies.
 
+## Surface Usage Analytics
+
+The first **inbound** observability surface, paired with the outbound webhook delivery log. Every successful share-surface response increments a counter on disk (`<sim_dir>/surface-stats.json`); `GET /api/simulation/<id>/surface-stats` returns the per-surface counts so an operator running MiroShark for a DeFi fund or research group can see which surfaces their audience actually uses.
+
+Counters tracked (one per share surface):
+
+- `share_card` — `share-card.png` serves
+- `replay_gif` — `replay.gif` serves
+- `transcript_md` / `transcript_json` — `transcript.md` / `transcript.json` serves
+- `trajectory_csv` / `trajectory_jsonl` — `trajectory.csv` / `trajectory.jsonl` serves
+- `thread_txt` / `thread_json` — `thread.txt` / `thread.json` serves
+- `watch_page` — `/watch/<id>` serves (public sims only)
+- `feed_atom` / `feed_rss` — number of times this simulation was syndicated to an Atom or RSS feed render
+
+Plus a synthetic `total` summing all counters. Every key is always present (zero-defaulted), so a frontend renders the table without special-casing missing fields.
+
+Implementation:
+
+- **Atomic writes.** Each increment is a read-modify-write through a tempfile + `os.replace`, so two concurrent requests can't truncate the JSON to `{` and lose every prior count. Same pattern the webhook delivery log uses.
+- **Bounded.** A single small JSON object — only the keys in `SURFACE_KEYS` are persisted; an unknown key from a rogue caller is silently dropped, never written.
+- **Fire-and-forget.** Increment never raises; a corrupt counter file is silently reset to zeros. The serve path always succeeds, even when the analytics layer is broken (read-only mount, full disk, antivirus lock on the staging file).
+- **Stdlib only.** `json` + `os` + `tempfile`. Zero new dependencies.
+
+The Embed dialog has a "📊 Distribution" panel (collapsed by default, click the chevron to expand) — a sorted two-column table (surface · count, ranked by count desc), a `Total serves: N` row, and a `↻ Refresh` button. The panel is publish-gated; private sims see "Publish the simulation to see distribution stats." instead. Same publish gate as every other share surface (`is_public=true`).
+
 ## Article Generation
 
 After a simulation finishes, click **Write Article** and MiroShark asks the Smart model to produce a 400–600-word Substack-style write-up grounded in what actually happened — key findings, market dynamics, belief shifts, and implications. The article is cached at `generated_article.json` so it doesn't re-spend tokens on reopen; pass `force_regenerate=true` to refresh.

--- a/docs/FEATURES.zh-CN.md
+++ b/docs/FEATURES.zh-CN.md
@@ -190,6 +190,31 @@ WONDERWALL_MODEL_NAME=your-model-id
 
 实现:`app/services/thread_formatter.py`(纯标准库 `json` + `os`,~430 行)+ `app/api/simulation.py` 中的 `_serve_thread()` 共享函数体,镜像 `_serve_transcript` / `_serve_trajectory` 模式。零新增依赖。
 
+## 分发统计(分享面使用分析)
+
+第一个**入站**可观测性界面,与出站 Webhook 投递日志相对应。每一次成功的分享面响应都会在磁盘上(`<sim_dir>/surface-stats.json`)递增一个计数器;`GET /api/simulation/<id>/surface-stats` 返回每个分享面的计数,让运维 MiroShark 的 DeFi 基金或研究小组,能看到他们的受众实际上使用的是哪一个面。
+
+跟踪的计数器(每个分享面一个):
+
+- `share_card` — `share-card.png` 服务次数
+- `replay_gif` — `replay.gif` 服务次数
+- `transcript_md` / `transcript_json` — `transcript.md` / `transcript.json` 服务次数
+- `trajectory_csv` / `trajectory_jsonl` — `trajectory.csv` / `trajectory.jsonl` 服务次数
+- `thread_txt` / `thread_json` — `thread.txt` / `thread.json` 服务次数
+- `watch_page` — `/watch/<id>` 服务次数(仅公开模拟)
+- `feed_atom` / `feed_rss` — 此模拟出现在已渲染的 Atom 或 RSS 订阅源中的次数
+
+以及一个合成的 `total` 字段汇总所有计数器。每个键都始终存在(零默认),因此前端无需为缺失字段做特殊处理。
+
+实现:
+
+- **原子写入。** 每次递增是一个通过 tempfile + `os.replace` 的读-改-写过程,确保两个并发请求不会把 JSON 截断为 `{` 而丢失全部历史计数。与 webhook 投递日志使用同一模式。
+- **有界。** 单个小型 JSON 对象 — 仅 `SURFACE_KEYS` 中的键被持久化;来自调用方的未知键会被静默丢弃,绝不会写入。
+- **fire-and-forget。** 递增永远不抛异常;损坏的计数器文件会被静默重置为零。即使分析层故障(只读挂载、磁盘满、暂存文件被杀毒锁定),服务路径也始终成功。
+- **仅标准库。** `json` + `os` + `tempfile`。零新增依赖。
+
+嵌入对话框有「📊 分发统计」面板(默认折叠,点击 ▾ 展开)— 一个有序的两列表(分享面 · 计数,按计数倒序排序),一个「总服务数:N」行,以及一个「↻ 刷新」按钮。该面板有发布门控;私有模拟会显示「发布模拟以查看分发统计。」。与每个其他分享面一样的发布门控(`is_public=true`)。
+
 ## 图库搜索与筛选
 
 `/explore` 是公开研究界面 — 每一次发布的 MiroShark 模拟,都以卡片网格浏览。当语料库突破几十条后,反向时间序列的滚动列表就不再是工具,因此图库现在自带索引:卡片之上有一个关键词搜索框、一组共识筛选芯片、一组质量筛选芯片以及一个排序下拉。激活的筛选集合保存在 URL 参数中(`?q=…&consensus=bearish&quality=excellent&sort=rounds`),因此任意筛选视图都可作为书签分享 — "每一次关于 Aave 的优秀质量看跌预言"成了一个可发推文的 URL。

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -548,6 +548,29 @@ export const getThreadJsonUrl = (simulationId, origin) => {
 }
 
 /**
+ * Fetch per-share-surface request counters for a published
+ * simulation. Returns `{success, simulation_id, stats}` where `stats`
+ * is the per-surface counter dict — `share_card`, `replay_gif`,
+ * `transcript_md` / `transcript_json`, `trajectory_csv` /
+ * `trajectory_jsonl`, `thread_txt` / `thread_json`, `watch_page`,
+ * `feed_atom` / `feed_rss`, plus a synthetic `total`.
+ *
+ * The inbound observability surface — pairs with the outbound
+ * webhook delivery log so an operator running MiroShark for a DeFi
+ * fund or research group can see which surfaces their audience
+ * actually uses.
+ *
+ * Same publish gate as the share card / transcript / trajectory /
+ * thread endpoints. Returns 403 for unpublished simulations.
+ *
+ * @param {string} simulationId
+ * @returns {Promise<{success: boolean, simulation_id: string, stats: object}>}
+ */
+export const getSurfaceStats = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/surface-stats`)
+}
+
+/**
  * Build the absolute URL of the public share landing page for a
  * simulation. The page exposes Open Graph + Twitter Card meta tags so
  * pasting the URL into Twitter/X / Discord / Slack / LinkedIn unfurls

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -468,6 +468,80 @@
               </div>
             </div>
 
+            <!-- Inbound observability — per-share-surface request
+                 counters. Pairs with the outbound webhook delivery log
+                 so an operator running MiroShark for a DeFi fund or
+                 research group has both directions of the distribution
+                 loop visible from the same dialog. Collapsed by default
+                 to keep the panel compact for users who only care about
+                 the share / publish / outcome flow. -->
+            <div class="transcript-section surface-stats-section">
+              <div class="transcript-head surface-stats-head" @click="toggleSurfaceStats">
+                <span class="transcript-icon">📊</span>
+                <div class="transcript-head-body">
+                  <div class="transcript-title">
+                    {{ $tr('Distribution', '分发统计') }}
+                    <span v-if="isPublic && surfaceStatsTotal > 0" class="surface-stats-total-badge">
+                      {{ surfaceStatsTotal }}
+                    </span>
+                  </div>
+                  <div class="transcript-sub">
+                    {{ $tr('How many times each share surface has been served — the inbound side of the distribution loop the webhook log tracks on the outbound side.', '每个分享面已被服务的次数 — 分发回路的入站侧,webhook 日志跟踪的是出站侧。') }}
+                  </div>
+                </div>
+                <button
+                  class="surface-stats-chevron"
+                  :class="{ 'surface-stats-chevron-open': surfaceStatsExpanded }"
+                  :aria-expanded="surfaceStatsExpanded"
+                  type="button"
+                >
+                  ▾
+                </button>
+              </div>
+
+              <div v-if="surfaceStatsExpanded" class="surface-stats-body">
+                <div v-if="!isPublic" class="transcript-empty">
+                  {{ $tr('Publish the simulation to see distribution stats.', '发布模拟以查看分发统计。') }}
+                </div>
+                <div v-else-if="surfaceStatsLoading" class="surface-stats-loading">
+                  {{ $tr('Loading distribution data…', '加载分发数据…') }}
+                </div>
+                <div v-else-if="surfaceStatsError" class="transcript-empty surface-stats-error">
+                  {{ surfaceStatsError }}
+                </div>
+                <div v-else-if="surfaceStatsAllZero" class="transcript-empty">
+                  {{ $tr('No surface serves recorded yet — share this simulation to see distribution data appear here.', '尚未记录任何分享面服务 — 分享此模拟即可在此查看分发数据。') }}
+                </div>
+                <div v-else class="surface-stats-table">
+                  <div
+                    v-for="row in surfaceStatsRows"
+                    :key="`stats-row-${row.key}`"
+                    class="surface-stats-row"
+                    :class="{ 'surface-stats-row-zero': row.count === 0 }"
+                  >
+                    <span class="surface-stats-label">{{ row.label }}</span>
+                    <span class="surface-stats-count">{{ row.count }}</span>
+                  </div>
+                  <div class="surface-stats-row surface-stats-row-total">
+                    <span class="surface-stats-label">{{ $tr('Total serves', '总服务数') }}</span>
+                    <span class="surface-stats-count">{{ surfaceStatsTotal }}</span>
+                  </div>
+                </div>
+
+                <div v-if="isPublic" class="surface-stats-actions">
+                  <button
+                    class="surface-stats-refresh"
+                    type="button"
+                    :disabled="surfaceStatsLoading"
+                    @click="loadSurfaceStats"
+                  >
+                    <span v-if="surfaceStatsLoading">{{ $tr('Refreshing…', '刷新中…') }}</span>
+                    <span v-else>↻ {{ $tr('Refresh', '刷新') }}</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+
             <!-- Verified-prediction annotation — lets operators turn a
                  published simulation into a "called it" record on the
                  /verified gallery page. Only meaningful once the run is
@@ -664,6 +738,7 @@ import {
   getTrajectoryJsonlUrl,
   getThreadTxtUrl,
   getThreadJsonUrl,
+  getSurfaceStats,
   getFeedUrl,
   getSimulationOutcome,
   submitSimulationOutcome,
@@ -851,6 +926,90 @@ const loadThread = async () => {
     threadTruncated.value = false
   } finally {
     threadLoading.value = false
+  }
+}
+
+// ── Surface-stats state ────────────────────────────────────────────────
+// The first inbound observability surface — pairs with the outbound
+// webhook delivery log. Counters live in `<sim_dir>/surface-stats.json`
+// and are incremented by every successful `_serve_X` handler. The
+// panel is collapsed by default to keep the dialog compact for users
+// who only care about the share / publish / outcome flow.
+const surfaceStatsExpanded = ref(false)
+const surfaceStatsLoading = ref(false)
+const surfaceStatsError = ref('')
+const surfaceStats = ref(null)
+
+const SURFACE_STAT_LABELS = [
+  { key: 'share_card', label: tr('Share card · PNG', '分享卡片 · PNG') },
+  { key: 'replay_gif', label: tr('Replay GIF', '回放 GIF') },
+  { key: 'transcript_md', label: tr('Transcript · Markdown', '记录 · Markdown') },
+  { key: 'transcript_json', label: tr('Transcript · JSON', '记录 · JSON') },
+  { key: 'trajectory_csv', label: tr('Trajectory · CSV', '轨迹 · CSV') },
+  { key: 'trajectory_jsonl', label: tr('Trajectory · JSONL', '轨迹 · JSONL') },
+  { key: 'thread_txt', label: tr('Tweet thread · TXT', '推文串 · TXT') },
+  { key: 'thread_json', label: tr('Tweet thread · JSON', '推文串 · JSON') },
+  { key: 'watch_page', label: tr('Watch page', '观看页面') },
+  { key: 'feed_atom', label: tr('Atom feed', 'Atom 源') },
+  { key: 'feed_rss', label: tr('RSS feed', 'RSS 源') },
+]
+
+const surfaceStatsRows = computed(() => {
+  const stats = surfaceStats.value || {}
+  return SURFACE_STAT_LABELS
+    .map((row) => ({ ...row, count: Number(stats[row.key] || 0) }))
+    .sort((a, b) => b.count - a.count)
+})
+
+const surfaceStatsTotal = computed(() => {
+  if (!surfaceStats.value) return 0
+  return Number(surfaceStats.value.total || 0)
+})
+
+const surfaceStatsAllZero = computed(() => {
+  if (!surfaceStats.value) return true
+  return surfaceStatsTotal.value === 0
+})
+
+const loadSurfaceStats = async () => {
+  if (!props.simulationId || !isPublic.value) {
+    surfaceStats.value = null
+    return
+  }
+  surfaceStatsLoading.value = true
+  surfaceStatsError.value = ''
+  try {
+    const res = await getSurfaceStats(props.simulationId)
+    if (res?.success && res.stats) {
+      surfaceStats.value = res.stats
+    } else if (res?.data?.stats) {
+      surfaceStats.value = res.data.stats
+    } else {
+      surfaceStats.value = null
+      surfaceStatsError.value = res?.error
+        || tr('Could not load distribution stats.', '无法加载分发统计。')
+    }
+  } catch (err) {
+    if (err?.response?.status === 403) {
+      surfaceStatsError.value = tr(
+        'Publish the simulation to see distribution stats.',
+        '发布模拟以查看分发统计。',
+      )
+    } else {
+      surfaceStatsError.value = err?.response?.data?.error
+        || err?.message
+        || tr('Could not load distribution stats.', '无法加载分发统计。')
+    }
+    surfaceStats.value = null
+  } finally {
+    surfaceStatsLoading.value = false
+  }
+}
+
+const toggleSurfaceStats = () => {
+  surfaceStatsExpanded.value = !surfaceStatsExpanded.value
+  if (surfaceStatsExpanded.value && !surfaceStats.value) {
+    loadSurfaceStats()
   }
 }
 
@@ -1083,6 +1242,14 @@ watch(() => props.open, async (val) => {
   // gate, so a private sim resolves cleanly to the empty state without
   // an extra round-trip on every dialog open.
   loadThread()
+  // Reset surface-stats state on each open so a previously expanded
+  // panel doesn't show stale numbers from a different sim. The
+  // counters are only fetched on demand (when the operator expands
+  // the panel) so a viewer who only cares about the share flow
+  // doesn't pay the network round-trip.
+  surfaceStatsExpanded.value = false
+  surfaceStats.value = null
+  surfaceStatsError.value = ''
 })
 
 // When the operator toggles public on, the share-card endpoint flips from
@@ -1092,6 +1259,13 @@ watch(isPublic, () => {
   // Re-fetch the thread when the publish flag flips — going public means
   // the gate now passes, so the previously-403 fetch should retry.
   loadThread()
+  // Same publish-gate flip applies to the surface-stats panel — pull
+  // fresh counters if the user has the panel expanded.
+  if (surfaceStatsExpanded.value) {
+    loadSurfaceStats()
+  } else {
+    surfaceStats.value = null
+  }
 })
 </script>
 
@@ -1825,6 +1999,160 @@ watch(isPublic, () => {
   font-size: 11px;
   color: #6b6b6b;
   font-style: italic;
+}
+
+/* Surface usage analytics — pairs visually with the transcript /
+   trajectory / thread sections (same shell, same head shape) so the
+   dialog reads as one continuous Publish & Embed flow. The head is
+   the click target that toggles the body open / closed; body uses a
+   compact two-column grid (label / count) sorted by count desc so
+   the operator's most-used surface lands at the top of the table. */
+.surface-stats-section {
+  cursor: default;
+}
+
+.surface-stats-head {
+  cursor: pointer;
+  user-select: none;
+  align-items: center;
+}
+
+.surface-stats-head:hover .surface-stats-chevron {
+  color: #0a0a0a;
+}
+
+.surface-stats-total-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 8px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #0a0a0a;
+  background: #f4ecd8;
+  border-radius: 999px;
+  vertical-align: middle;
+}
+
+.surface-stats-chevron {
+  border: 0;
+  background: transparent;
+  font-size: 16px;
+  line-height: 1;
+  color: #6b6b6b;
+  cursor: pointer;
+  padding: 4px 6px;
+  transition: transform 0.15s, color 0.15s;
+}
+
+.surface-stats-chevron-open {
+  transform: rotate(180deg);
+  color: #0a0a0a;
+}
+
+.surface-stats-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.surface-stats-loading {
+  font-size: 12px;
+  color: #6b6b6b;
+  font-style: italic;
+}
+
+.surface-stats-error {
+  color: #b91c1c;
+}
+
+.surface-stats-table {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  row-gap: 4px;
+  column-gap: 14px;
+  padding: 10px 12px;
+  background: #fafaf7;
+  border: 1px solid #ececec;
+  border-radius: 8px;
+  font-size: 12px;
+}
+
+.surface-stats-row {
+  display: contents;
+  color: #1a1a1a;
+}
+
+.surface-stats-row > .surface-stats-label {
+  padding: 3px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.surface-stats-row > .surface-stats-count {
+  padding: 3px 0;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.surface-stats-row-zero > .surface-stats-label,
+.surface-stats-row-zero > .surface-stats-count {
+  color: #9b9b9b;
+  font-weight: 400;
+}
+
+.surface-stats-row-total {
+  border-top: 1px solid #ececec;
+  margin-top: 2px;
+  padding-top: 2px;
+}
+
+.surface-stats-row-total > .surface-stats-label {
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+
+.surface-stats-row-total > .surface-stats-count {
+  font-weight: 700;
+}
+
+.surface-stats-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.surface-stats-refresh {
+  border: 1px solid #d4d4d4;
+  background: #ffffff;
+  color: #1a1a1a;
+  padding: 6px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.surface-stats-refresh:hover:not(:disabled) {
+  background: #f4ecd8;
+  border-color: #c2a76b;
+}
+
+.surface-stats-refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 600px) {
+  .surface-stats-table {
+    font-size: 11px;
+  }
 }
 
 /* Live watch page — distinct visual treatment (warm orange tint)

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -528,6 +528,10 @@
                   </div>
                 </div>
 
+                <div v-if="!surfaceStatsAllZero" class="surface-stats-caveat">
+                  {{ $tr('Counts origin hits only — CDN and browser caches are not counted, so true audience reach is higher.', '仅统计源服务器命中 — 不计入 CDN 与浏览器缓存,实际受众覆盖更高。') }}
+                </div>
+
                 <div v-if="isPublic" class="surface-stats-actions">
                   <button
                     class="surface-stats-refresh"
@@ -958,7 +962,7 @@ const surfaceStatsRows = computed(() => {
   const stats = surfaceStats.value || {}
   return SURFACE_STAT_LABELS
     .map((row) => ({ ...row, count: Number(stats[row.key] || 0) }))
-    .sort((a, b) => b.count - a.count)
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key))
 })
 
 const surfaceStatsTotal = computed(() => {
@@ -2118,6 +2122,16 @@ watch(isPublic, () => {
 
 .surface-stats-row-total > .surface-stats-count {
   font-weight: 700;
+}
+
+.surface-stats-caveat {
+  margin-top: 8px;
+  padding: 6px 8px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: #6b6b6b;
+  background: #f7f7f7;
+  border-radius: 4px;
 }
 
 .surface-stats-actions {


### PR DESCRIPTION
## What

Adds the **inbound** observability layer that pairs with the outbound webhook delivery log (PR #73). Every successful share-surface response now increments a counter on disk; `GET /api/simulation/<id>/surface-stats` returns the per-surface counts.

- **`<sim_dir>/surface-stats.json`** — single small JSON object, one counter per share surface. Atomic read-modify-write through `tempfile.mkstemp` + `os.replace`, so two concurrent requests can't truncate the file. Schema is locked by `SURFACE_KEYS`; an unknown key from a rogue caller is silently dropped, never written.
- **`GET /api/simulation/<id>/surface-stats`** — publish-gated, returns `{success, simulation_id, stats}` where `stats` is every counter (zero-defaulted) plus a synthetic `total`. The frontend renders the table without special-casing missing fields.
- **EmbedDialog "📊 Distribution" panel** — collapsed by default to keep the dialog compact for users who only care about the share / publish / outcome flow. Click the chevron to expand → sorted two-column table (surface · count, ranked by count desc), `Total serves: N` row, `↻ Refresh` button. Publish-gated.

Counters tracked:

| Key | Surface |
|---|---|
| `share_card` | `share-card.png` serves |
| `replay_gif` | `replay.gif` serves |
| `transcript_md` / `transcript_json` | `transcript.md` / `transcript.json` |
| `trajectory_csv` / `trajectory_jsonl` | `trajectory.csv` / `trajectory.jsonl` |
| `thread_txt` / `thread_json` | `thread.txt` / `thread.json` |
| `watch_page` | `/watch/<id>` (public sims only) |
| `feed_atom` / `feed_rss` | times this sim was syndicated to a feed render |

Plus a synthetic `total` summing all counters.

## Why

PR #73 closed the outbound observability gap — operators can now see whether the webhook fired and what HTTP status it returned. But there was no equivalent visibility for the inbound side: how many times was the share card served? How many RSS subscribers fetched the feed? How many people copied the thread? An operator running MiroShark for a DeFi fund or research group publishes simulation results across ten share surfaces and had zero signal on which ones their audience actually used.

One atomic counter increment per `_serve_X` handler, one read endpoint, one EmbedDialog panel. The first operator-side feedback loop on which surfaces matter — without any new deps, without any architectural shift.

Pivot from May 6 repo-actions idea #4 — picked over #1 Simulation Config Export (touches the existing sim-creation path, more integration risk), #2 Python Client SDK (needs a new GitHub Actions workflow file — PAT scope concern), #3 Director Event Timeline Overlay (needs chartjs-plugin-annotation check + frontend chart annotation), and #5 Comparative Run View (clean but lower operator-side impact than analytics) because #4 was the cleanest small-effort autonomous pick: pure stdlib, follows the just-shipped \`_record_*\` / \`read_*\` pattern from PR #73, increments inline in every existing \`_serve_X\` handler, zero new dependencies.

## Changes

- **`backend/app/services/surface_stats.py`** — pure stdlib (`json` + `os` + `tempfile`). `SURFACE_KEYS` frozenset locks the schema, `increment_surface_stat` is fire-and-forget with atomic tempfile + `os.replace`, `read_surface_stats` zero-defaults every key plus a synthetic `total`. Negative on-disk values clamped to zero; corrupt JSON silently resets to zeros rather than 500ing the read.
- **`backend/app/api/simulation.py`** — `surface_stats.increment_surface_stat(...)` call in every `_serve_X` handler (`share_card`, `replay_gif`, `transcript_md` / `_json`, `trajectory_csv` / `_jsonl`, `thread_txt` / `_json`) + new `GET /<id>/surface-stats` route handler, publish-gated.
- **`backend/app/api/watch.py`** — increment `watch_page` only after a *public* sim served a successful broadcast page (the generic broadcast page rendered for private / missing sims must never write to a non-existent `sim_dir`).
- **`backend/app/api/feed.py`** — per-card increment for `feed_atom` / `feed_rss` so the operator-facing question "was my sim syndicated to RSS this poll cycle?" gets a per-sim answer, not a global feed-fetch count.
- **`backend/openapi.yaml`** — `/api/simulation/{id}/surface-stats` path under Publish & Embed + `SimulationSurfaceStats` schema. Drift-detection test passes.
- **`backend/tests/test_unit_surface_stats.py`** — 18 offline tests covering: `SURFACE_KEYS` parity, atomic-write contract, fire-and-forget failure swallowing, unknown-key drop, falsy `sim_dir` no-op, corrupt-file reset, negative clamp, route-decorator presence guard, per-handler increment line guard.
- **`frontend/src/api/simulation.js`** — `getSurfaceStats` helper.
- **`frontend/src/components/EmbedDialog.vue`** — collapsible "📊 Distribution" panel between the thread section and the outcome section, with a sorted table, refresh button, and full responsive CSS. Publish-gated.
- **`README.md`** (en + zh-CN), **`docs/FEATURES.md`** + **`docs/FEATURES.zh-CN.md`**, **`docs/API.md`** + **`docs/API.zh-CN.md`** — feature row + full docs section.

Zero new dependencies — pure stdlib backend, vanilla Vue frontend, no new npm packages. The streak now spans 14 consecutive PRs without a new dep.

---
*Built autonomously by Aeon*