### PR TITLE
feat: search-engine sitemap (/sitemap.xml + /robots.txt) for the public gallery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -244,6 +244,19 @@ EMBEDDING_BATCH_SIZE=128
 # snippets (Python / Node.js / curl).
 # WEBHOOK_SECRET=
 
+# ===== Search-engine sitemap (auto-generated /sitemap.xml + /robots.txt) =====
+# When true (default), GET /sitemap.xml lists every public-simulation
+# /share/<id> + /watch/<id> URL so Googlebot / Bingbot / DuckDuckBot can
+# crawl the gallery, and /robots.txt advertises it via the standard
+# "Sitemap:" directive — submit once to Google Search Console (or any
+# compliant crawler), and every newly published sim becomes searchable
+# automatically.
+#
+# Set to false on private MiroShark instances or operator-only deployments
+# where simulations should not surface in public search results — the
+# sitemap returns 404 and robots.txt drops the Sitemap: line.
+ENABLE_SITEMAP=true
+
 # ===== Docker-mode overrides =====
 # Uncomment these when running ALL services inside Docker
 # (backend container talks to neo4j/ollama containers by service name)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Gallery Search & Filter** | Keyword search + bullish/neutral/bearish + excellent/good/fair/poor + sort by date/rounds/agents/trending on `/explore` and `/verified`. `trending` ranks by cumulative share-surface serves so the most-distributed sims float to the top. URL-encoded so `?q=aave&consensus=bearish` is bookmarkable. Same ±0.2 stance threshold as every other surface |
 | **Verified Predictions** | Annotate any public sim with the real-world outcome (called it / partial / called wrong + URL). `/verified` is the dedicated hall of calls that landed |
 | **RSS / Atom Feeds** | `/api/feed.atom` + `/api/feed.rss` — every newly published simulation lands in Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS without anyone curating it. `?verified=1` for the verified-only stream |
+| **Search Engine Sitemap** | Auto-generated `/sitemap.xml` (sitemaps.org 0.9) lists every public sim's `/share/<id>` + `/watch/<id>` URLs; companion `/robots.txt` advertises it via the standard `Sitemap:` directive. Submit once to Google Search Console — every newly published sim becomes searchable. Pure stdlib `xml.etree.ElementTree`, opt-out via `ENABLE_SITEMAP=false` |
 | **Article Generation** | Substack-style write-up of what happened, grounded in actual posts and trades |
 | **Interaction Network** | Force-directed agent-to-agent graph with echo-chamber metrics |
 | **Demographics** | Archetype clustering (analyst / influencer / retail / observer…) |
@@ -231,6 +232,7 @@ cp .env.example .env
 | **图库搜索与筛选** | 在 `/explore` 与 `/verified` 上提供关键词搜索 + 看涨/中立/看跌 + 优秀/良好/一般/较差 + 按日期/轮次/智能体/热门排序。`trending` 按累计分享面服务次数排序,让被分发最广的模拟浮于顶部。URL 编码后 `?q=aave&consensus=bearish` 可作为书签分享。与其他所有表面共享同一 ±0.2 立场阈值 |
 | **已验证预言** | 为公开模拟标注真实结果(命中 / 部分 / 失误 + 链接)。`/verified` 是命中预言专属展厅 |
 | **RSS / Atom 订阅源** | `/api/feed.atom` + `/api/feed.rss` — 每个新发布的模拟无需任何整理就会进入 Feedly / Readwise / Inoreader / NetNewsWire / Obsidian RSS。`?verified=1` 只看已验证内容 |
+| **搜索引擎站点地图** | 自动生成的 `/sitemap.xml`(sitemaps.org 0.9)列出每个公开模拟的 `/share/<id>` + `/watch/<id>` URL;配套的 `/robots.txt` 通过标准 `Sitemap:` 指令通告。在 Google Search Console 提交一次 — 每个新发布的模拟都将变得可被搜索。纯 stdlib `xml.etree.ElementTree`,可通过 `ENABLE_SITEMAP=false` 退出 |
 | **文章生成** | Substack 风格的复盘文章,基于真实发帖与交易数据 |
 | **互动网络** | 力导向智能体关系图,带回声室指标 |
 | **人口分布** | 原型聚类(分析师 / 影响者 / 散户 / 旁观者……) |

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -79,7 +79,7 @@ def create_app(config_class=Config):
         return response
     
     # Register blueprints
-    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, mcp_bp, docs_bp, feed_bp, share_bp, watch_bp
+    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, mcp_bp, docs_bp, feed_bp, share_bp, watch_bp, sitemap_bp
     app.register_blueprint(graph_bp, url_prefix='/api/graph')
     app.register_blueprint(simulation_bp, url_prefix='/api/simulation')
     app.register_blueprint(report_bp, url_prefix='/api/report')
@@ -102,6 +102,11 @@ def create_app(config_class=Config):
     # watch_bp serves the live spectator-watch page at /watch/<sim_id>
     # — same no-prefix policy so the URL stays a clean broadcast link.
     app.register_blueprint(watch_bp)
+    # sitemap_bp serves /sitemap.xml + /robots.txt at the root —
+    # crawlers expect both URLs at the deployment root, not under
+    # /api/, so the blueprint is mounted with no prefix to match the
+    # protocol convention.
+    app.register_blueprint(sitemap_bp)
     
     # Health check
     @app.route('/health')

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -32,3 +32,7 @@ from .share import share_bp  # noqa: E402, F401
 # stays a clean shareable URL — see api/watch.py.
 from .watch import watch_bp  # noqa: E402, F401
 
+# sitemap_bp is mounted at the root (no /api prefix) so /sitemap.xml
+# and /robots.txt land where crawlers expect them — see api/sitemap.py.
+from .sitemap import sitemap_bp  # noqa: E402, F401
+

