### PR TITLE
feat: reproducibility config export — citation primitive for share surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Completion Webhook** | POST a JSON summary the moment a sim finishes — wires Slack, Discord, Zapier, Make, n8n, or any custom endpoint with one URL field |
 | **Webhook Delivery Log** | Per-sim `webhook-log.jsonl` records every dispatch attempt (status code, latency, error). Inspect from the EmbedDialog and re-fire any failed delivery with a "Retry" button — closes the operational blindspot every Zapier / n8n integration eventually hits |
 | **Surface Usage Analytics** | `GET /api/simulation/<id>/surface-stats` — per-share-surface request counters (share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS) with a synthetic `total`. Inbound observability for the distribution loop the webhook log tracks on the outbound side |
+| **Reproducibility Config** | `GET /api/simulation/<id>/reproduce.json` — citation primitive for the share surfaces. A v1-schema JSON blob carrying every parameter another operator needs to re-run the same simulation: scenario, agent count, total rounds, platform toggles, time-config knobs, director events, and fork / counterfactual lineage. Identical exports of a finished sim are bytewise-identical, so the file hash is a stable citation key |
 
 Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 
@@ -237,6 +238,7 @@ cp .env.example .env
 | **完成 Webhook** | 模拟一结束即 POST 一份 JSON 摘要 — 一个 URL 字段即可连通 Slack、Discord、Zapier、Make、n8n 或任意自定义端点 |
 | **Webhook 投递日志** | 每个模拟在 `webhook-log.jsonl` 记录每次投递尝试(HTTP 状态码、延迟、错误)。可在 EmbedDialog 中查看,并通过「重试」按钮重发任何失败的投递 — 弥补每个 Zapier / n8n 集成最终都会遇到的运维盲点 |
 | **分发统计(分享面使用分析)** | `GET /api/simulation/<id>/surface-stats` — 每个分享面的请求计数器(分享卡 / 回放 GIF / 转录 / 轨迹 / 推文串 / 观看页 / Atom / RSS),以及合成的 `total`。Webhook 日志在出站侧跟踪分发回路,本面则负责入站可观测性 |
+| **可复现配置导出** | `GET /api/simulation/<id>/reproduce.json` — 分享面背后的引用基元。v1-schema 的 JSON 文档,携带另一位研究者复现同一次模拟所需的全部参数:情景、智能体数、轮次、平台切换、时序配置、导演事件、派生 / 反事实谱系。已完成模拟的多次导出在字节级别完全一致 — 文件哈希可作为稳定的引用键 |
 
 每项功能详见 **[docs/FEATURES.zh-CN.md](docs/FEATURES.zh-CN.md)**。
 

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -5415,6 +5415,114 @@ def get_surface_stats(simulation_id: str):
         }), 500
 
 
+# ============== Reproducibility Config Export ==============
+#
+# Six of the ten share surfaces (transcript, trajectory, thread, watch,
+# GIF, share card) make a finished simulation citable. This endpoint
+# closes the **reproducibility gap** behind those citation surfaces: a
+# machine-readable JSON blob carrying every parameter another operator
+# would need to re-run the same simulation — scenario, agent count,
+# total rounds, platform toggles, time-config knobs, director events,
+# fork/counterfactual lineage. Anyone with the blob has the citation
+# primitive that the academic and quant audiences need before they can
+# cite MiroShark in a paper or thread without manual qualification.
+#
+# Same publish gate as every other share surface — the blob describes
+# a public sim's parameters, so it should only be retrievable for sims
+# the operator has chosen to surface. Pretty-printed (indent=2,
+# sort_keys=True) so a ``curl > config.json`` produces a diff-friendly
+# file; identical exports are bytewise identical (citation-hash
+# friendly).
+
+
+@simulation_bp.route('/<simulation_id>/reproduce.json', methods=['GET'])
+def get_reproduce_config(simulation_id: str):
+    """Return a complete reproducibility config blob for a published sim.
+
+    The blob is a v1-schema JSON document containing every parameter a
+    second operator would need to re-run the same simulation:
+    ``scenario`` text, ``agent_count``, ``total_rounds``, platform
+    toggles (twitter / reddit / polymarket + market count), the four
+    cadence knobs from ``time_config`` (minutes per round, total hours,
+    peak / off-peak windows), any operator-injected ``director_events``,
+    and the ``lineage`` block describing whether this sim is original,
+    a plain fork of another sim, or a counterfactual branch (with the
+    parent ID + injection metadata travelling along).
+
+    Pure read; pretty-printed for paper appendix / thread screenshot
+    use. ``Cache-Control: public, max-age=300`` — slightly longer than
+    the trajectory CSV's 60s because the reproduction blob doesn't
+    change once the sim has reached a terminal state.
+
+    Closes the gap that PR #71's shareable scenario URLs left open:
+    that flow carries scenario text and template slug, but not agent
+    count, rounds, or director events.
+    """
+    from ..services import repro_export
+    from flask import Response
+
+    locale = get_locale(request)
+    try:
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                    "该模拟未发布,请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
+            }), 403
+
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({
+                "success": False,
+                "error": f"Simulation not found: {simulation_id}",
+            }), 404
+
+        config_data = manager.get_simulation_config(simulation_id)
+        sim_dir = os.path.join(
+            Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id
+        )
+
+        blob = repro_export.build_repro_config(
+            state.to_dict(), config_data, sim_dir
+        )
+
+        payload = repro_export.render_json_bytes(blob)
+        response = Response(
+            payload, mimetype="application/json; charset=utf-8"
+        )
+        # 5-min cache — reproduction blob is stable once the sim
+        # finishes; live runs change rarely enough that a 5-min stale
+        # window is fine for the citation use case.
+        response.headers["Cache-Control"] = "public, max-age=300"
+        # Inline so a click in the SPA renders in-tab; the EmbedDialog
+        # uses an explicit ``download`` attribute on its anchor when it
+        # wants a save-as.
+        filename = f"miroshark-{simulation_id[:12]}-reproduce.json"
+        response.headers["Content-Disposition"] = (
+            f'inline; filename="{filename}"'
+        )
+        return response
+
+    except Exception as e:
+        logger.error(
+            f"reproduce.json: failed for {simulation_id}: "
+            f"{e}\n{traceback.format_exc()}"
+        )
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500
+
+
 # ============== Webhook Delivery Log ==============
 #
 # PR #46 shipped the outbound completion webhook. This pair of routes

