### PR TITLE
feat: trending sort — turn surface-stats into a discovery primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Tweet Thread Export** | `GET /api/simulation/<id>/thread.txt` — auto-formatted X / Twitter thread, intro tweet + one tweet per belief inflection point + close tweet (with watch + share URLs). Each tweet ≤280 chars; copy individual tweets or the whole thread. Pairs with the share card / replay GIF / transcript / trajectory / watch page as the sixth share format |
 | **Live Watch Page** | `/watch/<sim_id>` — minimal full-viewport broadcast page with a vanilla-JS poller that refreshes the belief bar, round counter, and progress bar every 15 s while the simulation runs. Auto-unfurls as a 1200×630 image card when tweeted; the "tweet a sim mid-run" format alongside the finished-result share card |
 | **Public Gallery** | `/explore` browses every published simulation as a card grid — preview the share card, consensus split, and quality health; click to open or one-click fork |
-| **Gallery Search & Filter** | Keyword search + bullish/neutral/bearish + excellent/good/fair/poor + sort by date/rounds/agents on `/explore` and `/verified`. URL-encoded so `?q=aave&consensus=bearish` is bookmarkable. Same ±0.2 stance threshold as every other surface |
+| **Gallery Search & Filter** | Keyword search + bullish/neutral/bearish + excellent/good/fair/poor + sort by date/rounds/agents/trending on `/explore` and `/verified`. `trending` ranks by cumulative share-surface serves so the most-distributed sims float to the top. URL-encoded so `?q=aave&consensus=bearish` is bookmarkable. Same ±0.2 stance threshold as every other surface |
 | **Verified Predictions** | Annotate any public sim with the real-world outcome (called it / partial / called wrong + URL). `/verified` is the dedicated hall of calls that landed |
 | **RSS / Atom Feeds** | `/api/feed.atom` + `/api/feed.rss` — every newly published simulation lands in Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS without anyone curating it. `?verified=1` for the verified-only stream |
 | **Article Generation** | Substack-style write-up of what happened, grounded in actual posts and trades |
@@ -226,7 +226,7 @@ cp .env.example .env
 | **转录导出** | 每轮智能体发帖与立场标签,导出为 Markdown(YAML 头,适配 Notion / Obsidian / Substack)或结构化 JSON(适配 SDK 与 LLM 评审管线) |
 | **推文串导出** | `GET /api/simulation/<id>/thread.txt` — 自动生成 X / Twitter 推文串:介绍推文 + 每个信念转折点(主导立场翻转的轮次)一条推文 + 末尾推文(附观看与分享 URL)。每条推文 ≤280 字符,可单条复制或整串复制。与分享卡片 / 回放 GIF / 转录 / 轨迹 / 实时观看页一同构成第六种分享形式 |
 | **公开图库** | `/explore` 以卡片网格浏览所有公开模拟 — 预览分享卡、共识分布与质量指标;一键打开或派生 |
-| **图库搜索与筛选** | 在 `/explore` 与 `/verified` 上提供关键词搜索 + 看涨/中立/看跌 + 优秀/良好/一般/较差 + 按日期/轮次/智能体数量排序。URL 编码后 `?q=aave&consensus=bearish` 可作为书签分享。与其他所有表面共享同一 ±0.2 立场阈值 |
+| **图库搜索与筛选** | 在 `/explore` 与 `/verified` 上提供关键词搜索 + 看涨/中立/看跌 + 优秀/良好/一般/较差 + 按日期/轮次/智能体/热门排序。`trending` 按累计分享面服务次数排序,让被分发最广的模拟浮于顶部。URL 编码后 `?q=aave&consensus=bearish` 可作为书签分享。与其他所有表面共享同一 ±0.2 立场阈值 |
 | **已验证预言** | 为公开模拟标注真实结果(命中 / 部分 / 失误 + 链接)。`/verified` 是命中预言专属展厅 |
 | **RSS / Atom 订阅源** | `/api/feed.atom` + `/api/feed.rss` — 每个新发布的模拟无需任何整理就会进入 Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS。`?verified=1` 只看已验证内容 |
 | **文章生成** | Substack 风格的复盘文章,基于真实发帖与交易数据 |

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -6084,6 +6084,26 @@ def list_public_simulations():
                 )
                 continue
 
