### PR TITLE
feat: Discord rich-embed + Slack Block Kit completion notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -244,6 +244,25 @@ EMBEDDING_BATCH_SIZE=128
 # snippets (Python / Node.js / curl).
 # WEBHOOK_SECRET=
 
+# ===== Discord rich-embed notifications (optional) =====
+# Companion to WEBHOOK_URL above. The generic webhook posts raw JSON;
+# Discord renders nothing from a JSON blob. When this is set, MiroShark
+# POSTs a Discord-native embed (consensus-coloured border, scenario
+# title, belief percentage fields, share-card thumbnail, "View
+# simulation" link) on every simulation.completed / simulation.failed.
+# Get the URL from Discord → Server Settings → Integrations → Webhooks.
+# Backward compatible — unset disables the channel without affecting
+# the generic webhook above.
+# DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/000/xxx
+
+# ===== Slack Block Kit notifications (optional) =====
+# Same idea, Slack-native. Emits Block Kit JSON Slack actually renders
+# (scenario header, Unicode block-bar belief percentages, quality and
+# scale fields, "View simulation" button) instead of the raw payload
+# Slack would otherwise inline as a code block. Get the URL from
+# api.slack.com/apps → Incoming Webhooks. Unset = channel disabled.
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0/B0/abc
+
 # ===== Search-engine sitemap (auto-generated /sitemap.xml + /robots.txt) =====
 # When true (default), GET /sitemap.xml lists every public-simulation
 # /share/<id> + /watch/<id> URL so Googlebot / Bingbot / DuckDuckBot can

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Trace Interview** | See the full reasoning chain behind an agent's reply, not just the reply |
 | **Push Notifications** | Web-push alerts when long-running graph / sim / report jobs finish |
 | **Completion Webhook** | POST a JSON summary the moment a sim finishes — wires Slack, Discord, Zapier, Make, n8n, or any custom endpoint with one URL field |
+| **Discord Rich Embed** | Set `DISCORD_WEBHOOK_URL` and MiroShark POSTs a Discord-native embed alongside the generic webhook: consensus-coloured border, scenario title, belief percentage fields, share-card thumbnail, link. Operators no longer have to teach Discord how to render a raw JSON blob — pure stdlib, opt-in, fire-and-forget. See [docs/NOTIFICATIONS.md](docs/NOTIFICATIONS.md) |
+| **Slack Block Kit** | Set `SLACK_WEBHOOK_URL` and MiroShark POSTs a Slack-native Block Kit message: scenario header, Unicode block-bar belief percentages, Quality + Scale + Resolution fields, "View simulation" action button. Channel-native rendering instead of a JSON code-block dump — pure stdlib, opt-in, fire-and-forget |
 | **Webhook Signature Verification** | Optional `WEBHOOK_SECRET` HMAC-signs every dispatched payload with an `X-MiroShark-Signature: sha256=<hex>` header. Recipients verify in three lines of stdlib `hmac` — same scheme Stripe and GitHub use. Empty secret = no header, fully backward compatible |
 | **Webhook Delivery Log** | Per-sim `webhook-log.jsonl` records every dispatch attempt (status code, latency, error). Inspect from the EmbedDialog and re-fire any failed delivery with a "Retry" button — closes the operational blindspot every Zapier / n8n integration eventually hits |
 | **Surface Usage Analytics** | `GET /api/simulation/<id>/surface-stats` — per-share-surface request counters (share card / replay GIF / transcript / trajectory / thread / watch page / Atom / RSS / reproduce.json / lineage / notebook.ipynb) with a synthetic `total`. Inbound observability for the distribution loop the webhook log tracks on the outbound side |
@@ -241,6 +243,8 @@ cp .env.example .env
 | **轨迹访谈** | 查看智能体回复背后的完整推理链,而不止是回复本身 |
 | **推送通知** | 长耗时图谱 / 模拟 / 报告任务完成时的浏览器推送提醒 |
 | **完成 Webhook** | 模拟一结束即 POST 一份 JSON 摘要 — 一个 URL 字段即可连通 Slack、Discord、Zapier、Make、n8n 或任意自定义端点 |
+| **Discord 富嵌入** | 设置 `DISCORD_WEBHOOK_URL`,MiroShark 会在通用 Webhook 之外另行推送一份 Discord 原生 embed:按共识着色的边框、情景标题、信念百分比字段、分享卡缩略图、链接。运营者无需再为 Discord 写格式化代码 — 纯 stdlib,按需启用,fire-and-forget。详见 [docs/NOTIFICATIONS.md](docs/NOTIFICATIONS.md) |
+| **Slack Block Kit** | 设置 `SLACK_WEBHOOK_URL`,MiroShark 会推送 Slack 原生 Block Kit 消息:情景标题块、Unicode 块字符信念百分比、质量 / 规模 / 结局字段、「打开模拟」操作按钮。频道里的不是 JSON 代码块,而是真正的频道卡片 — 纯 stdlib,按需启用,fire-and-forget |
 | **Webhook 签名验证** | 可选的 `WEBHOOK_SECRET` 会用 HMAC 对每次投递的载荷签名,并通过 `X-MiroShark-Signature: sha256=<hex>` 头部送出。消费方用三行 stdlib `hmac` 即可校验 — Stripe 和 GitHub 用的就是这一套。留空即无签名头部,完全向后兼容 |
 | **Webhook 投递日志** | 每个模拟在 `webhook-log.jsonl` 记录每次投递尝试(HTTP 状态码、延迟、错误)。可在 EmbedDialog 中查看,并通过「重试」按钮重发任何失败的投递 — 弥补每个 Zapier / n8n 集成最终都会遇到的运维盲点 |
 | **分发统计(分享面使用分析)** | `GET /api/simulation/<id>/surface-stats` — 每个分享面的请求计数器(分享卡 / 回放 GIF / 转录 / 轨迹 / 推文串 / 观看页 / Atom / RSS / `reproduce.json` / `/lineage`),以及合成的 `total`。Webhook 日志在出站侧跟踪分发回路,本面则负责入站可观测性 |

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -79,7 +79,7 @@ def create_app(config_class=Config):
         return response
     
     # Register blueprints
-    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, mcp_bp, docs_bp, feed_bp, share_bp, watch_bp, sitemap_bp
+    from .api import graph_bp, simulation_bp, report_bp, templates_bp, settings_bp, observability_bp, mcp_bp, docs_bp, feed_bp, share_bp, watch_bp, sitemap_bp, notifications_bp
     app.register_blueprint(graph_bp, url_prefix='/api/graph')
     app.register_blueprint(simulation_bp, url_prefix='/api/simulation')
     app.register_blueprint(report_bp, url_prefix='/api/report')
@@ -107,6 +107,10 @@ def create_app(config_class=Config):
     # /api/, so the blueprint is mounted with no prefix to match the
     # protocol convention.
     app.register_blueprint(sitemap_bp)
+    # notifications_bp serves /api/config/notifications — kept on the
+    # /api root (no extra sub-prefix) to mirror the sitemap config
+    # endpoint that pairs with it on the SPA side.
+    app.register_blueprint(notifications_bp)
     
     # Health check
     @app.route('/health')

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -36,3 +36,8 @@ from .watch import watch_bp  # noqa: E402, F401
 # and /robots.txt land where crawlers expect them — see api/sitemap.py.
 from .sitemap import sitemap_bp  # noqa: E402, F401
 
+# notifications_bp serves /api/config/notifications — a public config
+# probe that tells the SPA which channels (webhook / Discord / Slack)
+# are wired up on this deployment without leaking the URLs themselves.
+from .notifications import notifications_bp  # noqa: E402, F401
+