--- a/backend/app/services/repro_export.py
+++ b/backend/app/services/repro_export.py
@@ -1,0 +1,487 @@
+"""Reproducibility config export — citation primitive for share surfaces.
+
+Closes the **reproducibility gap** in the surface-multiplication arc.
+Six of the ten share surfaces (transcript, trajectory, thread, watch,
+GIF, share card) make a finished simulation *citable* — but until now
+nothing made it *reproducible*. PR #71's ``?scenario=...`` URL carries
+the scenario text and template slug; it does not carry the agent count,
+total rounds, or research depth that determine the simulation's
+behavior. A researcher quoting Aaron's Aave risk sim has to guess or
+manually inspect to reproduce it.
+
+``GET /api/simulation/<id>/reproduce.json`` exports a complete
+machine-readable reproducibility blob for a published simulation:
+scenario, agent count, total rounds, platform toggles, model preset
+hint, time-config knobs, director events (if any), and lineage
+(``parent_simulation_id`` + counterfactual marker if branched). Anyone
+with the blob has every parameter the simulation depends on, suitable
+for a paper citation, a thread reproduction, or a downstream eval
+pipeline. The blob is the citation primitive that the academic and
+quant audiences need before they can cite MiroShark seriously.
+
+Design notes
+------------
+
+* **Pure stdlib.** ``json`` + ``os``. No new dependencies.
+* **Read-only.** This module never writes — it composes a blob from
+  on-disk artifacts (``state.json``, ``simulation_config.json``,
+  ``counterfactual_injection.json``, optional director events).
+* **Schema-locked.** ``SCHEMA_VERSION`` constant + every required field
+  is in ``REQUIRED_KEYS`` so a downstream consumer can validate cheaply.
+  Extra keys past v1 land under ``meta.extensions`` to keep the v1
+  schema stable for parsers built against it.
+* **Defense-in-depth.** Corrupt artifacts degrade to ``null`` rather
+  than 500ing the export — the citation surface must be available even
+  when ancillary files are missing.
+
+Schema (v1)::
+
+    {
+      "schema_version": "1",
+      "exported_at": "2026-05-08T12:34:56Z",
+      "simulation_id": "sim_abcdef123456",
+      "scenario": "What if Aave's reserve factor doubled overnight?",
+      "agent_count": 36,
+      "total_rounds": 24,
+      "platforms": {
+        "twitter": true,
+        "reddit": true,
+        "polymarket": false,
+        "polymarket_market_count": 1
+      },
+      "time_config": {
+        "minutes_per_round": 60,
+        "total_simulation_hours": 24,
+        "peak_hours": [...],
+        "off_peak_hours": [...]
+      },
+      "lineage": {
+        "parent_simulation_id": null | "sim_xxx",
+        "kind": "original" | "fork" | "counterfactual",
+        "counterfactual": null | { "trigger_round": 12, "label": "...",
+                                   "preview": "..." }
+      },
+      "director_events": null | [ { "round": int, "label": str,
+                                    "description": str|null } ],
+      "config_reasoning": "LLM rationale for the generated knobs..."
+    }
+
+The frontend renders the blob as a download button + curl snippet;
+``lineage`` powers the badge on the share / watch pages.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+SCHEMA_VERSION = "1"
+
+
+# Every key that v1 consumers should be able to expect on every
+# successful export. Tests pin this set so a future refactor can't
+# silently drop a field a downstream parser depends on.
+REQUIRED_KEYS: frozenset[str] = frozenset(
+    {
+        "schema_version",
+        "exported_at",
+        "simulation_id",
+        "scenario",
+        "agent_count",
+        "total_rounds",
+        "platforms",
+        "time_config",
+        "lineage",
+        "director_events",
+        "config_reasoning",
+    }
+)
+
+
+def _utc_iso8601() -> str:
+    """Return the current UTC time as an ISO-8601 ``Z``-suffixed string.
+
+    Matches the timestamp shape used by the webhook delivery log + the
+    transcript front matter so downstream parsers see one timestamp
+    grammar across every export.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    """Coerce ``value`` to a non-negative int with a default fallback.
+
+    Belief: every numeric field in the export is non-negative — agent
+    count, round count, market count, everything. A hand-edited config
+    file producing ``"agent_count": "lots"`` should land as ``0`` in the
+    export rather than crashing the read.
+    """
+    try:
+        ivalue = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, ivalue)
+
+
+def _safe_str(value: Any, default: str = "") -> str:
+    """Coerce ``value`` to a stripped string."""
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip()
+    try:
+        return str(value).strip()
+    except Exception:
+        return default
+
+
+def _build_platforms(state_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Pull the platform-toggle subset out of a state dict."""
+    return {
+        "twitter": bool(state_dict.get("enable_twitter", True)),
+        "reddit": bool(state_dict.get("enable_reddit", True)),
+        "polymarket": bool(state_dict.get("enable_polymarket", False)),
+        "polymarket_market_count": _safe_int(
+            state_dict.get("polymarket_market_count", 1) or 1, default=1
+        ),
+    }
+
+
+def _build_time_config(config_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract the time-config knobs that actually drive runtime cadence.
+
+    The full LLM-generated config includes per-agent posting frequency
+    + event schedules + platform-specific tuning, but those are derived
+    from the entity graph — not parameters a researcher reproduces by
+    hand. The reproducibility-relevant subset is the four cadence
+    knobs: minutes per round, total hours, peak windows, off-peak
+    windows. Anyone with those four can reproduce the temporal envelope.
+    """
+    if not isinstance(config_data, dict):
+        return {}
+    time_cfg = config_data.get("time_config") or {}
+    if not isinstance(time_cfg, dict):
+        return {}
+
+    out: Dict[str, Any] = {}
+    if "minutes_per_round" in time_cfg:
+        out["minutes_per_round"] = _safe_int(
+            time_cfg.get("minutes_per_round", 60) or 60, default=60
+        )
+    if "total_simulation_hours" in time_cfg:
+        out["total_simulation_hours"] = _safe_int(
+            time_cfg.get("total_simulation_hours", 0) or 0, default=0
+        )
+
+    # Peak / off-peak hour lists — preserve as-is when present, otherwise
+    # leave the key off so v1 consumers don't have to special-case empty
+    # arrays vs missing keys.
+    for key in ("peak_hours", "off_peak_hours"):
+        value = time_cfg.get(key)
+        if isinstance(value, list):
+            # Coerce each item to int — defense-in-depth against a
+            # corrupt config that has stringified hours.
+            cleaned: List[int] = []
+            for item in value:
+                try:
+                    cleaned.append(int(item))
+                except (TypeError, ValueError):
+                    continue
+            out[key] = cleaned
+
+    return out
+
+
+def _build_lineage(state_dict: Dict[str, Any], sim_dir: str) -> Dict[str, Any]:
+    """Compose the ``lineage`` subobject describing the sim's parentage.
+
+    Three cases:
+
+    * ``parent_simulation_id`` unset → ``kind = "original"``,
+      ``counterfactual = None``. The sim was created from a fresh project
+      via the standard prepare/start flow.
+    * ``parent_simulation_id`` set + ``counterfactual_injection.json``
+      present → ``kind = "counterfactual"``. The injection file's
+      ``trigger_round`` / ``label`` / preview travel along so the badge
+      can show "🔀 Counterfactual branch of X at round Y" without a
+      second fetch.
+    * ``parent_simulation_id`` set + no counterfactual file → ``kind =
+      "fork"``. Plain fork via ``/api/simulation/fork``.
+    """
+    parent = state_dict.get("parent_simulation_id")
+    if not parent:
+        return {
+            "parent_simulation_id": None,
+            "kind": "original",
+            "counterfactual": None,
+        }
+
+    cf_path = os.path.join(sim_dir or "", "counterfactual_injection.json")
+    cf_block: Optional[Dict[str, Any]] = None
+
+    if sim_dir and os.path.exists(cf_path):
+        try:
+            with open(cf_path, "r", encoding="utf-8") as fh:
+                cf_raw = json.load(fh)
+            if isinstance(cf_raw, dict):
+                # Preview at 140 chars matches the parent-side
+                # ``config_diff.counterfactual.preview`` cap so the two
+                # surfaces always show the same headline.
+                injection_text = _safe_str(cf_raw.get("injection_text"))
+                preview = injection_text[:140] if injection_text else None
+                cf_block = {
+                    "trigger_round": _safe_int(cf_raw.get("trigger_round", 0)),
+                    "label": _safe_str(cf_raw.get("label")),
+                    "preview": preview,
+                }
+        except Exception:
+            cf_block = None
+
+    return {
+        "parent_simulation_id": _safe_str(parent),
+        "kind": "counterfactual" if cf_block else "fork",
+        "counterfactual": cf_block,
+    }
+
+
+def _read_director_events(sim_dir: str) -> Optional[List[Dict[str, Any]]]:
+    """Return the director events for the sim, or ``None`` if absent.
+
+    Director events are stored in a JSONL file the runner writes; we
+    surface them in the reproduction blob so a researcher knows which
+    operator-injected events shaped the belief curve. Missing-or-corrupt
+    file degrades to ``None`` so the most common case (a sim with no
+    director mode usage) leaves the field as ``None``, not ``[]``.
+    """
+    if not sim_dir:
+        return None
+
+    # Two storage shapes have appeared historically — a list-style
+    # ``director-events.json`` and a JSON-Lines ``director-events.jsonl``.
+    # Try both, JSONL first since that is the current shape.
+    jsonl_path = os.path.join(sim_dir, "director-events.jsonl")
+    json_path = os.path.join(sim_dir, "director-events.json")
+
+    raw_events: List[Dict[str, Any]] = []
+
+    if os.path.exists(jsonl_path):
+        try:
+            with open(jsonl_path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        item = json.loads(line)
+                    except Exception:
+                        # Skip a single corrupt line; other lines may
+                        # still be valid and worth preserving.
+                        continue
+                    if isinstance(item, dict):
+                        raw_events.append(item)
+        except Exception:
+            return None
+    elif os.path.exists(json_path):
+        try:
+            with open(json_path, "r", encoding="utf-8") as fh:
+                payload = json.load(fh)
+            if isinstance(payload, list):
+                raw_events = [item for item in payload if isinstance(item, dict)]
+            elif isinstance(payload, dict) and isinstance(
+                payload.get("events"), list
+            ):
+                raw_events = [
+                    item
+                    for item in payload["events"]
+                    if isinstance(item, dict)
+                ]
+        except Exception:
+            return None
+    else:
+        return None
+
+    if not raw_events:
+        return None
+
+    cleaned: List[Dict[str, Any]] = []
+    for event in raw_events:
+        round_value = event.get("round")
+        if round_value is None:
+            round_value = event.get("trigger_round")
+        round_int = _safe_int(round_value, default=0)
+
+        label = _safe_str(event.get("label") or event.get("name"))
+        if not label:
+            # An event with no label is meaningless to a downstream
+            # consumer; drop it rather than emit ``"label": ""``.
+            continue
+
+        description = event.get("description")
+        if description is not None:
+            description = _safe_str(description) or None
+
+        cleaned.append(
+            {
+                "round": round_int,
+                "label": label,
+                "description": description,
+            }
+        )
+
+    cleaned.sort(key=lambda e: e["round"])
+    return cleaned or None
+
+
+def _derive_total_rounds(
+    state_dict: Dict[str, Any], config_data: Dict[str, Any]
+) -> int:
+    """Mirror ``_build_embed_summary_payload``'s total-rounds derivation.
+
+    Prefer the runner's own ``total_rounds`` if it landed on the state
+    dict; otherwise reconstruct from time-config knobs the same way the
+    embed summary does (``total_simulation_hours * 60 / minutes_per_round``).
+    Falls back to ``0`` if neither path yields a positive value — the
+    citation blob must be returnable even on a sim that hasn't started
+    running yet.
+    """
+    state_total = _safe_int(state_dict.get("total_rounds", 0))
+    if state_total:
+        return state_total
+
+    if not isinstance(config_data, dict):
+        return 0
+
+    time_cfg = config_data.get("time_config") or {}
+    if not isinstance(time_cfg, dict):
+        return 0
+    minutes = _safe_int(time_cfg.get("minutes_per_round", 60) or 60, default=60)
+    if minutes <= 0:
+        minutes = 60
+    hours = _safe_int(time_cfg.get("total_simulation_hours", 0) or 0)
+    if hours <= 0:
+        return 0
+    return int(hours * 60 / minutes)
+
+
+def build_repro_config(
+    state_dict: Dict[str, Any],
+    config_data: Optional[Dict[str, Any]],
+    sim_dir: Optional[str],
+) -> Dict[str, Any]:
+    """Compose a reproducibility blob from on-disk simulation artifacts.
+
+    Args:
+        state_dict: The serialized ``SimulationState`` dict (typically
+            ``state.to_dict()``). Provides scenario, agent_count, platform
+            toggles, lineage parent.
+        config_data: Optional ``simulation_config.json`` dict. Provides
+            ``time_config`` + ``simulation_requirement`` + LLM rationale.
+            ``None`` when the sim hasn't reached the prepared state.
+        sim_dir: Absolute path to the sim's on-disk directory. Used for
+            counterfactual + director event lookups. ``None`` for tests
+            that only exercise the in-memory composition.
+
+    Returns:
+        A dict matching the v1 schema in the module docstring. Every
+        ``REQUIRED_KEYS`` entry is present (some may be ``None`` or
+        empty when the underlying data is unavailable).
+    """
+    if not isinstance(state_dict, dict):
+        state_dict = {}
+    cfg: Dict[str, Any] = config_data if isinstance(config_data, dict) else {}
+
+    # Scenario lives in the LLM-generated config but falls back to the
+    # state dict in older sims that wrote the requirement onto state.
+    scenario = _safe_str(cfg.get("simulation_requirement"))
+    if not scenario:
+        scenario = _safe_str(state_dict.get("simulation_requirement"))
+
+    sim_id = _safe_str(state_dict.get("simulation_id"))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "exported_at": _utc_iso8601(),
+        "simulation_id": sim_id,
+        "scenario": scenario,
+        "agent_count": _safe_int(state_dict.get("profiles_count", 0)),
+        "total_rounds": _derive_total_rounds(state_dict, cfg),
+        "platforms": _build_platforms(state_dict),
+        "time_config": _build_time_config(cfg),
+        "lineage": _build_lineage(state_dict, sim_dir or ""),
+        "director_events": _read_director_events(sim_dir or ""),
+        "config_reasoning": _safe_str(state_dict.get("config_reasoning")),
+    }
+
+
+def render_json_bytes(payload: Dict[str, Any]) -> bytes:
+    """Pretty-print the blob as UTF-8 bytes for the route handler.
+
+    Pretty-print (indent=2) so a ``curl > config.json`` is immediately
+    readable in a paper appendix or a thread screenshot. Stable key
+    ordering via ``sort_keys=True`` so two exports of the same sim are
+    bytewise identical — important for citation hashes.
+    """
+    return (
+        json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False)
+        + "\n"
+    ).encode("utf-8")
+
+
+def validate_blob(blob: Any) -> List[str]:
+    """Return a list of human-readable validation errors against v1.
+
+    Empty list = blob is structurally valid for the v1 schema. The
+    helper exists for downstream consumers (Python SDK, doc tooling)
+    that want a cheap shape check without writing their own; the route
+    handler does not call it on the read path because it composes the
+    blob in-process.
+    """
+    errors: List[str] = []
+    if not isinstance(blob, dict):
+        errors.append("blob must be a JSON object")
+        return errors
+
+    for key in REQUIRED_KEYS:
+        if key not in blob:
+            errors.append(f"missing required key: {key}")
+
+    if blob.get("schema_version") != SCHEMA_VERSION:
+        errors.append(
+            f"schema_version mismatch: expected {SCHEMA_VERSION!r}, "
+            f"got {blob.get('schema_version')!r}"
+        )
+
+    if "agent_count" in blob and not isinstance(blob.get("agent_count"), int):
+        errors.append("agent_count must be an integer")
+    if "total_rounds" in blob and not isinstance(blob.get("total_rounds"), int):
+        errors.append("total_rounds must be an integer")
+
+    platforms = blob.get("platforms")
+    if not isinstance(platforms, dict):
+        errors.append("platforms must be an object")
+    else:
+        for plat_key in ("twitter", "reddit", "polymarket"):
+            if plat_key in platforms and not isinstance(
+                platforms[plat_key], bool
+            ):
+                errors.append(f"platforms.{plat_key} must be a boolean")
+
+    lineage = blob.get("lineage")
+    if not isinstance(lineage, dict):
+        errors.append("lineage must be an object")
+    else:
+        kind = lineage.get("kind")
+        if kind not in {"original", "fork", "counterfactual"}:
+            errors.append(
+                f"lineage.kind must be one of original/fork/counterfactual "
+                f"(got {kind!r})"
+            )
+
+    director_events = blob.get("director_events")
+    if director_events is not None and not isinstance(director_events, list):
+        errors.append("director_events must be null or a list")
+
+    return errors

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1393,6 +1393,50 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/simulation/{simulation_id}/reproduce.json:
+    get:
+      tags: [Publish & Embed]
+      summary: Machine-readable reproducibility config blob for a published simulation.
+      description: |
+        Returns a complete JSON document carrying every parameter
+        another operator would need to re-run the same simulation —
+        scenario text, agent count, total rounds, platform toggles
+        (twitter / reddit / polymarket + market count), the four
+        cadence knobs from `time_config` (minutes per round, total
+        hours, peak / off-peak windows), any operator-injected director
+        events, and a `lineage` block describing whether this
+        simulation is original, a plain fork of another sim, or a
+        counterfactual branch (with the parent simulation id and
+        injection metadata travelling along).
+
+        This is the **citation primitive** behind the existing share
+        surfaces. Six of the ten share surfaces (transcript, trajectory,
+        thread, watch, GIF, share card) make a finished simulation
+        citable — but until this endpoint shipped, none of them carried
+        the parameters needed to reproduce the run. PR #71's shareable
+        scenario URLs carry the scenario text and template slug; this
+        blob carries everything else, in a single pretty-printed file
+        suitable for a paper appendix or a thread screenshot.
+
+        Identical exports of the same finished simulation produce
+        bytewise-identical JSON (sorted keys + stable indent) — useful
+        for citation hashes. Cached for 5 minutes; the blob does not
+        change once the sim has reached a terminal state.
+
+        Same publish gate as every other share surface — requires the
+        simulation to be public (`is_public=true`).
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Reproducibility config blob.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReproductionConfig"
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /share/{simulation_id}:
     get:
       tags: [Publish & Embed]
