### PR TITLE
feat: track reproduce.json + lineage in surface-stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Push Notifications** | Web-push alerts when long-running graph / sim / report jobs finish |
 | **Completion Webhook** | POST a JSON summary the moment a sim finishes — wires Slack, Discord, Zapier, Make, n8n, or any custom endpoint with one URL field |
 | **Webhook Delivery Log** | Per-sim `webhook-log.jsonl` records every dispatch attempt (status code, latency, error). Inspect from the EmbedDialog and re-fire any failed delivery with a "Retry" button — closes the operational blindspot every Zapier / n8n integration eventually hits |
-| **Surface Usage Analytics** | `GET /api/simulation/<id>/surface-stats` — per-share-surface request counters (share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS) with a synthetic `total`. Inbound observability for the distribution loop the webhook log tracks on the outbound side |
+| **Surface Usage Analytics** | `GET /api/simulation/<id>/surface-stats` — per-share-surface request counters (share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS / reproduce.json / lineage) with a synthetic `total`. Inbound observability for the distribution loop the webhook log tracks on the outbound side |
 | **Reproducibility Config** | `GET /api/simulation/<id>/reproduce.json` — citation primitive for the share surfaces. A v1-schema JSON blob carrying every parameter another operator needs to re-run the same simulation: scenario, agent count, total rounds, platform toggles, time-config knobs, director events, and fork / counterfactual lineage. Identical exports of a finished sim are bytewise-identical, so the file hash is a stable citation key |
 | **Lineage Navigator** | `GET /api/simulation/<id>/lineage` — turn the `parent_simulation_id` pointer into a navigable graph. Surfaces the parent a sim was forked / branched from plus every public child whose parent points back at it. Trace the intellectual ancestry of a result without remembering each child sim id |
 
@@ -238,7 +238,7 @@ cp .env.example .env
 | **推送通知** | 长耗时图谱 / 模拟 / 报告任务完成时的浏览器推送提醒 |
 | **完成 Webhook** | 模拟一结束即 POST 一份 JSON 摘要 — 一个 URL 字段即可连通 Slack、Discord、Zapier、Make、n8n 或任意自定义端点 |
 | **Webhook 投递日志** | 每个模拟在 `webhook-log.jsonl` 记录每次投递尝试(HTTP 状态码、延迟、错误)。可在 EmbedDialog 中查看,并通过「重试」按钮重发任何失败的投递 — 弥补每个 Zapier / n8n 集成最终都会遇到的运维盲点 |
-| **分发统计(分享面使用分析)** | `GET /api/simulation/<id>/surface-stats` — 每个分享面的请求计数器(分享卡 / 回放 GIF / 转录 / 轨迹 / 推文串 / 观看页 / Atom / RSS),以及合成的 `total`。Webhook 日志在出站侧跟踪分发回路,本面则负责入站可观测性 |
+| **分发统计(分享面使用分析)** | `GET /api/simulation/<id>/surface-stats` — 每个分享面的请求计数器(分享卡 / 回放 GIF / 转录 / 轨迹 / 推文串 / 观看页 / Atom / RSS / `reproduce.json` / `/lineage`),以及合成的 `total`。Webhook 日志在出站侧跟踪分发回路,本面则负责入站可观测性 |
 | **可复现配置导出** | `GET /api/simulation/<id>/reproduce.json` — 分享面背后的引用基元。v1-schema 的 JSON 文档,携带另一位研究者复现同一次模拟所需的全部参数:情景、智能体数、轮次、平台切换、时序配置、导演事件、派生 / 反事实谱系。已完成模拟的多次导出在字节级别完全一致 — 文件哈希可作为稳定的引用键 |
 | **谱系导航** | `GET /api/simulation/<id>/lineage` — 将 `parent_simulation_id` 指针转化为可导航的图。展示该模拟派生 / 分支自的父模拟,以及每一个把父级指回此模拟的公开子模拟。无需记住每个子模拟 ID,即可追踪一项结果的思想脉络 |
 

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -5366,8 +5366,10 @@ def get_surface_stats(simulation_id: str):
     Returns the number of times each share surface has served a
     successful response for this simulation — share card PNG, replay
     GIF, transcript (Markdown + JSON), trajectory (CSV + JSONL), tweet