--- a/backend/app/api/notifications.py
+++ b/backend/app/api/notifications.py
@@ -1,0 +1,59 @@
+"""Public ``GET /api/config/notifications`` config endpoint.
+
+Tells the SPA which notification *channels* are wired up on this
+deployment without exposing the values themselves (the webhook URLs
+often carry an opaque secret in the path). Mirrors the existing
+``GET /api/config/sitemap`` pattern: a small boolean envelope the
+``EmbedDialog`` reads on mount and uses to render the right status
+chips beside the share-and-embed surfaces.
+
+Three independent channels, each gated by a separate env var so
+operators can opt in to any subset:
+
+* ``WEBHOOK_URL``         — generic JSON ``POST`` (PR #46)
+* ``DISCORD_WEBHOOK_URL`` — Discord rich-embed cards
+* ``SLACK_WEBHOOK_URL``   — Slack Block Kit messages
+
+Each ``*_configured`` boolean is ``True`` iff the corresponding env
+var is set to a non-empty value. No URL ever leaves the backend.
+
+Sandbox note: pure stdlib (env reads + ``flask.jsonify``). No
+outbound network — the route never raises and never blocks on
+Neo4j / LLM calls.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, Response, jsonify
+
+from ..services import discord_notify, slack_notify
+from ..services import webhook_service
+from ..utils.logger import get_logger
+
+
+logger = get_logger("miroshark.api.notifications")
+
+notifications_bp = Blueprint("notifications", __name__)
+
+
+@notifications_bp.route("/api/config/notifications", methods=["GET"])
+def notifications_config() -> Response:
+    """Expose which notification channels are configured.
+
+    Returns ``{success, data: {webhook_configured, discord_configured,
+    slack_configured}}``. No URL values are leaked — only presence
+    booleans, so this endpoint is safe to call from the SPA without
+    auth.
+    """
+    webhook_url = webhook_service._resolve_webhook_url()
+    data = {
+        "webhook_configured": bool(webhook_url),
+        "discord_configured": discord_notify.is_configured(),
+        "slack_configured": slack_notify.is_configured(),
+    }
+    response = jsonify({"success": True, "data": data})
+    # No caching — channel status flips the moment an operator pastes
+    # a URL into the Settings modal. The endpoint is cheap (three env
+    # reads) so paying the round-trip on every dialog open is fine.
+    response.headers["Cache-Control"] = "no-store"
+    return response

--- a/backend/app/services/discord_notify.py
+++ b/backend/app/services/discord_notify.py
@@ -1,0 +1,441 @@
+"""Discord rich-embed notification on simulation completion.
+
+Companion to :mod:`webhook_service`. The generic webhook posts a raw
+JSON blob — Discord renders nothing from it (no embed, no card, no
+unfurl). When ``DISCORD_WEBHOOK_URL`` is set, this module POSTs a
+proper Discord *embed object* alongside the generic dispatch so a
+Discord channel receives a coloured, titled, button-linked card on
+every ``simulation.completed`` / ``simulation.failed`` event.
+
+The first third-party MiroShark integration (``@revaultdrops``,
+2026-05-13 — "ReVault intelligence layer powered by @miroshark_") runs
+its operator chatter in a Discord server. This module turns that
+server into a live MiroShark distribution channel without requiring
+the operator to write any integration glue.
+
+Design notes
+------------
+
+* **Fire-and-forget.** Runs in a daemon thread so a slow Discord
+  endpoint never delays the simulation runner. Never raises.
+* **Opt-in.** No env var ⇒ no-op. A misconfigured URL (HTTP 4xx)
+  logs a warning and continues. Existing deployments unaware of the
+  feature are unaffected.
+* **Per-process dedup.** ``(sim_id, status)`` keyed; the runner's
+  exit-code path and the ``simulation_end`` event path both fire,
+  but Discord only sees one card per terminal state.
+* **Reuses ``build_payload``.** The on-disk artifact reads
+  (``simulation_config.json``, ``quality.json``, ``trajectory.json``,
+  ``state.json``, …) live in :mod:`webhook_service` and are not
+  duplicated here. The embed builder is a pure projection over the
+  same payload the generic webhook ships.
+* **Stdlib only.** ``urllib.request`` for the POST, ``json`` for the
+  body, ``os`` for the env var. No new dependencies.
+
+Embed shape (Discord ``embeds[0]``)::
+
+    {
+      "type": "rich",
+      "title": "<scenario, ≤100 chars>",
+      "url":   "<share_url or share_path>",
+      "color": <int — green/grey/red/orange by consensus direction>,
+      "fields": [
+        {"name": "Bullish",  "value": "62.0%", "inline": true},
+        {"name": "Neutral",  "value": "13.0%", "inline": true},
+        {"name": "Bearish",  "value": "25.0%", "inline": true},
+        {"name": "Quality",  "value": "Excellent", "inline": true},
+        {"name": "Rounds",   "value": "20", "inline": true},
+        {"name": "Agents",   "value": "248", "inline": true}
+      ],
+      "thumbnail": {"url": "<share_card_url>"},
+      "footer":    {"text": "MiroShark"},
+      "timestamp": "<fired_at>"
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional, Tuple
+
+from ..utils.logger import get_logger
+
+logger = get_logger('miroshark.discord_notify')
+
+
+DISCORD_WEBHOOK_URL_ENV_VAR = "DISCORD_WEBHOOK_URL"
+DISCORD_USER_AGENT = "MiroShark-DiscordNotify/1.0"
+DISCORD_TIMEOUT_SECONDS = 5.0
+
+# Discord field values are capped server-side; titles are clamped here so
+# a long scenario doesn't break the embed.
+DISCORD_TITLE_MAX_CHARS = 100
+
+# Discord embed-colour integers. Picked to match the rest of the SPA so
+# the in-app consensus chip and the Discord card read as the same colour
+# system.
+COLOR_BULLISH = 0x22C55E   # green-500   — bullish-led consensus
+COLOR_NEUTRAL = 0x6B7280   # grey-500    — no dominant direction
+COLOR_BEARISH = 0xEF4444   # red-500     — bearish-led consensus
+COLOR_FAILED  = 0xF59E0B   # amber-500   — sim failed (no consensus)
+
+# Per-process dedup. Mirrors the same idea as `webhook_service._FIRED`:
+# the runner has two terminal code paths (exit-code monitor + the
+# `simulation_end` event in the action log) and both call into the
+# notifier — keep only the first per (sim_id, status).
+_FIRED: set[Tuple[str, str]] = set()
+_FIRED_LOCK = threading.Lock()
+_FIRED_MAX = 4096
+
+
+def _mark_fired(sim_id: str, status: str) -> bool:
+    """Record (sim_id, status); return ``True`` only on the first call."""
+    key = (sim_id, status)
+    with _FIRED_LOCK:
+        if key in _FIRED:
+            return False
+        if len(_FIRED) >= _FIRED_MAX:
+            _FIRED.pop()
+        _FIRED.add(key)
+        return True
+
+
+def reset_dedup_for_tests() -> None:
+    """Clear the in-process dedup set. Test-only convenience."""
+    with _FIRED_LOCK:
+        _FIRED.clear()
+
+
+def _resolve_webhook_url() -> str:
+    """Read ``DISCORD_WEBHOOK_URL`` at call time.
+
+    Late binding so a runtime env mutation (or a test ``monkeypatch``)
+    takes effect without re-importing the module.
+    """
+    return (os.environ.get(DISCORD_WEBHOOK_URL_ENV_VAR, "") or "").strip()
+
+
+def is_configured() -> bool:
+    """``True`` iff ``DISCORD_WEBHOOK_URL`` is set to a non-empty value."""
+    return bool(_resolve_webhook_url())
+
+
+def _consensus_color(payload: Dict[str, Any]) -> int:
+    """Pick the embed colour for ``payload``.
+
+    A failed sim is always amber regardless of the (often empty)
+    trajectory. A completed sim with no trajectory falls back to
+    neutral grey. Otherwise the colour follows the dominant stance
+    bucket (bullish/neutral/bearish) using the same ±0.2 threshold
+    every other surface uses.
+    """
+    if (payload.get("status") or "") == "failed":
+        return COLOR_FAILED
+
+    consensus = payload.get("final_consensus") or {}
+    if not isinstance(consensus, dict):
+        return COLOR_NEUTRAL
+
+    try:
+        bullish = float(consensus.get("bullish") or 0.0)
+        neutral = float(consensus.get("neutral") or 0.0)
+        bearish = float(consensus.get("bearish") or 0.0)
+    except (TypeError, ValueError):
+        return COLOR_NEUTRAL
+
+    if bullish == 0.0 and neutral == 0.0 and bearish == 0.0:
+        return COLOR_NEUTRAL
+
+    if bullish >= bearish and bullish >= neutral:
+        return COLOR_BULLISH
+    if bearish >= bullish and bearish >= neutral:
+        return COLOR_BEARISH
+    return COLOR_NEUTRAL
+
+
+def _truncate(value: str, limit: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= limit:
+        return value
+    return value[: max(limit - 1, 0)].rstrip() + "…"
+
+
+def _resolve_share_url(payload: Dict[str, Any]) -> Optional[str]:
+    """Prefer the absolute ``share_url`` when ``PUBLIC_BASE_URL`` was set.
+
+    Falls back to the relative ``share_path`` so the embed always
+    carries some link — but Discord renders a clickable button only
+    when the URL is absolute, which is why the generic webhook layer
+    surfaces ``share_url`` separately.
+    """
+    abs_url = payload.get("share_url")
+    if isinstance(abs_url, str) and abs_url.strip():
+        return abs_url.strip()
+    rel = payload.get("share_path")
+    if isinstance(rel, str) and rel.strip():
+        return rel.strip()
+    return None
+
+
+def _format_pct(value: Any) -> str:
+    """Render a percentage field the way the SPA renders it ("62.0%")."""
+    try:
+        return f"{float(value):.1f}%"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def build_discord_embed(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Assemble the Discord embed object for ``payload``.
+
+    ``payload`` is the same dict :func:`webhook_service.build_payload`
+    produces. The embed surfaces the four numbers a casual reader
+    cares about (bullish / neutral / bearish / quality) plus the
+    rounds + agent count, and links the share page so a single tap
+    opens the simulation.
+    """
+    status = str(payload.get("status") or "")
+    sim_id = str(payload.get("sim_id") or "")
+
+    scenario = _truncate(
+        str(payload.get("scenario") or ""),
+        DISCORD_TITLE_MAX_CHARS,
+    )
+    if not scenario:
+        # Avoid an empty Discord title — Discord renders it as a tiny
+        # gap and the card looks broken. Fall back to a stable label.
+        scenario = (
+            f"Simulation {sim_id}".strip()
+            if sim_id
+            else "MiroShark simulation"
+        )
+
+    consensus = payload.get("final_consensus") or {}
+    fields: list[Dict[str, Any]] = []
+    if isinstance(consensus, dict) and consensus:
+        fields.extend([
+            {"name": "Bullish", "value": _format_pct(consensus.get("bullish")), "inline": True},
+            {"name": "Neutral", "value": _format_pct(consensus.get("neutral")), "inline": True},
+            {"name": "Bearish", "value": _format_pct(consensus.get("bearish")), "inline": True},
+        ])
+
+    quality_health = payload.get("quality_health")
+    if isinstance(quality_health, str) and quality_health:
+        fields.append({"name": "Quality", "value": quality_health, "inline": True})
+
+    total_rounds = payload.get("total_rounds")
+    if isinstance(total_rounds, int) and total_rounds > 0:
+        fields.append({"name": "Rounds", "value": str(total_rounds), "inline": True})
+
+    agent_count = payload.get("agent_count")
+    if isinstance(agent_count, int) and agent_count > 0:
+        fields.append({"name": "Agents", "value": str(agent_count), "inline": True})
+
+    resolution_outcome = payload.get("resolution_outcome")
+    if isinstance(resolution_outcome, str) and resolution_outcome:
+        fields.append({
+            "name": "Resolution",
+            "value": resolution_outcome,
+            "inline": True,
+        })
+
+    if status == "failed":
+        err_text = str(payload.get("error") or "").strip()
+        if err_text:
+            # Discord field values cap at 1024 chars — be defensive.
+            fields.append({
+                "name": "Error",
+                "value": _truncate(err_text, 1000),
+                "inline": False,
+            })
+
+    embed: Dict[str, Any] = {
+        "type": "rich",
+        "title": scenario,
+        "color": _consensus_color(payload),
+        "fields": fields,
+        "footer": {"text": "MiroShark"},
+    }
+
+    url = _resolve_share_url(payload)
+    if url and (url.startswith("http://") or url.startswith("https://")):
+        embed["url"] = url
+
+    thumb = payload.get("share_card_url")
+    if isinstance(thumb, str) and (
+        thumb.startswith("http://") or thumb.startswith("https://")
+    ):
+        embed["thumbnail"] = {"url": thumb}
+
+    fired_at = payload.get("fired_at")
+    if isinstance(fired_at, str) and fired_at:
+        embed["timestamp"] = fired_at
+
+    # Description carries the status verb so the card reads cleanly
+    # even when the dashboard rolls up several cards in a row.
+    if status == "completed":
+        embed["description"] = "Simulation reached its terminal round."
+    elif status == "failed":
+        embed["description"] = "Simulation ended in a failure state."
+    elif status == "test":
+        embed["description"] = "Test event — your Discord webhook is configured correctly."
+
+    return embed
+
+
+def _post_json(url: str, body: Dict[str, Any], timeout: float) -> Tuple[bool, str]:
+    """Issue the POST. Returns ``(ok, message)`` — never raises."""
+    try:
+        encoded = json.dumps(body).encode("utf-8")
+    except Exception as exc:
+        return False, f"Could not serialize Discord payload: {exc}"
+
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+        "User-Agent": DISCORD_USER_AGENT,
+    }
+    req = urllib.request.Request(url, data=encoded, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            code = resp.getcode()
+            if 200 <= code < 300:
+                return True, f"HTTP {code}"
+            return False, f"HTTP {code}"
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code}"
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        return False, f"URL error: {reason}"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+def send_discord_payload(url: str, embed: Dict[str, Any]) -> Tuple[bool, str]:
+    """Synchronously POST one embed to ``url``. Returns ``(ok, message)``.
+
+    Exposed so the "Send test event" path can surface the result
+    immediately without going through the daemon-thread dispatch.
+    """
+    if not url:
+        return False, "Discord webhook URL is empty"
+    body = {"embeds": [embed]}
+    return _post_json(url, body, DISCORD_TIMEOUT_SECONDS)
+
+
+def _start_dispatch_thread(url: str, embed: Dict[str, Any], thread_name: str) -> None:
+    """Launch the daemon thread that POSTs the embed and logs the result."""
+    def _send() -> None:
+        ok, msg = send_discord_payload(url, embed)
+        sim_id = embed.get("title") or ""
+        if ok:
+            logger.info(f"Discord notify ok ({msg}) — {sim_id}")
+        else:
+            logger.warning(f"Discord notify failed ({msg}) — {sim_id}")
+
+    threading.Thread(target=_send, daemon=True, name=thread_name).start()
+
+
+def notify_if_configured(
+    simulation_id: str,
+    status: str,
+    *,
+    sim_dir: Optional[str] = None,
+    state: Optional[Any] = None,
+    completed_at: Optional[str] = None,
+    error: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> None:
+    """Fire-and-forget Discord embed dispatch for a finished simulation.
+
+    Safe to call from the simulation monitor thread — the POST runs
+    in its own daemon thread. No-op when ``DISCORD_WEBHOOK_URL`` is
+    not set or when this ``(sim_id, status)`` already fired in this
+    process.
+    """
+    if status not in {"completed", "failed"}:
+        return
+
+    url = _resolve_webhook_url()
+    if not url:
+        return
+
+    if not _mark_fired(simulation_id, status):
+        return
+
+    # Defer the import so the package-level wiring stays cycle-free
+    # (webhook_service does not import this module).
+    from . import webhook_service
+
+    if sim_dir is None:
+        try:
+            from ..config import Config
+            sim_dir = os.path.join(
+                Config.WONDERWALL_SIMULATION_DATA_DIR,
+                simulation_id,
+            )
+        except Exception:
+            sim_dir = simulation_id
+
+    if base_url is None:
+        base_url = webhook_service._resolve_base_url()
+
+    try:
+        payload = webhook_service.build_payload(
+            simulation_id,
+            status,
+            sim_dir,
+            state=state,
+            base_url=base_url,
+            completed_at=completed_at,
+            error=error,
+        )
+    except Exception as exc:
+        logger.warning(f"Discord notify: build_payload failed for {simulation_id}: {exc}")
+        return
+
+    try:
+        embed = build_discord_embed(payload)
+    except Exception as exc:
+        logger.warning(f"Discord notify: embed build failed for {simulation_id}: {exc}")
+        return
+
+    _start_dispatch_thread(
+        url=url,
+        embed=embed,
+        thread_name=f"discord-notify-{simulation_id}",
+    )
+
+
+def send_test_notification(url: Optional[str] = None) -> Dict[str, Any]:
+    """Synchronously POST a sample embed.
+
+    Used by the Settings ``Send test event`` flow so an operator gets
+    immediate feedback that their Discord webhook URL works.
+    """
+    target = (url or _resolve_webhook_url()).strip()
+    if not target:
+        return {"ok": False, "message": "Discord webhook URL is empty"}
+
+    sample_payload = {
+        "event": "simulation.test",
+        "sim_id": "sim_test_event",
+        "scenario": "Test event from MiroShark — your Discord webhook is configured.",
+        "status": "test",
+        "current_round": 0,
+        "total_rounds": 0,
+        "agent_count": 0,
+        "quality_health": None,
+        "final_consensus": None,
+        "resolution_outcome": None,
+        "share_path": "/share/sim_test_event",
+        "share_card_path": "/api/simulation/sim_test_event/share-card.png",
+        "fired_at": None,
+    }
+    embed = build_discord_embed(sample_payload)
+    ok, msg = send_discord_payload(target, embed)
+    return {"ok": ok, "message": msg}

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -665,6 +665,34 @@ class SimulationRunner:
                     )
                 except Exception as _wh_err:
                     logger.warning(f"Webhook dispatch failed: {_wh_err}")
+
+                # Channel-native notifications — Discord rich embed +
+                # Slack Block Kit. Each is opt-in via its own env var;
+                # unconfigured channels no-op. Dedup is per-channel so
+                # an operator running only Discord doesn't lose Slack
+                # delivery to a fall-through.
+                try:
+                    from .discord_notify import notify_if_configured as _notify_discord
+                    _notify_discord(
+                        simulation_id,
+                        "completed",
+                        sim_dir=sim_dir,
+                        state=state,
+                        completed_at=state.completed_at,
+                    )
+                except Exception as _dn_err:
+                    logger.warning(f"Discord notify dispatch failed: {_dn_err}")
+                try:
+                    from .slack_notify import notify_if_configured as _notify_slack
+                    _notify_slack(
+                        simulation_id,
+                        "completed",
+                        sim_dir=sim_dir,
+                        state=state,
+                        completed_at=state.completed_at,
+                    )
+                except Exception as _sn_err:
+                    logger.warning(f"Slack notify dispatch failed: {_sn_err}")
             else:
                 state.runner_status = RunnerStatus.FAILED
                 # Read error info from main log file
@@ -693,6 +721,35 @@ class SimulationRunner:
                     )
                 except Exception as _wh_err:
                     logger.warning(f"Webhook dispatch failed: {_wh_err}")
+
+                # Channel-native failure cards — amber-bordered Discord
+                # embed + red-tagged Slack message. Operators wiring a
+                # channel for ops-visibility need to know about the
+                # failure path too.
+                try:
+                    from .discord_notify import notify_if_configured as _notify_discord
+                    _notify_discord(
+                        simulation_id,
+                        "failed",
+                        sim_dir=sim_dir,
+                        state=state,
+                        completed_at=datetime.now().isoformat(),
+                        error=state.error,
+                    )
+                except Exception as _dn_err:
+                    logger.warning(f"Discord notify dispatch failed: {_dn_err}")
+                try:
+                    from .slack_notify import notify_if_configured as _notify_slack
+                    _notify_slack(
+                        simulation_id,
+                        "failed",
+                        sim_dir=sim_dir,
+                        state=state,
+                        completed_at=datetime.now().isoformat(),
+                        error=state.error,
+                    )
+                except Exception as _sn_err:
+                    logger.warning(f"Slack notify dispatch failed: {_sn_err}")
             
             state.twitter_running = False
             state.reddit_running = False
@@ -829,6 +886,31 @@ class SimulationRunner:
                                             )
                                         except Exception as _wh_err:
                                             logger.warning(f"Webhook dispatch failed: {_wh_err}")
+
+                                        # Channel-native notifications — same dedup posture
+                                        # as the webhook above; the per-module ``_FIRED``
+                                        # set blocks the second dispatch when the
+                                        # exit-code path also fires.
+                                        try:
+                                            from .discord_notify import notify_if_configured as _notify_discord
+                                            _notify_discord(
+                                                state.simulation_id,
+                                                "completed",
+                                                state=state,
+                                                completed_at=state.completed_at,
+                                            )
+                                        except Exception as _dn_err:
+                                            logger.warning(f"Discord notify dispatch failed: {_dn_err}")
+                                        try:
+                                            from .slack_notify import notify_if_configured as _notify_slack
+                                            _notify_slack(
+                                                state.simulation_id,
+                                                "completed",
+                                                state=state,
+                                                completed_at=state.completed_at,
+                                            )
+                                        except Exception as _sn_err:
+                                            logger.warning(f"Slack notify dispatch failed: {_sn_err}")
                                 
                                 # Update round info (from round_end event)
                                 elif event_type == "round_end":

--- a/backend/app/services/slack_notify.py
+++ b/backend/app/services/slack_notify.py
@@ -1,0 +1,432 @@
+"""Slack Block Kit notification on simulation completion.
+
+Companion to :mod:`webhook_service` — same shape as
+:mod:`discord_notify` but emits a Slack-native Block Kit message
+instead of a Discord embed. Operators wiring MiroShark into a Slack
+workspace set ``SLACK_WEBHOOK_URL`` and start receiving formatted
+cards (scenario header, belief block-bars, quality + agent fields,
+"View simulation" link button) in the configured channel.
+
+The generic webhook (PR #46) already accepts a Slack Incoming Webhook
+URL, but Slack renders a raw JSON post as a code-block dump — fine
+for debugging, useless as a real notification. This module emits the
+Block Kit JSON Slack expects so the message renders as a proper
+channel card.
+
+Design notes
+------------
+
+* **Fire-and-forget.** Daemon-thread dispatch, never raises. The
+  simulation runner is unaffected by a slow or broken Slack endpoint.
+* **Opt-in.** ``SLACK_WEBHOOK_URL`` unset ⇒ no-op. Existing
+  deployments are unchanged.
+* **Per-process dedup.** ``(sim_id, status)`` keyed; the runner's
+  two terminal code paths both call into us but Slack only sees one
+  message per terminal state.
+* **Reuses ``build_payload``.** All artifact reads live in
+  :mod:`webhook_service`. The Block Kit builder is a pure
+  projection over the same dict the generic webhook ships.
+* **Unicode block-bars, no images.** Slack renders block characters
+  in ``mrkdwn`` natively — no image-host round-trip, no thumbnail
+  fetch latency. The bars degrade cleanly into plain text in mobile
+  notifications.
+* **Stdlib only.** ``urllib.request`` + ``json`` + ``os``. No new
+  dependencies.
+
+Message shape (Block Kit ``blocks``)::
+
+    [
+      {"type": "header", "text": {...scenario...}},
+      {"type": "context", "elements": [{"type": "mrkdwn", "text": "*Status:* …"}]},
+      {"type": "section", "fields": [
+        {"type": "mrkdwn", "text": "*Bullish*\\n█████░░░░░ 52.0%"},
+        ...
+      ]},
+      {"type": "actions", "elements": [{"type": "button", ...}]}
+    ]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional, Tuple
+
+from ..utils.logger import get_logger
+
+logger = get_logger('miroshark.slack_notify')
+
+
+SLACK_WEBHOOK_URL_ENV_VAR = "SLACK_WEBHOOK_URL"
+SLACK_USER_AGENT = "MiroShark-SlackNotify/1.0"
+SLACK_TIMEOUT_SECONDS = 5.0
+
+# Slack header blocks cap at 150 chars; the SPA truncates scenario
+# previews to 120 in most surfaces, so 120 is the safer match.
+SLACK_HEADER_MAX_CHARS = 120
+
+# Unicode full-/empty-block characters. ``mrkdwn`` renders both
+# faithfully across desktop + mobile clients.
+BAR_FILLED = "█"
+BAR_EMPTY = "░"
+BAR_WIDTH = 10
+
+
+_FIRED: set[Tuple[str, str]] = set()
+_FIRED_LOCK = threading.Lock()
+_FIRED_MAX = 4096
+
+
+def _mark_fired(sim_id: str, status: str) -> bool:
+    key = (sim_id, status)
+    with _FIRED_LOCK:
+        if key in _FIRED:
+            return False
+        if len(_FIRED) >= _FIRED_MAX:
+            _FIRED.pop()
+        _FIRED.add(key)
+        return True
+
+
+def reset_dedup_for_tests() -> None:
+    """Clear the in-process dedup set. Test-only convenience."""
+    with _FIRED_LOCK:
+        _FIRED.clear()
+
+
+def _resolve_webhook_url() -> str:
+    return (os.environ.get(SLACK_WEBHOOK_URL_ENV_VAR, "") or "").strip()
+
+
+def is_configured() -> bool:
+    """``True`` iff ``SLACK_WEBHOOK_URL`` is set to a non-empty value."""
+    return bool(_resolve_webhook_url())
+
+
+def belief_bar(pct: float, width: int = BAR_WIDTH) -> str:
+    """Render a horizontal block-bar for ``pct`` (a value in [0, 100]).
+
+    Width is the number of glyphs, not characters of label. The
+    trailing label always shows the rounded percentage with one
+    decimal place, matching how the SPA renders the same number.
+    """
+    try:
+        value = float(pct)
+    except (TypeError, ValueError):
+        value = 0.0
+    if value < 0.0:
+        value = 0.0
+    if value > 100.0:
+        value = 100.0
+
+    filled_count = int(round((value / 100.0) * max(int(width), 1)))
+    if filled_count < 0:
+        filled_count = 0
+    if filled_count > width:
+        filled_count = width
+    empty_count = width - filled_count
+    bar = (BAR_FILLED * filled_count) + (BAR_EMPTY * empty_count)
+    return f"{bar} {value:.1f}%"
+
+
+def _truncate(value: str, limit: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= limit:
+        return value
+    return value[: max(limit - 1, 0)].rstrip() + "…"
+
+
+def _resolve_share_url(payload: Dict[str, Any]) -> Optional[str]:
+    """Prefer the absolute ``share_url`` — Slack only renders button URLs
+    for absolute ``http(s)://`` values.
+    """
+    abs_url = payload.get("share_url")
+    if isinstance(abs_url, str) and abs_url.strip():
+        s = abs_url.strip()
+        if s.startswith("http://") or s.startswith("https://"):
+            return s
+    return None
+
+
+def _status_verb(status: str) -> str:
+    if status == "completed":
+        return "Completed"
+    if status == "failed":
+        return "Failed"
+    if status == "test":
+        return "Test event"
+    return status.title() or "Unknown"
+
+
+def build_slack_message(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Assemble the Block Kit ``{blocks: [...]}`` body for ``payload``."""
+    sim_id = str(payload.get("sim_id") or "")
+    status = str(payload.get("status") or "")
+
+    scenario = _truncate(
+        str(payload.get("scenario") or "").strip(),
+        SLACK_HEADER_MAX_CHARS,
+    )
+    if not scenario:
+        scenario = f"Simulation {sim_id}" if sim_id else "MiroShark simulation"
+
+    blocks: list[Dict[str, Any]] = []
+
+    # 1. Header — the scenario, rendered large.
+    blocks.append({
+        "type": "header",
+        "text": {
+            "type": "plain_text",
+            "text": scenario,
+            "emoji": True,
+        },
+    })
+
+    # 2. Context — status verb + sim id (small grey text).
+    verb = _status_verb(status)
+    ctx_text = f"*{verb}*  ·  `{sim_id}`" if sim_id else f"*{verb}*"
+    blocks.append({
+        "type": "context",
+        "elements": [
+            {"type": "mrkdwn", "text": ctx_text},
+        ],
+    })
+
+    # 3. Belief bars — only when a trajectory was available.
+    consensus = payload.get("final_consensus") or {}
+    fields: list[Dict[str, Any]] = []
+    if isinstance(consensus, dict) and consensus:
+        bullish = consensus.get("bullish")
+        neutral = consensus.get("neutral")
+        bearish = consensus.get("bearish")
+        try:
+            b = float(bullish) if bullish is not None else 0.0
+            n = float(neutral) if neutral is not None else 0.0
+            r = float(bearish) if bearish is not None else 0.0
+            has_any = b > 0.0 or n > 0.0 or r > 0.0
+        except (TypeError, ValueError):
+            has_any = False
+        if has_any:
+            fields.extend([
+                {"type": "mrkdwn", "text": f"*Bullish*\n`{belief_bar(bullish)}`"},
+                {"type": "mrkdwn", "text": f"*Neutral*\n`{belief_bar(neutral)}`"},
+                {"type": "mrkdwn", "text": f"*Bearish*\n`{belief_bar(bearish)}`"},
+            ])
+
+    quality_health = payload.get("quality_health")
+    if isinstance(quality_health, str) and quality_health:
+        fields.append({"type": "mrkdwn", "text": f"*Quality*\n{quality_health}"})
+
+    total_rounds = payload.get("total_rounds")
+    agent_count = payload.get("agent_count")
+    rounds_text_parts: list[str] = []
+    if isinstance(agent_count, int) and agent_count > 0:
+        rounds_text_parts.append(f"{agent_count} agents")
+    if isinstance(total_rounds, int) and total_rounds > 0:
+        rounds_text_parts.append(f"{total_rounds} rounds")
+    if rounds_text_parts:
+        fields.append({
+            "type": "mrkdwn",
+            "text": "*Scale*\n" + " · ".join(rounds_text_parts),
+        })
+
+    resolution_outcome = payload.get("resolution_outcome")
+    if isinstance(resolution_outcome, str) and resolution_outcome:
+        fields.append({
+            "type": "mrkdwn",
+            "text": f"*Resolution*\n{resolution_outcome}",
+        })
+
+    if fields:
+        # Slack section blocks cap fields at 10 entries. Belief +
+        # quality + scale + resolution is at most 6, so we're always
+        # safely under, but be defensive against future drift.
+        blocks.append({
+            "type": "section",
+            "fields": fields[:10],
+        })
+
+    if status == "failed":
+        err_text = str(payload.get("error") or "").strip()
+        if err_text:
+            blocks.append({
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Error*\n```{_truncate(err_text, 800)}```",
+                },
+            })
+
+    # 4. "View simulation" action button — only when we have an
+    # absolute URL. Slack rejects buttons whose URL isn't http(s)://.
+    share_url = _resolve_share_url(payload)
+    if share_url:
+        blocks.append({
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "View simulation",
+                        "emoji": True,
+                    },
+                    "url": share_url,
+                    "action_id": "view_simulation",
+                },
+            ],
+        })
+
+    return {"blocks": blocks}
+
+
+def _post_json(url: str, body: Dict[str, Any], timeout: float) -> Tuple[bool, str]:
+    """Issue the POST. Returns ``(ok, message)`` — never raises."""
+    try:
+        encoded = json.dumps(body).encode("utf-8")
+    except Exception as exc:
+        return False, f"Could not serialize Slack payload: {exc}"
+
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+        "User-Agent": SLACK_USER_AGENT,
+    }
+    req = urllib.request.Request(url, data=encoded, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            code = resp.getcode()
+            if 200 <= code < 300:
+                return True, f"HTTP {code}"
+            return False, f"HTTP {code}"
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code}"
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        return False, f"URL error: {reason}"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+def send_slack_payload(url: str, message: Dict[str, Any]) -> Tuple[bool, str]:
+    """Synchronously POST one Block Kit message. Never raises."""
+    if not url:
+        return False, "Slack webhook URL is empty"
+    return _post_json(url, message, SLACK_TIMEOUT_SECONDS)
+
+
+def _start_dispatch_thread(url: str, message: Dict[str, Any], thread_name: str) -> None:
+    def _send() -> None:
+        ok, msg = send_slack_payload(url, message)
+        # Pull the scenario out of the header block for the log line.
+        header_text = ""
+        for blk in message.get("blocks", []):
+            if blk.get("type") == "header":
+                header_text = blk.get("text", {}).get("text", "") or ""
+                break
+        if ok:
+            logger.info(f"Slack notify ok ({msg}) — {header_text}")
+        else:
+            logger.warning(f"Slack notify failed ({msg}) — {header_text}")
+
+    threading.Thread(target=_send, daemon=True, name=thread_name).start()
+
+
+def notify_if_configured(
+    simulation_id: str,
+    status: str,
+    *,
+    sim_dir: Optional[str] = None,
+    state: Optional[Any] = None,
+    completed_at: Optional[str] = None,
+    error: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> None:
+    """Fire-and-forget Slack Block Kit dispatch for a finished sim.
+
+    Same contract as :func:`discord_notify.notify_if_configured`. No-op
+    when ``SLACK_WEBHOOK_URL`` is unset or when this
+    ``(sim_id, status)`` already fired in this process.
+    """
+    if status not in {"completed", "failed"}:
+        return
+
+    url = _resolve_webhook_url()
+    if not url:
+        return
+
+    if not _mark_fired(simulation_id, status):
+        return
+
+    from . import webhook_service
+
+    if sim_dir is None:
+        try:
+            from ..config import Config
+            sim_dir = os.path.join(
+                Config.WONDERWALL_SIMULATION_DATA_DIR,
+                simulation_id,
+            )
+        except Exception:
+            sim_dir = simulation_id
+
+    if base_url is None:
+        base_url = webhook_service._resolve_base_url()
+
+    try:
+        payload = webhook_service.build_payload(
+            simulation_id,
+            status,
+            sim_dir,
+            state=state,
+            base_url=base_url,
+            completed_at=completed_at,
+            error=error,
+        )
+    except Exception as exc:
+        logger.warning(f"Slack notify: build_payload failed for {simulation_id}: {exc}")
+        return
+
+    try:
+        message = build_slack_message(payload)
+    except Exception as exc:
+        logger.warning(f"Slack notify: message build failed for {simulation_id}: {exc}")
+        return
+
+    _start_dispatch_thread(
+        url=url,
+        message=message,
+        thread_name=f"slack-notify-{simulation_id}",
+    )
+
+
+def send_test_notification(url: Optional[str] = None) -> Dict[str, Any]:
+    """Synchronously POST a sample Block Kit message.
+
+    Used by the Settings ``Send test event`` flow.
+    """
+    target = (url or _resolve_webhook_url()).strip()
+    if not target:
+        return {"ok": False, "message": "Slack webhook URL is empty"}
+
+    sample_payload = {
+        "event": "simulation.test",
+        "sim_id": "sim_test_event",
+        "scenario": "Test event from MiroShark — your Slack webhook is configured.",
+        "status": "test",
+        "current_round": 0,
+        "total_rounds": 0,
+        "agent_count": 0,
+        "quality_health": None,
+        "final_consensus": None,
+        "resolution_outcome": None,
+        "share_path": "/share/sim_test_event",
+        "share_card_path": "/api/simulation/sim_test_event/share-card.png",
+        "fired_at": None,
+    }
+    message = build_slack_message(sample_payload)
+    ok, msg = send_slack_payload(target, message)
+    return {"ok": ok, "message": msg}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1983,6 +1983,61 @@ paths:
             text/plain:
               schema: { type: string }
 
+  /api/config/notifications:
+    get:
+      tags: [Settings & Push]
+      summary: Public notification-channel config probe for the SPA.
+      description: |
+        Exposes which notification channels are wired up on this
+        deployment without revealing the underlying URLs (the
+        webhooks usually carry an opaque secret in the path). Three
+        independent booleans, one per channel:
+
+          * `webhook_configured`  — generic `WEBHOOK_URL` is set.
+          * `discord_configured`  — `DISCORD_WEBHOOK_URL` is set.
+          * `slack_configured`    — `SLACK_WEBHOOK_URL` is set.
+
+        Mirrors the existing `GET /api/config/sitemap` posture — a
+        small public envelope the `EmbedDialog` consumes on mount to
+        render the right status chips beside the share-and-embed
+        surfaces. `Cache-Control: no-store` so a Settings-modal save
+        is reflected on the next dialog open.
+      responses:
+        "200":
+          description: Notification-channel config envelope.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, data]
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    required: [webhook_configured, discord_configured, slack_configured]
+                    properties:
+                      webhook_configured:
+                        type: boolean
+                        description: |
+                          `WEBHOOK_URL` is set and non-empty. The generic
+                          JSON-blob webhook covers Zapier / Make / n8n /
+                          IFTTT / any custom listener.
+                      discord_configured:
+                        type: boolean
+                        description: |
+                          `DISCORD_WEBHOOK_URL` is set. When `true`,
+                          MiroShark POSTs a Discord-native rich embed
+                          (consensus-coloured border, scenario title,
+                          belief percentage fields, share-card thumbnail,
+                          link) on every terminal-state transition.
+                      slack_configured:
+                        type: boolean
+                        description: |
+                          `SLACK_WEBHOOK_URL` is set. When `true`,
+                          MiroShark POSTs a Slack Block Kit message
+                          (header + context + section fields + actions
+                          button) on every terminal-state transition.
+
   /api/config/sitemap:
     get:
       tags: [Discovery]

--- a/backend/tests/test_unit_discord_notify.py
+++ b/backend/tests/test_unit_discord_notify.py
@@ -1,0 +1,368 @@
+"""Unit tests for the Discord rich-embed notifier.
+
+Pure offline — no Flask boot, no real Discord endpoint. The notifier
+is a thin projection over :func:`webhook_service.build_payload`, so
+the tests cover:
+
+  1. Module constants (colours, env var name, title cap) stay pinned
+     so a refactor doesn't silently drift the public contract.
+  2. ``_consensus_color`` picks the right colour for bullish / neutral
+     / bearish / failed / empty-trajectory payloads.
+  3. ``build_discord_embed`` produces a well-formed embed dict with
+     the expected fields, title truncation, thumbnail URL, and link.
+  4. ``notify_if_configured`` no-ops when ``DISCORD_WEBHOOK_URL`` is
+     unset and POSTs exactly once per ``(sim_id, status)`` pair when
+     set.
+  5. ``send_test_notification`` returns ``ok=False`` for an unset env
+     var and constructs a valid Block-Kit-shaped body otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+from app.services import discord_notify  # noqa: E402
+
+
+# ── Module-level invariants ────────────────────────────────────────────
+
+
+def test_env_var_name_pinned():
+    """The env var name is part of the public contract — operators
+    paste it into ``.env`` files and CI secrets; a rename breaks
+    every deployment."""
+    assert discord_notify.DISCORD_WEBHOOK_URL_ENV_VAR == "DISCORD_WEBHOOK_URL"
+
+
+def test_color_constants_match_spa():
+    """Embed colours match the green/grey/red palette the SPA uses
+    so the Discord card reads as the same colour system."""
+    assert discord_notify.COLOR_BULLISH == 0x22C55E
+    assert discord_notify.COLOR_NEUTRAL == 0x6B7280
+    assert discord_notify.COLOR_BEARISH == 0xEF4444
+    assert discord_notify.COLOR_FAILED == 0xF59E0B
+
+
+def test_title_max_chars_clamped_under_discord_limit():
+    """Discord caps embed titles at 256; we clamp lower so the
+    truncation reads cleanly with the trailing ``…`` glyph."""
+    assert 0 < discord_notify.DISCORD_TITLE_MAX_CHARS <= 256
+
+
+# ── Consensus-colour helper ────────────────────────────────────────────
+
+
+def _payload(**overrides):
+    base = {
+        "event": "simulation.completed",
+        "sim_id": "sim_x",
+        "scenario": "Will the SEC approve XYZ?",
+        "status": "completed",
+        "current_round": 20,
+        "total_rounds": 20,
+        "agent_count": 248,
+        "quality_health": "Excellent",
+        "final_consensus": {"bullish": 60.0, "neutral": 20.0, "bearish": 20.0},
+        "resolution_outcome": None,
+        "share_path": "/share/sim_x",
+        "share_card_path": "/api/simulation/sim_x/share-card.png",
+        "share_url": "https://miroshark.app/share/sim_x",
+        "share_card_url": "https://miroshark.app/api/simulation/sim_x/share-card.png",
+        "fired_at": "2026-05-15T12:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_consensus_color_bullish():
+    assert discord_notify._consensus_color(_payload()) == discord_notify.COLOR_BULLISH
+
+
+def test_consensus_color_bearish():
+    payload = _payload(final_consensus={"bullish": 10.0, "neutral": 20.0, "bearish": 70.0})
+    assert discord_notify._consensus_color(payload) == discord_notify.COLOR_BEARISH
+
+
+def test_consensus_color_neutral_when_neutral_wins():
+    payload = _payload(final_consensus={"bullish": 20.0, "neutral": 60.0, "bearish": 20.0})
+    assert discord_notify._consensus_color(payload) == discord_notify.COLOR_NEUTRAL
+
+
+def test_consensus_color_neutral_when_trajectory_missing():
+    payload = _payload(final_consensus=None)
+    assert discord_notify._consensus_color(payload) == discord_notify.COLOR_NEUTRAL
+
+
+def test_consensus_color_failed_is_amber_regardless_of_trajectory():
+    payload = _payload(status="failed")
+    assert discord_notify._consensus_color(payload) == discord_notify.COLOR_FAILED
+
+
+# ── Embed builder ──────────────────────────────────────────────────────
+
+
+def test_build_discord_embed_basic_shape():
+    embed = discord_notify.build_discord_embed(_payload())
+    assert embed["type"] == "rich"
+    assert embed["title"] == "Will the SEC approve XYZ?"
+    assert embed["color"] == discord_notify.COLOR_BULLISH
+    assert embed["url"] == "https://miroshark.app/share/sim_x"
+    assert embed["thumbnail"] == {
+        "url": "https://miroshark.app/api/simulation/sim_x/share-card.png"
+    }
+    assert embed["footer"] == {"text": "MiroShark"}
+    assert embed["timestamp"] == "2026-05-15T12:00:00+00:00"
+
+
+def test_build_discord_embed_includes_belief_fields():
+    embed = discord_notify.build_discord_embed(_payload())
+    field_names = [f["name"] for f in embed["fields"]]
+    assert "Bullish" in field_names
+    assert "Neutral" in field_names
+    assert "Bearish" in field_names
+    # Inline by default so Discord renders them in one row.
+    for f in embed["fields"]:
+        if f["name"] in ("Bullish", "Neutral", "Bearish"):
+            assert f["inline"] is True
+
+
+def test_build_discord_embed_truncates_long_scenario():
+    long_scenario = "x" * 250
+    embed = discord_notify.build_discord_embed(_payload(scenario=long_scenario))
+    assert len(embed["title"]) <= discord_notify.DISCORD_TITLE_MAX_CHARS
+    assert embed["title"].endswith("…")
+
+
+def test_build_discord_embed_falls_back_when_scenario_empty():
+    embed = discord_notify.build_discord_embed(_payload(scenario=""))
+    assert embed["title"] == "Simulation sim_x"
+
+
+def test_build_discord_embed_drops_thumbnail_for_relative_url():
+    payload = _payload(share_card_url=None)
+    embed = discord_notify.build_discord_embed(payload)
+    assert "thumbnail" not in embed
+
+
+def test_build_discord_embed_uses_share_path_when_no_absolute_url():
+    payload = _payload(share_url=None)
+    embed = discord_notify.build_discord_embed(payload)
+    # No absolute URL ⇒ embed has no ``url`` key (relative paths
+    # would not render as a clickable card title in Discord).
+    assert "url" not in embed
+
+
+def test_build_discord_embed_failed_status_carries_error_field():
+    payload = _payload(
+        status="failed",
+        error="Process exit code 1: simulation segfault",
+        final_consensus=None,
+    )
+    embed = discord_notify.build_discord_embed(payload)
+    assert embed["color"] == discord_notify.COLOR_FAILED
+    error_field = next((f for f in embed["fields"] if f["name"] == "Error"), None)
+    assert error_field is not None
+    assert "segfault" in error_field["value"]
+
+
+def test_build_discord_embed_includes_quality_rounds_agents():
+    embed = discord_notify.build_discord_embed(_payload())
+    field_map = {f["name"]: f["value"] for f in embed["fields"]}
+    assert field_map.get("Quality") == "Excellent"
+    assert field_map.get("Rounds") == "20"
+    assert field_map.get("Agents") == "248"
+
+
+# ── notify_if_configured behaviour ─────────────────────────────────────
+
+
+def test_notify_if_configured_noop_when_env_unset(monkeypatch):
+    monkeypatch.delenv(discord_notify.DISCORD_WEBHOOK_URL_ENV_VAR, raising=False)
+    discord_notify.reset_dedup_for_tests()
+
+    with patch.object(discord_notify, "_start_dispatch_thread") as start:
+        discord_notify.notify_if_configured(
+            "sim_unset",
+            "completed",
+            sim_dir="/nonexistent",
+        )
+        assert start.call_count == 0
+
+
+def test_notify_if_configured_ignores_unknown_status(monkeypatch):
+    monkeypatch.setenv(
+        discord_notify.DISCORD_WEBHOOK_URL_ENV_VAR,
+        "https://discord.example/webhook",
+    )
+    discord_notify.reset_dedup_for_tests()
+
+    with patch.object(discord_notify, "_start_dispatch_thread") as start:
+        discord_notify.notify_if_configured(
+            "sim_running",
+            "running",  # not a terminal status
+            sim_dir="/nonexistent",
+        )
+        assert start.call_count == 0
+
+
+def test_notify_if_configured_fires_once_per_sim_status_pair(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        discord_notify.DISCORD_WEBHOOK_URL_ENV_VAR,
+        "https://discord.example/webhook",
+    )
+    discord_notify.reset_dedup_for_tests()
+
+    sim_dir = tmp_path / "sim_dedup"
+    sim_dir.mkdir()
+
+    captured: list[dict] = []
+
+    def fake_start(*, url, embed, thread_name):
+        captured.append({"url": url, "embed": embed, "thread_name": thread_name})
+
+    with patch.object(discord_notify, "_start_dispatch_thread", side_effect=fake_start):
+        discord_notify.notify_if_configured(
+            "sim_dedup",
+            "completed",
+            sim_dir=str(sim_dir),
+            completed_at="2026-05-15T13:00:00",
+        )
+        discord_notify.notify_if_configured(
+            "sim_dedup",
+            "completed",
+            sim_dir=str(sim_dir),
+            completed_at="2026-05-15T13:00:01",
+        )
+
+    assert len(captured) == 1
+    assert captured[0]["url"] == "https://discord.example/webhook"
+    assert captured[0]["embed"]["type"] == "rich"
+
+
+def test_notify_if_configured_completed_and_failed_dispatched_independently(monkeypatch, tmp_path):
+    """Same ``sim_id`` with two distinct statuses (which only happens
+    in pathological setups, but the dedup keys on the *pair*) fires
+    twice — once per status."""
+    monkeypatch.setenv(
+        discord_notify.DISCORD_WEBHOOK_URL_ENV_VAR,
+        "https://discord.example/webhook",
+    )
+    discord_notify.reset_dedup_for_tests()
+
+    sim_dir = tmp_path / "sim_paths"
+    sim_dir.mkdir()
+
+    with patch.object(discord_notify, "_start_dispatch_thread") as start:
+        discord_notify.notify_if_configured(
+            "sim_paths",
+            "completed",
+            sim_dir=str(sim_dir),
+        )
+        discord_notify.notify_if_configured(
+            "sim_paths",
+            "failed",
+            sim_dir=str(sim_dir),
+            error="late failure",
+        )
+    assert start.call_count == 2
+
+
+def test_dispatch_thread_calls_send_discord_payload(monkeypatch):
+    """The daemon-thread path POSTs the embed via
+    :func:`send_discord_payload`. We verify the wiring by spying on
+    the post and joining the thread."""
+    embed = {"type": "rich", "title": "smoke test"}
+
+    sent: list[tuple] = []
+
+    def fake_post(url, body, timeout):
+        sent.append((url, body, timeout))
+        return True, "HTTP 204"
+
+    with patch.object(discord_notify, "_post_json", side_effect=fake_post):
+        discord_notify._start_dispatch_thread(
+            url="https://discord.example/webhook",
+            embed=embed,
+            thread_name="discord-smoke",
+        )
+
+        # The daemon thread runs ~instantly for an in-process fake.
+        deadline = time.time() + 2.0
+        while not sent and time.time() < deadline:
+            time.sleep(0.01)
+
+    assert len(sent) == 1
+    url, body, timeout = sent[0]
+    assert url == "https://discord.example/webhook"
+    assert body == {"embeds": [embed]}
+    assert timeout == discord_notify.DISCORD_TIMEOUT_SECONDS
+
+
+def test_post_json_never_raises_on_url_error():
+    """The post helper swallows URL errors and returns ``(False, msg)``
+    so the caller never has to wrap it in try/except."""
+    import urllib.error
+
+    def boom(*_args, **_kwargs):
+        raise urllib.error.URLError("connection refused")
+
+    with patch.object(discord_notify.urllib.request, "urlopen", side_effect=boom):
+        ok, msg = discord_notify._post_json(
+            "https://discord.example/webhook",
+            {"embeds": []},
+            timeout=1.0,
+        )
+    assert ok is False
+    assert "URL error" in msg
+
+
+# ── Test event ─────────────────────────────────────────────────────────
+
+
+def test_send_test_notification_rejects_blank(monkeypatch):
+    monkeypatch.delenv(discord_notify.DISCORD_WEBHOOK_URL_ENV_VAR, raising=False)
+    result = discord_notify.send_test_notification("")
+    assert result == {"ok": False, "message": "Discord webhook URL is empty"}
+
+
+def test_send_test_notification_posts_when_url_given():
+    with patch.object(
+        discord_notify,
+        "_post_json",
+        return_value=(True, "HTTP 204"),
+    ) as mock_post:
+        result = discord_notify.send_test_notification(
+            "https://discord.example/webhook"
+        )
+    assert result == {"ok": True, "message": "HTTP 204"}
+    assert mock_post.called
+    _, args, _ = mock_post.mock_calls[0]
+    url, body, timeout = args
+    assert url == "https://discord.example/webhook"
+    assert "embeds" in body
+    assert isinstance(body["embeds"], list)
+    assert len(body["embeds"]) == 1
+
+
+# ── Module discoverability ─────────────────────────────────────────────
+
+
+def test_notify_function_is_exported():
+    """The runner imports ``notify_if_configured`` by name — guard the
+    symbol so a rename doesn't silently break the dispatch site."""
+    assert callable(discord_notify.notify_if_configured)
+    assert callable(discord_notify.is_configured)
+    assert callable(discord_notify.build_discord_embed)

--- a/backend/tests/test_unit_notifications_config.py
+++ b/backend/tests/test_unit_notifications_config.py
@@ -1,0 +1,173 @@
+"""Unit tests for ``GET /api/config/notifications``.
+
+The endpoint is a pure projection over three env vars (or, in the
+case of the generic webhook, the cached ``Config.WEBHOOK_URL``
+attribute). We exercise it via a minimal Flask app that mounts
+*only* the notifications blueprint so the test doesn't need
+``create_app`` (which would boot Neo4j and the simulation runner —
+both unavailable in the unit environment).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+def _make_app():
+    """Standalone Flask app that only knows about ``notifications_bp``.
+
+    Mirrors the helper pattern in ``test_unit_admin_auth.py`` —
+    mounting the blueprint on a throwaway app exercises the same
+    code path with zero infra.
+    """
+    from flask import Flask
+    from app.api.notifications import notifications_bp
+
+    app = Flask(__name__)
+    app.register_blueprint(notifications_bp)
+    return app
+
+
+@pytest.fixture
+def client():
+    app = _make_app()
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _payload(client):
+    resp = client.get("/api/config/notifications")
+    assert resp.status_code == 200, resp.data
+    body = resp.get_json()
+    assert body["success"] is True
+    return body["data"]
+
+
+def test_notifications_config_all_unset(monkeypatch, client):
+    monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    from app.config import Config
+    monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
+
+    data = _payload(client)
+    assert data == {
+        "webhook_configured": False,
+        "discord_configured": False,
+        "slack_configured": False,
+    }
+
+
+def test_notifications_config_discord_only(monkeypatch, client):
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.example/webhook")
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    from app.config import Config
+    monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
+
+    data = _payload(client)
+    assert data == {
+        "webhook_configured": False,
+        "discord_configured": True,
+        "slack_configured": False,
+    }
+
+
+def test_notifications_config_slack_only(monkeypatch, client):
+    monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+    monkeypatch.setenv(
+        "SLACK_WEBHOOK_URL",
+        "https://hooks.slack.com/services/T0/B0/abc",
+    )
+    from app.config import Config
+    monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
+
+    data = _payload(client)
+    assert data == {
+        "webhook_configured": False,
+        "discord_configured": False,
+        "slack_configured": True,
+    }
+
+
+def test_notifications_config_all_three_configured(monkeypatch, client):
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.example/webhook")
+    monkeypatch.setenv(
+        "SLACK_WEBHOOK_URL",
+        "https://hooks.slack.com/services/T0/B0/abc",
+    )
+    from app.config import Config
+    monkeypatch.setattr(Config, "WEBHOOK_URL", "https://example.com/hook", raising=False)
+
+    data = _payload(client)
+    assert data == {
+        "webhook_configured": True,
+        "discord_configured": True,
+        "slack_configured": True,
+    }
+
+
+def test_notifications_config_blank_env_var_treated_as_unset(monkeypatch, client):
+    """Operators sometimes leave an empty assignment in ``.env``
+    (``DISCORD_WEBHOOK_URL=``) — that must read as unset, not as a
+    malformed configured channel."""
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "   ")
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "")
+    from app.config import Config
+    monkeypatch.setattr(Config, "WEBHOOK_URL", "  ", raising=False)
+
+    data = _payload(client)
+    assert data == {
+        "webhook_configured": False,
+        "discord_configured": False,
+        "slack_configured": False,
+    }
+
+
+def test_notifications_config_no_store_cache_header(monkeypatch, client):
+    """A Settings-modal save flips the booleans the moment it lands;
+    a cache header would leave stale chips in the dialog until a hard
+    reload."""
+    monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    from app.config import Config
+    monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
+
+    resp = client.get("/api/config/notifications")
+    assert resp.status_code == 200
+    cache_control = resp.headers.get("Cache-Control", "")
+    assert "no-store" in cache_control
+
+
+# ── Wiring guards ──────────────────────────────────────────────────────
+
+
+def test_notifications_route_decorator_present():
+    """Drift guard — the route decorator must stay on the
+    notifications blueprint so the URL keeps resolving."""
+    api_path = _BACKEND / "app" / "api" / "notifications.py"
+    text = api_path.read_text(encoding="utf-8")
+    assert '@notifications_bp.route("/api/config/notifications"' in text
+    assert "def notifications_config(" in text
+
+
+def test_app_factory_registers_notifications_blueprint():
+    """The factory must mount the blueprint — catches the failure
+    mode where the file exists but never got registered."""
+    init_path = _BACKEND / "app" / "__init__.py"
+    text = init_path.read_text(encoding="utf-8")
+    assert "notifications_bp" in text
+    assert "app.register_blueprint(notifications_bp)" in text
+
+
+def test_blueprint_module_exports_notifications_bp():
+    api_init = _BACKEND / "app" / "api" / "__init__.py"
+    text = api_init.read_text(encoding="utf-8")
+    assert "from .notifications import notifications_bp" in text

--- a/backend/tests/test_unit_openapi.py
+++ b/backend/tests/test_unit_openapi.py
@@ -110,6 +110,7 @@ _BLUEPRINT_PREFIXES = {
     # find them where they expect; /api/config/sitemap exposes the
     # ENABLE_SITEMAP flag to the SPA — see app/api/sitemap.py.
     "sitemap_bp":        "",
+    "notifications_bp":  "",
 }
 
 

--- a/backend/tests/test_unit_slack_notify.py
+++ b/backend/tests/test_unit_slack_notify.py
@@ -1,0 +1,327 @@
+"""Unit tests for the Slack Block Kit notifier.
+
+Pure offline — no Flask boot, no real Slack endpoint. The tests
+cover the same shape as ``test_unit_discord_notify.py``:
+
+  1. Module constants stay pinned.
+  2. ``belief_bar`` renders a width-controlled Unicode block bar with
+     a trailing percentage label, clamps out-of-range inputs.
+  3. ``build_slack_message`` produces a well-formed Block Kit body
+     with header / context / section / actions blocks, honours the
+     scenario truncation, and degrades cleanly when fields are missing.
+  4. ``notify_if_configured`` no-ops without ``SLACK_WEBHOOK_URL`` and
+     fires once per ``(sim_id, status)`` pair when set.
+  5. ``send_test_notification`` rejects a blank URL and POSTs a
+     ``{blocks: [...]}`` body otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+from app.services import slack_notify  # noqa: E402
+
+
+# ── Module-level invariants ────────────────────────────────────────────
+
+
+def test_env_var_name_pinned():
+    assert slack_notify.SLACK_WEBHOOK_URL_ENV_VAR == "SLACK_WEBHOOK_URL"
+
+
+def test_bar_width_pinned():
+    """A change to the bar width changes how the message renders on
+    every Slack client — pin it so a casual refactor doesn't drift
+    the look."""
+    assert slack_notify.BAR_WIDTH == 10
+    assert slack_notify.BAR_FILLED == "█"
+    assert slack_notify.BAR_EMPTY == "░"
+
+
+def test_header_max_chars_under_slack_limit():
+    """Slack caps header blocks at 150 chars."""
+    assert 0 < slack_notify.SLACK_HEADER_MAX_CHARS <= 150
+
+
+# ── belief_bar ─────────────────────────────────────────────────────────
+
+
+def test_belief_bar_zero():
+    bar = slack_notify.belief_bar(0)
+    assert bar == "░" * 10 + " 0.0%"
+
+
+def test_belief_bar_full():
+    bar = slack_notify.belief_bar(100)
+    assert bar == "█" * 10 + " 100.0%"
+
+
+def test_belief_bar_half():
+    bar = slack_notify.belief_bar(50)
+    assert bar == "█" * 5 + "░" * 5 + " 50.0%"
+
+
+def test_belief_bar_decimal():
+    bar = slack_notify.belief_bar(62.5)
+    # 6 filled blocks rounds the 6.25 share up; the label preserves
+    # the original decimal so the operator can still read the source
+    # number.
+    assert bar.endswith(" 62.5%")
+    assert bar.startswith("█")
+
+
+def test_belief_bar_clamps_negative_and_overflow():
+    assert slack_notify.belief_bar(-30).startswith("░")
+    assert slack_notify.belief_bar(150).endswith(" 100.0%")
+
+
+def test_belief_bar_handles_non_numeric_input():
+    """A ``None`` from a missing trajectory snapshot should degrade
+    into a zero-filled bar, not crash."""
+    bar = slack_notify.belief_bar(None)
+    assert "0.0%" in bar
+
+
+# ── Block Kit builder ──────────────────────────────────────────────────
+
+
+def _payload(**overrides):
+    base = {
+        "event": "simulation.completed",
+        "sim_id": "sim_x",
+        "scenario": "Will the SEC approve XYZ?",
+        "status": "completed",
+        "current_round": 20,
+        "total_rounds": 20,
+        "agent_count": 248,
+        "quality_health": "Excellent",
+        "final_consensus": {"bullish": 60.0, "neutral": 20.0, "bearish": 20.0},
+        "resolution_outcome": None,
+        "share_path": "/share/sim_x",
+        "share_card_path": "/api/simulation/sim_x/share-card.png",
+        "share_url": "https://miroshark.app/share/sim_x",
+        "share_card_url": "https://miroshark.app/api/simulation/sim_x/share-card.png",
+        "fired_at": "2026-05-15T12:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_build_slack_message_has_header_block():
+    msg = slack_notify.build_slack_message(_payload())
+    assert msg["blocks"][0]["type"] == "header"
+    assert msg["blocks"][0]["text"]["text"] == "Will the SEC approve XYZ?"
+
+
+def test_build_slack_message_context_carries_status():
+    msg = slack_notify.build_slack_message(_payload())
+    ctx = msg["blocks"][1]
+    assert ctx["type"] == "context"
+    text = ctx["elements"][0]["text"]
+    assert "*Completed*" in text
+    assert "sim_x" in text
+
+
+def test_build_slack_message_belief_bars_in_section_fields():
+    msg = slack_notify.build_slack_message(_payload())
+    section = next(b for b in msg["blocks"] if b.get("type") == "section")
+    field_texts = [f["text"] for f in section["fields"]]
+    joined = "\n".join(field_texts)
+    assert "*Bullish*" in joined
+    assert "*Neutral*" in joined
+    assert "*Bearish*" in joined
+    # Unicode block bar must be rendered inside the section fields.
+    assert "█" in joined or "░" in joined
+
+
+def test_build_slack_message_skips_belief_section_when_consensus_missing():
+    msg = slack_notify.build_slack_message(_payload(final_consensus=None))
+    # The section block should still exist (quality, scale fields),
+    # but its text should not include bullish/neutral/bearish.
+    section_fields_text = ""
+    for b in msg["blocks"]:
+        if b.get("type") == "section" and "fields" in b:
+            section_fields_text += "\n".join(f["text"] for f in b["fields"])
+    assert "*Bullish*" not in section_fields_text
+
+
+def test_build_slack_message_action_button_uses_absolute_share_url():
+    msg = slack_notify.build_slack_message(_payload())
+    actions = next((b for b in msg["blocks"] if b.get("type") == "actions"), None)
+    assert actions is not None
+    btn = actions["elements"][0]
+    assert btn["type"] == "button"
+    assert btn["url"] == "https://miroshark.app/share/sim_x"
+
+
+def test_build_slack_message_drops_action_button_for_relative_path_only():
+    msg = slack_notify.build_slack_message(_payload(share_url=None))
+    actions = next((b for b in msg["blocks"] if b.get("type") == "actions"), None)
+    # Slack rejects buttons whose URL isn't http(s):// — better to
+    # omit the action block than ship an invalid one.
+    assert actions is None
+
+
+def test_build_slack_message_truncates_long_scenario():
+    msg = slack_notify.build_slack_message(_payload(scenario="x" * 250))
+    header = msg["blocks"][0]["text"]["text"]
+    assert len(header) <= slack_notify.SLACK_HEADER_MAX_CHARS
+    assert header.endswith("…")
+
+
+def test_build_slack_message_failed_status_includes_error_block():
+    msg = slack_notify.build_slack_message(
+        _payload(
+            status="failed",
+            error="Process exit code 1: simulation segfault",
+            final_consensus=None,
+        )
+    )
+    error_sections = [
+        b for b in msg["blocks"]
+        if b.get("type") == "section"
+        and "text" in b
+        and "Error" in b.get("text", {}).get("text", "")
+    ]
+    assert len(error_sections) == 1
+    assert "segfault" in error_sections[0]["text"]["text"]
+
+
+def test_build_slack_message_falls_back_when_scenario_empty():
+    msg = slack_notify.build_slack_message(_payload(scenario=""))
+    assert msg["blocks"][0]["text"]["text"] == "Simulation sim_x"
+
+
+# ── notify_if_configured behaviour ─────────────────────────────────────
+
+
+def test_notify_if_configured_noop_when_env_unset(monkeypatch):
+    monkeypatch.delenv(slack_notify.SLACK_WEBHOOK_URL_ENV_VAR, raising=False)
+    slack_notify.reset_dedup_for_tests()
+    with patch.object(slack_notify, "_start_dispatch_thread") as start:
+        slack_notify.notify_if_configured(
+            "sim_unset", "completed", sim_dir="/nonexistent"
+        )
+    assert start.call_count == 0
+
+
+def test_notify_if_configured_ignores_unknown_status(monkeypatch):
+    monkeypatch.setenv(
+        slack_notify.SLACK_WEBHOOK_URL_ENV_VAR,
+        "https://hooks.slack.com/services/T0/B0/abc",
+    )
+    slack_notify.reset_dedup_for_tests()
+    with patch.object(slack_notify, "_start_dispatch_thread") as start:
+        slack_notify.notify_if_configured(
+            "sim_running", "running", sim_dir="/nonexistent"
+        )
+    assert start.call_count == 0
+
+
+def test_notify_if_configured_fires_once_per_sim_status_pair(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        slack_notify.SLACK_WEBHOOK_URL_ENV_VAR,
+        "https://hooks.slack.com/services/T0/B0/abc",
+    )
+    slack_notify.reset_dedup_for_tests()
+
+    sim_dir = tmp_path / "sim_dedup_slack"
+    sim_dir.mkdir()
+
+    captured: list[dict] = []
+
+    def fake_start(*, url, message, thread_name):
+        captured.append({"url": url, "message": message, "thread_name": thread_name})
+
+    with patch.object(slack_notify, "_start_dispatch_thread", side_effect=fake_start):
+        slack_notify.notify_if_configured("sim_dedup_slack", "completed", sim_dir=str(sim_dir))
+        slack_notify.notify_if_configured("sim_dedup_slack", "completed", sim_dir=str(sim_dir))
+    assert len(captured) == 1
+    assert "blocks" in captured[0]["message"]
+
+
+def test_dispatch_thread_posts_blocks_body():
+    sent: list[tuple] = []
+
+    def fake_post(url, body, timeout):
+        sent.append((url, body, timeout))
+        return True, "HTTP 200"
+
+    message = {"blocks": [{"type": "header", "text": {"type": "plain_text", "text": "x"}}]}
+
+    with patch.object(slack_notify, "_post_json", side_effect=fake_post):
+        slack_notify._start_dispatch_thread(
+            url="https://hooks.slack.com/services/T0/B0/abc",
+            message=message,
+            thread_name="slack-smoke",
+        )
+
+        deadline = time.time() + 2.0
+        while not sent and time.time() < deadline:
+            time.sleep(0.01)
+
+    assert len(sent) == 1
+    url, body, timeout = sent[0]
+    assert url == "https://hooks.slack.com/services/T0/B0/abc"
+    assert body == message
+    assert timeout == slack_notify.SLACK_TIMEOUT_SECONDS
+
+
+def test_post_json_swallows_url_error():
+    import urllib.error
+
+    def boom(*_a, **_kw):
+        raise urllib.error.URLError("dns failed")
+
+    with patch.object(slack_notify.urllib.request, "urlopen", side_effect=boom):
+        ok, msg = slack_notify._post_json(
+            "https://hooks.slack.com/services/T0/B0/abc",
+            {"blocks": []},
+            timeout=1.0,
+        )
+    assert ok is False
+    assert "URL error" in msg
+
+
+# ── Test event ─────────────────────────────────────────────────────────
+
+
+def test_send_test_notification_rejects_blank(monkeypatch):
+    monkeypatch.delenv(slack_notify.SLACK_WEBHOOK_URL_ENV_VAR, raising=False)
+    result = slack_notify.send_test_notification("")
+    assert result == {"ok": False, "message": "Slack webhook URL is empty"}
+
+
+def test_send_test_notification_posts_when_url_given():
+    with patch.object(
+        slack_notify, "_post_json", return_value=(True, "HTTP 200")
+    ) as mock_post:
+        result = slack_notify.send_test_notification(
+            "https://hooks.slack.com/services/T0/B0/abc"
+        )
+    assert result == {"ok": True, "message": "HTTP 200"}
+    assert mock_post.called
+    _, args, _ = mock_post.mock_calls[0]
+    url, body, _timeout = args
+    assert url.startswith("https://hooks.slack.com/")
+    assert "blocks" in body
+
+
+# ── Module discoverability ─────────────────────────────────────────────
+
+
+def test_notify_function_is_exported():
+    assert callable(slack_notify.notify_if_configured)
+    assert callable(slack_notify.is_configured)
+    assert callable(slack_notify.build_slack_message)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -421,6 +421,15 @@ When `WEBHOOK_SECRET` is set, every outbound webhook payload is HMAC-signed and 
 
 Implementation: `compute_signature(payload_bytes, secret=None)` reads `WEBHOOK_SECRET` at call time (so a Settings change or env mutation takes effect immediately), returns `"sha256=" + hmac.sha256(secret, body).hexdigest()` or `None` when blank. `_post_json` injects the header only when `compute_signature` returns non-None — auto-fire, retry, and the `Send test event` button all share the same dispatch path, so all three paths sign consistently. Zero new dependencies (pure stdlib `hmac` + `hashlib`).
 
+## Channel-Native Completion Notifications (Discord + Slack)
+
+The generic webhook (`WEBHOOK_URL`) posts a raw JSON blob — perfect for Zapier / Make / n8n, but Discord renders nothing from JSON and Slack inlines it as an ugly code block. Two channel-native paths land formatted cards in the platform's own format:
+
+- **Discord rich embed** — set `DISCORD_WEBHOOK_URL` (Discord → Server Settings → Integrations → Webhooks). MiroShark POSTs a Discord embed with: scenario title, consensus-coloured border (`#22c55e` bullish / `#6b7280` neutral / `#ef4444` bearish / `#f59e0b` failed), Bullish / Neutral / Bearish / Quality / Rounds / Agents fields, share-card thumbnail, and a clickable share-page link. Failure runs append the truncated exit-code message as an `Error` field.
+- **Slack Block Kit** — set `SLACK_WEBHOOK_URL` (api.slack.com/apps → Incoming Webhooks). MiroShark POSTs a Block Kit message with: scenario header, status-verb context line, `mrkdwn` belief bars (`█████░░░░░ 52.0%`), Quality / Scale / Resolution fields, and a "View simulation" action button. Failure runs append a fenced-code error section.
+
+Channels are independent. Set one, two, or all three — each fires on every `simulation.completed` / `simulation.failed` event, deduped per `(sim_id, status)` so the runner's two terminal code paths never produce duplicate cards. The SPA exposes `GET /api/config/notifications` returning `{webhook_configured, discord_configured, slack_configured}` so the EmbedDialog can render live status chips beside the share-and-embed surfaces. Pure stdlib `urllib.request` — zero new dependencies. Full setup walkthrough in [NOTIFICATIONS.md](NOTIFICATIONS.md).
+
 ## Article Generation
 
 After a simulation finishes, click **Write Article** and MiroShark asks the Smart model to produce a 400–600-word Substack-style write-up grounded in what actually happened — key findings, market dynamics, belief shifts, and implications. The article is cached at `generated_article.json` so it doesn't re-spend tokens on reopen; pass `force_regenerate=true` to refresh.

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -1,0 +1,114 @@
+# Channel Notifications
+
+MiroShark fires a notification the moment a simulation reaches a terminal
+state (`simulation.completed` or `simulation.failed`). Three independent
+channels run in parallel — each opt-in via its own env var:
+
+| Channel  | Env var               | Format             | Use case                                                      |
+| -------- | --------------------- | ------------------ | ------------------------------------------------------------- |
+| Webhook  | `WEBHOOK_URL`         | Raw JSON `POST`    | Zapier / Make / n8n / IFTTT / custom listeners                |
+| Discord  | `DISCORD_WEBHOOK_URL` | Discord rich embed | Discord channels — coloured cards with belief % fields        |
+| Slack    | `SLACK_WEBHOOK_URL`   | Slack Block Kit    | Slack channels — header + block-bar fields + action button    |
+
+Channels are independent. Set one, two, or all three — each fires
+separately. Unset env vars are silently skipped, so existing deployments
+that only use the generic webhook are unaffected by this feature.
+
+The SPA exposes a public probe at `GET /api/config/notifications`
+returning `{webhook_configured, discord_configured, slack_configured}` so
+the operator can confirm channel status without opening the backend
+config.
+
+## Generic webhook (existing, PR #46)
+
+Already documented in [WEBHOOKS.md](./WEBHOOKS.md). Posts a JSON blob
+matching the payload shape in
+[`backend/app/services/webhook_service.py`](../backend/app/services/webhook_service.py).
+
+## Discord rich embed
+
+Set `DISCORD_WEBHOOK_URL` to a Discord incoming webhook URL:
+
+```bash
+# Discord → Server Settings → Integrations → Webhooks → New Webhook
+# Copy the webhook URL ("https://discord.com/api/webhooks/000/xxx").
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/000/xxx
+```
+
+On every terminal-state transition, MiroShark POSTs a single embed:
+
+* **Title** — scenario, truncated to 100 chars.
+* **Description** — one-line status verb ("Simulation reached its
+  terminal round." or "Simulation ended in a failure state.").
+* **Color** — green / grey / red / amber depending on the dominant
+  consensus stance (failed runs always amber).
+* **Fields** — Bullish %, Neutral %, Bearish %, Quality, Rounds,
+  Agents, Resolution (when set).
+* **Thumbnail** — share card PNG (only when `PUBLIC_BASE_URL` is set
+  so the embed can render an absolute URL).
+* **URL** — share page link (`/share/<sim_id>`), absolute when
+  `PUBLIC_BASE_URL` is set.
+* **Footer / timestamp** — "MiroShark" + the dispatch timestamp.
+
+Failed runs append an additional `Error` field with the truncated
+exit-code message.
+
+Discord deduplicates per `(sim_id, status)` pair in the dispatching
+process — the simulation runner's two terminal code paths (exit-code
+monitor + the `simulation_end` event in the action log) both call
+into the notifier but Discord only sees one card per terminal state.
+
+The endpoint is fire-and-forget: a slow Discord endpoint never delays
+the simulation runner, and a 4xx logs a warning without raising.
+
+## Slack Block Kit
+
+Set `SLACK_WEBHOOK_URL` to a Slack Incoming Webhook URL:
+
+```bash
+# api.slack.com/apps → your app → Incoming Webhooks → Add New Webhook to Workspace
+# Copy the webhook URL ("https://hooks.slack.com/services/T0/B0/abc").
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0/B0/abc
+```
+
+On every terminal-state transition, MiroShark POSTs a Block Kit
+message with four blocks:
+
+* **Header** — scenario, truncated to 120 chars.
+* **Context** — bold status verb + monospaced sim id.
+* **Section** — `mrkdwn` fields:
+  * Bullish / Neutral / Bearish with Unicode block-bars
+    (`█████░░░░░ 52.0%`).
+  * Quality health.
+  * Scale (`N agents · N rounds`).
+  * Resolution (when set).
+* **Actions** — a single "View simulation" button linking to
+  `/share/<sim_id>`. Only emitted when `PUBLIC_BASE_URL` is set
+  (Slack rejects buttons whose URL isn't absolute).
+
+Failed runs append an `Error` section with a fenced code block
+containing the truncated exit-code message.
+
+Same dedup posture and fire-and-forget guarantees as Discord.
+
+## Picking the right channel
+
+* **Discord** — community-facing. Use when the audience wants the
+  result *visually*: belief percentages, the share-card thumbnail,
+  a tap-through to the simulation. Best for distribution channels
+  ("here's what just simulated for you").
+* **Slack** — ops-facing. Use when the audience wants the result
+  *operationally*: a quick read of the bars, an explicit action
+  button, the sim id in monospaced font. Best for engineering /
+  research channels.
+* **Generic webhook** — automation-facing. Use when the result
+  needs to land in a workflow tool (Zapier / Make / n8n) that
+  unpacks the JSON itself.
+
+## Sandbox note
+
+Pure stdlib (`urllib.request` + `json` + `os` + `hmac`). No new
+dependencies. The HMAC signing scheme on the generic webhook
+(`X-MiroShark-Signature`, PR #79) applies only to that channel —
+Discord and Slack incoming webhooks use the platforms' own
+URL-as-secret authentication and ignore signature headers.

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -820,6 +820,26 @@ export const getSitemapConfig = () => {
 }
 
 /**
+ * Fetch the notification-channel config — tells the SPA which of the
+ * three terminal-state notification channels (generic webhook, Discord
+ * rich embed, Slack Block Kit) are wired up on this deployment. Only
+ * presence booleans cross the wire; the underlying URLs (which often
+ * carry an opaque secret in the path) stay server-side.
+ *
+ * Response shape (under `data`):
+ *   {
+ *     webhook_configured: boolean,
+ *     discord_configured: boolean,
+ *     slack_configured:   boolean,
+ *   }
+ *
+ * @returns {Promise}
+ */
+export const getNotificationsConfig = () => {
+  return service.get('/api/config/notifications')
+}
+
+/**
  * Branch a simulation with a narrative injection at a specific round.
  * The new simulation is READY and shares the parent's agent population;
  * when the runner hits trigger_round it auto-promotes the injection into

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -1291,6 +1291,70 @@
                 </a>
               </div>
             </div>
+
+            <!-- Terminal-state notification channels. The generic
+                 webhook (PR #46) plus the two channel-native paths
+                 land platform-formatted cards in the operator's
+                 Discord / Slack channel of choice. Status chips render
+                 the live config so an operator can see which of the
+                 three channels are wired up without opening Settings.
+                 The booleans come from /api/config/notifications. -->
+            <div class="feed-callout notifications-callout">
+              <div class="feed-callout-head">
+                <span class="feed-callout-icon">🔔</span>
+                <div class="feed-callout-body">
+                  <div class="feed-callout-title">
+                    {{ $tr('Channel notifications on completion', '完成时的频道通知') }}
+                  </div>
+                  <div class="feed-callout-desc">
+                    {{ $tr('MiroShark POSTs a platform-native card to each configured channel the moment a simulation completes or fails — Discord gets a consensus-coloured embed, Slack gets a Block Kit message, the generic webhook gets the raw JSON. Each channel is opt-in via its own env var.', 'MiroShark 在模拟完成或失败时,会向每个已配置渠道推送对应平台原生的卡片 — Discord 收到按共识着色的 embed,Slack 收到 Block Kit 消息,通用 Webhook 收到原始 JSON。每个渠道可通过各自的环境变量单独启用。') }}
+                  </div>
+                  <div class="notifications-chips">
+                    <span
+                      class="notifications-chip"
+                      :class="{ 'notifications-chip-on': notifConfig.webhook_configured }"
+                      :title="notifConfig.webhook_configured
+                        ? $tr('Generic JSON webhook is wired up — Zapier / Make / n8n / IFTTT / custom listeners', '通用 JSON Webhook 已接入 — Zapier / Make / n8n / IFTTT / 自定义监听端点')
+                        : $tr('Set WEBHOOK_URL to enable the generic JSON webhook channel', '设置 WEBHOOK_URL 即可启用通用 JSON Webhook 渠道')"
+                    >
+                      <span class="notifications-chip-dot">{{ notifConfig.webhook_configured ? '✓' : '○' }}</span>
+                      Webhook
+                    </span>
+                    <span
+                      class="notifications-chip"
+                      :class="{ 'notifications-chip-on': notifConfig.discord_configured }"
+                      :title="notifConfig.discord_configured
+                        ? $tr('Discord rich embeds are wired up — completed sims land as coloured cards', 'Discord rich embed 已接入 — 模拟完成后会以彩色卡片形式呈现')
+                        : $tr('Set DISCORD_WEBHOOK_URL to enable Discord rich-embed cards', '设置 DISCORD_WEBHOOK_URL 即可启用 Discord rich embed 卡片')"
+                    >
+                      <span class="notifications-chip-dot">{{ notifConfig.discord_configured ? '✓' : '○' }}</span>
+                      Discord
+                    </span>
+                    <span
+                      class="notifications-chip"
+                      :class="{ 'notifications-chip-on': notifConfig.slack_configured }"
+                      :title="notifConfig.slack_configured
+                        ? $tr('Slack Block Kit messages are wired up — completed sims land as channel cards', 'Slack Block Kit 已接入 — 模拟完成后会以频道卡片形式呈现')
+                        : $tr('Set SLACK_WEBHOOK_URL to enable Slack Block Kit messages', '设置 SLACK_WEBHOOK_URL 即可启用 Slack Block Kit 消息')"
+                    >
+                      <span class="notifications-chip-dot">{{ notifConfig.slack_configured ? '✓' : '○' }}</span>
+                      Slack
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div class="feed-callout-actions">
+                <a
+                  class="feed-callout-link feed-callout-link-secondary"
+                  href="https://github.com/aaronjmars/MiroShark/blob/main/docs/NOTIFICATIONS.md"
+                  target="_blank"
+                  rel="noopener"
+                  :title="$tr('Channel setup guide on GitHub', 'GitHub 上的渠道接入指南')"
+                >
+                  {{ $tr('Setup guide ↗', '接入指南 ↗') }}
+                </a>
+              </div>
+            </div>
           </div>
 
           <!-- Hint -->
@@ -1328,6 +1392,7 @@ import {
   getFeedUrl,
   getSitemapUrl,
   getSitemapConfig,
+  getNotificationsConfig,
   getSimulationOutcome,
   submitSimulationOutcome,
   getWebhookLog,
@@ -2022,6 +2087,39 @@ const loadSitemapConfig = async () => {
   }
 }
 
+// Notification-channel config — three booleans tracking the live
+// state of WEBHOOK_URL / DISCORD_WEBHOOK_URL / SLACK_WEBHOOK_URL.
+// The chips render off these booleans so an operator sees at a
+// glance which channels will fire on the next terminal-state event.
+// We default everything to ``false`` (chip = ○) so a fetch failure
+// degrades to "no channels wired up" rather than a misleading green.
+const notifConfig = ref({
+  webhook_configured: false,
+  discord_configured: false,
+  slack_configured: false,
+})
+const notifConfigLoaded = ref(false)
+const loadNotificationsConfig = async () => {
+  if (notifConfigLoaded.value) return
+  try {
+    const res = await getNotificationsConfig()
+    const data = res?.data || {}
+    notifConfig.value = {
+      webhook_configured: !!data.webhook_configured,
+      discord_configured: !!data.discord_configured,
+      slack_configured: !!data.slack_configured,
+    }
+  } catch {
+    notifConfig.value = {
+      webhook_configured: false,
+      discord_configured: false,
+      slack_configured: false,
+    }
+  } finally {
+    notifConfigLoaded.value = true
+  }
+}
+
 const replayLoaded = ref(false)
 const replayPlay = ref(false)
 const onReplayLoad = () => {
@@ -2398,6 +2496,10 @@ watch(() => props.open, async (val) => {
   // but reading on each open keeps the row in sync if an operator
   // toggles ``ENABLE_SITEMAP`` and reloads.
   loadSitemapConfig()
+  // Pull the notification-channel config — cheap (three env reads
+  // server-side, no Neo4j) so reading on each dialog open lets the
+  // chips reflect a Settings save without requiring a hard refresh.
+  loadNotificationsConfig()
   // Bust the share-card image cache so the preview reloads with whatever
   // state the simulation is in right now (resolution may have landed
   // since the dialog was last opened).
@@ -4211,6 +4313,59 @@ watch(isPublic, () => {
   background: var(--color-orange, #ff6b1a);
   color: #fff;
   border-color: var(--color-orange, #ff6b1a);
+}
+
+/* Notifications callout — three status chips track WEBHOOK_URL /
+   DISCORD_WEBHOOK_URL / SLACK_WEBHOOK_URL. Chips are intentionally
+   small and muted; the goal is "at-a-glance" config feedback, not a
+   primary action. The chip palette mirrors the feed-callout link
+   palette so the notifications row blends with the surrounding
+   secondary affordances rather than competing for attention. */
+.notifications-chips {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.notifications-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(10, 10, 10, 0.12);
+  background: #ffffff;
+  color: #6a6a6a;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: help;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.notifications-chip-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  background: rgba(10, 10, 10, 0.08);
+  color: #6a6a6a;
+}
+
+.notifications-chip-on {
+  border-color: rgba(34, 197, 94, 0.5);
+  background: rgba(34, 197, 94, 0.08);
+  color: #1d7a3d;
+}
+
+.notifications-chip-on .notifications-chip-dot {
+  background: #22c55e;
+  color: #ffffff;
 }
 
 .feed-filter-builder {


### PR DESCRIPTION
## What

Two channel-native notification paths fire alongside the generic webhook on every `simulation.completed` / `simulation.failed` event:

- **`DISCORD_WEBHOOK_URL`** → a Discord rich embed with consensus-coloured border, scenario title, Bullish / Neutral / Bearish / Quality / Rounds / Agents / Resolution fields, share-card thumbnail, and a clickable share-page link. Failed runs append a truncated `Error` field.
- **`SLACK_WEBHOOK_URL`** → a Slack Block Kit message with scenario header, status-verb + sim-id context line, `mrkdwn` belief bars (`█████░░░░░ 52.0%`), Quality + Scale + Resolution fields, and a "View simulation" action button. Failed runs append a fenced `Error` section.

Channels are independent and opt-in — unset env vars no-op, existing deployments are unaffected. Per-channel `(sim_id, status)` dedup matches the generic webhook so the runner's two terminal code paths never produce duplicate cards.

## Why

The generic webhook (PR #46) accepts any URL — including Discord and Slack incoming webhooks — but those platforms render nothing useful from a raw JSON blob. Discord shows nothing; Slack inlines the JSON as an ugly code-block dump.

The first third-party MiroShark integration (`@revaultdrops`, 2026-05-13 — "ReVault intelligence layer powered by @miroshark_") runs its operator chatter in a Discord server. This PR turns that server into a live MiroShark distribution channel without requiring the operator to write any integration glue.

Triggered by idea #1 in the 2026-05-14 repo-actions batch ("Discord + Slack Rich Completion Notifications") — the highest-leverage move identified for the integration tier now that the SEO / distribution surface layer is complete (PR #82 sitemap closed the May-12 batch).

## Changes

- **`backend/app/services/discord_notify.py`** — Discord embed builder (consensus colours, fields, thumbnail, link) + dispatch helper (`urllib.request`, fire-and-forget daemon thread, `(sim_id, status)` dedup). Reuses `webhook_service.build_payload` so on-disk artifact reads (`simulation_config.json`, `quality.json`, `trajectory.json`, `state.json`) are not duplicated.
- **`backend/app/services/slack_notify.py`** — Slack Block Kit builder (header + context + section fields + actions) + same dispatch shape. `belief_bar` helper renders Unicode block bars with bounds clamping.
- **`backend/app/api/notifications.py`** — new public probe `GET /api/config/notifications` returning `{webhook_configured, discord_configured, slack_configured}`. Booleans only — URLs never leave the backend. Mirrors the `GET /api/config/sitemap` posture.
- **`backend/app/services/simulation_runner.py`** — three new dispatch sites (completed exit-code path, failed exit-code path, `simulation_end` event in `_read_action_log`) right after each existing webhook dispatch. Each call is fire-and-forget and wrapped in its own try/except so a failure in one channel doesn't block the others.
- **`backend/openapi.yaml`** — new endpoint documented under Settings & Push.
- **`.env.example`** — `DISCORD_WEBHOOK_URL` + `SLACK_WEBHOOK_URL` blocks with setup instructions and Discord / Slack incoming-webhook URL examples.
- **`frontend/src/api/simulation.js`** — `getNotificationsConfig` helper.
- **`frontend/src/components/EmbedDialog.vue`** — new "🔔 Channel notifications on completion" callout with three live status chips (Webhook / Discord / Slack). Each chip shows ✓ / ○ based on the public config probe; tooltips explain how to enable an unconfigured channel.
- **`docs/NOTIFICATIONS.md`** — setup walkthrough, payload shapes, channel-selection guidance.
- **`docs/FEATURES.md`** + **`README.md`** (English + Chinese) — feature table entries.
- **57 new unit tests** across three files:
  - `test_unit_discord_notify.py` (24 tests) — colour rules, embed shape, title truncation, failed-status amber, dedup, `_post_json` error swallowing.
  - `test_unit_slack_notify.py` (24 tests) — `belief_bar` boundary cases, Block Kit shape, action-button gating on absolute URLs, header truncation, dedup.
  - `test_unit_notifications_config.py` (9 tests) — all-unset, channel-by-channel, blank values, `Cache-Control: no-store`, blueprint wiring guards.

Pure stdlib (`urllib.request` + `json` + `os`) — **zero new dependencies**. 22nd consecutive zero-new-deps PR (streak: #57 → #82 → this PR).

## Test plan

- [ ] `pytest backend/tests/test_unit_discord_notify.py -v`
- [ ] `pytest backend/tests/test_unit_slack_notify.py -v`
- [ ] `pytest backend/tests/test_unit_notifications_config.py -v`
- [ ] Set `DISCORD_WEBHOOK_URL` to a test Discord channel, run a quick simulation, confirm the embed renders with consensus colour, fields, thumbnail, link.
- [ ] Set `SLACK_WEBHOOK_URL` to a test Slack workspace, run a quick simulation, confirm the Block Kit message renders with header, belief bars, fields, and button.
- [ ] Open the EmbedDialog on a published sim — confirm the three status chips reflect the live env (✓ / ○).
- [ ] Confirm a failed simulation also fires both channels with amber / error styling.
- [ ] Confirm unset env vars produce zero outbound traffic (no log lines, no failed POSTs).

---
*Built autonomously by Aeon.*