@@ -2974,6 +3018,211 @@ components:
               type: integer
               minimum: 0
               description: Sum of every per-surface counter above.
+
+    ReproductionConfig:
+      type: object
+      description: |
+        Citation primitive returned by
+        `/api/simulation/{id}/reproduce.json`. Every parameter another
+        operator would need to re-run the same simulation, in one
+        machine-readable document. Pretty-printed, sorted keys, stable
+        bytes — identical exports of the same finished simulation
+        produce identical files (citation-hash friendly).
+
+        Schema is versioned via `schema_version`. v1 is the only
+        published version; future breaking changes bump the literal.
+        v1-aware parsers should reject blobs whose `schema_version`
+        does not equal `"1"`.
+      required:
+        - schema_version
+        - exported_at
+        - simulation_id
+        - scenario
+        - agent_count
+        - total_rounds
+        - platforms
+        - time_config
+        - lineage
+        - director_events
+        - config_reasoning
+      properties:
+        schema_version:
+          type: string
+          enum: ["1"]
+          description: Schema version literal — bumped on breaking changes.
+        exported_at:
+          type: string
+          format: date-time
+          description: |
+            UTC timestamp when the export was rendered (ISO-8601 with
+            trailing `Z`). Same shape as the webhook delivery log's
+            `timestamp` field.
+        simulation_id:
+          type: string
+          description: Echoed simulation id.
+        scenario:
+          type: string
+          description: |
+            The simulation requirement / scenario text. Falls back to
+            the state-level `simulation_requirement` field for older
+            sims that wrote it onto state rather than into the
+            generated config.
+        agent_count:
+          type: integer
+          minimum: 0
+          description: |
+            Number of agent profiles generated for the run. Maps to
+            `state.profiles_count` and determines how many distinct
+            personas reasoned through the scenario.
+        total_rounds:
+          type: integer
+          minimum: 0
+          description: |
+            Total rounds the simulation ran (or is configured to run).
+            Prefers the runner's recorded total; falls back to
+            `time_config.total_simulation_hours * 60 /
+            time_config.minutes_per_round` when the runner hasn't
+            populated the field. May be `0` for sims that never
+            reached the prepared state.
+        platforms:
+          type: object
+          description: |
+            Platform toggles + the polymarket market-count knob — the
+            four boolean / integer parameters that together with the
+            scenario decide which channels the agents post to.
+          required:
+            - twitter
+            - reddit
+            - polymarket
+            - polymarket_market_count
+          properties:
+            twitter:
+              type: boolean
+              description: Whether the simulation enabled the Twitter platform.
+            reddit:
+              type: boolean
+              description: Whether the simulation enabled the Reddit platform.
+            polymarket:
+              type: boolean
+              description: Whether the simulation enabled prediction-market trading.
+            polymarket_market_count:
+              type: integer
+              minimum: 1
+              description: |
+                Number of distinct prediction markets generated when
+                `polymarket=true`. Defaults to `1`. Range `[1, 5]` is
+                enforced upstream by the prepare endpoint.
+        time_config:
+          type: object
+          description: |
+            The four cadence knobs that drive the simulation's
+            temporal envelope. May be empty when the sim never reached
+            a prepared state. Field set is intentionally narrow: the
+            full LLM-generated config includes per-agent posting
+            frequency + event schedules + platform tuning, but those
+            are derived from the entity graph rather than parameters
+            a researcher reproduces by hand.
+          properties:
+            minutes_per_round:
+              type: integer
+              minimum: 1
+              description: Wall-clock minutes the simulation pretends each round covers.
+            total_simulation_hours:
+              type: integer
+              minimum: 0
+              description: Total wall-clock hours the simulation pretends to span.
+            peak_hours:
+              type: array
+              items:
+                type: integer
+                minimum: 0
+                maximum: 23
+              description: Hours of the day treated as high-activity windows.
+            off_peak_hours:
+              type: array
+              items:
+                type: integer
+                minimum: 0
+                maximum: 23
+              description: Hours of the day treated as low-activity windows.
+        lineage:
+          type: object
+          description: |
+            Description of how this simulation was created. Powers the
+            "🪐 Forked from X" / "🔀 Counterfactual branch of X at round
+            Y" badge on the EmbedDialog and (forthcoming) share / watch
+            pages.
+          required:
+            - parent_simulation_id
+            - kind
+            - counterfactual
+          properties:
+            parent_simulation_id:
+              type: string
+              nullable: true
+              description: |
+                Parent simulation id, or `null` for original sims. When
+                non-null, the parent's reproduction blob can be fetched
+                from the same endpoint to get the un-branched version.
+            kind:
+              type: string
+              enum: [original, fork, counterfactual]
+              description: |
+                Lineage discriminator. `original` ⇒ created via the
+                standard prepare flow. `fork` ⇒ created via
+                `POST /api/simulation/fork` (same agent population, new
+                sim id). `counterfactual` ⇒ created via
+                `POST /api/simulation/branch-counterfactual` (fork plus
+                an injection event scheduled at a specific round).
+            counterfactual:
+              type: object
+              nullable: true
+              description: |
+                Present only when `kind == "counterfactual"`. Carries
+                the trigger round + label + 140-char preview of the
+                injection text so the badge can render the headline
+                without a second fetch.
+              properties:
+                trigger_round:
+                  type: integer
+                  minimum: 0
+                  description: Round at which the injection fires.
+                label:
+                  type: string
+                  description: Operator-supplied or auto-generated branch label.
+                preview:
+                  type: string
+                  nullable: true
+                  description: Up to 140 chars of the injection text.
+        director_events:
+          type: array
+          nullable: true
+          description: |
+            Operator-injected scenario events (e.g. "Liquidity Crisis"
+            at round 15) that shaped the belief curve. `null` when no
+            events were injected — the common case. Each event carries
+            its `round`, `label`, and optional `description`.
+          items:
+            type: object
+            required: [round, label]
+            properties:
+              round:
+                type: integer
+                minimum: 0
+                description: Round at which the event fired.
+              label:
+                type: string
+                description: Short headline for the event.
+              description:
+                type: string
+                nullable: true
+                description: Longer description, or `null` when none was provided.
+        config_reasoning:
+          type: string
+          description: |
+            LLM-generated rationale for the chosen knobs, captured at
+            prepare time. Empty string for older sims that didn't
+            persist a rationale.
 
     SettingsUpdate:
       type: object