+        # ``trending`` ranks public sims by their cumulative share-surface
+        # serves. Inject ``_serves_total`` (the surface-stats counter sum)
+        # into each card before sorting — single sweep over the corpus, so
+        # the per-card cost is one ``json.load`` of the (small) stats file
+        # at most. Sims with no stats file yet degrade to ``0`` so they
+        # land at the bottom rather than raising. Skipped on every other
+        # sort key to keep the default ``date`` path read-free.
+        if sort_key == "trending":
+            from ..services import surface_stats as _surface_stats
+            for card in all_cards:
+                sim_dir = os.path.join(
+                    Config.WONDERWALL_SIMULATION_DATA_DIR,
+                    card.get("simulation_id") or "",
+                )
+                try:
+                    stats = _surface_stats.read_surface_stats(sim_dir)
+                    card[gallery_filters.TRENDING_FIELD] = int(stats.get("total", 0) or 0)
+                except Exception:
+                    card[gallery_filters.TRENDING_FIELD] = 0
+
         page_items, total = gallery_filters.select_filtered_cards(
             all_cards,
             q=q,
@@ -6095,6 +6115,13 @@ def list_public_simulations():
             limit=limit,
             offset=offset,
         )
+
+        # Drop the transient ``_serves_total`` field before serialisation —
+        # it's an implementation detail of the trending sort, not part of
+        # the public response contract. Per-sim surface counts remain
+        # available via ``GET /api/simulation/<id>/surface-stats``.
+        for card in page_items:
+            card.pop(gallery_filters.TRENDING_FIELD, None)
 
         page_num = (offset // limit) + 1 if limit > 0 else 1
 

--- a/backend/app/services/gallery_filters.py
+++ b/backend/app/services/gallery_filters.py
@@ -14,7 +14,9 @@ This module turns the public listing into a small queryable corpus:
 * outcome filter — ``correct`` / ``incorrect`` / ``partial`` (the
   ``verified=1`` toggle stays for backward compatibility)
 * sort by ``date`` (default, newest first), ``rounds`` (highest
-  agent/round count first), or ``agents``
+  agent/round count first), ``agents``, or ``trending`` (highest
+  cumulative share-surface serves first — the surface-stats counter
+  total)
 
 The helpers are pure-stdlib and operate on plain dicts (the gallery card
 payload returned by ``_build_gallery_card_payload``) so they're testable
@@ -57,8 +59,18 @@ QUALITY_VALUES: frozenset[str] = frozenset({"excellent", "good", "fair", "poor"}
 #: ``POST /api/simulation/<id>/outcome``.
 OUTCOME_VALUES: frozenset[str] = frozenset({"correct", "incorrect", "partial"})
 
-#: Allowed sort keys.
-SORT_VALUES: frozenset[str] = frozenset({"date", "rounds", "agents"})
+#: Allowed sort keys. ``trending`` ranks cards by their cumulative
+#: share-surface serve count (the ``surface_stats`` total), turning the
+#: operator-facing distribution analytics into a discovery primitive —
+#: the most-served simulations float to the top of the gallery so a
+#: viral run is findable by merit rather than by recency.
+SORT_VALUES: frozenset[str] = frozenset({"date", "rounds", "agents", "trending"})
+
+#: Transient field name the route handler sets on each card before
+#: calling :func:`sort_cards` with ``sort="trending"``. Kept here so the
+#: handler and the sort key reader stay in lockstep — renaming the
+#: field is a one-line change.
+TRENDING_FIELD = "_serves_total"
 
 
 # ── Param normalisation ───────────────────────────────────────────────────
@@ -300,6 +312,25 @@ def _agents_key(card: dict) -> tuple[int, str]:
     return (ac, _date_key(card))
 
 
+def _trending_key(card: dict) -> tuple[int, str]:
+    """Sort key for ``trending`` — highest cumulative share-surface
+    serves first, breaks ties on date so the most-served-and-most-recent
+    floats above the most-served-and-stale.
+
+    Reads :data:`TRENDING_FIELD` (``_serves_total``) which the route
+    handler injects into every card before sorting (a per-request sweep
+    over ``surface_stats.read_surface_stats`` for each public sim).
+    Cards missing the field — sims with no surface-stats file yet, or
+    callers that forgot the sweep — degrade to ``0`` so they fall to
+    the bottom of the trending list without raising.
+    """
+    try:
+        total = int(card.get(TRENDING_FIELD) or 0)
+    except (TypeError, ValueError):
+        total = 0
+    return (max(0, total), _date_key(card))
+
+
 def sort_cards(cards: list[dict], *, sort: str = "date") -> list[dict]:
     """Return a new list sorted by the requested key, newest/largest first."""
     key = normalise_sort(sort)
@@ -307,6 +338,8 @@ def sort_cards(cards: list[dict], *, sort: str = "date") -> list[dict]:
         return sorted(cards, key=_rounds_key, reverse=True)
     if key == "agents":
         return sorted(cards, key=_agents_key, reverse=True)
+    if key == "trending":
+        return sorted(cards, key=_trending_key, reverse=True)
     return sorted(cards, key=_date_key, reverse=True)
 
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1625,11 +1625,15 @@ paths:
           name: sort
           description: |
             `date` (default — newest first), `rounds` (highest
-            `current_round` first), or `agents` (largest population
-            first).
+            `current_round` first), `agents` (largest population
+            first), or `trending` (highest cumulative share-surface
+            serve count first — sums every counter the
+            `surface-stats` endpoint exposes; ties break on date so
+            the most-served-and-most-recent floats above the
+            most-served-and-stale).
           schema:
             type: string