-    thread (TXT + JSON), live watch page, and Atom / RSS feeds. Plus a
-    synthetic ``total`` summing all counters.
+    thread (TXT + JSON), live watch page, Atom / RSS feeds,
+    reproducibility config (``reproduce.json``), and the lineage graph
+    slice (``/lineage``). Plus a synthetic ``total`` summing all
+    counters.
 
     The first **inbound** observability surface — pairs with the
     outbound webhook delivery log (``/<id>/webhook-log``) so an operator
@@ -5375,9 +5377,9 @@ def get_surface_stats(simulation_id: str):
     EmbedDialog.
 
     Same publish gate as the share card / transcript / trajectory /
-    thread endpoints — the counter file lives inside the sim's
-    on-disk directory and is only meaningful for sims the operator has
-    chosen to surface publicly.
+    thread / reproduce.json / lineage endpoints — the counter file
+    lives inside the sim's on-disk directory and is only meaningful
+    for sims the operator has chosen to surface publicly.
     """
     from ..services import surface_stats
 
@@ -5459,6 +5461,7 @@ def get_reproduce_config(simulation_id: str):
     count, rounds, or director events.
     """
     from ..services import repro_export
+    from ..services import surface_stats
     from flask import Response
 
     locale = get_locale(request)
@@ -5510,6 +5513,7 @@ def get_reproduce_config(simulation_id: str):
         response.headers["Content-Disposition"] = (
             f'inline; filename="{filename}"'
         )
+        surface_stats.increment_surface_stat(sim_dir, "reproduce_json")
         return response
 
     except Exception as e:
@@ -5578,6 +5582,7 @@ def get_simulation_lineage(simulation_id: str):
     once the parent and its branches reach terminal states.
     """
     from ..services import lineage_service
+    from ..services import surface_stats
 
     locale = get_locale(request)
     try:
@@ -5611,6 +5616,10 @@ def get_simulation_lineage(simulation_id: str):
 
         response = jsonify({"success": True, "data": payload})
         response.headers["Cache-Control"] = "public, max-age=300"
+        sim_dir = os.path.join(
+            Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id
+        )
+        surface_stats.increment_surface_stat(sim_dir, "lineage")
         return response
 
     except Exception as e:

--- a/backend/app/services/surface_stats.py
+++ b/backend/app/services/surface_stats.py
@@ -4,9 +4,10 @@ Closes the **inbound** observability gap that paired with the outbound
 webhook delivery log (PR #73). Every public share surface
 (``share-card.png``, ``replay.gif``, ``transcript.md`` / ``.json``,
 ``trajectory.csv`` / ``.jsonl``, ``thread.txt`` / ``.json``,
-``/watch/<id>``, ``/api/feed.atom`` + ``feed.rss``) increments a counter
-on disk after it serves a successful response. The counts are returned
-by ``GET /api/simulation/<id>/surface-stats`` so an operator running
+``/watch/<id>``, ``/api/feed.atom`` + ``feed.rss``, ``reproduce.json``,
+``/lineage``) increments a counter on disk after it serves a successful
+response. The counts are returned by
+``GET /api/simulation/<id>/surface-stats`` so an operator running
 MiroShark for a DeFi fund or research group can see which surfaces
 their audience actually uses — the first operator-side feedback loop on
 distribution.
@@ -39,7 +40,9 @@ Schema::
       "thread_json": 0,
       "watch_page": 0,
       "feed_atom": 0,
-      "feed_rss": 0
+      "feed_rss": 0,
+      "reproduce_json": 0,
+      "lineage": 0
     }
 
 The ``read_surface_stats`` helper returns the same dict with every key
@@ -74,6 +77,8 @@ SURFACE_KEYS: frozenset[str] = frozenset(
         "watch_page",
         "feed_atom",
         "feed_rss",
+        "reproduce_json",
+        "lineage",
     }
 )
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1412,8 +1412,9 @@ paths:
         successful response for this simulation — share card PNG,
         replay GIF, transcript (Markdown + JSON), trajectory
         (CSV + JSONL), tweet thread (TXT + JSON), live watch page,
-        and Atom / RSS feeds — plus a synthetic `total` summing all
-        counters.
+        Atom / RSS feeds, reproducibility config (`reproduce.json`),
+        and the lineage graph slice (`/lineage`) — plus a synthetic
+        `total` summing all counters.
 
         The **inbound** observability surface — pairs with the
         outbound webhook delivery log so an operator running MiroShark
@@ -3011,6 +3012,8 @@ components:
             - watch_page
             - feed_atom
             - feed_rss
+            - reproduce_json
+            - lineage
             - total
           properties:
             share_card:
@@ -3063,6 +3066,14 @@ components:
               minimum: 0
               description: |
                 Same semantics as `feed_atom` for the RSS 2.0 form.
+            reproduce_json:
+              type: integer
+              minimum: 0
+              description: Successful `reproduce.json` serves.
+            lineage:
+              type: integer
+              minimum: 0
+              description: Successful `/lineage` serves.
             total:
               type: integer
               minimum: 0

--- a/backend/tests/test_unit_surface_stats.py
+++ b/backend/tests/test_unit_surface_stats.py
@@ -74,6 +74,8 @@ def test_surface_keys_includes_every_serve_handler():
         "watch_page",
         "feed_atom",
         "feed_rss",
+        "reproduce_json",
+        "lineage",
     }
     assert set(surface_stats.SURFACE_KEYS) == expected
 
@@ -269,6 +271,8 @@ def test_surface_stats_route_decorator_registered():
         "trajectory_jsonl",
         "thread_txt",
         "thread_json",
+        "reproduce_json",
+        "lineage",
     ],
 )
 def test_serve_handlers_increment_their_surface_key(surface_key: str):

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,7 +93,7 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `GET` | `/api/simulation/<id>/trajectory.jsonl` | Per-round belief JSONL (DuckDB / pipelines) |
 | `GET` | `/api/simulation/<id>/thread.txt` | Auto-formatted X / Twitter tweet thread (one tweet per belief inflection point, ≤280 chars each) |
 | `GET` | `/api/simulation/<id>/thread.json` | Same tweet thread as `thread.txt` but as `{tweets, total, inflections_recorded, truncated}` for programmatic consumers |
-| `GET` | `/api/simulation/<id>/surface-stats` | Per-share-surface request counters — share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS, plus a synthetic `total` |
+| `GET` | `/api/simulation/<id>/surface-stats` | Per-share-surface request counters — share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS / reproduce.json / lineage, plus a synthetic `total` |
 | `GET` | `/api/simulation/<id>/reproduce.json` | Citation primitive — v1-schema reproducibility config blob carrying scenario, agent count, total rounds, platform toggles, time-config knobs, director events, and fork / counterfactual lineage. Identical exports of a finished sim are bytewise-identical (citation-hash friendly) |
 | `GET` | `/api/simulation/<id>/lineage` | Lineage graph slice — parent the sim was forked / branched from + every public child whose `parent_simulation_id` points back at it. Closes the navigation gap the reproduction config left open |
 | `GET` | `/api/simulation/<id>/webhook-log` | Recent outbound-webhook delivery attempts (last 10 + total count). Admin-token gated |

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -87,7 +87,7 @@
 | `GET` | `/api/simulation/<id>/embed-summary` | 嵌入载荷(仅公开模拟) |
 | `GET` | `/api/simulation/<id>/thread.txt` | 自动生成的 X / Twitter 推文串(每个信念转折点一条推文,每条 ≤280 字符) |
 | `GET` | `/api/simulation/<id>/thread.json` | 同样的推文串内容,以 `{tweets, total, inflections_recorded, truncated}` 形式返回,供程序消费 |
-| `GET` | `/api/simulation/<id>/surface-stats` | 每个分享面的请求计数器 — 分享卡 / 回放 GIF / 转录 / 推文串 / 观看页 / Atom / RSS,以及合成的 `total` |
+| `GET` | `/api/simulation/<id>/surface-stats` | 每个分享面的请求计数器 — 分享卡 / 回放 GIF / 转录 / 轨迹 / 推文串 / 观看页 / Atom / RSS / `reproduce.json` / `/lineage`,以及合成的 `total` |
 | `GET` | `/api/simulation/<id>/reproduce.json` | 引用基元 — v1-schema 可复现配置 blob,携带情景、智能体数、总轮次、平台切换、时序配置旋钮、导演事件以及派生 / 反事实谱系。已完成模拟的多次导出在字节级别完全一致(便于以哈希引用) |
 | `GET` | `/api/simulation/<id>/lineage` | 谱系图切片 — 该模拟派生 / 分支自的父模拟,以及每一个 `parent_simulation_id` 指回此模拟的公开子模拟。弥补可复现配置遗留的导航空白 |
 | `GET` | `/api/simulation/<id>/webhook-log` | 最近的出站 webhook 投递记录(最近 10 条 + 总次数)。需管理员 token |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -267,6 +267,8 @@ Counters tracked (one per share surface):
 - `thread_txt` / `thread_json` — `thread.txt` / `thread.json` serves
 - `watch_page` — `/watch/<id>` serves (public sims only)
 - `feed_atom` / `feed_rss` — number of times this simulation was syndicated to an Atom or RSS feed render
+- `reproduce_json` — `reproduce.json` serves (citation primitive — every fetch is an attempted reproduction)
+- `lineage` — `/lineage` serves (graph navigation — every fetch is an operator walking the fork tree)
 
 Plus a synthetic `total` summing all counters. Every key is always present (zero-defaulted), so a frontend renders the table without special-casing missing fields.
 

--- a/docs/FEATURES.zh-CN.md
+++ b/docs/FEATURES.zh-CN.md
@@ -203,6 +203,8 @@ WONDERWALL_MODEL_NAME=your-model-id
 - `thread_txt` / `thread_json` — `thread.txt` / `thread.json` 服务次数
 - `watch_page` — `/watch/<id>` 服务次数(仅公开模拟)
 - `feed_atom` / `feed_rss` — 此模拟出现在已渲染的 Atom 或 RSS 订阅源中的次数
+- `reproduce_json` — `reproduce.json` 服务次数(引用基元 — 每次抓取都对应一次复现尝试)
+- `lineage` — `/lineage` 服务次数(谱系导航 — 每次抓取都对应一次研究者在派生树上的浏览)
 
 以及一个合成的 `total` 字段汇总所有计数器。每个键都始终存在(零默认),因此前端无需为缺失字段做特殊处理。
 

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -1326,6 +1326,8 @@ const SURFACE_STAT_LABELS = [
   { key: 'watch_page', label: tr('Watch page', '观看页面') },
   { key: 'feed_atom', label: tr('Atom feed', 'Atom 源') },
   { key: 'feed_rss', label: tr('RSS feed', 'RSS 源') },
+  { key: 'reproduce_json', label: tr('Reproduce config · JSON', '可复现配置 · JSON') },
+  { key: 'lineage', label: tr('Lineage graph', '谱系图') },
 ]
 
 const surfaceStatsRows = computed(() => {


### PR DESCRIPTION
## Summary

Adds the two newest share surfaces (`reproduce.json` from PR #75, `/lineage` from PR #76) to the per-share-surface counter table — the Distribution panel currently undercounts because both shipped after PR #74's `surface-stats` and never got wired in.

## Changes

- `backend/app/services/surface_stats.py` — `reproduce_json` + `lineage` added to `SURFACE_KEYS` frozenset; module docstring + on-disk schema example extended.
- `backend/app/api/simulation.py` — `surface_stats.increment_surface_stat(sim_dir, "reproduce_json")` wired into `get_reproduce_config` and `surface_stats.increment_surface_stat(sim_dir, "lineage")` into `get_simulation_lineage`. Same placement as every other handler: after the response object is built, before the return. `get_surface_stats` docstring updated to list the two new surfaces.
- `backend/openapi.yaml` — `SimulationSurfaceStats.stats` gains the two new properties + `required` entries; `/surface-stats` route description updated.
- `backend/tests/test_unit_surface_stats.py` — `test_surface_keys_includes_every_serve_handler` expected set extended; the parametrized `test_serve_handlers_increment_their_surface_key` adds `reproduce_json` + `lineage` so a future increment removal trips CI.
- `frontend/src/components/EmbedDialog.vue` — two new rows in `SURFACE_STAT_LABELS` (EN + zh-CN) so the Distribution table renders the new counters.
- `docs/FEATURES.md` + `docs/FEATURES.zh-CN.md` + `docs/API.md` + `docs/API.zh-CN.md` + `README.md` (EN + 中文 features tables) — surface-stats prose extended to mention the two new counters.

## Context

The `surface_stats` test suite already had a locked-set guard (`test_surface_keys_includes_every_serve_handler`) plus a parametrized handler-presence guard, but neither knew about `reproduce.json` or `/lineage` because both endpoints landed in the same week as `surface-stats` and the operator-facing Distribution panel silently dropped their counts. Total in the panel was therefore systematically lower than true serve volume — exactly the kind of silent observability gap the panel exists to close.

Zero new dependencies. All changes additive — pre-existing counter files keep working (`reproduce_json` / `lineage` zero-default to 0 on read).

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)