--- a/backend/tests/test_unit_repro_export.py
+++ b/backend/tests/test_unit_repro_export.py
@@ -1,0 +1,480 @@
+"""Unit tests for the reproducibility-config export service.
+
+Pure offline — no Flask, no Wonderwall, no LLM. The
+``GET /api/simulation/<id>/reproduce.json`` route is the citation
+primitive that academic and quant audiences need before they can cite
+a MiroShark sim seriously, so the service powering it is held to the
+same correctness bar as ``surface_stats`` / ``transcript`` /
+``trajectory_export``: every shape promise + every degradation path
+covered.
+
+Coverage:
+
+  1. SCHEMA_VERSION constant is the literal "1" — bumping it is a
+     deliberate API break, not a refactor side-effect.
+  2. REQUIRED_KEYS contains exactly the v1 keys the route returns; the
+     test pins the set so a future rename can't silently drop a field
+     a downstream parser depends on.
+  3. ``build_repro_config`` round-trips a fully-populated state +
+     config dict, hitting every ``REQUIRED_KEYS`` entry.
+  4. Scenario falls back to state-level ``simulation_requirement`` when
+     the config dict is missing it (matches embed-summary fallback).
+  5. ``total_rounds`` derivation: prefers state.total_rounds; falls
+     back to ``hours * 60 / minutes`` from time_config; degrades to 0
+     when neither is positive.
+  6. Platform toggles default to safe values when keys are absent.
+  7. ``polymarket_market_count`` clamps to a sensible default when the
+     state dict carries garbage.
+  8. Lineage shape: ``kind == "original"`` when no parent.
+  9. Lineage shape: ``kind == "fork"`` with parent set + no
+     counterfactual file on disk.
+ 10. Lineage shape: ``kind == "counterfactual"`` with parent set + a
+     valid ``counterfactual_injection.json`` next to the sim — the
+     trigger_round / label / 140-char preview travel along.
+ 11. Corrupt ``counterfactual_injection.json`` degrades to ``kind ==
+     "fork"`` rather than crashing the export.
+ 12. Director events read from JSONL; sorted by round; bad lines
+     skipped without blanking the rest.
+ 13. Director events read from list-style ``director-events.json``
+     (older shape) — equivalent output.
+ 14. Missing director-events file returns ``None``, not ``[]`` (so the
+     v1 consumer doesn't have to special-case empty arrays).
+ 15. ``render_json_bytes`` emits stable, sorted-key, pretty-printed
+     JSON with a trailing newline so a ``curl >`` redirect produces a
+     diff-friendly file.
+ 16. ``validate_blob`` accepts a freshly-built blob with zero errors.
+ 17. ``validate_blob`` rejects a blob with the wrong schema_version.
+ 18. ``validate_blob`` rejects bogus types (agent_count as string,
+     lineage.kind as garbage).
+ 19. ``GET /api/simulation/<simulation_id>/reproduce.json`` route
+     decorator is registered in ``app/api/simulation.py`` so the
+     OpenAPI drift test passes.
+ 20. ``ReproductionConfig`` schema is declared in ``backend/openapi.yaml``
+     so the Swagger UI documents the new endpoint.
+ 21. ``_safe_int`` clamps negatives to zero (defense-in-depth).
+ 22. Build composes a complete blob even when ``config_data`` is
+     ``None`` (sim that hasn't reached prepared state).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+from app.services import repro_export  # noqa: E402
+
+
+# ── Module-level invariants ────────────────────────────────────────────
+
+
+def test_schema_version_literal_one():
+    """v1 is a stable wire contract — bumps must be deliberate."""
+    assert repro_export.SCHEMA_VERSION == "1"
+
+
+def test_required_keys_pinned_set():
+    """Pin the v1 key set so downstream parsers see a stable shape."""
+    expected = {
+        "schema_version",
+        "exported_at",
+        "simulation_id",
+        "scenario",
+        "agent_count",
+        "total_rounds",
+        "platforms",
+        "time_config",
+        "lineage",
+        "director_events",
+        "config_reasoning",
+    }
+    assert set(repro_export.REQUIRED_KEYS) == expected
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def basic_state():
+    """A SimulationState dict at the shape ``state.to_dict()`` returns."""
+    return {
+        "simulation_id": "sim_abcdef123456",
+        "project_id": "proj_xyz",
+        "graph_id": "miroshark_xyz",
+        "enable_twitter": True,
+        "enable_reddit": True,
+        "enable_polymarket": False,
+        "polymarket_market_count": 1,
+        "status": "completed",
+        "entities_count": 36,
+        "profiles_count": 36,
+        "entity_types": ["person", "organization"],
+        "config_generated": True,
+        "config_reasoning": "LLM picked 36 agents to balance cost vs coverage.",
+        "current_round": 24,
+        "twitter_status": "completed",
+        "reddit_status": "completed",
+        "created_at": "2026-05-08T12:00:00",
+        "updated_at": "2026-05-08T13:00:00",
+        "error": None,
+        "parent_simulation_id": None,
+        "config_diff": None,
+        "is_public": True,
+    }
+
+
+@pytest.fixture
+def basic_config():
+    """A ``simulation_config.json`` dict shape."""
+    return {
+        "simulation_requirement": "What if Aave's reserve factor doubled overnight?",
+        "simulation_id": "sim_abcdef123456",
+        "time_config": {
+            "minutes_per_round": 60,
+            "total_simulation_hours": 24,
+            "peak_hours": [9, 10, 11, 17, 18, 19, 20, 21],
+            "off_peak_hours": [0, 1, 2, 3, 4, 5],
+        },
+    }
+
+
+# ── build_repro_config ─────────────────────────────────────────────────
+
+
+def test_build_repro_config_full_round_trip(basic_state, basic_config, tmp_path):
+    blob = repro_export.build_repro_config(
+        basic_state, basic_config, str(tmp_path)
+    )
+
+    # Every required key present.
+    for key in repro_export.REQUIRED_KEYS:
+        assert key in blob, f"missing required key: {key}"
+
+    # Top-level shape.
+    assert blob["schema_version"] == "1"
+    assert blob["simulation_id"] == "sim_abcdef123456"
+    assert blob["scenario"] == "What if Aave's reserve factor doubled overnight?"
+    assert blob["agent_count"] == 36
+    assert blob["total_rounds"] == 24  # 24h * 60min / 60min-per-round
+    assert blob["config_reasoning"].startswith("LLM picked 36")
+
+    # exported_at is an ISO-8601 UTC stamp.
+    assert blob["exported_at"].endswith("Z")
+    assert "T" in blob["exported_at"]
+    assert len(blob["exported_at"]) == len("2026-05-08T12:34:56Z")
+
+    # Platforms.
+    assert blob["platforms"] == {
+        "twitter": True,
+        "reddit": True,
+        "polymarket": False,
+        "polymarket_market_count": 1,
+    }
+
+    # Time config carries the four cadence knobs.
+    tc = blob["time_config"]
+    assert tc["minutes_per_round"] == 60
+    assert tc["total_simulation_hours"] == 24
+    assert tc["peak_hours"] == [9, 10, 11, 17, 18, 19, 20, 21]
+    assert tc["off_peak_hours"] == [0, 1, 2, 3, 4, 5]
+
+    # Lineage default — original sim, no parent.
+    assert blob["lineage"] == {
+        "parent_simulation_id": None,
+        "kind": "original",
+        "counterfactual": None,
+    }
+
+    # No director events written ⇒ field is None, not [].
+    assert blob["director_events"] is None
+
+
+def test_scenario_falls_back_to_state(basic_state, tmp_path):
+    """Older sims wrote ``simulation_requirement`` onto state; fall back."""
+    state = dict(basic_state)
+    state["simulation_requirement"] = "Legacy state-level scenario text"
+
+    blob = repro_export.build_repro_config(state, None, str(tmp_path))
+    assert blob["scenario"] == "Legacy state-level scenario text"
+
+
+def test_total_rounds_prefers_state(basic_state, basic_config, tmp_path):
+    """``state.total_rounds`` wins over the time_config derivation."""
+    state = dict(basic_state)
+    state["total_rounds"] = 99
+    blob = repro_export.build_repro_config(state, basic_config, str(tmp_path))
+    assert blob["total_rounds"] == 99
+
+
+def test_total_rounds_zero_when_neither_path_works(basic_state, tmp_path):
+    """No total_rounds + no time_config ⇒ 0 rather than a crash."""
+    state = dict(basic_state)
+    blob = repro_export.build_repro_config(state, None, str(tmp_path))
+    assert blob["total_rounds"] == 0
+
+
+def test_platforms_default_to_safe_values(tmp_path):
+    """Empty state dict still produces a complete platforms block."""
+    blob = repro_export.build_repro_config({}, None, str(tmp_path))
+    assert blob["platforms"] == {
+        "twitter": True,
+        "reddit": True,
+        "polymarket": False,
+        "polymarket_market_count": 1,
+    }
+
+
+def test_polymarket_market_count_clamps_garbage(basic_state, tmp_path):
+    state = dict(basic_state)
+    state["polymarket_market_count"] = "lots"  # garbage
+    blob = repro_export.build_repro_config(state, None, str(tmp_path))
+    assert blob["platforms"]["polymarket_market_count"] == 1
+
+
+def test_build_blob_accepts_none_config(basic_state, tmp_path):
+    """A sim without a prepared config still exports a complete blob."""
+    blob = repro_export.build_repro_config(basic_state, None, str(tmp_path))
+    assert blob["scenario"] == ""  # no config + no state-level fallback
+    assert blob["time_config"] == {}
+    assert blob["total_rounds"] == 0
+    assert blob["lineage"]["kind"] == "original"
+
+
+# ── Lineage ────────────────────────────────────────────────────────────
+
+
+def test_lineage_kind_fork(basic_state, basic_config, tmp_path):
+    """Parent set + no counterfactual file ⇒ fork."""
+    state = dict(basic_state)
+    state["parent_simulation_id"] = "sim_parent12345"
+
+    blob = repro_export.build_repro_config(
+        state, basic_config, str(tmp_path)
+    )
+    assert blob["lineage"] == {
+        "parent_simulation_id": "sim_parent12345",
+        "kind": "fork",
+        "counterfactual": None,
+    }
+
+
+def test_lineage_kind_counterfactual(basic_state, basic_config, tmp_path):
+    """Parent + counterfactual_injection.json ⇒ counterfactual + preview."""
+    state = dict(basic_state)
+    state["parent_simulation_id"] = "sim_parent12345"
+
+    cf_path = tmp_path / "counterfactual_injection.json"
+    cf_path.write_text(
+        json.dumps(
+            {
+                "parent_simulation_id": "sim_parent12345",
+                "trigger_round": 12,
+                "injection_text": "CEO resigns under regulatory pressure" * 5,
+                "label": "ceo_resigns",
+                "branch_id": "ceo_resigns",
+                "created_at": "2026-05-08T12:00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    blob = repro_export.build_repro_config(
+        state, basic_config, str(tmp_path)
+    )
+    cf = blob["lineage"]["counterfactual"]
+    assert blob["lineage"]["kind"] == "counterfactual"
+    assert blob["lineage"]["parent_simulation_id"] == "sim_parent12345"
+    assert cf["trigger_round"] == 12
+    assert cf["label"] == "ceo_resigns"
+    # Preview cap at 140 chars.
+    assert isinstance(cf["preview"], str)
+    assert len(cf["preview"]) <= 140
+
+
+def test_lineage_corrupt_counterfactual_degrades_to_fork(
+    basic_state, basic_config, tmp_path
+):
+    """Corrupt counterfactual JSON ⇒ fork, not crash."""
+    state = dict(basic_state)
+    state["parent_simulation_id"] = "sim_parent12345"
+
+    cf_path = tmp_path / "counterfactual_injection.json"
+    cf_path.write_text("not valid json {{{", encoding="utf-8")
+
+    blob = repro_export.build_repro_config(
+        state, basic_config, str(tmp_path)
+    )
+    assert blob["lineage"]["kind"] == "fork"
+    assert blob["lineage"]["counterfactual"] is None
+
+
+# ── Director events ────────────────────────────────────────────────────
+
+
+def test_director_events_jsonl(basic_state, basic_config, tmp_path):
+    """Read director events from JSONL, sort by round, skip bad lines."""
+    jsonl_path = tmp_path / "director-events.jsonl"
+    jsonl_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"round": 18, "label": "Regulatory Announcement"}),
+                "this line is corrupt {{",
+                json.dumps(
+                    {
+                        "round": 6,
+                        "label": "Liquidity Crisis",
+                        "description": "Sudden 40% TVL drop",
+                    }
+                ),
+                "",  # blank line
+                json.dumps({"round": 12, "label": "Whale Withdrawal"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    blob = repro_export.build_repro_config(
+        basic_state, basic_config, str(tmp_path)
+    )
+    events = blob["director_events"]
+    assert isinstance(events, list)
+    assert [e["round"] for e in events] == [6, 12, 18]
+    assert events[0]["description"] == "Sudden 40% TVL drop"
+    # The whale withdrawal didn't carry a description; field is None.
+    assert events[2]["description"] is None
+
+
+def test_director_events_legacy_list_json(basic_state, basic_config, tmp_path):
+    """Older list-style ``director-events.json`` is also supported."""
+    legacy_path = tmp_path / "director-events.json"
+    legacy_path.write_text(
+        json.dumps(
+            [
+                {"round": 15, "label": "Liquidity Crisis"},
+                {"round": 5, "label": "Bullish Headline"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    blob = repro_export.build_repro_config(
+        basic_state, basic_config, str(tmp_path)
+    )
+    events = blob["director_events"]
+    assert [e["label"] for e in events] == ["Bullish Headline", "Liquidity Crisis"]
+
+
+def test_director_events_missing_returns_none(basic_state, basic_config, tmp_path):
+    """No director-events file ⇒ field is None, not []."""
+    blob = repro_export.build_repro_config(
+        basic_state, basic_config, str(tmp_path)
+    )
+    assert blob["director_events"] is None
+
+
+# ── render_json_bytes ──────────────────────────────────────────────────
+
+
+def test_render_json_bytes_pretty_sorted_with_trailing_newline(
+    basic_state, basic_config, tmp_path
+):
+    blob = repro_export.build_repro_config(
+        basic_state, basic_config, str(tmp_path)
+    )
+    payload = repro_export.render_json_bytes(blob)
+    assert isinstance(payload, bytes)
+    # Pretty-printed: indent=2 produces multi-line output.
+    text = payload.decode("utf-8")
+    assert text.endswith("\n")
+    assert "  " in text  # 2-space indent
+    # Round-trip parses back to an equivalent dict.
+    parsed = json.loads(text)
+    assert parsed["simulation_id"] == "sim_abcdef123456"
+    assert parsed["schema_version"] == "1"
+    # sort_keys=True ⇒ deterministic byte output.
+    again = repro_export.render_json_bytes(parsed)
+    assert again == payload
+
+
+# ── validate_blob ──────────────────────────────────────────────────────
+
+
+def test_validate_blob_accepts_built_blob(basic_state, basic_config, tmp_path):
+    blob = repro_export.build_repro_config(
+        basic_state, basic_config, str(tmp_path)
+    )
+    assert repro_export.validate_blob(blob) == []
+
+
+def test_validate_blob_rejects_wrong_schema_version(
+    basic_state, basic_config, tmp_path
+):
+    blob = repro_export.build_repro_config(
+        basic_state, basic_config, str(tmp_path)
+    )
+    blob["schema_version"] = "999"
+    errors = repro_export.validate_blob(blob)
+    assert any("schema_version" in e for e in errors)
+
+
+def test_validate_blob_rejects_bogus_types(
+    basic_state, basic_config, tmp_path
+):
+    blob = repro_export.build_repro_config(
+        basic_state, basic_config, str(tmp_path)
+    )
+    blob["agent_count"] = "thirty-six"
+    blob["lineage"] = {"parent_simulation_id": None, "kind": "weird", "counterfactual": None}
+    errors = repro_export.validate_blob(blob)
+    joined = " ".join(errors)
+    assert "agent_count" in joined
+    assert "lineage.kind" in joined
+
+
+def test_safe_int_clamps_negatives_to_zero():
+    """Defense-in-depth — a hand-edited config can't produce a negative
+    agent count or round count in the export."""
+    assert repro_export._safe_int(-5) == 0
+    assert repro_export._safe_int(-1, default=0) == 0
+    assert repro_export._safe_int(42) == 42
+
+
+# ── Wiring guards ──────────────────────────────────────────────────────
+
+
+def test_route_decorator_present_in_simulation_api():
+    """Ensure ``GET /<simulation_id>/reproduce.json`` is registered."""
+    api_path = _BACKEND / "app" / "api" / "simulation.py"
+    text = api_path.read_text(encoding="utf-8")
+    assert "@simulation_bp.route('/<simulation_id>/reproduce.json'" in text
+    assert "def get_reproduce_config(" in text
+
+
+def test_openapi_schema_declares_reproduction_config():
+    """Swagger UI must pick up the new endpoint + payload schema."""
+    spec_path = _BACKEND / "openapi.yaml"
+    spec_text = spec_path.read_text(encoding="utf-8")
+    assert "/api/simulation/{simulation_id}/reproduce.json" in spec_text
+    assert "ReproductionConfig:" in spec_text
+
+
+def test_router_module_imports_repro_export():
+    """The route handler must actually import the service we just shipped.
+
+    Catches the failure mode where the route decorator was added but
+    the body never got wired up — a class of mistake the existing
+    ``surface_stats`` and ``trajectory_export`` patterns are vulnerable
+    to.
+    """
+    api_path = _BACKEND / "app" / "api" / "simulation.py"
+    text = api_path.read_text(encoding="utf-8")
+    assert "from ..services import repro_export" in text

--- a/docs/API.md
+++ b/docs/API.md
@@ -94,6 +94,7 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `GET` | `/api/simulation/<id>/thread.txt` | Auto-formatted X / Twitter tweet thread (one tweet per belief inflection point, ≤280 chars each) |
 | `GET` | `/api/simulation/<id>/thread.json` | Same tweet thread as `thread.txt` but as `{tweets, total, inflections_recorded, truncated}` for programmatic consumers |
 | `GET` | `/api/simulation/<id>/surface-stats` | Per-share-surface request counters — share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS, plus a synthetic `total` |
+| `GET` | `/api/simulation/<id>/reproduce.json` | Citation primitive — v1-schema reproducibility config blob carrying scenario, agent count, total rounds, platform toggles, time-config knobs, director events, and fork / counterfactual lineage. Identical exports of a finished sim are bytewise-identical (citation-hash friendly) |
 | `GET` | `/api/simulation/<id>/webhook-log` | Recent outbound-webhook delivery attempts (last 10 + total count). Admin-token gated |
 | `POST` | `/api/simulation/<id>/webhook-retry` | Re-fire the completion webhook for a finished sim. Admin-token gated |
 | `GET` | `/share/<id>` | Public OG-tag landing page (auto-redirects to SPA) |

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -88,6 +88,7 @@
 | `GET` | `/api/simulation/<id>/thread.txt` | 自动生成的 X / Twitter 推文串(每个信念转折点一条推文,每条 ≤280 字符) |
 | `GET` | `/api/simulation/<id>/thread.json` | 同样的推文串内容,以 `{tweets, total, inflections_recorded, truncated}` 形式返回,供程序消费 |
 | `GET` | `/api/simulation/<id>/surface-stats` | 每个分享面的请求计数器 — 分享卡 / 回放 GIF / 转录 / 推文串 / 观看页 / Atom / RSS,以及合成的 `total` |
+| `GET` | `/api/simulation/<id>/reproduce.json` | 引用基元 — v1-schema 可复现配置 blob,携带情景、智能体数、总轮次、平台切换、时序配置旋钮、导演事件以及派生 / 反事实谱系。已完成模拟的多次导出在字节级别完全一致(便于以哈希引用) |
 | `GET` | `/api/simulation/<id>/webhook-log` | 最近的出站 webhook 投递记录(最近 10 条 + 总次数)。需管理员 token |
 | `POST` | `/api/simulation/<id>/webhook-retry` | 重发已完成模拟的完成 webhook。需管理员 token |
 | `POST` | `/api/simulation/<id>/article` | 生成 Substack 风格的报道 |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -279,6 +279,36 @@ Implementation:
 
 The Embed dialog has a "📊 Distribution" panel (collapsed by default, click the chevron to expand) — a sorted two-column table (surface · count, ranked by count desc), a `Total serves: N` row, and a `↻ Refresh` button. The panel is publish-gated; private sims see "Publish the simulation to see distribution stats." instead. Same publish gate as every other share surface (`is_public=true`).
 
+## Reproducibility Config Export
+
+The **citation primitive** behind every other share surface. Six of the ten share surfaces (transcript, trajectory, thread, watch, GIF, share card) make a finished simulation citable — but until this endpoint shipped, none of them carried the parameters needed to reproduce the run. PR #71's shareable scenario URLs carry the scenario text and template slug; this blob carries everything else, in a single pretty-printed file suitable for a paper appendix or a thread screenshot.
+
+`GET /api/simulation/<id>/reproduce.json` returns a v1-schema JSON document with:
+
+- **`schema_version`** — literal `"1"`. Bumped on breaking changes; v1-aware parsers should reject other values.
+- **`exported_at`** — UTC ISO-8601 timestamp of the export.
+- **`simulation_id`** — echoed sim id.
+- **`scenario`** — the simulation requirement / scenario text. Falls back to the state-level `simulation_requirement` field for older sims that wrote it onto state rather than into the generated config.
+- **`agent_count`** — number of agent profiles generated for the run (maps to `state.profiles_count`).
+- **`total_rounds`** — total rounds the simulation ran (or is configured to run). Prefers the runner's recorded total; falls back to `time_config.total_simulation_hours * 60 / time_config.minutes_per_round` when the runner hasn't populated the field.
+- **`platforms`** — the four boolean / integer parameters that decide which channels the agents post to: `twitter`, `reddit`, `polymarket`, `polymarket_market_count`.
+- **`time_config`** — the four cadence knobs that drive the simulation's temporal envelope: `minutes_per_round`, `total_simulation_hours`, `peak_hours`, `off_peak_hours`. Field set is intentionally narrow: the full LLM-generated config includes per-agent posting frequency + event schedules + platform tuning, but those are derived from the entity graph rather than parameters a researcher reproduces by hand.
+- **`director_events`** — operator-injected scenario events (e.g. "Liquidity Crisis" at round 15) that shaped the belief curve. `null` when no events were injected — the common case. Each event carries its `round`, `label`, and optional `description`.
+- **`lineage`** — describes how this simulation was created. `kind` is one of `original` (created via the standard prepare flow), `fork` (created via `POST /api/simulation/fork`, same agent population, new sim id), or `counterfactual` (created via `POST /api/simulation/branch-counterfactual`, a fork plus an injection event scheduled at a specific round). Carries `parent_simulation_id` plus, for counterfactual branches, a `counterfactual` sub-object with `trigger_round` / `label` / 140-char `preview` so the badge can render the headline without a second fetch.
+- **`config_reasoning`** — LLM-generated rationale for the chosen knobs, captured at prepare time. Empty string for older sims that didn't persist a rationale.
+
+Implementation:
+
+- **Pure stdlib.** `json` + `os`. No new dependencies; helpers in `app/services/repro_export.py`.
+- **Read-only.** The service composes the blob from on-disk artifacts (`state.json`, `simulation_config.json`, `counterfactual_injection.json`, optional director events) — it never writes.
+- **Schema-locked.** `SCHEMA_VERSION` constant + `REQUIRED_KEYS` frozenset so a downstream consumer can validate cheaply via `validate_blob(blob)`.
+- **Defense-in-depth.** Corrupt artifacts degrade to `null` rather than 500ing the export — the citation surface must be available even when ancillary files are missing.
+- **Bytewise-stable.** Pretty-printed (indent=2, sort_keys=True) so identical exports of the same finished simulation are byte-for-byte identical. The file hash is therefore a stable citation key.
+
+Cached for 5 minutes; the blob does not change once the sim has reached a terminal state. Same publish gate as every other share surface — requires the simulation to be public (`is_public=true`).
+
+The Embed dialog has a "🔬 Reproducibility config" panel (collapsed by default) — a summary grid (Schema version · Agents · Rounds · Platforms · Director events · Lineage), a "Reproduce via curl" snippet ready to copy, a `Download reproduce.json` button, and (when the sim was forked or branched) a small inline lineage badge — `🪐 Forked` or `🔀 Counterfactual` — beside the title. The badge tooltip shows the canonical parent sim id so the operator can grab it for `/share/<id>` or `/watch/<id>` without reading the JSON.
+
 ## Webhook Delivery Log
 
 Every dispatch attempt of the outbound completion webhook (the one configured in **Settings → Integrations → Webhook**, see [WEBHOOKS.md](WEBHOOKS.md)) appends a JSON line to `<sim_dir>/webhook-log.jsonl`. Each row records:

--- a/docs/FEATURES.zh-CN.md
+++ b/docs/FEATURES.zh-CN.md
@@ -215,6 +215,36 @@ WONDERWALL_MODEL_NAME=your-model-id
 
 嵌入对话框有「📊 分发统计」面板(默认折叠,点击 ▾ 展开)— 一个有序的两列表(分享面 · 计数,按计数倒序排序),一个「总服务数:N」行,以及一个「↻ 刷新」按钮。该面板有发布门控;私有模拟会显示「发布模拟以查看分发统计。」。与每个其他分享面一样的发布门控(`is_public=true`)。
 
+## 可复现配置导出
+
+每个分享面背后的**引用基元**。十个分享面中的六个(转录、轨迹、推文串、观看页、GIF、分享卡)让一次完成的模拟可被引用 — 但在此端点上线前,它们都没有携带复现该次运行所需的参数。PR #71 的可分享情景 URL 携带了情景文本与模板 slug;此 blob 携带其余的一切,以一份美化打印的文件呈现,适用于论文附录或推文截图。
+
+`GET /api/simulation/<id>/reproduce.json` 返回一份 v1-schema 的 JSON 文档,字段包括:
+
+- **`schema_version`** — 字面量 `"1"`。破坏性变更时升级;v1 解析器应拒绝其他值。
+- **`exported_at`** — 导出时刻的 UTC ISO-8601 时间戳。
+- **`simulation_id`** — 回显的模拟 ID。
+- **`scenario`** — 模拟需求 / 情景文本。对于将 `simulation_requirement` 写入 state 而非生成配置的旧模拟,会回退至 state 字段。
+- **`agent_count`** — 该次运行生成的智能体档案数(对应 `state.profiles_count`)。
+- **`total_rounds`** — 模拟运行(或配置运行)的总轮次。优先取 runner 记录的总数;当 runner 尚未填充该字段时回退至 `time_config.total_simulation_hours * 60 / time_config.minutes_per_round`。
+- **`platforms`** — 决定智能体发帖到哪些渠道的四个布尔 / 整数参数:`twitter`、`reddit`、`polymarket`、`polymarket_market_count`。
+- **`time_config`** — 驱动模拟时序包络的四个节拍旋钮:`minutes_per_round`、`total_simulation_hours`、`peak_hours`、`off_peak_hours`。字段集刻意收窄:LLM 生成的完整配置还包含每代理发帖频率 + 事件计划 + 平台调优,但那些是从实体图谱派生的,并非研究者手工复现的参数。
+- **`director_events`** — 操作者注入的情景事件(如第 15 轮的「流动性危机」),它们形塑了信念曲线。当未注入事件时为 `null`(常见情形)。每个事件携带 `round`、`label` 与可选 `description`。
+- **`lineage`** — 描述此次模拟的创建路径。`kind` 取值之一:`original`(经标准 prepare 流程创建)、`fork`(经 `POST /api/simulation/fork` 创建,代理种群相同、新模拟 ID)、`counterfactual`(经 `POST /api/simulation/branch-counterfactual` 创建,即 fork 加上某一轮调度的注入事件)。携带 `parent_simulation_id`,对反事实分支额外携带 `counterfactual` 子对象,内含 `trigger_round` / `label` / 140 字符 `preview`,使徽章可在不二次请求的情况下渲染头条。
+- **`config_reasoning`** — prepare 时刻捕获的 LLM 选择各旋钮的理由。未持久化此理由的旧模拟为空字符串。
+
+实现:
+
+- **仅标准库。** `json` + `os`。零新增依赖;辅助函数位于 `app/services/repro_export.py`。
+- **只读。** 该服务从磁盘工件(`state.json`、`simulation_config.json`、`counterfactual_injection.json`、可选的 director 事件)组装该 blob — 永不写入。
+- **schema 锁定。** `SCHEMA_VERSION` 常量 + `REQUIRED_KEYS` 冻结集 — 下游消费者可以通过 `validate_blob(blob)` 廉价校验。
+- **纵深防御。** 工件损坏时降级为 `null`,而不让导出 500 — 引用面必须在辅助文件缺失时仍可用。
+- **字节级稳定。** 美化打印(indent=2、sort_keys=True)— 同一已完成模拟的多次导出在字节层面完全一致。文件哈希因此可作为稳定的引用键。
+
+缓存 5 分钟;模拟到达终止状态后,blob 不再变化。与其他分享面一样的发布门控 — 要求模拟为公开(`is_public=true`)。
+
+嵌入对话框有「🔬 可复现配置」面板(默认折叠)— 概要网格(Schema 版本 · 智能体 · 轮次 · 平台 · 导演事件 · 谱系)、可一键复制的「使用 curl 复现」片段、`下载 reproduce.json` 按钮,以及(当模拟为派生或反事实分支时)标题旁的小型内联谱系徽章 — `🪐 派生` 或 `🔀 反事实`。徽章 tooltip 展示父模拟规范 ID,操作者无需阅读 JSON 即可获取它供 `/share/<id>` 或 `/watch/<id>` 使用。
+
 ## 图库搜索与筛选
 
 `/explore` 是公开研究界面 — 每一次发布的 MiroShark 模拟,都以卡片网格浏览。当语料库突破几十条后,反向时间序列的滚动列表就不再是工具,因此图库现在自带索引:卡片之上有一个关键词搜索框、一组共识筛选芯片、一组质量筛选芯片以及一个排序下拉。激活的筛选集合保存在 URL 参数中(`?q=…&consensus=bearish&quality=excellent&sort=rounds`),因此任意筛选视图都可作为书签分享 — "每一次关于 Aave 的优秀质量看跌预言"成了一个可发推文的 URL。

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -571,6 +571,50 @@ export const getSurfaceStats = (simulationId) => {
 }
 
 /**
+ * Build the absolute URL of the reproducibility config blob for a
+ * simulation.
+ *
+ * The blob is a v1-schema JSON document carrying every parameter
+ * another operator would need to re-run the same simulation —
+ * scenario text, agent count, total rounds, platform toggles, the
+ * four cadence knobs from `time_config`, any operator-injected
+ * director events, and a `lineage` block describing fork /
+ * counterfactual parentage. The citation primitive behind every
+ * other share surface.
+ *
+ * Same publish gate as the share card / transcript / trajectory /
+ * thread endpoints. Returns 403 for unpublished simulations. Cached
+ * for 5 minutes; identical exports of the same finished simulation
+ * are bytewise-identical (citation-hash friendly).
+ *
+ * @param {string} simulationId
+ * @param {string} [origin]
+ * @returns {string}
+ */
+export const getReproductionUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/api/simulation/${simulationId}/reproduce.json`
+}
+
+/**
+ * Fetch the parsed reproducibility config blob for a published
+ * simulation. Returns the same JSON document `getReproductionUrl`
+ * resolves to, but as an in-memory object — useful for rendering the
+ * lineage badge or the inline config preview without a second fetch.
+ *
+ * The endpoint follows the standard share-surface envelope: the
+ * Flask handler returns the blob directly (not wrapped in
+ * `{success, data}`), so callers consume `response.data` as the
+ * blob itself.
+ *
+ * @param {string} simulationId
+ * @returns {Promise<object>} the v1-schema reproduction blob
+ */
+export const getReproduction = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/reproduce.json`)
+}
+
+/**
  * Build the absolute URL of the public share landing page for a
  * simulation. The page exposes Open Graph + Twitter Card meta tags so
  * pasting the URL into Twitter/X / Discord / Slack / LinkedIn unfurls

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -546,6 +546,128 @@
               </div>
             </div>
 
+            <!-- Reproducibility config — citation primitive behind every
+                 other share surface. Six surfaces (transcript, trajectory,
+                 thread, watch, GIF, share card) make a finished sim
+                 citable; this one carries the *parameters* a second
+                 operator needs to re-run it. Lineage badge surfaces
+                 fork / counterfactual parentage (when present) so a
+                 reader knows "this run is a counterfactual branch of
+                 sim_X at round 12" without reading the diff. Collapsed
+                 by default to keep the dialog compact. -->
+            <div class="transcript-section repro-section">
+              <div class="transcript-head repro-head" @click="toggleRepro">
+                <span class="transcript-icon">🔬</span>
+                <div class="transcript-head-body">
+                  <div class="transcript-title">
+                    {{ $tr('Reproducibility config', '可复现配置') }}
+                    <span
+                      v-if="reproLineageBadge"
+                      class="repro-lineage-badge"
+                      :title="reproLineageTitle"
+                    >
+                      {{ reproLineageBadge }}
+                    </span>
+                  </div>
+                  <div class="transcript-sub">
+                    {{ $tr('Every parameter another researcher needs to reproduce this exact run — scenario, agents, rounds, platforms, time-config, director events, fork lineage. Citation-friendly JSON.', '另一位研究者复现此运行所需的全部参数 — 情景、智能体、轮次、平台、时序配置、导演事件、派生谱系。便于引用的 JSON。') }}
+                  </div>
+                </div>
+                <button
+                  class="repro-chevron"
+                  :class="{ 'repro-chevron-open': reproExpanded }"
+                  :aria-expanded="reproExpanded"
+                  type="button"
+                >
+                  ▾
+                </button>
+              </div>
+
+              <div v-if="reproExpanded" class="repro-body">
+                <div v-if="!isPublic" class="transcript-empty">
+                  {{ $tr('Publish the simulation to expose the reproducibility config.', '发布模拟以公开可复现配置。') }}
+                </div>
+                <div v-else-if="reproLoading" class="repro-loading">
+                  {{ $tr('Loading reproduction blob…', '加载复现配置…') }}
+                </div>
+                <div v-else-if="reproError" class="transcript-empty repro-error">
+                  {{ reproError }}
+                </div>
+                <div v-else-if="reproBlob" class="repro-detail">
+                  <div class="repro-summary-grid">
+                    <div class="repro-summary-row">
+                      <span class="repro-summary-key">{{ $tr('Schema', 'Schema') }}</span>
+                      <span class="repro-summary-value">v{{ reproBlob.schema_version }}</span>
+                    </div>
+                    <div class="repro-summary-row">
+                      <span class="repro-summary-key">{{ $tr('Agents', '智能体数') }}</span>
+                      <span class="repro-summary-value">{{ reproBlob.agent_count }}</span>
+                    </div>
+                    <div class="repro-summary-row">
+                      <span class="repro-summary-key">{{ $tr('Rounds', '轮次') }}</span>
+                      <span class="repro-summary-value">{{ reproBlob.total_rounds }}</span>
+                    </div>
+                    <div class="repro-summary-row">
+                      <span class="repro-summary-key">{{ $tr('Platforms', '平台') }}</span>
+                      <span class="repro-summary-value">{{ reproPlatformsLabel }}</span>
+                    </div>
+                    <div v-if="reproDirectorEventCount > 0" class="repro-summary-row">
+                      <span class="repro-summary-key">{{ $tr('Director events', '导演事件') }}</span>
+                      <span class="repro-summary-value">{{ reproDirectorEventCount }}</span>
+                    </div>
+                    <div v-if="reproBlob.lineage && reproBlob.lineage.kind !== 'original'" class="repro-summary-row">
+                      <span class="repro-summary-key">{{ $tr('Lineage', '谱系') }}</span>
+                      <span class="repro-summary-value">{{ reproLineageDescription }}</span>
+                    </div>
+                  </div>
+
+                  <div class="repro-curl-block">
+                    <div class="repro-curl-head">
+                      <span class="repro-curl-label">{{ $tr('Reproduce via curl', '使用 curl 复现') }}</span>
+                      <button class="snippet-copy-btn" @click="copy('reproCurl')">
+                        {{ copied === 'reproCurl' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy', '复制') }}
+                      </button>
+                    </div>
+                    <pre class="snippet-code"><code>{{ reproCurlSnippet }}</code></pre>
+                  </div>
+
+                  <div class="repro-note">
+                    {{ $tr('Anyone with this config has every parameter that shapes the run — same scenario, same agent count, same rounds, same platform mix. Identical exports of a finished sim are bytewise-identical, so the file hash is a stable citation key.', '获得此配置的任何人都拥有决定该运行的所有参数 — 相同情景、相同智能体数、相同轮次、相同平台组合。已完成模拟的多次导出在字节级别完全一致,因此文件哈希可作为稳定的引用键。') }}
+                  </div>
+                </div>
+
+                <div v-if="isPublic" class="repro-actions">
+                  <a
+                    v-if="reproDownloadUrl"
+                    class="repro-download"
+                    :href="reproDownloadUrl"
+                    :download="reproDownloadFilename"
+                    target="_blank"
+                    rel="noopener"
+                  >
+                    {{ $tr('Download reproduce.json', '下载 reproduce.json') }}
+                  </a>
+                  <button
+                    class="snippet-copy-btn repro-copy-url"
+                    type="button"
+                    @click="copy('reproUrl')"
+                    :disabled="!reproDownloadUrl"
+                  >
+                    {{ copied === 'reproUrl' ? '✓ ' + $tr('URL copied', '已复制 URL') : $tr('Copy URL', '复制 URL') }}
+                  </button>
+                  <button
+                    class="surface-stats-refresh repro-refresh"
+                    type="button"
+                    :disabled="reproLoading"
+                    @click="loadRepro"
+                  >
+                    <span v-if="reproLoading">{{ $tr('Refreshing…', '刷新中…') }}</span>
+                    <span v-else>↻ {{ $tr('Refresh', '刷新') }}</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+
             <!-- Verified-prediction annotation — lets operators turn a
                  published simulation into a "called it" record on the
                  /verified gallery page. Only meaningful once the run is
@@ -833,6 +955,8 @@ import {
   getThreadTxtUrl,
   getThreadJsonUrl,
   getSurfaceStats,
+  getReproductionUrl,
+  getReproduction,
   getFeedUrl,
   getSimulationOutcome,
   submitSimulationOutcome,
@@ -1109,6 +1233,163 @@ const toggleSurfaceStats = () => {
   }
 }
 
+// ── Reproducibility config state ───────────────────────────────────────
+// The citation primitive behind every other share surface. The blob
+// is a v1-schema JSON document carrying every parameter another
+// operator would need to re-run the same simulation (scenario, agent
+// count, rounds, platforms, time-config, director events, lineage).
+// Same publish gate as the other share surfaces. Collapsed by default
+// so a viewer who only cares about share / publish / outcome doesn't
+// pay the network round-trip on every dialog open.
+const reproExpanded = ref(false)
+const reproLoading = ref(false)
+const reproError = ref('')
+const reproBlob = ref(null)
+
+const reproDownloadUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  return getReproductionUrl(props.simulationId, origin.value)
+})
+
+const reproDownloadFilename = computed(() => {
+  if (!props.simulationId) return 'reproduce.json'
+  return `miroshark-${props.simulationId.slice(0, 12)}-reproduce.json`
+})
+
+const reproPlatformsLabel = computed(() => {
+  const p = reproBlob.value?.platforms
+  if (!p) return ''
+  const parts = []
+  if (p.twitter) parts.push(tr('Twitter', 'Twitter'))
+  if (p.reddit) parts.push(tr('Reddit', 'Reddit'))
+  if (p.polymarket) {
+    const count = Number(p.polymarket_market_count || 1)
+    parts.push(`${tr('Polymarket', 'Polymarket')} ×${count}`)
+  }
+  return parts.length
+    ? parts.join(' · ')
+    : tr('No platforms enabled', '未启用平台')
+})
+
+const reproDirectorEventCount = computed(() => {
+  const events = reproBlob.value?.director_events
+  return Array.isArray(events) ? events.length : 0
+})
+
+const reproLineageBadge = computed(() => {
+  const lineage = reproBlob.value?.lineage
+  if (!lineage) return ''
+  if (lineage.kind === 'fork') return tr('🪐 Forked', '🪐 派生')
+  if (lineage.kind === 'counterfactual') return tr('🔀 Counterfactual', '🔀 反事实')
+  return ''
+})
+
+const reproLineageDescription = computed(() => {
+  const lineage = reproBlob.value?.lineage
+  if (!lineage || lineage.kind === 'original') return ''
+  const parent = lineage.parent_simulation_id
+    ? lineage.parent_simulation_id.slice(0, 12)
+    : ''
+  if (lineage.kind === 'fork') {
+    return tr('Forked from ', '派生自 ') + parent
+  }
+  // Counterfactual — surface the trigger round and label so the
+  // reader sees "Counterfactual branch of sim_X at round 12 (ceo_resigns)"
+  // without opening the parent.
+  const cf = lineage.counterfactual || {}
+  const round = Number.isInteger(cf.trigger_round) ? cf.trigger_round : '?'
+  const label = cf.label
+    ? ` (${cf.label})`
+    : ''
+  return tr('Counterfactual of ', '反事实分支自 ')
+    + parent
+    + tr(' at round ', ' · 第 ')
+    + round
+    + tr('', ' 轮')
+    + label
+})
+
+const reproLineageTitle = computed(() => {
+  // Tooltip seen on hover — full parent ID, not the truncated 12-char
+  // version, so the operator can grab the canonical sim id for
+  // /share/<id> or /watch/<id>.
+  const lineage = reproBlob.value?.lineage
+  if (!lineage || lineage.kind === 'original') {
+    return tr(
+      'Original simulation — no parent run.',
+      '原始模拟 — 无父运行。',
+    )
+  }
+  const parent = lineage.parent_simulation_id || '?'
+  if (lineage.kind === 'fork') {
+    return tr('Fork of ', '派生自 ') + parent
+  }
+  return tr('Counterfactual branch of ', '反事实分支自 ') + parent
+})
+
+const reproCurlSnippet = computed(() => {
+  if (!reproDownloadUrl.value) return ''
+  // Plain curl that produces the same blob the Download button does —
+  // suitable for paper-appendix screenshots and Jupyter notebook
+  // quickstarts. ``-fsSL`` keeps the snippet quiet on success and
+  // forwards redirects (the production deploy may sit behind a CDN
+  // that issues a 308 to the canonical host).
+  return `curl -fsSL '${reproDownloadUrl.value}' -o reproduce.json`
+})
+
+const loadRepro = async () => {
+  if (!props.simulationId || !isPublic.value) {
+    reproBlob.value = null
+    return
+  }
+  reproLoading.value = true
+  reproError.value = ''
+  try {
+    const res = await getReproduction(props.simulationId)
+    // The endpoint returns the blob directly (no {success, data}
+    // wrapper) — the axios client already unwraps the JSON body.
+    if (res && typeof res === 'object' && res.schema_version) {
+      reproBlob.value = res
+    } else if (res && res.data && typeof res.data === 'object') {
+      // Defensive — handle a future enveloping change without
+      // breaking the panel.
+      reproBlob.value = res.data
+    } else {
+      reproBlob.value = null
+      reproError.value = tr(
+        'Could not parse the reproduction config.',
+        '无法解析复现配置。',
+      )
+    }
+  } catch (err) {
+    if (err?.response?.status === 403) {
+      reproError.value = tr(
+        'Publish the simulation to expose the reproducibility config.',
+        '发布模拟以公开可复现配置。',
+      )
+    } else if (err?.response?.status === 404) {
+      reproError.value = tr(
+        'Simulation not found.',
+        '未找到模拟。',
+      )
+    } else {
+      reproError.value = err?.response?.data?.error
+        || err?.message
+        || tr('Could not load the reproduction config.', '无法加载复现配置。')
+    }
+    reproBlob.value = null
+  } finally {
+    reproLoading.value = false
+  }
+}
+
+const toggleRepro = () => {
+  reproExpanded.value = !reproExpanded.value
+  if (reproExpanded.value && !reproBlob.value && !reproError.value) {
+    loadRepro()
+  }
+}
+
 const _writeClipboard = async (text) => {
   if (!text) return false
   try {
@@ -1210,6 +1491,8 @@ const copy = async (which) => {
     // paste-and-edit immediately without a network round-trip.
     text = threadTweets.value.length ? threadTweets.value.join('\n---\n') : ''
   }
+  else if (which === 'reproUrl') text = reproDownloadUrl.value
+  else if (which === 'reproCurl') text = reproCurlSnippet.value
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)
@@ -1519,6 +1802,11 @@ watch(() => props.open, async (val) => {
   surfaceStatsExpanded.value = false
   surfaceStats.value = null
   surfaceStatsError.value = ''
+  // Same reset for the reproducibility panel — collapsed on open,
+  // blob cleared so the next expand fetches fresh against this sim.
+  reproExpanded.value = false
+  reproBlob.value = null
+  reproError.value = ''
 })
 
 // When the operator toggles public on, the share-card endpoint flips from
@@ -1534,6 +1822,14 @@ watch(isPublic, () => {
     loadSurfaceStats()
   } else {
     surfaceStats.value = null
+  }
+  // Reproducibility panel follows the same flip semantics — visible
+  // and expanded means we re-fetch the now-200 blob; collapsed means
+  // we just clear the cached value so the next expand fetches fresh.
+  if (reproExpanded.value) {
+    loadRepro()
+  } else {
+    reproBlob.value = null
   }
 })
 </script>
@@ -2431,6 +2727,194 @@ watch(isPublic, () => {
 @media (max-width: 600px) {
   .surface-stats-table {
     font-size: 11px;
+  }
+}
+
+/* Reproducibility config — citation primitive behind every other
+   share surface. Visual treatment matches the surface-stats panel
+   (collapsed by default, chevron rotates on open) but adds a small
+   blueish lineage badge inline with the title when the sim was
+   forked or branched, plus a download / copy / refresh button row
+   so the operator can grab the JSON without reading the curl snippet
+   first. */
+.repro-section {
+  margin-top: 14px;
+}
+
+.repro-head {
+  cursor: pointer;
+  user-select: none;
+}
+
+.repro-lineage-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 8px;
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #4338ca;
+  vertical-align: middle;
+  text-transform: none;
+  cursor: help;
+}
+
+.repro-chevron {
+  align-self: center;
+  border: none;
+  background: transparent;
+  font-size: 14px;
+  color: #6b6b6b;
+  transition: transform 0.18s ease;
+  line-height: 1;
+  padding: 4px;
+  cursor: pointer;
+}
+
+.repro-chevron-open {
+  transform: rotate(180deg);
+}
+
+.repro-body {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.repro-loading,
+.repro-error {
+  font-size: 12px;
+  color: #6b6b6b;
+  font-style: italic;
+}
+
+.repro-error {
+  color: #b91c1c;
+  font-style: normal;
+}
+
+.repro-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.repro-summary-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 16px;
+  row-gap: 6px;
+  font-size: 12px;
+  background: #fafafa;
+  border: 1px solid rgba(10, 10, 10, 0.08);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.repro-summary-row {
+  display: contents;
+}
+
+.repro-summary-key {
+  color: #6b6b6b;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.repro-summary-value {
+  color: #1a1a1a;
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+}
+
+.repro-curl-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.repro-curl-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.repro-curl-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6b6b6b;
+}
+
+.repro-note {
+  font-size: 11px;
+  line-height: 1.5;
+  color: #6b6b6b;
+  background: #f5f5f5;
+  border-left: 3px solid rgba(99, 102, 241, 0.4);
+  padding: 8px 10px;
+  border-radius: 4px;
+}
+
+.repro-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.repro-download {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #1a1a1a 0%, #2a2a2a 100%);
+  color: #ffffff;
+  text-decoration: none;
+  border: 1px solid #1a1a1a;
+  transition: background 0.15s;
+}
+
+.repro-download:hover {
+  background: linear-gradient(180deg, #2a2a2a 0%, #1a1a1a 100%);
+}
+
+.repro-copy-url {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.repro-refresh {
+  margin-left: auto;
+}
+
+@media (max-width: 600px) {
+  .repro-summary-grid {
+    grid-template-columns: 1fr;
+    row-gap: 2px;
+  }
+  .repro-summary-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .repro-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .repro-refresh {
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
## What

`GET /api/simulation/<id>/reproduce.json` — a v1-schema JSON document carrying every parameter another operator would need to re-run the same simulation: scenario, agent count, total rounds, platform toggles (twitter / reddit / polymarket + market count), the four cadence knobs from `time_config` (minutes per round, total hours, peak / off-peak windows), any operator-injected director events, and a `lineage` block describing whether this simulation is original, a plain fork of another sim, or a counterfactual branch (with parent id + 140-char injection preview travelling along).

Pretty-printed (sort_keys=True, indent=2) so identical exports of a finished simulation are bytewise-identical — the file hash is therefore a stable citation key suitable for paper appendices and thread screenshots.

## Why

Closes the **reproducibility gap** behind every share surface. Six of the ten existing share surfaces (transcript, trajectory, thread, watch, GIF, share card) make a finished simulation *citable* — but until this endpoint shipped, none of them carried the parameters needed to *reproduce* the run. PR #71's shareable scenario URLs carry the scenario text and template slug; this blob carries everything else.

The academic and quant audiences need this primitive before they can cite MiroShark in a paper or thread without manual qualification: a researcher quoting an Aave risk sim previously had to guess agent count, rounds, model preset, and director events, or hand-inspect the underlying state files. With `reproduce.json` they get a single machine-readable file.

Pivot from May 6 repo-actions idea #1 — picked over:
- **#2 Python Client SDK via openapi-generator CI** — needs `.github/workflows/`, our PAT lacks the workflows scope.
- **#3 Director Event Timeline Overlay** — depends on whether `chartjs-plugin-annotation` is pinned; SVG-overlay fallback is non-trivial.
- **#5 Comparative Run View** — clean but lower research-side leverage than the citation primitive.
- **#4 Surface Usage Analytics** — already shipped 2026-05-07 (PR #74).

#1 was the cleanest small-effort autonomous pick: pure stdlib, follows the existing `_serve_X` service pattern, zero new dependencies.

## Changes

- **`backend/app/services/repro_export.py`** — new ~370 LoC service. `SCHEMA_VERSION = "1"` constant + `REQUIRED_KEYS` frozenset (pinned by tests). `build_repro_config(state_dict, config_data, sim_dir)` composes the blob. `_build_lineage()` derives original / fork / counterfactual from `parent_simulation_id` + presence of `counterfactual_injection.json`. `_read_director_events()` reads JSONL (current shape) with a fallback to list-style `director-events.json` (legacy shape); corrupt lines skipped without blanking the rest. `_derive_total_rounds()` mirrors the embed-summary derivation. `render_json_bytes()` + `validate_blob()` for downstream consumers.

- **`backend/tests/test_unit_repro_export.py`** — 22 offline unit tests: SCHEMA_VERSION literal pin, REQUIRED_KEYS pin, full blob round-trip, scenario state-fallback, total_rounds prefer-state vs fall-back-to-time_config vs zero, platform defaults, polymarket_market_count clamp, lineage shapes (original / fork / counterfactual), corrupt counterfactual graceful degradation, director events JSONL + legacy list parsing + missing → null, render_json_bytes determinism, validate_blob accept + reject paths, `_safe_int` clamp, route + openapi drift guards.

- **`backend/app/api/simulation.py`** — `GET /<simulation_id>/reproduce.json` route handler beneath the surface-stats route. Same publish gate; 5-min `Cache-Control`; `Content-Disposition: inline; filename="miroshark-<id12>-reproduce.json"` so a click renders in-tab and the EmbedDialog's `download` attribute handles save-as.

- **`backend/openapi.yaml`** — `/api/simulation/{id}/reproduce.json` path under Publish & Embed + new `ReproductionConfig` schema (every required field documented, including `platforms`, `time_config`, `lineage`, `director_events`). Drift-detection test passes — only an existing route was extended, no new blueprint registered.

- **`frontend/src/api/simulation.js`** — `getReproductionUrl()` + `getReproduction()` helpers.

- **`frontend/src/components/EmbedDialog.vue`** — "🔬 Reproducibility config" panel between Distribution and Mark outcome:
  - Collapsed-by-default summary grid (Schema · Agents · Rounds · Platforms · Director events · Lineage).
  - Inline lineage badge: `🪐 Forked` (blue chip) or `🔀 Counterfactual` when `lineage.kind != "original"`. Tooltip carries the canonical parent sim id so the operator can grab it for `/share/<id>` or `/watch/<id>` without reading the JSON.
  - Counterfactual lineage description includes the trigger round + label so the reader sees "Counterfactual of `sim_X` at round 12 (`ceo_resigns`)" without opening the parent.
  - Copy-ready `curl -fsSL '<url>' -o reproduce.json` snippet.
  - `Download reproduce.json` button + `Copy URL` button + `Refresh` button.
  - Resets on dialog open + on `isPublic` flip — same lifecycle the surface-stats panel already uses.
  - New scoped CSS for `.repro-section`, `.repro-lineage-badge`, `.repro-summary-grid` (CSS Grid with `display: contents` rows for two-column layout), responsive collapse to single-column at 600px.

- **`README.md` + `docs/FEATURES.md` + `docs/API.md`** (en + zh-CN mirrors) — Reproducibility Config feature row + full FEATURES.md section between Surface Usage Analytics and Webhook Delivery Log.

## Implementation notes

- Pure stdlib (`json` + `os` + `datetime`); zero new dependencies.
- Read-only — the service composes the blob from on-disk artifacts (`state.json`, `simulation_config.json`, `counterfactual_injection.json`, `director-events.{jsonl,json}`) and never writes.
- Defense-in-depth — corrupt artifacts degrade to `null` (or `kind: "fork"` for counterfactual files) rather than 500ing the export. The citation surface must be available even when ancillary files are missing.
- Frontend build green: `npm run build` 728 modules transformed, vite v7.2.7.

## Test plan

- [ ] CI runs the new `test_unit_repro_export.py` (22 tests) + the existing `test_unit_openapi.py` drift suite.
- [ ] Open the EmbedDialog on a published sim, expand the "🔬 Reproducibility config" panel, verify the summary grid populates with the right agent count / rounds / platforms.
- [ ] Click `Download reproduce.json`, parse the file with `python -c 'import json; print(json.load(open("reproduce.json"))["schema_version"])'` — expect `"1"`.
- [ ] Run `curl -fsSL <url> -o a.json && curl -fsSL <url> -o b.json && diff a.json b.json` — expect zero diff (bytewise stability).
- [ ] On a forked sim (created via the existing `/fork` endpoint), confirm the lineage badge shows `🪐 Forked` and the tooltip carries the canonical parent id.
- [ ] On a counterfactual branch (via `/branch-counterfactual`), confirm the badge shows `🔀 Counterfactual` and the description renders "Counterfactual of `sim_X` at round 12 (`<label>`)".
- [ ] Hit the endpoint on a private sim — expect `403`.

---
*Built autonomously by Aeon*