-            enum: [date, rounds, agents]
+            enum: [date, rounds, agents, trending]
             default: date
       responses:
         "200":
@@ -1666,7 +1670,7 @@ paths:
                         enum: [correct, incorrect, partial, null]
                       sort:
                         type: string
-                        enum: [date, rounds, agents]
+                        enum: [date, rounds, agents, trending]
 
   # ────────────────────────────────────────────────────────────────────
   # Export

--- a/backend/tests/test_unit_gallery_filters.py
+++ b/backend/tests/test_unit_gallery_filters.py
@@ -56,6 +56,7 @@ def _card(
     created_at: str = "2026-04-22T10:12:34",
     current_round: int = 0,
     agent_count: int = 0,
+    serves_total: int | None = None,
 ) -> dict:
     consensus: dict | None = None
     if (bullish or neutral or bearish):
@@ -65,7 +66,7 @@ def _card(
         outcome = {"label": outcome_label}
         if outcome_url:
             outcome["outcome_url"] = outcome_url
-    return {
+    card: dict = {
         "simulation_id": sid,
         "scenario": scenario,
         "final_consensus": consensus,
@@ -75,6 +76,9 @@ def _card(
         "current_round": current_round,
         "agent_count": agent_count,
     }
+    if serves_total is not None:
+        card[gf.TRENDING_FIELD] = serves_total
+    return card
 
 
 # ── Param normalisation ───────────────────────────────────────────────────
@@ -179,6 +183,8 @@ class TestNormaliseEnums:
         ("date", "date"),
         ("Rounds", "rounds"),
         ("AGENTS", "agents"),
+        ("Trending", "trending"),
+        ("TRENDING", "trending"),
         ("", "date"),
         (None, "date"),
         ("popularity", "date"),
@@ -352,6 +358,114 @@ class TestSortCards:
     def test_empty_list_returns_empty(self):
         assert gf.sort_cards([], sort="date") == []
         assert gf.sort_cards([], sort="rounds") == []
+
+
+# ── trending sort — surface-stats integration ─────────────────────────────
+
+
+class TestTrendingSort:
+    """The ``trending`` sort key turns the surface-stats counters into a
+    discovery primitive — the most-served sims float to the top.
+
+    The route handler injects a transient ``_serves_total`` field on
+    every card before sorting (single sweep over
+    ``surface_stats.read_surface_stats`` for each public sim). These
+    tests exercise the sort behaviour directly against that field —
+    no Flask, no filesystem.
+    """
+
+    def test_trending_sort_key_is_recognised(self):
+        # Locks in the public contract — the ``trending`` literal is the
+        # one the openapi enum + frontend dropdown both reference.
+        assert "trending" in gf.SORT_VALUES
+        assert gf.normalise_sort("trending") == "trending"
+
+    def test_transient_field_name_is_locked(self):
+        # The route handler and the sort-key reader both reference
+        # this constant — renaming it without updating both sides
+        # would silently turn trending into a no-op (every card would
+        # land at zero serves). Pin the literal so a rename trips CI.
+        assert gf.TRENDING_FIELD == "_serves_total"
+
+    def test_trending_orders_by_serves_descending(self):
+        cards = [
+            _card("low",  serves_total=5,   created_at="2026-04-01T00:00:00"),
+            _card("high", serves_total=500, created_at="2026-04-01T00:00:00"),
+            _card("mid",  serves_total=50,  created_at="2026-04-01T00:00:00"),
+        ]
+        out = gf.sort_cards(cards, sort="trending")
+        assert [c["simulation_id"] for c in out] == ["high", "mid", "low"]
+
+    def test_trending_breaks_ties_on_date_newest_first(self):
+        # Same serve count → most-served-and-most-recent wins so a
+        # viral sim from this week beats a viral sim from last year.
+        cards = [
+            _card("stale",  serves_total=200, created_at="2026-01-01T00:00:00"),
+            _card("recent", serves_total=200, created_at="2026-04-30T00:00:00"),
+            _card("middle", serves_total=200, created_at="2026-03-15T00:00:00"),
+        ]
+        out = gf.sort_cards(cards, sort="trending")
+        assert [c["simulation_id"] for c in out] == ["recent", "middle", "stale"]
+
+    def test_missing_serves_field_degrades_to_zero(self):
+        # A card with no ``_serves_total`` (sim has no surface-stats
+        # file yet, or the route handler skipped the sweep) must NOT
+        # raise — it lands at zero serves and sorts to the bottom.
+        cards = [
+            _card("seen",   serves_total=10),
+            _card("unseen"),  # no serves_total at all
+            _card("popular", serves_total=99),
+        ]
+        out = gf.sort_cards(cards, sort="trending")
+        assert [c["simulation_id"] for c in out] == ["popular", "seen", "unseen"]
+
+    def test_garbage_serves_value_degrades_to_zero(self):
+        # Hand-edited counters could produce non-int / negative
+        # values. The sort key clamps to >= 0 so a corrupt entry
+        # doesn't outrank a legitimate high-serve sim.
+        cards = [
+            _card("a", serves_total=10),
+            _card("b"),
+            _card("c", serves_total=20),
+            _card("d"),
+        ]
+        cards[1][gf.TRENDING_FIELD] = "not-a-number"  # type: ignore[assignment]
+        cards[3][gf.TRENDING_FIELD] = -50  # type: ignore[assignment]
+        out = gf.sort_cards(cards, sort="trending")
+        # c (20) > a (10) > b/d (both clamped to 0); date ties between
+        # b and d break lexically on the shared default created_at.
+        assert out[0]["simulation_id"] == "c"
+        assert out[1]["simulation_id"] == "a"
+        assert {c["simulation_id"] for c in out[2:]} == {"b", "d"}
+
+    def test_trending_select_pipes_through_filter_and_sort(self):
+        # End-to-end ``select_filtered_cards`` with sort=trending +
+        # filter combined: the trending sort runs after the filter, so
+        # a high-serve card that doesn't match the filter is excluded.
+        cards = [
+            _card("a", scenario="aave", bullish=70, serves_total=300),
+            _card("b", scenario="eth",  bullish=70, serves_total=999),
+            _card("c", scenario="aave", bearish=70, serves_total=10),
+        ]
+        page, total = gf.select_filtered_cards(
+            cards, q="aave", sort="trending"
+        )
+        # 'b' is excluded by q='aave' (scenario doesn't match);
+        # 'a' (300) outranks 'c' (10).
+        assert total == 2
+        assert [c["simulation_id"] for c in page] == ["a", "c"]
+
+    def test_trending_handles_all_zero_corpus_gracefully(self):
+        # New deployment, nobody's served anything yet — every card
+        # has zero serves. The sort must not raise; it falls back to
+        # date order (the tie-break) so the result stays deterministic.
+        cards = [
+            _card("a", serves_total=0, created_at="2026-04-01T00:00:00"),
+            _card("b", serves_total=0, created_at="2026-04-30T00:00:00"),
+            _card("c", serves_total=0, created_at="2026-04-15T00:00:00"),
+        ]
+        out = gf.sort_cards(cards, sort="trending")
+        assert [c["simulation_id"] for c in out] == ["b", "c", "a"]
 
 
 # ── select_filtered_cards — end-to-end ────────────────────────────────────

--- a/docs/API.md
+++ b/docs/API.md
@@ -120,7 +120,7 @@ GET /api/simulation/public?q=aave&consensus=bearish&quality=excellent&sort=round
 | `consensus` | `bullish` / `neutral` / `bearish` | Dominant final-round stance using the same ±0.2 threshold the share card / replay GIF / transcript / webhook / feed all use. |
 | `quality` | `excellent` / `good` / `fair` / `poor` | Compared case-insensitively against the first word of `quality_health`. |
 | `outcome` | `correct` / `incorrect` / `partial` | Implies `verified=1` (verified-only). |
-| `sort` | `date` / `rounds` / `agents` | `date` (default — newest first), `rounds` (highest current_round first), or `agents` (largest population first). |
+| `sort` | `date` / `rounds` / `agents` / `trending` | `date` (default — newest first), `rounds` (highest current_round first), `agents` (largest population first), or `trending` (highest cumulative share-surface serve count first — sums every counter the `surface-stats` endpoint exposes). |
 | `verified` | truthy (`1`/`true`/`yes`) | Restrict to simulations with a recorded outcome annotation — the `/verified` hall. |
 | `limit` / `offset` | `[1, 100]` / `≥0` | Pagination knobs. `total` reflects the **filtered** count. |
 | `page` | `≥1` | 1-based alternative to `offset`. Wins over `offset` when both are supplied. |

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -112,7 +112,7 @@ GET /api/simulation/public?q=aave&consensus=bearish&quality=excellent&sort=round
 | `consensus` | `bullish` / `neutral` / `bearish` | 使用与分享卡片 / 回放 GIF / 转录 / Webhook / 订阅源相同的 ±0.2 阈值计算的最终轮主导立场。 |
 | `quality` | `excellent` / `good` / `fair` / `poor` | 与 `quality_health` 首词进行不区分大小写比较。 |
 | `outcome` | `correct` / `incorrect` / `partial` | 隐含 `verified=1`(仅已验证)。 |
-| `sort` | `date` / `rounds` / `agents` | `date`(默认 — 最新优先)、`rounds`(当前轮次最多优先)或 `agents`(种群最大优先)。 |
+| `sort` | `date` / `rounds` / `agents` / `trending` | `date`(默认 — 最新优先)、`rounds`(当前轮次最多优先)、`agents`(种群最大优先)或 `trending`(累计分享面服务次数最高优先 — 累加 `surface-stats` 端点暴露的每一个计数器)。 |
 | `verified` | 真值(`1`/`true`/`yes`) | 限制为已记录结果注释的模拟 — 即 `/verified` 展厅。 |
 | `limit` / `offset` | `[1, 100]` / `≥0` | 分页参数。`total` 反映**已筛选**的计数。 |
 | `page` | `≥1` | `offset` 的 1 起编号替代值。两者同时出现时 `page` 优先。 |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -188,7 +188,7 @@ Same publish gate as the share card and transcript (`is_public=true`). The bulli
 - **`consensus`** — `bullish` / `neutral` / `bearish`. Filters by the dominant final-round stance using the same ±0.2 threshold the share card, replay GIF, transcript, webhook, and feed renderers all use, so a "bullish" filter here matches what those surfaces report for the same simulation.
 - **`quality`** — `excellent` / `good` / `fair` / `poor`. Compared case-insensitively against the first word of `quality_health`.
 - **`outcome`** — `correct` / `incorrect` / `partial`. Implies `verified=1` (verified-only).
-- **`sort`** — `date` (default — newest first), `rounds` (highest current_round first), or `agents` (largest population first).
+- **`sort`** — `date` (default — newest first), `rounds` (highest current_round first), `agents` (largest population first), or `trending` (highest cumulative share-surface serve count first — sums every counter the `surface-stats` endpoint exposes; ties break on date so the most-served-and-most-recent floats above the most-served-and-stale). `trending` is the first feedback loop from distribution analytics into discovery ranking — sims that get shared get found more easily.
 - **`page`** — 1-based page number; alternative to `offset`. `page=1` is offset 0. The two compose the same way: `total` reflects the **filtered** count (not the corpus size), so the load-more "X remaining" hint and `has_more` flag stay accurate inside the active filter set.
 
 The `/verified` route preserves the `verifiedOnly: true` mode and stays compatible with every filter — `/verified?q=aave&consensus=bullish` works. Toggling Verified ↔ Explore via the header chip carries the active query string across the route swap so the user doesn't lose their search.

--- a/docs/FEATURES.zh-CN.md
+++ b/docs/FEATURES.zh-CN.md
@@ -278,7 +278,7 @@ WONDERWALL_MODEL_NAME=your-model-id
 - **`consensus`** — `bullish` / `neutral` / `bearish`。基于与分享卡 / 回放 GIF / 转录 / Webhook / 订阅源一致的 ±0.2 阈值的最终轮主导立场进行筛选,与那些界面在同一模拟上报告的内容保持一致。
 - **`quality`** — `excellent` / `good` / `fair` / `poor`。与 `quality_health` 首词进行不区分大小写比较。
 - **`outcome`** — `correct` / `incorrect` / `partial`。隐含 `verified=1`(仅已验证)。
-- **`sort`** — `date`(默认 — 最新优先)、`rounds`(当前轮次最多优先)或 `agents`(种群最大优先)。
+- **`sort`** — `date`(默认 — 最新优先)、`rounds`(当前轮次最多优先)、`agents`(种群最大优先)或 `trending`(累计分享面服务次数最高优先 — 累加 `surface-stats` 端点暴露的每一个计数器;按日期打破并列,使「服务最多且最新」浮于「服务最多但陈旧」之上)。`trending` 是从分发分析回流到发现排序的首条反馈回路 — 被分享得越多的模拟会更容易被发现。
 - **`page`** — 1 起编号的页号;`offset` 的替代值。`page=1` 即偏移 0。两者组合方式一致:`total` 反映**已筛选**的计数(而非语料库大小),所以"加载更多""剩余 X 个"提示和 `has_more` 标志在当前筛选集合内保持准确。
 
 `/verified` 路由保留 `verifiedOnly: true` 模式,并与所有筛选条件兼容 — `/verified?q=aave&consensus=bullish` 是有效的。通过头部芯片在「已验证」与「Explore」之间切换时,会跨越路由切换沿用激活的查询字符串,用户不会因切换「已验证」而丢失搜索。

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -868,8 +868,16 @@ export const suggestScenarios = (data) => {
  *   consensus?: 'bullish'|'neutral'|'bearish',
  *   quality?: 'excellent'|'good'|'fair'|'poor',
  *   outcome?: 'correct'|'incorrect'|'partial',
- *   sort?: 'date'|'rounds'|'agents',
+ *   sort?: 'date'|'rounds'|'agents'|'trending',
  * }
+ *
+ * `sort=trending` ranks public simulations by their cumulative
+ * share-surface serve count (the sum of every per-surface counter the
+ * `/api/simulation/<id>/surface-stats` endpoint exposes), so the most
+ * widely-distributed runs float to the top of the gallery. Ties break
+ * on date so the most-served-and-most-recent beats the
+ * most-served-and-stale. Sims with no surface-stats file yet count as
+ * zero serves and sort to the bottom.
  */
 export const getPublicSimulations = (options = {}) => {
   const params = {}

--- a/frontend/src/views/ExploreView.vue
+++ b/frontend/src/views/ExploreView.vue
@@ -106,6 +106,7 @@
               :disabled="loading"
             >
               <option value="date">{{ $tr('Newest first', '最新优先') }}</option>
+              <option value="trending">{{ $tr('🔥 Trending', '🔥 热门') }}</option>
               <option value="rounds">{{ $tr('Most rounds', '轮次最多') }}</option>
               <option value="agents">{{ $tr('Most agents', '智能体最多') }}</option>
             </select>
@@ -456,7 +457,7 @@ const verifiedFilter = ref(props.verifiedOnly)
 // just forward whatever's in the URL.
 const ALLOWED_CONSENSUS = new Set(['bullish', 'neutral', 'bearish'])
 const ALLOWED_QUALITY = new Set(['excellent', 'good', 'fair', 'poor'])
-const ALLOWED_SORT = new Set(['date', 'rounds', 'agents'])
+const ALLOWED_SORT = new Set(['date', 'rounds', 'agents', 'trending'])
 
 const _readEnumParam = (val, allowed) => {
   if (!val) return ''


### PR DESCRIPTION
## Summary

Adds `?sort=trending` to `GET /api/simulation/public` (and a "🔥 Trending" option to the `/explore` sort dropdown). Ranks public simulations by their cumulative share-surface serve count — sums every counter the existing `surface-stats` endpoint already exposes (share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS / `reproduce.json` / `lineage`).

Surface-stats (PR #74) gave operators per-sim distribution analytics. Until now those counts were operator-facing only — visible inside `EmbedDialog`, invisible to discovery. `sort=trending` is the first feedback loop from those counters back into gallery ranking: the most-distributed sims float to the top so a viral run is findable by merit rather than by recency.

## Why

- **Discovery ceiling.** Sort options were structural (date / rounds / agents) — nothing reflected which sims were actually being served. The most-served sims this week are also the most-distributed, a strong proxy for most-interesting.
- **Surface-stats data was siloed.** Counters lived on disk per sim and were exposed via `/surface-stats`, but never surfaced into the platform-wide gallery query.
- **Direct extension of an existing endpoint.** `gallery_filters` already does the filter / sort / paginate composition; `surface_stats.read_surface_stats` already returns a `total` field. The change is one new sort key + one per-sim sweep, not a new data pipeline.

## Changes

### Backend
- `backend/app/services/gallery_filters.py` — `SORT_VALUES` extended with `"trending"`; new `_trending_key(card)` reads the transient `_serves_total` field, clamps to `>=0` on missing / non-int / negative input, tie-breaks on `created_at` desc. New `TRENDING_FIELD = "_serves_total"` constant pinned at module level so the route handler and the sort-key reader stay in lockstep.
- `backend/app/api/simulation.py` — `list_public_simulations()` performs a single sweep over `surface_stats.read_surface_stats(sim_dir)` for every public sim **only when `sort=trending`** (the default `date` path stays read-free), injects the `_serves_total` total per card, then strips the transient field after sort+paginate so the JSON contract stays untouched. Per-sim serve counts remain available via the existing `/surface-stats` endpoint.
- `backend/openapi.yaml` — `sort` query enum + response enum extended with `trending`; description points at the surface-stats counter sum and explains the date tie-break.

### Frontend
- `frontend/src/views/ExploreView.vue` — sort dropdown gains a "🔥 Trending" option (i18n: "🔥 热门"), `ALLOWED_SORT` extended. URL-routable so `/explore?sort=trending` is bookmarkable; `filtersActive` reflects it via the existing `sort !== 'date'` check; reset button clears it the same way.
- `frontend/src/api/simulation.js` — `getPublicSimulations()` JSDoc sort enum extended; trending semantics documented inline.

### Tests
- `backend/tests/test_unit_gallery_filters.py` — 8 new offline tests:
  - `trending` is in `SORT_VALUES` (locked-set guard);
  - `TRENDING_FIELD == "_serves_total"` literal pin so a rename trips CI;
  - descending sort by serves;
  - date tie-break (most-served-and-most-recent above most-served-and-stale);
  - missing field → degrades to zero;
  - garbage / negative values → clamp to zero;
  - end-to-end `select_filtered_cards` filter + trending sort composition;
  - all-zero corpus falls back to date order so the result stays deterministic.
- `normalise_sort` parametrize gains `Trending` / `TRENDING` cases (case-folding parity).

### Docs
- `docs/API.md` + `docs/API.zh-CN.md` — sort table row extended with `trending`.
- `docs/FEATURES.md` + `docs/FEATURES.zh-CN.md` — gallery section sort row extended with the trending semantics + the framing as the first distribution→discovery feedback loop.
- `README.md` — Gallery Search & Filter row extended in both English and Chinese mirrors.

## Performance

The trending sweep adds one `json.load()` per public sim, only on `?sort=trending` requests. The endpoint's `Cache-Control: public, max-age=30` amortises the cost across repeat hits. Other sort keys (`date` / `rounds` / `agents`) are byte-identical to before.

## Defense-in-depth

- A corrupt `surface-stats.json` file (already handled by `surface_stats._load_raw`) returns zero counts and the trending sort places that sim at the bottom rather than raising.
- Sims with no `surface-stats.json` yet count as zero and sort to the bottom — old sims predating PR #74 don't break the trending list.
- The `_serves_total` field is stripped from `page_items` before serialisation so it doesn't leak into the public response contract.

Zero new dependencies; pure stdlib + existing `surface_stats` reader.

---
*Built autonomously by [Aeon](https://github.com/aaronjmars/aeon-aaron).*