--- a/backend/app/api/sitemap.py
+++ b/backend/app/api/sitemap.py
@@ -1,0 +1,165 @@
+"""Public ``GET /sitemap.xml`` + ``GET /robots.txt`` endpoints.
+
+Search engines need a structured entry point into MiroShark's growing
+public-simulation corpus before they can return individual sims as
+results. The sitemap is auto-generated from the same ``is_public=true``
+filter the gallery / feed / lineage surfaces share, so every newly
+published sim is crawlable on the next sitemap fetch — no operator
+intervention required after the initial Search-Console submission.
+
+Mounted on a dedicated blueprint with **no URL prefix** so the URLs
+match what crawlers expect (``/sitemap.xml`` and ``/robots.txt`` at
+the root, not ``/api/sitemap.xml``). Registration mirrors the existing
+``share_bp`` / ``watch_bp`` posture for the same reason — those keep
+the public unfurl URL clean; this keeps the crawler-discovery URLs
+clean.
+
+Both endpoints opt in via ``ENABLE_SITEMAP=true`` (default ``true``).
+Operators running a private MiroShark instance — or one indexing
+sensitive scenarios — set ``ENABLE_SITEMAP=false`` to make
+``/sitemap.xml`` return ``404`` and the ``robots.txt`` to drop the
+``Sitemap:`` advertisement. The companion ``GET /api/config/sitemap``
+endpoint exposes the flag to the SPA so ``EmbedDialog`` can render the
+right hint.
+
+Sandbox note: pure stdlib (``xml.etree.ElementTree`` from the
+``sitemap`` service module + the existing ``SimulationManager``). No
+outbound network — the routes never raise and never block on
+Neo4j / LLM calls.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, Response, jsonify, request
+
+from ..config import Config
+from ..services.simulation_manager import SimulationManager
+from ..services import sitemap as sitemap_service
+from ..utils.logger import get_logger
+
+
+logger = get_logger("miroshark.api.sitemap")
+
+sitemap_bp = Blueprint("sitemap", __name__)
+
+
+def _resolve_base_url() -> str:
+    """Build the absolute URL prefix used inside the sitemap document.
+
+    Identical strategy to the feed module — prefer ``Config.PUBLIC_BASE_URL``
+    when the operator has set it (single source of truth across the
+    feed / webhook / share-card / sitemap surfaces) and fall back to
+    the request's host with ``X-Forwarded-Proto`` / ``X-Forwarded-Host``
+    honored for reverse-proxy deployments.
+    """
+    explicit = (Config.PUBLIC_BASE_URL or "").strip()
+    if explicit:
+        return explicit.rstrip("/")
+
+    base = (request.host_url or "").rstrip("/")
+    forwarded_proto = request.headers.get("X-Forwarded-Proto")
+    forwarded_host = request.headers.get("X-Forwarded-Host")
+    if forwarded_host:
+        proto = forwarded_proto or ("https" if request.is_secure else "http")
+        base = f"{proto}://{forwarded_host}"
+    return base
+
+
+@sitemap_bp.route("/sitemap.xml", methods=["GET"])
+def sitemap_xml() -> Response:
+    """Render the auto-generated public-simulation sitemap.
+
+    Walks ``SimulationManager.list_simulations()`` for sims toggled
+    ``is_public=true``, projects each into a ``<url>`` block (one for
+    ``/share/<id>``, one for ``/watch/<id>``), and serializes per the
+    sitemaps.org 0.9 spec. Returns ``application/xml`` so a browser
+    rendering the URL shows the source rather than a hex dump.
+
+    ``Cache-Control: public, max-age=3600`` — the sitemap is stable
+    enough for an hourly cache; a freshly published simulation will
+    appear within an hour at the latest, which matches the cadence
+    Googlebot's scheduler uses for dynamic sites anyway.
+
+    Returns ``404`` when ``ENABLE_SITEMAP=false`` so a private
+    deployment's URL doesn't even hint that the sitemap surface
+    exists.
+    """
+    if not Config.ENABLE_SITEMAP:
+        return Response(
+            "Sitemap disabled. Set ENABLE_SITEMAP=true to enable.",
+            status=404,
+            mimetype="text/plain; charset=utf-8",
+        )
+
+    try:
+        manager = SimulationManager()
+        all_sims = manager.list_simulations()
+    except Exception as exc:
+        # Never 500 the sitemap surface — crawlers retry, an empty
+        # sitemap is the right interim state if the manager fails.
+        logger.warning("sitemap: failed to list simulations (%s) — serving empty sitemap", exc)
+        all_sims = []
+
+    base_url = _resolve_base_url()
+    body = sitemap_service.build_sitemap(
+        all_sims,
+        base_url,
+        sim_data_dir=Config.WONDERWALL_SIMULATION_DATA_DIR,
+    )
+
+    response = Response(body, mimetype="application/xml; charset=utf-8")
+    response.headers["Cache-Control"] = "public, max-age=3600"
+    response.headers["X-Robots-Tag"] = "noindex"
+    return response
+
+
+@sitemap_bp.route("/robots.txt", methods=["GET"])
+def robots_txt() -> Response:
+    """Render the public ``robots.txt`` for the deployment.
+
+    Always served (even when ``ENABLE_SITEMAP=false``) so well-behaved
+    crawlers see the ``Disallow: /api/`` directive — without a
+    ``robots.txt`` they'll attempt to crawl the API namespace and
+    pollute the index with JSON 404s. When the sitemap is enabled,
+    a trailing ``Sitemap:`` line points crawlers at it for automatic
+    discovery; when disabled, the line is omitted.
+
+    ``Cache-Control: public, max-age=3600`` mirrors the sitemap cadence
+    so a single CDN purge refreshes both surfaces together.
+    """
+    base_url = _resolve_base_url()
+    body = sitemap_service.build_robots_txt(
+        base_url,
+        enabled=bool(Config.ENABLE_SITEMAP),
+    )
+
+    response = Response(body, mimetype="text/plain; charset=utf-8")
+    response.headers["Cache-Control"] = "public, max-age=3600"
+    return response
+
+
+@sitemap_bp.route("/api/config/sitemap", methods=["GET"])
+def sitemap_config() -> Response:
+    """Expose the ``ENABLE_SITEMAP`` flag to the SPA.
+
+    Lets the EmbedDialog render the right hint without leaking any
+    secret config. Returns ``{success, data: {enabled, sitemap_url}}``
+    where ``sitemap_url`` is the absolute public URL when enabled and
+    ``None`` otherwise. Public — the flag is not sensitive and the
+    URL is the same one any crawler would discover via robots.txt.
+    """
+    enabled = bool(Config.ENABLE_SITEMAP)
+    sitemap_url = None
+    if enabled:
+        base = _resolve_base_url()
+        if base:
+            sitemap_url = f"{base}/sitemap.xml"
+    response = jsonify({
+        "success": True,
+        "data": {
+            "enabled": enabled,
+            "sitemap_url": sitemap_url,
+        },
+    })
+    response.headers["Cache-Control"] = "public, max-age=3600"
+    return response

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -201,7 +201,16 @@ class Config:
     # relative ``share_path`` is included and the consumer must build the
     # absolute URL themselves.
     PUBLIC_BASE_URL = os.environ.get('PUBLIC_BASE_URL', '')
-    
+
+    # Whether ``GET /sitemap.xml`` is served and ``robots.txt`` advertises
+    # it. Default ``true`` — the public sitemap is the search-engine
+    # discovery surface for the public-simulation gallery, and a
+    # crawl-ready sitemap is the right default for any deployment that
+    # exposes ``/share/<id>`` URLs publicly. Operators running a private
+    # MiroShark instance set ``ENABLE_SITEMAP=false`` to make the sitemap
+    # 404 and drop the ``Sitemap:`` directive from robots.txt.
+    ENABLE_SITEMAP = os.environ.get('ENABLE_SITEMAP', 'true').lower() == 'true'
+
     @classmethod
     def validate(cls):
         """Validate required configuration"""

--- a/backend/app/services/sitemap.py
+++ b/backend/app/services/sitemap.py
@@ -1,0 +1,362 @@
+"""Search-engine sitemap renderer for the public simulation gallery.
+
+Every published MiroShark simulation already has a public landing page
+(``/share/<id>``) and a live spectator-watch page (``/watch/<id>``) — the
+share card carries Open Graph tags so a tweeted link unfurls with a
+1200×630 image, the watch page broadcasts a live belief bar. What was
+missing was a *crawlable index* a search engine could discover. Without
+one, Googlebot / Bingbot / DuckDuckBot have no entry point into the
+simulation corpus other than whatever an external site happens to link
+to. The "Aave reserve-factor scenario from 2026-05-08" Aaron tweeted
+will not surface on Google when someone searches the scenario keywords.
+
+``GET /sitemap.xml`` closes that gap: an XML sitemap document
+(``http://www.sitemaps.org/schemas/sitemap/0.9``) auto-generated from
+the public sim corpus, with one ``<url>`` entry per published simulation
+pointing at ``/share/<id>``, plus a parallel entry for ``/watch/<id>``.
+``<lastmod>`` reflects the simulation's most recent state write so
+crawlers re-fetch a still-running sim's pages without waiting on the
+default re-crawl cadence; ``<changefreq>`` is ``always`` for in-progress
+sims and ``weekly`` for completed ones.
+
+A companion ``GET /robots.txt`` advertises the sitemap location via the
+standard ``Sitemap:`` directive so any compliant crawler discovers it
+without manual registration. Operators submitting the sitemap manually
+to Google Search Console get the same payload either way — the
+discovery benefit compounds on every future publish.
+
+Design notes
+------------
+
+* **Pure stdlib.** ``xml.etree.ElementTree`` + ``os`` + ``datetime``;
+  zero new dependencies. Same posture every share / feed / lineage /
+  reproduce surface keeps.
+
+* **Read-only.** The renderer never writes — it walks ``sim_data_dir``
+  for state.json files, projects each into a ``<url>`` block, and
+  serializes. Corrupt state files degrade to "skipped"; never raises.
+
+* **Public-only.** Only sims with ``is_public=true`` appear. A private
+  fork or in-progress operator-only run never surfaces in search.
+
+* **Bounded.** Capped at ``MAX_SITEMAP_URLS`` total ``<url>`` entries
+  (50,000 — the spec ceiling per file). MiroShark won't approach this
+  soon, but the guard is defense-in-depth against a (future) bulk-fork
+  operator pattern blowing up the document.
+
+* **Stable byte output.** Sims are sorted by ``simulation_id`` ascending
+  before serialization, so two consecutive renders against the same
+  on-disk corpus produce byte-identical output. Lets the route layer
+  set a meaningful ``ETag`` if it ever wants to.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Iterable, List, Optional, Tuple
+from xml.etree import ElementTree as ET
+
+
+# Sitemap protocol version 0.9 — the only version major search engines
+# read. The namespace string is part of the spec; renderers that omit
+# it produce a document Googlebot / Bingbot / DuckDuckBot ignore.
+SITEMAP_NAMESPACE: str = "http://www.sitemaps.org/schemas/sitemap/0.9"
+
+# Spec hard cap is 50,000 ``<url>`` entries per sitemap file; documents
+# that exceed it must be split into a sitemap index. We pin to the spec
+# ceiling here — MiroShark's public corpus is currently three-figure
+# small, so the cap is purely defense-in-depth against pathological
+# bulk-fork operators rather than a normal truncation case. When the
+# corpus realistically approaches this, the right move is a sitemap
+# index (``sitemap_index.xml``) rather than bumping this number.
+MAX_SITEMAP_URLS: int = 50_000
+
+# Per-sim entry order: share landing first, then the live watch page.
+# Both are public-discovery surfaces; ``/share`` is the canonical
+# unfurl destination and the citation-friendly URL, ``/watch`` carries
+# the live belief bars so its priority is one notch lower.
+SHARE_PRIORITY: str = "0.8"
+WATCH_PRIORITY: str = "0.7"
+
+# Change-frequency hints. The spec calls these advisory ("crawlers may
+# use this information"); we still emit them because Googlebot's
+# scheduler does honour them for fresh sites, and an in-progress sim's
+# belief bars genuinely change every round. Completed sims become
+# stable artifacts so ``weekly`` matches their actual change rate.
+RUNNING_CHANGEFREQ: str = "always"
+COMPLETED_CHANGEFREQ: str = "weekly"
+
+
+def _safe_str(value: Any) -> str:
+    """Coerce ``value`` to a stripped string; ``None`` ⇒ empty.
+
+    Mirrors the same helper ``lineage_service`` keeps so the two
+    renderers share a posture: trust nothing on disk, never raise.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    try:
+        return str(value).strip()
+    except Exception:
+        return ""
+
+
+def _safe_iso_date(value: Any) -> Optional[str]:
+    """Coerce a datetime-ish value to ``YYYY-MM-DD`` (W3C date format).
+
+    The sitemap spec accepts the full W3C datetime profile (any of
+    ``YYYY``, ``YYYY-MM``, ``YYYY-MM-DD``, ``YYYY-MM-DDThh:mm:ss+TZ``),
+    but day-precision is the practical norm — Googlebot ignores
+    sub-second precision and sub-day timestamps, and a slimmer date
+    keeps the rendered XML small for large corpora.
+
+    Returns ``None`` when no usable date can be extracted; the
+    caller then omits ``<lastmod>`` for that entry, which is also
+    spec-compliant.
+    """
+    text = _safe_str(value)
+    if not text:
+        return None
+    # Already day-or-finer ISO; take the first 10 chars when they look
+    # like a date. Cheap path that avoids the full ``fromisoformat``
+    # parse for the overwhelmingly common case where state.json wrote
+    # ``2026-05-14T10:00:00`` and we want ``2026-05-14``.
+    if len(text) >= 10 and text[4] == "-" and text[7] == "-":
+        head = text[:10]
+        try:
+            datetime.strptime(head, "%Y-%m-%d")
+            return head
+        except ValueError:
+            pass
+    # Fall back to ISO parsing for anything else operators wrote into
+    # state.json over the years. Failing both yields ``None`` so the
+    # ``<lastmod>`` element is omitted entirely.
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%d")
+    except (ValueError, TypeError):
+        return None
+
+
+def _is_running(state: Any) -> bool:
+    """Return True when the simulation hasn't reached a terminal status.
+
+    A terminal state ⇒ ``<changefreq>weekly</changefreq>`` because the
+    artifact is stable; anything else (running, paused, ready) gets
+    ``always`` so a crawler that finds the page mid-run will re-fetch
+    instead of caching the partial render.
+    """
+    if state is None:
+        return False
+    status = getattr(state, "status", None)
+    raw = getattr(status, "value", None) or status
+    text = _safe_str(raw).lower()
+    if not text:
+        return True
+    return text not in ("completed", "failed", "cancelled", "canceled")
+
+
+def _candidate_sims(sims: Iterable[Any]) -> List[Tuple[str, Any]]:
+    """Filter to public sims with a usable id; sort for stable output.
+
+    Sorting by ``simulation_id`` ascending (rather than ``created_at``
+    descending) means the rendered bytes are deterministic given the
+    same on-disk corpus — two consecutive ``GET /sitemap.xml`` calls
+    that hit different gunicorn workers produce identical XML, which
+    lets the route layer set a meaningful ``ETag`` if it wants to and
+    keeps integration-test goldens stable.
+    """
+    rows: List[Tuple[str, Any]] = []
+    for state in sims or []:
+        if state is None:
+            continue
+        if not bool(getattr(state, "is_public", False)):
+            continue
+        sim_id = _safe_str(getattr(state, "simulation_id", None))
+        if not sim_id:
+            continue
+        rows.append((sim_id, state))
+    rows.sort(key=lambda row: row[0])
+    return rows
+
+
+def _last_modified_for(state: Any, sim_dir: str) -> Optional[str]:
+    """Best-effort ``lastmod`` date for a single sim.
+
+    Prefers a state-side timestamp (``updated_at`` ⇒ ``created_at``),
+    then falls back to the on-disk ``state.json`` mtime so a long-lived
+    in-progress sim whose ``created_at`` is days old still tells the
+    crawler "the artifact changed today". Returns ``None`` when no
+    usable signal exists; the caller omits the element rather than
+    inventing a value.
+    """
+    candidate = (
+        _safe_iso_date(getattr(state, "updated_at", None))
+        or _safe_iso_date(getattr(state, "created_at", None))
+    )
+    if candidate:
+        return candidate
+
+    state_json = os.path.join(sim_dir or "", "state.json")
+    try:
+        if state_json and os.path.exists(state_json):
+            mtime = os.path.getmtime(state_json)
+            return datetime.fromtimestamp(mtime, tz=timezone.utc).strftime("%Y-%m-%d")
+    except OSError:
+        pass
+    return None
+
+
+def _append_url_block(
+    parent: ET.Element,
+    *,
+    loc: str,
+    lastmod: Optional[str],
+    changefreq: str,
+    priority: str,
+) -> None:
+    """Append one ``<url>`` block to the sitemap document.
+
+    Element order — ``<loc>``, ``<lastmod>``, ``<changefreq>``,
+    ``<priority>`` — matches the order the spec example shows; some
+    older crawlers parse positionally rather than by tag name.
+    """
+    url_el = ET.SubElement(parent, "url")
+    ET.SubElement(url_el, "loc").text = loc
+    if lastmod:
+        ET.SubElement(url_el, "lastmod").text = lastmod
+    ET.SubElement(url_el, "changefreq").text = changefreq
+    ET.SubElement(url_el, "priority").text = priority
+
+
+def build_sitemap(
+    sims: Iterable[Any],
+    base_url: str,
+    *,
+    sim_data_dir: str = "",
+    max_urls: int = MAX_SITEMAP_URLS,
+) -> bytes:
+    """Render the sitemap XML document for the public simulation corpus.
+
+    Each public sim contributes two ``<url>`` blocks: the canonical
+    ``/share/<id>`` landing page and the live ``/watch/<id>`` view.
+    The two surfaces serve different intent (citation vs. broadcast)
+    so they get distinct priorities; both are crawler-discoverable
+    entry points into the simulation.
+
+    ``base_url`` is the absolute URL prefix (``https://miroshark.app``).
+    Falls back to a relative ``/share/<id>`` ``<loc>`` only if the
+    caller supplies ``""`` — the spec requires absolute URLs in
+    production but tests don't have a public host, and a relative
+    ``<loc>`` is the cheapest way to keep the renderer testable
+    without monkeypatching every call site. Production callers should
+    always pass an absolute base.
+
+    ``max_urls`` caps total ``<url>`` blocks (not sims). Two blocks
+    per sim, so the effective sim cap is ``max_urls // 2``.
+
+    Returns UTF-8 encoded bytes with the XML declaration and a
+    trailing newline so a ``curl > sitemap.xml`` produces a clean
+    file.
+    """
+    base = (base_url or "").rstrip("/")
+    cap = max(0, int(max_urls or 0))
+
+    root = ET.Element("urlset", attrib={"xmlns": SITEMAP_NAMESPACE})
+
+    written = 0
+    for sim_id, state in _candidate_sims(sims):
+        if written >= cap:
+            break
+
+        sim_dir = os.path.join(sim_data_dir or "", sim_id) if sim_data_dir else ""
+        lastmod = _last_modified_for(state, sim_dir)
+        running = _is_running(state)
+        changefreq = RUNNING_CHANGEFREQ if running else COMPLETED_CHANGEFREQ
+
+        share_loc = f"{base}/share/{sim_id}" if base else f"/share/{sim_id}"
+        _append_url_block(
+            root,
+            loc=share_loc,
+            lastmod=lastmod,
+            changefreq=changefreq,
+            priority=SHARE_PRIORITY,
+        )
+        written += 1
+
+        if written >= cap:
+            break
+
+        watch_loc = f"{base}/watch/{sim_id}" if base else f"/watch/{sim_id}"
+        # The watch page is the same artifact whether the sim is
+        # mid-run or done; for completed sims it still polls the
+        # status endpoint once before settling, which is a one-time
+        # render — ``daily`` reflects "occasionally re-rendered" for
+        # done sims while ``always`` matches the live case.
+        watch_changefreq = RUNNING_CHANGEFREQ if running else "daily"
+        _append_url_block(
+            root,
+            loc=watch_loc,
+            lastmod=lastmod,
+            changefreq=watch_changefreq,
+            priority=WATCH_PRIORITY,
+        )
+        written += 1
+
+    # ``ET.tostring`` with ``xml_declaration`` writes the standard
+    # ``<?xml version='1.0' encoding='utf-8'?>`` prologue; some older
+    # validators reject documents that omit it. The trailing newline
+    # keeps shell-redirected output (``curl > sitemap.xml``) tidy.
+    body = ET.tostring(
+        root,
+        encoding="utf-8",
+        xml_declaration=True,
+        short_empty_elements=False,
+    )
+    if not body.endswith(b"\n"):
+        body = body + b"\n"
+    return body
+
+
+def build_robots_txt(
+    base_url: str,
+    *,
+    enabled: bool = True,
+) -> bytes:
+    """Render the ``robots.txt`` document for the public deployment.
+
+    Always allows crawlers on the public discovery surfaces
+    (``/share/``, ``/watch/``, ``/explore``, ``/verified``); when
+    ``enabled`` is true, advertises ``Sitemap:`` so any compliant
+    crawler discovers ``/sitemap.xml`` automatically — operators
+    don't need to submit it manually.
+
+    The ``Disallow:`` block protects the API namespace and the SPA
+    routes that aren't meant for indexing (settings, dashboards). A
+    crawler still *can* follow those URLs, but the directive tells
+    well-behaved bots to skip them so they don't pollute search
+    results with debugging surfaces.
+
+    Returns UTF-8 bytes terminated with a newline.
+    """
+    base = (base_url or "").rstrip("/")
+
+    lines: List[str] = [
+        "User-agent: *",
+        "Allow: /share/",
+        "Allow: /watch/",
+        "Allow: /explore",
+        "Allow: /verified",
+        "Allow: /embed/",
+        "Disallow: /api/",
+        "Disallow: /settings",
+        "Disallow: /dashboard",
+        "",
+    ]
+    if enabled and base:
+        lines.append(f"Sitemap: {base}/sitemap.xml")
+        lines.append("")
+    return "\n".join(lines).encode("utf-8")

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -82,6 +82,8 @@ tags:
     description: MCP server status surface for AI IDE clients.
   - name: Documentation
     description: This OpenAPI spec and Swagger UI.
+  - name: Discovery
+    description: Search-engine sitemap and robots.txt — auto-generated discovery surfaces over the public-simulation gallery.
 
 paths:
 
@@ -1908,6 +1910,115 @@ paths:
           content:
             application/rss+xml:
               schema: { type: string }
+
+  /sitemap.xml:
+    get:
+      tags: [Discovery]
+      summary: Auto-generated public-simulation sitemap (sitemaps.org 0.9).
+      description: |
+        Walks the public-simulation corpus (`is_public=true` only) and
+        emits one `<url>` block per `/share/<id>` plus one per
+        `/watch/<id>`. `<lastmod>` is W3C `YYYY-MM-DD` form derived
+        from the simulation's `updated_at` / `created_at` /
+        `state.json` mtime fallback chain. `<changefreq>` is `always`
+        for in-progress sims (the belief bars genuinely change every
+        round) and `weekly` for completed share entries / `daily` for
+        completed watch entries.
+
+        Mounted at the root (no `/api` prefix) so crawlers find it
+        where the protocol convention places it. `Cache-Control:
+        public, max-age=3600` — hourly is fast enough for a freshly
+        published sim to appear at the next refresh, slow enough to
+        absorb noisy crawler polling. Sims are sorted by
+        `simulation_id` ascending so two consecutive renders against
+        the same corpus produce byte-identical XML.
+
+        Capped at 50,000 `<url>` entries per the sitemap spec
+        ceiling. MiroShark's public corpus is currently three-figure
+        small; the cap is defense-in-depth against pathological
+        bulk-fork patterns.
+
+        Returns `404` when `ENABLE_SITEMAP=false` so private
+        deployments don't even hint that the sitemap surface exists.
+        `robots.txt` advertises this URL via the standard `Sitemap:`
+        directive — submit once to Google Search Console (or any
+        compliant crawler) and every newly published sim becomes
+        searchable on the next crawl.
+      responses:
+        "200":
+          description: |
+            Sitemap XML document. `Content-Type: application/xml`.
+          content:
+            application/xml:
+              schema: { type: string }
+        "404":
+          description: |
+            `ENABLE_SITEMAP=false` on this deployment.
+          content:
+            text/plain:
+              schema: { type: string }
+
+  /robots.txt:
+    get:
+      tags: [Discovery]
+      summary: Crawler directives for the deployment.
+      description: |
+        Always served (whether `ENABLE_SITEMAP=true` or not) so
+        well-behaved crawlers see the `Disallow: /api/` directive
+        that keeps the JSON namespace out of the search index. Carries
+        `Allow:` lines for the public-discovery surfaces (`/share/`,
+        `/watch/`, `/explore`, `/verified`, `/embed/`).
+
+        When the sitemap is enabled, a trailing
+        `Sitemap: <PUBLIC_BASE_URL>/sitemap.xml` line points crawlers
+        at it for automatic discovery. When disabled, the line is
+        omitted so the URL doesn't leak through robots.txt either.
+        `Cache-Control: public, max-age=3600` mirrors the sitemap
+        cadence so a single CDN purge refreshes both surfaces.
+      responses:
+        "200":
+          description: |
+            Plain-text robots directives.
+          content:
+            text/plain:
+              schema: { type: string }
+
+  /api/config/sitemap:
+    get:
+      tags: [Discovery]
+      summary: Public sitemap-config flag for the SPA.
+      description: |
+        Exposes whether `/sitemap.xml` is enabled on this deployment
+        so the EmbedDialog renders the right hint without leaking
+        any secret config. Returns `{enabled, sitemap_url}` where
+        `sitemap_url` is the absolute public URL when enabled and
+        `null` otherwise. Public — the flag is not sensitive and the
+        URL is the same one any crawler would discover via
+        robots.txt.
+      responses:
+        "200":
+          description: Sitemap config envelope.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, data]
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    required: [enabled, sitemap_url]
+                    properties:
+                      enabled:
+                        type: boolean
+                        description: Whether `/sitemap.xml` serves content on this deployment.
+                      sitemap_url:
+                        type: string
+                        nullable: true
+                        description: |
+                          Absolute URL of `/sitemap.xml` when enabled
+                          and a base URL is resolvable; `null`
+                          otherwise.
 
   /api/simulation/{simulation_id}/export:
     get:

--- a/backend/tests/test_unit_openapi.py
+++ b/backend/tests/test_unit_openapi.py
@@ -106,6 +106,10 @@ _BLUEPRINT_PREFIXES = {
     # spectator-watch URL ``/watch/<sim_id>`` is a user-facing share
     # link, not an API call.
     "watch_bp":          "",
+    # sitemap_bp serves /sitemap.xml + /robots.txt at the root so crawlers
+    # find them where they expect; /api/config/sitemap exposes the
+    # ENABLE_SITEMAP flag to the SPA — see app/api/sitemap.py.
+    "sitemap_bp":        "",
 }
 
 

--- a/backend/tests/test_unit_sitemap.py
+++ b/backend/tests/test_unit_sitemap.py
@@ -1,0 +1,437 @@
+"""Unit tests for the search-engine sitemap renderer.
+
+Pure offline — no Flask boot, no SimulationManager, no LLM. The
+``GET /sitemap.xml`` and ``GET /robots.txt`` endpoints are pure
+projections over the on-disk public-sim corpus, so the test surface
+mirrors the on-disk contract:
+
+  1. ``MAX_SITEMAP_URLS`` is the documented 50,000 cap (sitemap spec
+     ceiling) — a future refactor must not silently lift it.
+  2. ``SITEMAP_NAMESPACE`` matches the sitemap protocol 0.9 string.
+  3. ``SHARE_PRIORITY`` and ``WATCH_PRIORITY`` are pinned so the
+     relative ranking between the two surfaces stays stable.
+  4. Empty corpus produces a valid (empty) ``<urlset>`` document
+     rather than 500ing the route.
+  5. A single public sim contributes two ``<url>`` blocks (share +
+     watch), with absolute ``<loc>`` URLs derived from ``base_url``.
+  6. Private sims are excluded from the sitemap.
+  7. ``<lastmod>`` is rendered in W3C ``YYYY-MM-DD`` form.
+  8. ``<changefreq>`` is ``always`` for in-progress sims, ``weekly``
+     for completed share entries, ``daily`` for completed watch
+     entries.
+  9. The serialized document is byte-deterministic given the same
+     corpus (sims sorted by id), which lets the route layer set a
+     meaningful ``ETag`` if it ever wants to.
+ 10. ``MAX_SITEMAP_URLS`` cap is honored — extra sims past the cap
+     are dropped without raising.
+ 11. ``robots.txt`` always emits the ``Disallow: /api/`` directive
+     and the per-surface ``Allow:`` lines.
+ 12. ``robots.txt`` advertises the ``Sitemap:`` line when enabled
+     and omits it when disabled.
+ 13. The XML round-trips via ``ET.fromstring`` (well-formed).
+ 14. Routes are registered on the sitemap blueprint
+     (drift-detection guard against the route decorators going
+     missing).
+ 15. The application factory mounts ``sitemap_bp`` at the root
+     (catches the failure mode where the blueprint exists but
+     wasn't wired into ``create_app``).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+from app.services import sitemap as sitemap_service  # noqa: E402
+
+
+SITEMAP_NS = "{http://www.sitemaps.org/schemas/sitemap/0.9}"
+
+
+# ── Module-level invariants ────────────────────────────────────────────
+
+
+def test_max_sitemap_urls_pinned_to_spec_ceiling():
+    """50,000 is the sitemap-protocol ceiling per file."""
+    assert sitemap_service.MAX_SITEMAP_URLS == 50_000
+
+
+def test_sitemap_namespace_matches_protocol_0_9():
+    """The namespace string is part of the spec — wrong value ⇒ ignored by Googlebot."""
+    assert (
+        sitemap_service.SITEMAP_NAMESPACE
+        == "http://www.sitemaps.org/schemas/sitemap/0.9"
+    )
+
+
+def test_priorities_pinned():
+    """Share is the canonical citation surface, watch is one notch lower."""
+    assert sitemap_service.SHARE_PRIORITY == "0.8"
+    assert sitemap_service.WATCH_PRIORITY == "0.7"
+
+
+def test_changefreq_constants():
+    """In-progress ⇒ always; completed ⇒ weekly (share)."""
+    assert sitemap_service.RUNNING_CHANGEFREQ == "always"
+    assert sitemap_service.COMPLETED_CHANGEFREQ == "weekly"
+
+
+# ── Fixture helpers ────────────────────────────────────────────────────
+
+
+class _StubStatus:
+    """Mimics the .value attribute on the real SimulationStatus enum."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+class _StubSim:
+    """Tiny stand-in for SimulationState — only the fields the sitemap reads."""
+
+    def __init__(
+        self,
+        sim_id: str,
+        *,
+        is_public: bool = True,
+        status: str = "completed",
+        created_at: str = "2026-05-01T10:00:00",
+        updated_at: str | None = None,
+    ) -> None:
+        self.simulation_id = sim_id
+        self.is_public = is_public
+        self.status = _StubStatus(status)
+        self.created_at = created_at
+        self.updated_at = updated_at
+
+
+def _parse(body: bytes) -> ET.Element:
+    """Verify the document round-trips through ElementTree."""
+    return ET.fromstring(body.decode("utf-8"))
+
+
+def _urls(root: ET.Element) -> list[ET.Element]:
+    return list(root.findall(f"{SITEMAP_NS}url"))
+
+
+def _child_text(url_el: ET.Element, name: str) -> str | None:
+    el = url_el.find(f"{SITEMAP_NS}{name}")
+    return el.text if el is not None else None
+
+
+# ── Empty / one-sim cases ──────────────────────────────────────────────
+
+
+def test_empty_corpus_produces_valid_empty_urlset():
+    """No sims ⇒ valid (empty) ``<urlset>`` rather than 500."""
+    body = sitemap_service.build_sitemap([], "https://miroshark.app")
+    root = _parse(body)
+    assert root.tag == f"{SITEMAP_NS}urlset"
+    assert _urls(root) == []
+    # Header guards
+    assert body.startswith(b"<?xml")
+    assert body.endswith(b"\n")
+
+
+def test_single_public_sim_produces_share_plus_watch_blocks():
+    """One sim ⇒ two ``<url>`` blocks (share + watch), absolute URLs."""
+    body = sitemap_service.build_sitemap(
+        [_StubSim("sim_alpha123")],
+        "https://miroshark.app",
+    )
+    root = _parse(body)
+    urls = _urls(root)
+    assert len(urls) == 2
+    locs = [_child_text(u, "loc") for u in urls]
+    assert locs == [
+        "https://miroshark.app/share/sim_alpha123",
+        "https://miroshark.app/watch/sim_alpha123",
+    ]
+
+
+def test_private_sims_are_excluded():
+    """Operators forking privately don't leak into search."""
+    sims = [
+        _StubSim("sim_publicA"),
+        _StubSim("sim_privateB", is_public=False),
+        _StubSim("sim_publicC"),
+    ]
+    body = sitemap_service.build_sitemap(sims, "https://miroshark.app")
+    root = _parse(body)
+    locs = {_child_text(u, "loc") for u in _urls(root)}
+    assert "https://miroshark.app/share/sim_publicA" in locs
+    assert "https://miroshark.app/share/sim_publicC" in locs
+    assert not any("sim_privateB" in loc for loc in locs)
+
+
+def test_sims_without_id_are_skipped():
+    """A SimulationState with a missing id never produces a malformed loc."""
+    sims = [
+        _StubSim(""),
+        _StubSim("sim_realID"),
+    ]
+    body = sitemap_service.build_sitemap(sims, "https://miroshark.app")
+    root = _parse(body)
+    locs = [_child_text(u, "loc") for u in _urls(root)]
+    assert all("sim_realID" in loc for loc in locs)
+    # Two entries (share + watch) for the one valid sim
+    assert len(locs) == 2
+
+
+# ── lastmod / changefreq semantics ─────────────────────────────────────
+
+
+def test_lastmod_renders_w3c_date_form():
+    """``YYYY-MM-DD`` matches the sitemap spec's day-precision norm."""
+    sims = [_StubSim("sim_X", updated_at="2026-05-14T12:34:56Z")]
+    body = sitemap_service.build_sitemap(sims, "https://miroshark.app")
+    root = _parse(body)
+    urls = _urls(root)
+    for u in urls:
+        assert _child_text(u, "lastmod") == "2026-05-14"
+
+
+def test_lastmod_falls_back_to_created_at_then_state_mtime(tmp_path):
+    """No updated_at ⇒ created_at ⇒ state.json mtime, in that order."""
+    sims = [_StubSim("sim_create_only", updated_at=None, created_at="2026-04-15T08:00:00")]
+    body = sitemap_service.build_sitemap(sims, "https://miroshark.app")
+    root = _parse(body)
+    urls = _urls(root)
+    for u in urls:
+        assert _child_text(u, "lastmod") == "2026-04-15"
+
+    # Now strip both timestamps and rely on the state.json mtime.
+    sim = _StubSim("sim_mtime", created_at="", updated_at=None)
+    sim_dir = tmp_path / "sim_mtime"
+    sim_dir.mkdir()
+    state_json = sim_dir / "state.json"
+    state_json.write_text("{}", encoding="utf-8")
+    fixed_ts = 1715600000  # 2024-05-13T13:13:20Z
+    os.utime(state_json, (fixed_ts, fixed_ts))
+
+    body = sitemap_service.build_sitemap(
+        [sim],
+        "https://miroshark.app",
+        sim_data_dir=str(tmp_path),
+    )
+    root = _parse(body)
+    urls = _urls(root)
+    # mtime falls back to a real date string; we don't assert the exact
+    # day (it's tz-dependent) — just that the element is present and
+    # well-formed.
+    for u in urls:
+        text = _child_text(u, "lastmod")
+        assert text is not None
+        assert len(text) == 10
+        assert text[4] == "-" and text[7] == "-"
+
+
+def test_changefreq_completed_sim_is_weekly_for_share_and_daily_for_watch():
+    """Completed sims are stable artifacts — ``weekly`` for share, ``daily`` for watch."""
+    body = sitemap_service.build_sitemap(
+        [_StubSim("sim_done", status="completed")],
+        "https://miroshark.app",
+    )
+    root = _parse(body)
+    urls = _urls(root)
+    assert _child_text(urls[0], "changefreq") == "weekly"
+    assert _child_text(urls[1], "changefreq") == "daily"
+
+
+def test_changefreq_in_progress_sim_is_always_for_both_surfaces():
+    """In-progress sims change every round — ``always`` matches reality."""
+    body = sitemap_service.build_sitemap(
+        [_StubSim("sim_live", status="running")],
+        "https://miroshark.app",
+    )
+    root = _parse(body)
+    urls = _urls(root)
+    assert _child_text(urls[0], "changefreq") == "always"
+    assert _child_text(urls[1], "changefreq") == "always"
+
+
+def test_priority_share_higher_than_watch():
+    """Share is the canonical citation surface; watch is one notch below."""
+    body = sitemap_service.build_sitemap(
+        [_StubSim("sim_pri")],
+        "https://miroshark.app",
+    )
+    root = _parse(body)
+    urls = _urls(root)
+    assert _child_text(urls[0], "priority") == "0.8"
+    assert _child_text(urls[1], "priority") == "0.7"
+
+
+# ── Determinism / cap ──────────────────────────────────────────────────
+
+
+def test_serialization_is_deterministic_for_same_corpus():
+    """Identical input ⇒ identical bytes (order is by simulation_id)."""
+    sims = [
+        _StubSim("sim_b"),
+        _StubSim("sim_a"),
+        _StubSim("sim_c"),
+    ]
+    body_one = sitemap_service.build_sitemap(sims, "https://miroshark.app")
+    # Pass the sims in a different order — the renderer must still
+    # produce identical bytes because it sorts internally.
+    body_two = sitemap_service.build_sitemap(
+        list(reversed(sims)),
+        "https://miroshark.app",
+    )
+    assert body_one == body_two
+
+    root = _parse(body_one)
+    locs = [_child_text(u, "loc") for u in _urls(root)]
+    # Sorted ascending by id ⇒ a, a, b, b, c, c
+    expected = [
+        "https://miroshark.app/share/sim_a",
+        "https://miroshark.app/watch/sim_a",
+        "https://miroshark.app/share/sim_b",
+        "https://miroshark.app/watch/sim_b",
+        "https://miroshark.app/share/sim_c",
+        "https://miroshark.app/watch/sim_c",
+    ]
+    assert locs == expected
+
+
+def test_max_urls_cap_is_honored():
+    """Sims past the cap are dropped without raising."""
+    # Cap at 4 ⇒ 2 sims (each contributes 2 url blocks).
+    sims = [_StubSim(f"sim_{i:03d}") for i in range(10)]
+    body = sitemap_service.build_sitemap(
+        sims,
+        "https://miroshark.app",
+        max_urls=4,
+    )
+    root = _parse(body)
+    urls = _urls(root)
+    assert len(urls) == 4
+    locs = [_child_text(u, "loc") for u in _urls(root)]
+    # Sorted ascending ⇒ first two sims (000 and 001) make the cut.
+    assert locs == [
+        "https://miroshark.app/share/sim_000",
+        "https://miroshark.app/watch/sim_000",
+        "https://miroshark.app/share/sim_001",
+        "https://miroshark.app/watch/sim_001",
+    ]
+
+
+# ── robots.txt ─────────────────────────────────────────────────────────
+
+
+def test_robots_always_disallows_api_namespace():
+    """Even with sitemap disabled, the API surface is gated from crawlers."""
+    body = sitemap_service.build_robots_txt("https://miroshark.app", enabled=False)
+    text = body.decode("utf-8")
+    assert "User-agent: *" in text
+    assert "Disallow: /api/" in text
+    assert "Allow: /share/" in text
+    assert "Allow: /watch/" in text
+
+
+def test_robots_advertises_sitemap_when_enabled():
+    """Compliant crawlers discover ``/sitemap.xml`` automatically when enabled."""
+    body = sitemap_service.build_robots_txt(
+        "https://miroshark.app", enabled=True
+    )
+    text = body.decode("utf-8")
+    assert "Sitemap: https://miroshark.app/sitemap.xml" in text
+
+
+def test_robots_omits_sitemap_when_disabled():
+    """Private deployments don't leak the sitemap URL via robots.txt."""
+    body = sitemap_service.build_robots_txt(
+        "https://miroshark.app", enabled=False
+    )
+    text = body.decode("utf-8")
+    assert "Sitemap:" not in text
+
+
+def test_robots_omits_sitemap_when_base_url_blank_even_if_enabled():
+    """A misconfigured deployment without PUBLIC_BASE_URL skips the line."""
+    body = sitemap_service.build_robots_txt("", enabled=True)
+    text = body.decode("utf-8")
+    assert "Sitemap:" not in text
+    assert "Disallow: /api/" in text
+
+
+# ── XML well-formedness ────────────────────────────────────────────────
+
+
+def test_sitemap_xml_is_well_formed_with_declaration_and_namespace():
+    """The whole document round-trips and carries the spec declarations."""
+    sims = [_StubSim("sim_one"), _StubSim("sim_two")]
+    body = sitemap_service.build_sitemap(sims, "https://miroshark.app")
+
+    text = body.decode("utf-8")
+    assert text.startswith("<?xml")
+    assert "encoding='utf-8'" in text or 'encoding="utf-8"' in text
+
+    root = _parse(body)
+    assert root.tag.endswith("urlset")
+    assert "http://www.sitemaps.org/schemas/sitemap/0.9" in root.tag
+
+
+# ── Wiring guards ──────────────────────────────────────────────────────
+
+
+def test_sitemap_route_decorator_present():
+    """``GET /sitemap.xml`` must be registered on sitemap_bp."""
+    api_path = _BACKEND / "app" / "api" / "sitemap.py"
+    text = api_path.read_text(encoding="utf-8")
+    assert '@sitemap_bp.route("/sitemap.xml"' in text
+    assert "def sitemap_xml(" in text
+
+
+def test_robots_route_decorator_present():
+    """``GET /robots.txt`` must be registered on sitemap_bp."""
+    api_path = _BACKEND / "app" / "api" / "sitemap.py"
+    text = api_path.read_text(encoding="utf-8")
+    assert '@sitemap_bp.route("/robots.txt"' in text
+    assert "def robots_txt(" in text
+
+
+def test_sitemap_config_route_decorator_present():
+    """``GET /api/config/sitemap`` exposes the flag to the SPA."""
+    api_path = _BACKEND / "app" / "api" / "sitemap.py"
+    text = api_path.read_text(encoding="utf-8")
+    assert '@sitemap_bp.route("/api/config/sitemap"' in text
+    assert "def sitemap_config(" in text
+
+
+def test_app_factory_registers_sitemap_blueprint():
+    """The blueprint must be mounted on ``create_app`` — catches the
+    failure mode where the file exists but wasn't wired in."""
+    init_path = _BACKEND / "app" / "__init__.py"
+    text = init_path.read_text(encoding="utf-8")
+    assert "sitemap_bp" in text
+    assert "app.register_blueprint(sitemap_bp)" in text
+
+
+def test_blueprint_module_exports_sitemap_bp():
+    """``app.api`` must re-export ``sitemap_bp`` for the factory import."""
+    api_init = _BACKEND / "app" / "api" / "__init__.py"
+    text = api_init.read_text(encoding="utf-8")
+    assert "from .sitemap import sitemap_bp" in text
+
+
+def test_config_exposes_enable_sitemap_flag():
+    """``ENABLE_SITEMAP`` must be readable off the Config class so the
+    routes can gate on it. Defaults to True."""
+    config_path = _BACKEND / "app" / "config.py"
+    text = config_path.read_text(encoding="utf-8")
+    assert "ENABLE_SITEMAP" in text
+    # The default must be true so the public-discovery posture is
+    # opt-out rather than opt-in.
+    assert "ENABLE_SITEMAP" in text and "'true'" in text

--- a/docs/API.md
+++ b/docs/API.md
@@ -101,6 +101,9 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `POST` | `/api/simulation/<id>/webhook-retry` | Re-fire the completion webhook for a finished sim. Admin-token gated |
 | `GET` | `/share/<id>` | Public OG-tag landing page (auto-redirects to SPA) |
 | `GET` | `/watch/<id>` | Live spectator-watch page — minimal full-viewport broadcast view, polls every 15 s, OG / Twitter-card unfurl |
+| `GET` | `/sitemap.xml` | Auto-generated sitemap (sitemaps.org 0.9) listing every public sim's `/share/<id>` + `/watch/<id>` URLs. `404` when `ENABLE_SITEMAP=false`. Cached 1 h |
+| `GET` | `/robots.txt` | Crawler directives — `Disallow: /api/`, `Allow: /share/` etc., advertises `Sitemap:` when enabled. Cached 1 h |
+| `GET` | `/api/config/sitemap` | Public flag `{enabled, sitemap_url}` exposed to the SPA so EmbedDialog renders the right indexing hint |
 | `POST` | `/api/simulation/<id>/article` | Generate a Substack-style write-up |
 | `GET` | `/api/simulation/<id>/export` | Full JSON export |
 | `GET` | `/api/simulation/list` | List simulations |
@@ -160,6 +163,19 @@ jupyter lab simulation.ipynb     # or: code simulation.ipynb, or upload to Colab
 ```
 
 The notebook is self-contained — the trajectory CSV is embedded as a Python string literal so the cells run in an air-gapped kernel. Identical exports of a finished simulation produce bytewise-identical notebooks (citation-hash friendly), same property the `reproduce.json` blob has. nbformat 4 spec: <https://nbformat.readthedocs.io/>.
+
+### Search Engine Discoverability
+
+Two infrastructure-tier endpoints make the public-simulation gallery discoverable to web search:
+
+- `GET /sitemap.xml` — auto-generated sitemap (sitemaps.org 0.9 schema). One `<url>` per published sim's `/share/<id>` page (priority `0.8`) plus one per `/watch/<id>` page (priority `0.7`). `<lastmod>` in W3C `YYYY-MM-DD` form. `<changefreq>always</changefreq>` for in-progress sims, `weekly` / `daily` for completed ones. Sorted by `simulation_id` so two consecutive renders against the same corpus are byte-identical. Returns `404` when `ENABLE_SITEMAP=false`. Cached `public, max-age=3600`.
+- `GET /robots.txt` — crawler directives. Always served. `Disallow: /api/` keeps the JSON namespace out of the index; `Allow:` lines for `/share/`, `/watch/`, `/explore`, `/verified`, `/embed/` invite crawlers into the public-discovery surfaces. When the sitemap is enabled, advertises it via the standard `Sitemap: <PUBLIC_BASE_URL>/sitemap.xml` directive.
+
+**Submission flow:** in Google Search Console (or Bing Webmaster Tools / Yandex Webmaster / etc.), add the site once and submit `https://<your-deployment>/sitemap.xml`. Every newly published simulation lands in the next crawl — no per-sim manual step.
+
+**Opt-out:** set `ENABLE_SITEMAP=false` in the deployment environment to make `/sitemap.xml` return 404 and drop the `Sitemap:` advertisement from `robots.txt`. Useful for private MiroShark instances or operator-only deployments where simulations should not surface in public search results.
+
+The Embed dialog has a "🔍 Discoverable in web search" callout that confirms the simulation is in the sitemap (or explains how to enable it when disabled). The flag is exposed via `GET /api/config/sitemap` — public, no secret config leaked.
 
 ## Report Agent
 

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -97,6 +97,22 @@
 | `GET` | `/api/simulation/list` | 列出模拟 |
 | `GET` | `/api/simulation/history` | 模拟历史 / 差异 |
 | `GET` | `/api/simulation/public` | 可筛选、分页的公开图库列表 |
+| `GET` | `/sitemap.xml` | 自动生成的站点地图(sitemaps.org 0.9),列出每个公开模拟的 `/share/<id>` + `/watch/<id>` URL。`ENABLE_SITEMAP=false` 时返回 404。缓存 1 小时 |
+| `GET` | `/robots.txt` | 爬虫指令 — `Disallow: /api/`、`Allow: /share/` 等;启用时通过标准 `Sitemap:` 行通告。缓存 1 小时 |
+| `GET` | `/api/config/sitemap` | 公开标志 `{enabled, sitemap_url}`,供 SPA 在 EmbedDialog 中渲染正确的索引提示 |
+
+### 搜索引擎可发现性
+
+两个基础设施级端点让公开模拟图库可被网页搜索发现:
+
+- `GET /sitemap.xml` — 自动生成的站点地图(sitemaps.org 0.9 schema)。每个已发布模拟的 `/share/<id>` 页面占一个 `<url>`(优先级 `0.8`),每个 `/watch/<id>` 页面占一个 `<url>`(优先级 `0.7`)。`<lastmod>` 为 W3C `YYYY-MM-DD` 形式。进行中模拟的 `<changefreq>` 为 `always`,已完成模拟为 `weekly` / `daily`。按 `simulation_id` 排序,使同一语料库的两次连续渲染产生字节相同的 XML。`ENABLE_SITEMAP=false` 时返回 `404`。缓存 `public, max-age=3600`。
+- `GET /robots.txt` — 爬虫指令。始终对外服务。`Disallow: /api/` 阻止 JSON 命名空间被收录;`Allow:` 行邀请爬虫进入 `/share/`、`/watch/`、`/explore`、`/verified`、`/embed/` 等公共发现面。启用站点地图时,通过标准 `Sitemap: <PUBLIC_BASE_URL>/sitemap.xml` 指令进行通告。
+
+**提交流程:** 在 Google Search Console(或 Bing Webmaster Tools / Yandex Webmaster 等)添加站点一次,提交 `https://<your-deployment>/sitemap.xml`。每个新发布的模拟将在下一次抓取时上线 — 无需逐个手动操作。
+
+**禁用方式:** 在部署环境中设置 `ENABLE_SITEMAP=false`,即可让 `/sitemap.xml` 返回 404,并从 `robots.txt` 中移除 `Sitemap:` 通告。适用于私有 MiroShark 实例或不希望模拟出现在公开搜索结果中的纯运营场景。
+
+Embed 对话框包含 "🔍 可在网页搜索中发现" 提示块,确认该模拟已纳入站点地图(或解释如何启用)。该标志通过 `GET /api/config/sitemap` 暴露 — 公开,不泄露任何机密配置。
 
 ### 图库搜索与筛选
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -219,6 +219,27 @@ Each entry carries the scenario as the title (truncated with an ellipsis past 10
 
 The Embed dialog has a "Follow the gallery via RSS" callout with one-click subscribe links for the Atom feed, the RSS 2.0 feed, and the verified-only Atom feed, plus a **filter builder** (consensus + quality + sort) that emits the matching `?consensus=…&quality=…&sort=…` URL with a copy button — the slice an operator picks lands directly in any reader that consumes RSS or Atom. The /explore header has a "📡 Subscribe via RSS" chip that mirrors the active filter (verified-only when the filter is on).
 
+## Search-Engine Sitemap (`/sitemap.xml` + `/robots.txt`)
+
+The auto-generated discovery surface for web search. Every other share surface (`/share/<id>`, `/watch/<id>`, RSS / Atom, replay GIF) makes an *individual* simulation findable to someone who already has the link. The sitemap closes the gap on the *other* half — researchers and operators who don't know the simulation exists yet but search for the scenario keywords.
+
+`GET /sitemap.xml` walks the public-simulation corpus once per request and emits the sitemaps.org 0.9 XML document Googlebot / Bingbot / DuckDuckBot expect:
+
+- One `<url>` block per published sim's `/share/<id>` page (priority `0.8`, the canonical citation surface).
+- One `<url>` block per published sim's `/watch/<id>` page (priority `0.7`, the live broadcast surface).
+- `<lastmod>` in W3C `YYYY-MM-DD` form, derived from `state.json`'s `updated_at` / `created_at` / file mtime fallback chain.
+- `<changefreq>always</changefreq>` for in-progress sims (the belief bars genuinely change every round); `weekly` for completed share entries, `daily` for completed watch entries (the watch page re-renders less often once the run terminates).
+- Sims sorted by `simulation_id` ascending so two consecutive renders against the same corpus produce byte-identical XML.
+
+`GET /robots.txt` is the companion discovery file. Every deployment serves it (whether the sitemap is enabled or not) so well-behaved crawlers see the `Disallow: /api/` directive that keeps the JSON namespace out of the search index. When the sitemap is enabled, a trailing `Sitemap: <PUBLIC_BASE_URL>/sitemap.xml` line points crawlers at it for automatic discovery — submit once to Google Search Console and every newly published sim becomes searchable on the next crawl. The robots file always carries `Allow:` lines for the public-discovery surfaces (`/share/`, `/watch/`, `/explore`, `/verified`, `/embed/`) so crawlers know which routes they're invited into.
+
+- **Opt-out:** `ENABLE_SITEMAP=false` (default `true`) makes `/sitemap.xml` return `404` and drops the `Sitemap:` line from `robots.txt`. Operators running a private MiroShark instance — or one indexing sensitive scenarios — flip the flag.
+- **Bounded:** capped at 50,000 `<url>` entries (the spec ceiling per file). MiroShark's public corpus is currently three-figure small; the cap is defense-in-depth against pathological bulk-fork patterns rather than a normal truncation case.
+- **Caching:** `Cache-Control: public, max-age=3600` — hourly is fast enough for a freshly published sim to surface to crawlers at the next refresh, slow enough that a noisy crawler doesn't tax the gallery query.
+- **Implementation:** `app/services/sitemap.py` (~270 LoC, pure stdlib `xml.etree.ElementTree` + `os` + `datetime`) + `app/api/sitemap.py` (Flask blueprint mounted at the root, no `/api` prefix, mirroring `share_bp` / `watch_bp`). Zero new dependencies.
+
+The Embed dialog has a "🔍 Discoverable in web search" callout — distinct from the RSS subscribe block above — with a "View sitemap.xml ↗" link. The flag comes from a public `GET /api/config/sitemap` endpoint so the dialog renders the right hint when an operator has opted out.
+
 ## Live Watch Page (Spectator Broadcast)
 
 The seventh thin renderer over the same on-disk `sim_dir/` folder. The previous six (gallery card, share card, replay GIF, transcript, RSS / Atom feed, trajectory CSV / JSONL) all surface a *finished* simulation; the watch page surfaces a *live* one — the format MiroShark was missing for "tweet a sim mid-run" sharing.

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -784,6 +784,42 @@ export const getFeedUrl = ({
 }
 
 /**
+ * Build the absolute URL of the auto-generated public sitemap.
+ *
+ * The sitemap lists every published simulation's `/share/<id>` and
+ * `/watch/<id>` URLs in the sitemaps.org 0.9 XML format, ready to
+ * submit once to Google Search Console (or any compliant crawler).
+ * `/robots.txt` advertises this URL via the standard `Sitemap:`
+ * directive, so well-behaved bots discover it automatically.
+ *
+ * Returns the URL even when the operator has set ENABLE_SITEMAP=false
+ * — the caller should consult `getSitemapConfig()` to know whether
+ * the URL actually serves content (404 when disabled).
+ *
+ * @param {string} [origin]
+ * @returns {string}
+ */
+export const getSitemapUrl = (origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/sitemap.xml`
+}
+
+/**
+ * Fetch the public sitemap config — exposes whether `/sitemap.xml`
+ * is enabled on this deployment so the EmbedDialog can render the
+ * right hint without leaking any secret config.
+ *
+ * Response shape (under `data`):
+ *   {
+ *     enabled: boolean,
+ *     sitemap_url: string | null
+ *   }
+ */
+export const getSitemapConfig = () => {
+  return service.get('/api/config/sitemap')
+}
+
+/**
  * Branch a simulation with a narrative injection at a specific round.
  * The new simulation is READY and shares the parent's agent population;
  * when the runner hits trigger_round it auto-promotes the injection into

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -1257,6 +1257,40 @@
                 </div>
               </div>
             </div>
+
+            <!-- Search-engine indexing row — every published simulation is
+                 a /share/<id> page that researchers might land on through
+                 a Google search. This row tells the operator their sim is
+                 in the auto-generated /sitemap.xml that crawlers discover
+                 via the standard robots.txt Sitemap: directive. -->
+            <div class="feed-callout sitemap-callout">
+              <div class="feed-callout-head">
+                <span class="feed-callout-icon">🔍</span>
+                <div class="feed-callout-body">
+                  <div class="feed-callout-title">
+                    {{ sitemapEnabled
+                        ? $tr('Discoverable in web search', '可在网页搜索中发现')
+                        : $tr('Search indexing disabled', '已禁用搜索索引') }}
+                  </div>
+                  <div class="feed-callout-desc">
+                    {{ sitemapEnabled
+                        ? $tr('Auto-generated /sitemap.xml lists every published simulation’s share + watch URLs. /robots.txt advertises it via the standard Sitemap: directive — submit once to Google Search Console and every newly published sim becomes searchable.', '自动生成的 /sitemap.xml 列出每个已发布模拟的 share 与 watch URL。/robots.txt 通过标准 Sitemap: 指令通告 — 在 Google Search Console 提交一次后,每个新发布的模拟即可被搜索到。')
+                        : $tr('Sitemap disabled — set ENABLE_SITEMAP=true in your environment to surface this deployment’s public simulations to search engines.', '已禁用 Sitemap — 在环境中设置 ENABLE_SITEMAP=true,即可让此部署的公开模拟被搜索引擎收录。') }}
+                  </div>
+                </div>
+              </div>
+              <div v-if="sitemapEnabled" class="feed-callout-actions">
+                <a
+                  class="feed-callout-link"
+                  :href="sitemapUrl"
+                  target="_blank"
+                  rel="noopener"
+                  :title="$tr('Open /sitemap.xml in a new tab', '在新标签中打开 /sitemap.xml')"
+                >
+                  {{ $tr('View sitemap.xml ↗', '查看 sitemap.xml ↗') }}
+                </a>
+              </div>
+            </div>
           </div>
 
           <!-- Hint -->
@@ -1292,6 +1326,8 @@ import {
   getNotebookUrl,
   getSimulationLineage,
   getFeedUrl,
+  getSitemapUrl,
+  getSitemapConfig,
   getSimulationOutcome,
   submitSimulationOutcome,
   getWebhookLog,
@@ -1958,6 +1994,34 @@ const copyFilteredFeedUrl = async () => {
   }
 }
 
+// Search-engine sitemap surface — independent of `simulationId` (the
+// sitemap lists every published sim across the gallery), exposed here
+// so an operator who just published gets a one-click "your sim is
+// crawler-discoverable" callout. The flag comes from the public
+// /api/config/sitemap endpoint so the dialog can swap to a "disabled"
+// hint when the deployment opted out.
+const sitemapUrl = computed(() => {
+  if (!origin.value) return ''
+  return getSitemapUrl(origin.value)
+})
+const sitemapEnabled = ref(true)
+const sitemapConfigLoaded = ref(false)
+const loadSitemapConfig = async () => {
+  if (sitemapConfigLoaded.value) return
+  try {
+    const res = await getSitemapConfig()
+    sitemapEnabled.value = !!res?.data?.enabled
+  } catch {
+    // Best-effort — a transient failure shouldn't blank out the row.
+    // Default to ``enabled = true`` so the operator still sees the
+    // sitemap link; the route itself returns 404 when disabled, which
+    // is the authoritative answer.
+    sitemapEnabled.value = true
+  } finally {
+    sitemapConfigLoaded.value = true
+  }
+}
+
 const replayLoaded = ref(false)
 const replayPlay = ref(false)
 const onReplayLoad = () => {
@@ -2328,6 +2392,12 @@ watch(() => props.open, async (val) => {
   // Always pull the saved outcome — the GET endpoint is publish-gate-free
   // so even private sims will reflect a previously recorded annotation.
   await loadOutcome()
+  // Pull the sitemap config once per dialog open so the search-engine
+  // indexing row knows whether to render the "enabled" or "disabled"
+  // hint. Cheap (single small JSON) and the result rarely changes,
+  // but reading on each open keeps the row in sync if an operator
+  // toggles ``ENABLE_SITEMAP`` and reloads.
+  loadSitemapConfig()
   // Bust the share-card image cache so the preview reloads with whatever
   // state the simulation is in right now (resolution may have landed
   // since the dialog was last opened).


### PR DESCRIPTION
## What

Auto-generates a [sitemaps.org 0.9](http://www.sitemaps.org/schemas/sitemap/0.9) XML document at `GET /sitemap.xml` over the public-simulation corpus so Googlebot / Bingbot / DuckDuckBot can crawl every published sim's `/share/<id>` and `/watch/<id>` pages. Companion `GET /robots.txt` advertises the sitemap via the standard `Sitemap:` directive — submit once to Google Search Console and every newly published sim becomes searchable on the next crawl, with no per-sim manual step.

Behaviour:

- One `<url>` block per published sim's `/share/<id>` page (priority `0.8`, the canonical citation surface).
- One `<url>` block per published sim's `/watch/<id>` page (priority `0.7`, the live broadcast surface).
- `<lastmod>` in W3C `YYYY-MM-DD` form, derived from a `state.updated_at` → `state.created_at` → `state.json` mtime fallback chain.
- `<changefreq>always</changefreq>` for in-progress sims (the belief bars genuinely change every round); `weekly` for completed share entries / `daily` for completed watch entries.
- Sims sorted by `simulation_id` ascending so two consecutive renders against the same corpus produce byte-identical XML — lets the route layer set a meaningful `ETag` later if it wants.
- Public-only — `is_public=false` sims are silently excluded; private forks of public sims never surface in search.
- Capped at the spec ceiling of 50,000 `<url>` entries (defense-in-depth against pathological bulk-fork patterns).
- Returns `404` when `ENABLE_SITEMAP=false` so private deployments don't even hint that the sitemap surface exists.

`/robots.txt` is always served (whether the sitemap is enabled or not) so well-behaved crawlers see the `Disallow: /api/` directive that keeps the JSON namespace out of the search index. `Allow:` lines explicitly invite crawlers into `/share/`, `/watch/`, `/explore`, `/verified`, `/embed/`. The trailing `Sitemap: <PUBLIC_BASE_URL>/sitemap.xml` line appears only when the sitemap is enabled — no leak through robots.txt either.

## Why

This is the **#5 idea from `repo-actions` 2026-05-12** — the long-tail growth surface that complements the rest of the discovery stack:

- `/share/<id>` (PR #44) — every sim is a 1200×630 unfurl page on Twitter / Discord / Slack / LinkedIn.
- `/watch/<id>` (PR #62) — every sim is a live broadcast page for "tweet a sim mid-run" sharing.
- `/api/feed.atom` + `/api/feed.rss` (PR #60, #81) — RSS readers and tooling subscribe in their existing toolchain.
- `/sitemap.xml` (this PR) — Googlebot / Bingbot / DuckDuckBot crawl the gallery and surface individual sims when someone searches the scenario keywords.

Every other surface assumes the reader already has the link. The sitemap closes the gap on the *other* half — researchers and operators who don't know a simulation exists yet but search for the scenario keywords. The "Aave reserve-factor scenario from May 8" Aaron tweeted will surface on Google when someone searches Aave reserve factor — without a sitemap, Googlebot has no structured way to discover the page.

The payoff compounds: each new published sim becomes a new organic entry point, with no marginal effort once the sitemap is submitted to Search Console once.

## Changes

**Backend (`backend/`):**

- `app/services/sitemap.py` (new, ~270 LoC, pure stdlib `xml.etree.ElementTree` + `os` + `datetime`). Pinned constants: `SITEMAP_NAMESPACE` (sitemaps.org 0.9), `MAX_SITEMAP_URLS = 50_000` (spec ceiling), `SHARE_PRIORITY = "0.8"` / `WATCH_PRIORITY = "0.7"`, `RUNNING_CHANGEFREQ = "always"` / `COMPLETED_CHANGEFREQ = "weekly"`. `build_sitemap()` walks public sims, projects each into `<url>` blocks, serializes via `ET.tostring` with `xml_declaration=True`. `build_robots_txt()` always emits the `Disallow: /api/` block + `Allow:` lines for the public-discovery surfaces, and adds the `Sitemap:` line when enabled.
- `app/api/sitemap.py` (new). `sitemap_bp` Blueprint with `GET /sitemap.xml`, `GET /robots.txt`, and `GET /api/config/sitemap` (the SPA-facing public flag). Mounted at the root with no `/api` prefix, mirroring `share_bp` / `watch_bp` so crawlers find the URLs where the protocol convention places them.
- `app/__init__.py` + `app/api/__init__.py` — register `sitemap_bp` (no prefix).
- `app/config.py` — `ENABLE_SITEMAP = os.environ.get('ENABLE_SITEMAP', 'true').lower() == 'true'`. Default `true` so any deployment that exposes `/share/<id>` URLs publicly is crawl-ready out of the box.
- `openapi.yaml` — new `Discovery` tag; documents `/sitemap.xml`, `/robots.txt`, and `/api/config/sitemap` with response schemas. Drift-detection test passes.

**Frontend (`frontend/`):**

- `src/api/simulation.js` — `getSitemapUrl(origin)` returns the absolute `/sitemap.xml` URL for one-click linking; `getSitemapConfig()` fetches the public config flag.
- `src/components/EmbedDialog.vue` — new "🔍 Discoverable in web search" callout beneath the existing RSS / Atom subscribe block. Shows a "View sitemap.xml ↗" button when enabled and a "Sitemap disabled — set `ENABLE_SITEMAP=true`" hint when not. Bilingual EN / zh-CN strings.

**Tests (`backend/tests/`):**

- `test_unit_sitemap.py` (new, 22 tests). Pinned-invariant guards (`MAX_SITEMAP_URLS == 50_000`, namespace string, share / watch priorities, changefreq constants), empty / one-sim / multi-sim cases, private-sim exclusion, missing-id skip, `<lastmod>` W3C formatting + `state.json` mtime fallback, `<changefreq>` semantics for in-progress vs completed sims, byte-deterministic serialization (sims sorted by id), `MAX_SITEMAP_URLS` cap honored, robots.txt always disallows `/api/`, robots advertises `Sitemap:` only when enabled + base URL is set, XML round-trips through `ET.fromstring`. Plus drift guards: route decorators present on `sitemap_bp`, blueprint exported by `app.api`, `app/__init__.py` mounts the blueprint, `Config.ENABLE_SITEMAP` declared.

**Docs (`docs/`):**

- `FEATURES.md` — new "Search-Engine Sitemap" section describing the sitemap shape, robots.txt directives, opt-out flag, and Embed dialog callout.
- `API.md` + `API.zh-CN.md` — three new rows in the "Publish / Embed / Export" table; new "Search Engine Discoverability" subsection with submission flow.
- `README.md` (EN + zh-CN) — new feature row in both feature tables.
- `.env.example` — new `ENABLE_SITEMAP=true` block with explanation.

## How it works

The renderer is a pure projection over `SimulationManager.list_simulations()`: filter to `is_public=true`, sort by `simulation_id` ascending, and for each sim emit two `<url>` blocks (share + watch). `<lastmod>` falls back through `updated_at` → `created_at` → `state.json` mtime so a long-lived in-progress sim whose `created_at` is days old still tells the crawler "the artifact changed today". `<changefreq>` reflects the runner status — `always` while the sim is running, `weekly` (share) / `daily` (watch) once it terminates.

The `/sitemap.xml` route layer reuses the same `_resolve_base_url()` strategy the feed module shipped — prefer `Config.PUBLIC_BASE_URL` when set, fall back to the request host with `X-Forwarded-Proto` / `X-Forwarded-Host` honored. `Cache-Control: public, max-age=3600` matches Googlebot's typical re-crawl cadence for dynamic sites; `X-Robots-Tag: noindex` keeps the sitemap document itself out of the search index (only the URLs it points to should rank).

`/robots.txt` is always served with the same caching cadence so a single CDN purge refreshes both surfaces together. The `Disallow: /api/` directive protects the JSON namespace from being crawled and ranked alongside the human-facing pages — a frequent failure mode for SaaS deployments that don't ship a robots file.

The frontend `/api/config/sitemap` endpoint exposes a public `{enabled, sitemap_url}` payload so the EmbedDialog can render the right hint when the operator has opted out, without any secret config leaking. Same posture the webhook-config endpoints established.

## What's next

The sitemap unlocks organic search as a discovery channel — every newly published simulation compounds. Follow-up ideas in the same arc: a sitemap *index* (`sitemap_index.xml`) once the corpus crosses ~10k public sims; structured-data JSON-LD on the `/share/<id>` landing pages so Google surfaces a rich card with the consensus split / scenario / quality badge directly in the SERP; per-sim `Last-Modified` headers on the share / watch routes so 304 responses cut crawler bandwidth.

---
*Built autonomously by Aeon — see `repo-actions-2026-05-12.md` idea #5.*