### PR TITLE
feat: OriginTrail DKG citation — on-chain provenance for finished sims

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Reproducibility Config** | `GET /api/simulation/<id>/reproduce.json` — citation primitive for the share surfaces. A v1-schema JSON blob carrying every parameter another operator needs to re-run the same simulation: scenario, agent count, total rounds, platform toggles, time-config knobs, director events, and fork / counterfactual lineage. Identical exports of a finished sim are bytewise-identical, so the file hash is a stable citation key |
 | **Jupyter Notebook Export** | `GET /api/simulation/<id>/notebook.ipynb` — analysis-ready companion to the reproducibility config. The trajectory CSV is embedded directly inside the notebook so it runs air-gapped; cells scaffold imports, the belief-evolution line chart, the final-consensus bar chart, and a quality summary DataFrame. Opens in JupyterLab, VS Code, or Google Colab in one click. Bytewise-stable, same citation-hash property as reproduce.json |
 | **Lineage Navigator** | `GET /api/simulation/<id>/lineage` — turn the `parent_simulation_id` pointer into a navigable graph. Surfaces the parent a sim was forked / branched from plus every public child whose parent points back at it. Trace the intellectual ancestry of a result without remembering each child sim id |
+| **OriginTrail DKG Citation** | Opt-in: set `DKG_API_URL` + `DKG_AUTH_TOKEN` + `DKG_CONTEXT_GRAPH_ID` and the EmbedDialog grows a "Publish to DKG" button. Anchors the scenario, agent count, final consensus, quality, lineage, and `reproduce.json` SHA-256 on the OriginTrail Decentralized Knowledge Graph as a cryptographically verifiable Knowledge Asset. Returned UAL + Merkle root + transaction hash become a permanent, un-rewritable citation key — provenance property that survives the MiroShark host going away. Idempotent (one publish per sim) and stdlib-only. See [docs/DKG.md](docs/DKG.md) |
 
 Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 
@@ -158,6 +159,7 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 | [CLI](docs/CLI.md) | `miroshark-cli` reference |
 | [MCP](docs/MCP.md) | Claude Desktop / Cursor / Windsurf / Continue integration + report agent tools (auto-generated snippets in Settings → AI Integration) |
 | [Webhooks](docs/WEBHOOKS.md) | Completion webhook payload, headers, delivery semantics, Slack/Discord/Zapier/n8n recipes |
+| [DKG citation](docs/DKG.md) | OriginTrail DKG anchoring — UAL + Merkle root + on-chain citation key for any finished sim |
 | [Observability](docs/OBSERVABILITY.md) | Debug panel, event stream, logging |
 | [Contributing](CONTRIBUTING.md) | Tests and development |
 

--- a/backend/app/api/notifications.py
+++ b/backend/app/api/notifications.py
@@ -14,6 +14,12 @@ operators can opt in to any subset:
 * ``DISCORD_WEBHOOK_URL`` — Discord rich-embed cards
 * ``SLACK_WEBHOOK_URL``   — Slack Block Kit messages
 
+Plus the OriginTrail DKG citation surface, which is wired up only when
+all three of ``DKG_API_URL`` / ``DKG_AUTH_TOKEN`` / ``DKG_CONTEXT_GRAPH_ID``
+are non-empty. The probe exposes ``dkg_configured`` and ``dkg_network``
+so the EmbedDialog can render the "Publish to DKG (testnet|mainnet)"
+button accordingly; the auth token itself never leaves the backend.
+
 Each ``*_configured`` boolean is ``True`` iff the corresponding env
 var is set to a non-empty value. No URL ever leaves the backend.
 
@@ -28,6 +34,7 @@ from flask import Blueprint, Response, jsonify
 
 from ..services import discord_notify, slack_notify
 from ..services import webhook_service
+from ..services import dkg_publisher
 from ..utils.logger import get_logger
 
 
@@ -46,10 +53,16 @@ def notifications_config() -> Response:
     auth.
     """
     webhook_url = webhook_service._resolve_webhook_url()
+    dkg_cfg = dkg_publisher._resolve_config()
     data = {
         "webhook_configured": bool(webhook_url),
         "discord_configured": discord_notify.is_configured(),
         "slack_configured": slack_notify.is_configured(),
+        "dkg_configured": dkg_publisher.is_configured(),
+        # Pure metadata — labels which chain the operator's daemon was
+        # configured against so the SPA can render "Publish to DKG
+        # (testnet|mainnet)" without leaking the API URL or auth token.
+        "dkg_network": dkg_cfg.get("network", "testnet") if dkg_publisher.is_configured() else None,
     }
     response = jsonify({"success": True, "data": data})
     # No caching — channel status flips the moment an operator pastes

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -5927,6 +5927,239 @@ def retry_webhook(simulation_id: str):
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+# ============== OriginTrail DKG citation surface ==============
+
+
+@simulation_bp.route('/<simulation_id>/dkg-citation', methods=['GET'])
+def get_dkg_citation(simulation_id: str):
+    """Return the persisted DKG citation for a published simulation.
+
+    Pure read of ``<sim_dir>/dkg-citation.json``. Returns 404 when the
+    sim has never been anchored to the OriginTrail DKG (the common case
+    for any sim that hasn't had the "Publish to DKG" button clicked).
+    No daemon call — the citation file is the source of truth once an
+    on-chain anchor exists.
+
+    Same publish gate as the reproduce.json / thread / lineage surfaces:
+    a private sim can't expose its citation publicly even if one
+    happened to be persisted.
+    """
+    from ..services import dkg_publisher
+
+    locale = get_locale(request)
+    try:
+        validate_simulation_id(simulation_id)
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation is not published.",
+                    "该模拟未发布。",
+                    locale,
+                ),
+            }), 403
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        citation = dkg_publisher.read_citation(sim_dir)
+        if not citation:
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "No DKG citation yet for this simulation.",
+                    "该模拟尚未生成 DKG 引用。",
+                    locale,
+                ),
+            }), 404
+
+        return jsonify({"success": True, "data": citation})
+    except ValueError as exc:
+        return jsonify({"success": False, "error": str(exc)}), 400
+    except Exception as e:
+        logger.error(
+            f"dkg-citation: failed for {simulation_id}: {e}\n{traceback.format_exc()}"
+        )
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@simulation_bp.route('/<simulation_id>/publish-dkg', methods=['POST'])
+@require_admin_token
+def publish_dkg(simulation_id: str):
+    """Anchor a finished simulation's citation surface on the OriginTrail DKG.
+
+    Triggered manually from the EmbedDialog "Publish to DKG" button.
+    Builds the same reproduce.json blob the existing ``/reproduce.json``
+    endpoint returns, hashes its bytes (citation key), wraps it in
+    Turtle RDF alongside the consensus / quality / scenario summary,
+    and walks the WM → SWM → VM publish pipeline on the operator's
+    local DKG daemon. Returns the ``ual`` + ``merkleRoot`` +
+    ``transactionHash`` + ``blockNumber`` so the SPA can render a
+    citation badge with an explorer link.
+
+    Idempotent: a successful publish persists the citation to
+    ``<sim_dir>/dkg-citation.json`` and subsequent calls return it
+    directly without re-hitting the daemon — no double-spend of TRAC /
+    gas. The on-disk file is the source of truth.
+
+    Auth: requires ``Authorization: Bearer $MIROSHARK_ADMIN_TOKEN``
+    because publishing has on-chain cost implications (TRAC + gas).
+
+    Status codes:
+      * 200  — publish succeeded (or cached citation returned)
+      * 400  — invalid simulation_id
+      * 403  — simulation not published (call POST /publish first)
+      * 404  — simulation not found
+      * 422  — sim reachable but the reproduce.json blob is empty
+        (sim hasn't reached the prepared state yet)
+      * 502  — DKG daemon returned an error (chain failure, insufficient
+        TRAC, name collision, etc.)
+      * 503  — DKG_* env vars not configured on this deployment
+      * 504  — DKG daemon unreachable / publish timed out
+    """
+    from ..services import dkg_publisher
+    from ..services import repro_export
+    from ..services import webhook_service
+
+    locale = get_locale(request)
+    try:
+        validate_simulation_id(simulation_id)
+
+        if not dkg_publisher.is_configured():
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "DKG publishing is not configured on this deployment. "
+                    "Set DKG_API_URL, DKG_AUTH_TOKEN, and DKG_CONTEXT_GRAPH_ID.",
+                    "该部署未配置 DKG 发布。请设置 DKG_API_URL、DKG_AUTH_TOKEN 与 DKG_CONTEXT_GRAPH_ID。",
+                    locale,
+                ),
+            }), 503
+
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish first.",
+                    "该模拟未发布,请先调用 POST /api/simulation/<id>/publish。",
+                    locale,
+                ),
+            }), 403
+
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({
+                "success": False,
+                "error": f"Simulation not found: {simulation_id}",
+            }), 404
+
+        config_data = manager.get_simulation_config(simulation_id)
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+
+        # Build the same reproduce.json bytes the public endpoint serves
+        # so the on-chain SHA-256 matches what a verifier would compute
+        # by fetching the URL.
+        repro_blob = repro_export.build_repro_config(state.to_dict(), config_data, sim_dir)
+        reproduce_json_bytes = repro_export.render_json_bytes(repro_blob)
+
+        # Sanity check: refuse to anchor a sim that hasn't reached the
+        # prepared state. agent_count==0 and total_rounds==0 means the
+        # blob is structurally valid but semantically empty — citing
+        # something with no parameters would be misleading.
+        if not (repro_blob.get("agent_count") or repro_blob.get("total_rounds")):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation has not reached the prepared state — nothing to anchor yet.",
+                    "模拟尚未到达可发布状态,暂无可锚定的数据。",
+                    locale,
+                ),
+            }), 422
+
+        # Reuse the webhook payload assembler so the consensus / quality
+        # / scenario claims on-chain match the notification claims
+        # byte-for-byte (single source of truth across surfaces).
+        run_state = SimulationRunner.get_run_state(simulation_id)
+        completed_at = getattr(run_state, "completed_at", None) if run_state else None
+        sim_status = (state.status.value if hasattr(state.status, "value") else str(state.status)).lower()
+        if sim_status not in ("completed", "failed"):
+            sim_status = "completed"  # we still anchor what's there
+
+        base_url = _resolve_share_base_url()
+        webhook_payload = webhook_service.build_payload(
+            simulation_id,
+            sim_status,
+            sim_dir,
+            state=run_state,
+            base_url=base_url,
+            completed_at=completed_at,
+        )
+
+        # ``force`` lets the caller request a re-anchor — exposed but
+        # not wired into the UI in v1. The on-disk citation guard handles
+        # the common idempotent case.
+        body = request.get_json(silent=True) or {}
+        force = bool(body.get("force", False))
+
+        result = dkg_publisher.publish_simulation(
+            simulation_id=simulation_id,
+            sim_dir=sim_dir,
+            repro_blob=repro_blob,
+            reproduce_json_bytes=reproduce_json_bytes,
+            webhook_payload=webhook_payload,
+            base_url=base_url,
+            force=force,
+        )
+
+        if not result.get("ok"):
+            stage = result.get("stage") or "unknown"
+            status_code = result.get("status_code") or 0
+            # Map daemon failures to sensible HTTP semantics:
+            # * 0 from transport (connection refused / timeout) → 504
+            # * 4xx from daemon (auth, validation, TRAC) → 502
+            # * 5xx from daemon (chain / RPC) → 502
+            # * not_configured → 503 (already handled above; defensive)
+            if stage == "not_configured":
+                http_status = 503
+            elif status_code == 0:
+                http_status = 504
+            else:
+                http_status = 502
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    f"DKG publish failed at stage '{stage}': {result.get('error', 'unknown')}",
+                    f"DKG 发布在阶段 '{stage}' 失败:{result.get('error', '未知')}",
+                    locale,
+                ),
+                "stage": stage,
+                "daemon_status_code": status_code,
+            }), http_status
+
+        return jsonify({
+            "success": True,
+            "data": result.get("citation"),
+            "cached": bool(result.get("cached")),
+        })
+
+    except ValueError as exc:
+        return jsonify({"success": False, "error": str(exc)}), 400
+    except Exception as e:
+        logger.error(
+            f"publish-dkg: failed for {simulation_id}: {e}\n{traceback.format_exc()}"
+        )
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
 # ============== Public Gallery ==============
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -202,6 +202,27 @@ class Config:
     # absolute URL themselves.
     PUBLIC_BASE_URL = os.environ.get('PUBLIC_BASE_URL', '')
 
+    # OriginTrail DKG (Decentralized Knowledge Graph) publishing.
+    # Optional integration that anchors a finished simulation's
+    # citation surface (scenario, agent count, final consensus, quality,
+    # lineage, reproduce.json hash) on the OriginTrail DKG as a
+    # cryptographically verifiable Knowledge Asset. The returned UAL +
+    # Merkle root + transaction hash become a permanent, blockchain-anchored
+    # citation key — same provenance property Stripe / DOI give a record,
+    # but for simulation results.
+    #
+    # All four vars empty → integration disabled, ``/api/config/notifications``
+    # reports ``dkg_configured: false``, the EmbedDialog hides the button.
+    # Operator runs the OriginTrail daemon locally (``dkg init && dkg
+    # start``) on the testnet faucet path, creates a context graph
+    # (``dkg context-graph create miroshark``), pastes the auth token + CG
+    # id here. ``DKG_NETWORK`` is metadata only — labels the chain the
+    # daemon was configured against so the explorer URL is correct.
+    DKG_API_URL = os.environ.get('DKG_API_URL', '').rstrip('/')
+    DKG_AUTH_TOKEN = os.environ.get('DKG_AUTH_TOKEN', '')
+    DKG_CONTEXT_GRAPH_ID = os.environ.get('DKG_CONTEXT_GRAPH_ID', '')
+    DKG_NETWORK = (os.environ.get('DKG_NETWORK', 'testnet') or 'testnet').strip().lower()
+
     # Whether ``GET /sitemap.xml`` is served and ``robots.txt`` advertises
     # it. Default ``true`` — the public sitemap is the search-engine
     # discovery surface for the public-simulation gallery, and a

--- a/backend/app/services/dkg_publisher.py
+++ b/backend/app/services/dkg_publisher.py
@@ -1,0 +1,709 @@
+"""OriginTrail DKG publishing — citation surface for finished simulations.
+
+Anchors a finished, published simulation's citation surface on the
+OriginTrail DKG as a cryptographically verifiable Knowledge Asset. The
+returned ``ual`` (Universal Asset Locator), ``merkleRoot``,
+``transactionHash``, and ``blockNumber`` become a permanent,
+blockchain-anchored citation key — the same provenance property Stripe
+gives a charge or a DOI gives a paper, but for a MiroShark simulation
+result. A researcher quoting Aaron's Aave risk sim can now point at the
+UAL and anyone can verify the underlying claims have not been edited.
+
+Design notes
+------------
+
+* **Optional + env-var-gated.** The four ``DKG_*`` vars empty → the
+  module is a no-op. Same shape as ``WEBHOOK_URL`` / ``DISCORD_WEBHOOK_URL``
+  / ``SLACK_WEBHOOK_URL``.
+* **Manual trigger.** Operator clicks "Publish to DKG" in the EmbedDialog;
+  the route handler calls :func:`publish_simulation`. There is no
+  auto-publish on completion — anchoring on-chain costs TRAC + gas, and
+  not every sim should hit the network.
+* **Synchronous publish.** Uses ``POST /api/shared-memory/publish`` so
+  the user clicking the button gets the citation back in the same
+  request. The async ``/api/publisher/enqueue`` flow exists in DKG but
+  adds polling complexity for v1.
+* **Idempotent.** A successful publish persists ``dkg-citation.json`` to
+  the sim dir; subsequent publishes return the existing citation without
+  re-hitting the daemon (no double-spend of TRAC / gas).
+* **Stdlib only.** ``urllib.request`` for HTTP, ``hashlib`` for the
+  reproduce.json content hash, ``json`` for serialization. No new deps.
+* **Never raises in the optional-noop path.** If the daemon is
+  unreachable, :func:`publish_simulation` returns a structured error
+  dict; the route handler maps that to a 502 / 504 / 503. Reading the
+  citation when none exists yields ``None`` — safe to call during
+  EmbedDialog mount.
+
+The four-step DKG flow
+----------------------
+
+The OriginTrail DKG v9/v10 daemon HTTP API requires a three-tier write:
+
+  1. ``POST /api/assertion/create``         — Working Memory (private draft)
+  2. ``POST /api/assertion/{name}/write``   — append Turtle/n-quads
+  3. ``POST /api/assertion/{name}/promote`` — WM → Shared Working Memory
+  4. ``POST /api/shared-memory/publish``    — SWM → Verified Memory (on-chain)
+
+Step 4 returns ``{ual, merkleRoot, transactionHash, blockNumber, finalized}``.
+
+The Turtle payload
+------------------
+
+A minimal RDF representation of the simulation, citable from anywhere::
+
+    @prefix mir: <https://miroshark.io/ns/sim#> .
+    @prefix schema: <https://schema.org/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <urn:miroshark:sim:sim_abc123> a mir:Simulation ;
+      schema:identifier "sim_abc123" ;
+      schema:name "Will the SEC approve …" ;
+      mir:agentCount 248 ;
+      mir:totalRounds 24 ;
+      mir:bullishPercent "62.0"^^xsd:decimal ;
+      …
+      mir:reproduceConfigSha256 "sha256:abc…" ;
+      mir:reproduceConfigUrl <https://host/api/simulation/sim_abc123/reproduce.json> .
+
+The ``mir:reproduceConfigSha256`` literal is the actual citation key — a
+verifier fetches the URL, hashes the bytes, and compares to the on-chain
+Merkle root. The reproduce.json blob is already bytewise-stable per the
+existing repro_export module, so this hash is durable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+from ..utils.logger import get_logger
+
+logger = get_logger("miroshark.dkg")
+
+
+# ---- HTTP defaults ---------------------------------------------------------
+
+DKG_USER_AGENT = "MiroShark-DKG/1.0"
+
+# The fast probes (status, citation read). Slow enough to detect a hung
+# daemon, fast enough not to block the EmbedDialog mount.
+DKG_PROBE_TIMEOUT_SECONDS = 4.0
+
+# Sub-step timeouts for the publish pipeline. The assertion writes are
+# essentially local disk + RocksDB writes; the final publish waits for
+# blockchain finality on the chosen chain and can be slow on testnet
+# under load. Tune conservatively — the EmbedDialog shows a spinner and
+# users will tolerate ~60s for a one-time citation anchor.
+DKG_WRITE_TIMEOUT_SECONDS = 15.0
+DKG_PUBLISH_TIMEOUT_SECONDS = 120.0
+
+
+# ---- Citation persistence --------------------------------------------------
+
+DKG_CITATION_FILENAME = "dkg-citation.json"
+
+
+# ---- Turtle namespaces -----------------------------------------------------
+
+MIROSHARK_NS = "https://miroshark.io/ns/sim#"
+SCHEMA_NS = "https://schema.org/"
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+
+# Lock the assertion name shape: ``miroshark-sim-<id>``. The DKG
+# ``/api/assertion/create`` endpoint returns 409 on name collision —
+# turning a re-click into a duplicate publish — which is exactly the
+# behaviour we want as a backstop to the on-disk citation check.
+def _assertion_name(simulation_id: str) -> str:
+    return f"miroshark-sim-{simulation_id}"
+
+
+def _subject_uri(simulation_id: str) -> str:
+    return f"urn:miroshark:sim:{simulation_id}"
+
+
+# ---- Explorer URL templates (per chain) -----------------------------------
+#
+# Per the user's "configurable, default testnet" choice: ``DKG_NETWORK``
+# picks the explorer template, not the daemon's chain — the daemon was
+# already pointed at a chain when the operator ran ``dkg init``. This is
+# pure metadata: it labels the citation with the chain the operator
+# anchored against so a recipient knows which explorer to open.
+
+_EXPLORER_TEMPLATES: Dict[str, str] = {
+    "testnet": "https://dkg-testnet.origintrail.io/explore?ual={ual}",
+    "mainnet": "https://dkg.origintrail.io/explore?ual={ual}",
+}
+
+
+def _explorer_url_for(ual: str, network: str) -> str:
+    template = _EXPLORER_TEMPLATES.get(network, _EXPLORER_TEMPLATES["testnet"])
+    return template.format(ual=ual)
+
+
+# ---- Config helpers (late-binding so Settings modal changes take effect) --
+
+
+def _resolve_config() -> Dict[str, str]:
+    """Read DKG_* env vars at call time via the ``Config`` class.
+
+    Late-binding mirrors webhook_service / discord_notify so an operator
+    pasting values into a future Settings modal sees them take effect
+    immediately without a server restart.
+    """
+    try:
+        from ..config import Config
+        return {
+            "api_url": (getattr(Config, "DKG_API_URL", "") or "").strip().rstrip("/"),
+            "auth_token": (getattr(Config, "DKG_AUTH_TOKEN", "") or "").strip(),
+            "context_graph_id": (getattr(Config, "DKG_CONTEXT_GRAPH_ID", "") or "").strip(),
+            "network": (getattr(Config, "DKG_NETWORK", "testnet") or "testnet").strip().lower(),
+        }
+    except Exception:
+        return {"api_url": "", "auth_token": "", "context_graph_id": "", "network": "testnet"}
+
+
+def is_configured() -> bool:
+    """True iff the three required DKG_* vars are non-empty.
+
+    ``DKG_NETWORK`` defaults to "testnet" and is never required — it's
+    explorer-URL metadata, not a connectivity prerequisite.
+    """
+    cfg = _resolve_config()
+    return bool(cfg["api_url"] and cfg["auth_token"] and cfg["context_graph_id"])
+
+
+def mask_token(token: str) -> str:
+    """Show the first 6 chars of an auth token for log lines / UI.
+
+    Mirrors :func:`webhook_service.mask_url`: never echo the full secret
+    back to logs or the frontend. ``abc123def456`` → ``abc123***``.
+    """
+    if not token:
+        return ""
+    stripped = token.strip()
+    if len(stripped) <= 6:
+        return "***"
+    return f"{stripped[:6]}***"
+
+
+# ---- HTTP transport --------------------------------------------------------
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    body: Optional[Dict[str, Any]] = None,
+    timeout: float,
+    auth_token: str,
+    api_url: str,
+) -> Tuple[bool, int, Any]:
+    """Issue one DKG daemon HTTP call.
+
+    Returns ``(ok, status_code, payload)``:
+      * ``ok`` — True for 2xx, False otherwise.
+      * ``status_code`` — 0 if the request never reached the daemon
+        (DNS / connection refused / timeout).
+      * ``payload`` — parsed JSON response when possible, otherwise the
+        raw body text as a string, or an error message on transport
+        failure.
+
+    Never raises — DKG calls happen inside a user-facing request handler
+    and must surface the failure as data so the frontend can render a
+    sensible error message instead of a generic 500.
+    """
+    url = f"{api_url}{path}"
+    headers: Dict[str, str] = {
+        "User-Agent": DKG_USER_AGENT,
+        "Authorization": f"Bearer {auth_token}",
+        "Accept": "application/json",
+    }
+    data: Optional[bytes] = None
+    if body is not None:
+        try:
+            data = json.dumps(body).encode("utf-8")
+        except Exception as exc:
+            return False, 0, f"could not serialize request body: {exc}"
+        headers["Content-Type"] = "application/json; charset=utf-8"
+
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = resp.getcode() or 0
+            raw = resp.read()
+            payload = _parse_body(raw)
+            ok = 200 <= status < 300
+            return ok, status, payload
+    except urllib.error.HTTPError as exc:
+        # Daemon returned a 4xx/5xx — read the body so the route can
+        # bubble up the structured error.
+        try:
+            raw = exc.read() or b""
+        except Exception:
+            raw = b""
+        payload = _parse_body(raw)
+        return False, exc.code or 0, payload
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        return False, 0, f"URL error: {reason}"
+    except Exception as exc:
+        return False, 0, f"{type(exc).__name__}: {exc}"
+
+
+def _parse_body(raw: bytes) -> Any:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except Exception:
+        try:
+            return raw.decode("utf-8", errors="replace")
+        except Exception:
+            return None
+
+
+# ---- Health probe ---------------------------------------------------------
+
+
+def health_check() -> Dict[str, Any]:
+    """Probe the daemon via ``GET /api/status``.
+
+    Used by the EmbedDialog mount (via ``/api/config/notifications``)
+    to render the "DKG daemon: reachable" badge before the user clicks
+    publish. Always returns a structured dict — never raises.
+    """
+    cfg = _resolve_config()
+    if not is_configured():
+        return {"ok": False, "configured": False, "reason": "not configured"}
+    ok, status, payload = _request(
+        "GET",
+        "/api/status",
+        timeout=DKG_PROBE_TIMEOUT_SECONDS,
+        auth_token=cfg["auth_token"],
+        api_url=cfg["api_url"],
+    )
+    return {
+        "ok": ok,
+        "configured": True,
+        "status_code": status,
+        "response": payload if ok else None,
+        "error": None if ok else (payload if isinstance(payload, str) else json.dumps(payload) if payload else "unreachable"),
+        "network": cfg["network"],
+    }
+
+
+# ---- Turtle generation ----------------------------------------------------
+
+
+def _escape_literal(value: str) -> str:
+    """Escape a Turtle string literal.
+
+    Turtle backslash + quote escaping per
+    https://www.w3.org/TR/turtle/#sec-escapes. We use the
+    triple-double-quote long-form variant to allow embedded newlines
+    cleanly.
+    """
+    if value is None:
+        return ""
+    s = str(value)
+    # Escape backslash first, then triple-quotes (rare but possible) so
+    # the long-form literal terminator can't be smuggled in.
+    s = s.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+    return s
+
+
+def _ttl_long_literal(value: str) -> str:
+    """Render ``value`` as a Turtle triple-quoted string literal.
+
+    Returns ``\"\"\"escaped\"\"\"``. Empty / None becomes ``\"\"`` so the
+    caller can still emit a triple without conditional logic.
+    """
+    if value is None or value == "":
+        return '""'
+    return f'"""{_escape_literal(value)}"""'
+
+
+def _ttl_decimal(value: float) -> str:
+    """Render a decimal as Turtle ``"NN.N"^^xsd:decimal``."""
+    return f'"{value:.1f}"^^xsd:decimal'
+
+
+def _ttl_int(value: int) -> str:
+    """Render an integer as a Turtle integer literal (xsd:integer implied)."""
+    return str(int(value))
+
+
+def _ttl_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _ttl_datetime(value: Optional[str]) -> Optional[str]:
+    """Render an ISO-8601 datetime as ``"…"^^xsd:dateTime``.
+
+    Returns ``None`` for missing / unparseable input so the caller can
+    omit the predicate rather than emit an invalid literal.
+    """
+    if not value:
+        return None
+    return f'"{_escape_literal(value)}"^^xsd:dateTime'
+
+
+def _sha256_hex(payload_bytes: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload_bytes).hexdigest()
+
+
+def build_turtle(
+    *,
+    simulation_id: str,
+    repro_blob: Dict[str, Any],
+    reproduce_json_bytes: bytes,
+    webhook_payload: Dict[str, Any],
+    base_url: str,
+) -> Tuple[str, str]:
+    """Compose the Turtle RDF for one simulation's Knowledge Asset.
+
+    Returns ``(turtle_text, reproduce_sha256)``. The hash is the
+    citation key — a verifier fetches ``mir:reproduceConfigUrl``,
+    SHA-256s the bytes, and compares against the literal stored on-chain.
+
+    ``webhook_payload`` is reused as the source of the consensus +
+    quality + scenario summary so the on-chain claim matches the
+    notification claim byte-for-byte.
+    """
+    subject = _subject_uri(simulation_id)
+    repro_sha = _sha256_hex(reproduce_json_bytes)
+
+    scenario = _ttl_long_literal(webhook_payload.get("scenario") or repro_blob.get("scenario") or "")
+
+    lines = [
+        f"@prefix mir: <{MIROSHARK_NS}> .",
+        f"@prefix schema: <{SCHEMA_NS}> .",
+        f"@prefix xsd: <{XSD_NS}> .",
+        "",
+        f"<{subject}> a mir:Simulation ;",
+        f'  schema:identifier "{_escape_literal(simulation_id)}" ;',
+        f"  schema:name {scenario} ;",
+    ]
+
+    agent_count = int(repro_blob.get("agent_count") or webhook_payload.get("agent_count") or 0)
+    total_rounds = int(repro_blob.get("total_rounds") or webhook_payload.get("total_rounds") or 0)
+    lines.append(f"  mir:agentCount {_ttl_int(agent_count)} ;")
+    lines.append(f"  mir:totalRounds {_ttl_int(total_rounds)} ;")
+
+    platforms = repro_blob.get("platforms") or {}
+    if isinstance(platforms, dict):
+        lines.append(f"  mir:twitterEnabled {_ttl_bool(bool(platforms.get('twitter', False)))} ;")
+        lines.append(f"  mir:redditEnabled {_ttl_bool(bool(platforms.get('reddit', False)))} ;")
+        lines.append(f"  mir:polymarketEnabled {_ttl_bool(bool(platforms.get('polymarket', False)))} ;")
+
+    consensus = webhook_payload.get("final_consensus")
+    if isinstance(consensus, dict):
+        if "bullish" in consensus:
+            lines.append(f"  mir:bullishPercent {_ttl_decimal(float(consensus.get('bullish') or 0.0))} ;")
+        if "neutral" in consensus:
+            lines.append(f"  mir:neutralPercent {_ttl_decimal(float(consensus.get('neutral') or 0.0))} ;")
+        if "bearish" in consensus:
+            lines.append(f"  mir:bearishPercent {_ttl_decimal(float(consensus.get('bearish') or 0.0))} ;")
+
+    quality_health = webhook_payload.get("quality_health")
+    if quality_health:
+        lines.append(f'  mir:qualityHealth "{_escape_literal(quality_health)}" ;')
+
+    resolution_outcome = webhook_payload.get("resolution_outcome")
+    if resolution_outcome:
+        lines.append(f'  mir:resolutionOutcome "{_escape_literal(resolution_outcome)}" ;')
+
+    created_at = _ttl_datetime(webhook_payload.get("created_at"))
+    if created_at:
+        lines.append(f"  mir:createdAt {created_at} ;")
+    completed_at = _ttl_datetime(webhook_payload.get("completed_at"))
+    if completed_at:
+        lines.append(f"  mir:completedAt {completed_at} ;")
+
+    # Lineage: original / fork / counterfactual + parent UAL pointer
+    lineage = repro_blob.get("lineage") or {}
+    if isinstance(lineage, dict):
+        kind = lineage.get("kind") or "original"
+        lines.append(f'  mir:lineageKind "{_escape_literal(kind)}" ;')
+        parent_id = lineage.get("parent_simulation_id")
+        if parent_id:
+            lines.append(f'  mir:parentSimulationId "{_escape_literal(parent_id)}" ;')
+            lines.append(f"  mir:parentSimulation <{_subject_uri(parent_id)}> ;")
+        cf = lineage.get("counterfactual") or {}
+        if isinstance(cf, dict) and cf.get("trigger_round"):
+            lines.append(f"  mir:counterfactualTriggerRound {_ttl_int(cf.get('trigger_round') or 0)} ;")
+            if cf.get("label"):
+                lines.append(f'  mir:counterfactualLabel "{_escape_literal(cf.get("label"))}" ;')
+
+    # Citation primitive: the SHA-256 of the reproduce.json bytes plus
+    # the canonical fetch URL. The Merkle root the DKG returns is a
+    # cryptographic commitment over this Turtle blob; the literal here
+    # makes the binding to the *reproduce.json* content explicit.
+    lines.append(f'  mir:reproduceConfigSha256 "{_escape_literal(repro_sha)}" ;')
+    if base_url:
+        base = base_url.rstrip("/")
+        lines.append(f"  mir:reproduceConfigUrl <{base}/api/simulation/{simulation_id}/reproduce.json> ;")
+        lines.append(f"  mir:shareUrl <{base}/share/{simulation_id}> ;")
+        lines.append(f"  mir:shareCardUrl <{base}/api/simulation/{simulation_id}/share-card.png> ;")
+
+    lines.append(f'  mir:publishedAt "{_now_iso()}"^^xsd:dateTime .')
+
+    return "\n".join(lines) + "\n", repro_sha
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---- Citation file --------------------------------------------------------
+
+
+def citation_path(sim_dir: str) -> str:
+    return os.path.join(sim_dir or "", DKG_CITATION_FILENAME)
+
+
+def read_citation(sim_dir: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Return the persisted citation dict, or ``None`` if absent.
+
+    Cheap read used by the EmbedDialog to render the existing citation
+    badge without forcing another publish. Never raises.
+    """
+    if not sim_dir:
+        return None
+    path = citation_path(sim_dir)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            obj = json.load(fh)
+        if isinstance(obj, dict):
+            return obj
+    except Exception:
+        return None
+    return None
+
+
+_CITATION_WRITE_LOCK = threading.Lock()
+
+
+def _write_citation(sim_dir: str, payload: Dict[str, Any]) -> None:
+    """Persist the citation atomically via tempfile + os.replace.
+
+    Mirrors surface_stats / webhook_log on-disk atomic-write pattern.
+    Never raises — a missed write is logged but doesn't break the
+    user-facing publish response (the response already carries the UAL).
+    """
+    if not sim_dir:
+        return
+    try:
+        os.makedirs(sim_dir, exist_ok=True)
+    except OSError as exc:
+        logger.warning(f"dkg-citation: could not ensure sim_dir for {sim_dir}: {exc}")
+        return
+    path = citation_path(sim_dir)
+    tmp_path = path + ".tmp"
+    with _CITATION_WRITE_LOCK:
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2, sort_keys=True)
+            os.replace(tmp_path, path)
+        except OSError as exc:
+            logger.warning(f"dkg-citation: write failed for {sim_dir}: {exc}")
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
+
+
+# ---- Publish flow ---------------------------------------------------------
+
+
+def publish_simulation(
+    *,
+    simulation_id: str,
+    sim_dir: str,
+    repro_blob: Dict[str, Any],
+    reproduce_json_bytes: bytes,
+    webhook_payload: Dict[str, Any],
+    base_url: str,
+    force: bool = False,
+) -> Dict[str, Any]:
+    """Anchor a simulation's citation surface on the OriginTrail DKG.
+
+    Idempotent: a successful citation is persisted to
+    ``<sim_dir>/dkg-citation.json`` and returned directly on subsequent
+    calls unless ``force=True``. Force is plumbed through so a future
+    "re-publish after correction" button can re-anchor without an
+    operator deleting the file by hand; the UI does not expose it in v1.
+
+    Returns one of these shapes:
+
+      * ``{ok: True, citation: {…}, cached: True}`` — citation already
+        on disk, no daemon call made.
+      * ``{ok: True, citation: {…}, cached: False}`` — fresh anchor.
+      * ``{ok: False, status_code: int, stage: str, error: str}`` —
+        anchor failed at ``stage``. Stage values: ``"not_configured"``,
+        ``"create"``, ``"write"``, ``"promote"``, ``"publish"``.
+
+    Never raises.
+    """
+    if not is_configured():
+        return {
+            "ok": False,
+            "status_code": 0,
+            "stage": "not_configured",
+            "error": "DKG_API_URL / DKG_AUTH_TOKEN / DKG_CONTEXT_GRAPH_ID not set",
+        }
+
+    if not force:
+        existing = read_citation(sim_dir)
+        if existing and existing.get("ual"):
+            return {"ok": True, "citation": existing, "cached": True}
+
+    cfg = _resolve_config()
+    name = _assertion_name(simulation_id)
+
+    turtle, repro_sha = build_turtle(
+        simulation_id=simulation_id,
+        repro_blob=repro_blob,
+        reproduce_json_bytes=reproduce_json_bytes,
+        webhook_payload=webhook_payload,
+        base_url=base_url,
+    )
+
+    masked = mask_token(cfg["auth_token"])
+    logger.info(
+        f"dkg-publish: starting {simulation_id} → CG={cfg['context_graph_id']} "
+        f"network={cfg['network']} token={masked}"
+    )
+
+    # Step 1: create the assertion in Working Memory. Idempotent re-runs
+    # after a previous mid-pipeline failure will 409 here — surface that
+    # as a clean error rather than masking it as success, since the
+    # operator needs to either ``dkg assertion discard`` or pass force.
+    ok, status, payload = _request(
+        "POST",
+        "/api/assertion/create",
+        body={"contextGraphId": cfg["context_graph_id"], "name": name},
+        timeout=DKG_WRITE_TIMEOUT_SECONDS,
+        auth_token=cfg["auth_token"],
+        api_url=cfg["api_url"],
+    )
+    if not ok:
+        return _fail("create", status, payload)
+
+    # Step 2: write the Turtle as quads. DKG accepts either Turtle
+    # serialization or n-quads on this endpoint; we send Turtle text in
+    # the ``quads`` field, which the daemon parses into named-graph
+    # quads on the way in.
+    ok, status, payload = _request(
+        "POST",
+        f"/api/assertion/{name}/write",
+        body={
+            "contextGraphId": cfg["context_graph_id"],
+            "quads": turtle,
+        },
+        timeout=DKG_WRITE_TIMEOUT_SECONDS,
+        auth_token=cfg["auth_token"],
+        api_url=cfg["api_url"],
+    )
+    if not ok:
+        return _fail("write", status, payload)
+
+    # Step 3: WM → SWM. ``entities: "all"`` promotes everything we just
+    # wrote — the simpler default. Per-entity selection exists for
+    # cases where an assertion holds drafts plus committed facts; ours
+    # is a fresh assertion per publish so all-or-nothing is correct.
+    ok, status, payload = _request(
+        "POST",
+        f"/api/assertion/{name}/promote",
+        body={
+            "contextGraphId": cfg["context_graph_id"],
+            "entities": "all",
+        },
+        timeout=DKG_WRITE_TIMEOUT_SECONDS,
+        auth_token=cfg["auth_token"],
+        api_url=cfg["api_url"],
+    )
+    if not ok:
+        return _fail("promote", status, payload)
+
+    # Step 4: SWM → VM. This is the slow path that waits for blockchain
+    # finality; bump the timeout. The response carries the citation
+    # primitives we hand back to the caller.
+    ok, status, payload = _request(
+        "POST",
+        "/api/shared-memory/publish",
+        body={"contextGraphId": cfg["context_graph_id"]},
+        timeout=DKG_PUBLISH_TIMEOUT_SECONDS,
+        auth_token=cfg["auth_token"],
+        api_url=cfg["api_url"],
+    )
+    if not ok:
+        return _fail("publish", status, payload)
+
+    if not isinstance(payload, dict):
+        return _fail("publish", status, f"unexpected response shape: {payload!r}")
+
+    ual = payload.get("ual") or ""
+    merkle_root = payload.get("merkleRoot") or payload.get("merkle_root") or ""
+    tx_hash = payload.get("transactionHash") or payload.get("transaction_hash") or ""
+    block_number = payload.get("blockNumber") or payload.get("block_number")
+    finalized = bool(payload.get("finalized", False))
+
+    if not ual:
+        return _fail("publish", status, f"daemon returned no ual: {payload!r}")
+
+    citation: Dict[str, Any] = {
+        "ual": ual,
+        "merkle_root": merkle_root,
+        "transaction_hash": tx_hash,
+        "block_number": block_number if isinstance(block_number, int) else None,
+        "finalized": finalized,
+        "network": cfg["network"],
+        "context_graph_id": cfg["context_graph_id"],
+        "assertion_name": name,
+        "reproduce_config_sha256": repro_sha,
+        "explorer_url": _explorer_url_for(ual, cfg["network"]),
+        "published_at": _now_iso(),
+        "schema_version": "1",
+    }
+
+    _write_citation(sim_dir, citation)
+    logger.info(
+        f"dkg-publish: ok {simulation_id} → {ual} "
+        f"(merkle={merkle_root[:10] if merkle_root else 'n/a'}…, "
+        f"tx={tx_hash[:10] if tx_hash else 'n/a'}…)"
+    )
+    return {"ok": True, "citation": citation, "cached": False}
+
+
+def _fail(stage: str, status: int, payload: Any) -> Dict[str, Any]:
+    """Shape a daemon failure into the structured response.
+
+    ``payload`` is whatever the daemon (or transport) returned. Trim long
+    bodies so the response stays a notification-sized blob.
+    """
+    if isinstance(payload, dict):
+        try:
+            err_text = json.dumps(payload, ensure_ascii=False)
+        except Exception:
+            err_text = str(payload)
+    else:
+        err_text = str(payload) if payload is not None else ""
+    if len(err_text) > 800:
+        err_text = err_text[:797].rstrip() + "…"
+    logger.warning(f"dkg-publish: stage={stage} status={status} error={err_text}")
+    return {
+        "ok": False,
+        "status_code": status,
+        "stage": stage,
+        "error": err_text or f"DKG daemon returned status {status}",
+    }

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1996,6 +1996,10 @@ paths:
           * `webhook_configured`  — generic `WEBHOOK_URL` is set.
           * `discord_configured`  — `DISCORD_WEBHOOK_URL` is set.
           * `slack_configured`    — `SLACK_WEBHOOK_URL` is set.
+          * `dkg_configured`      — all three of `DKG_API_URL`,
+            `DKG_AUTH_TOKEN`, `DKG_CONTEXT_GRAPH_ID` are set.
+          * `dkg_network`         — `"testnet"` / `"mainnet"` /
+            `null` (suppressed when the integration isn't usable).
 
         Mirrors the existing `GET /api/config/sitemap` posture — a
         small public envelope the `EmbedDialog` consumes on mount to
@@ -2037,6 +2041,25 @@ paths:
                           MiroShark POSTs a Slack Block Kit message
                           (header + context + section fields + actions
                           button) on every terminal-state transition.
+                      dkg_configured:
+                        type: boolean
+                        description: |
+                          All three of `DKG_API_URL`, `DKG_AUTH_TOKEN`,
+                          and `DKG_CONTEXT_GRAPH_ID` are set. When
+                          `true`, the EmbedDialog renders the
+                          OriginTrail DKG citation card with a publish
+                          CTA (or the citation primitives if already
+                          anchored). Auth token never leaves the
+                          backend.
+                      dkg_network:
+                        type: [string, "null"]
+                        enum: [testnet, mainnet, null]
+                        description: |
+                          Pure metadata — labels the chain the
+                          operator's daemon was configured against so
+                          the SPA renders the right network chip and
+                          explorer link. `null` when the integration
+                          isn't fully configured.
 
   /api/config/sitemap:
     get:
@@ -2338,6 +2361,181 @@ paths:
         "409":
           description: Simulation has not reached a terminal state yet.
         "503": { $ref: "#/components/responses/AdminAuthNotConfigured" }
+
+  /api/simulation/{simulation_id}/dkg-citation:
+    get:
+      tags: [Publish & Embed]
+      summary: Read the persisted OriginTrail DKG citation for a published sim.
+      description: |
+        Returns the on-chain citation primitives anchored when an
+        operator clicked "Publish to DKG" in the share dialog. Pure
+        read of `<sim_dir>/dkg-citation.json` — no daemon call. The
+        citation file is the source of truth once a Knowledge Asset
+        has been anchored.
+
+        Same publish gate as the `reproduce.json` / thread / lineage
+        surfaces: a private sim returns 403 even if a citation file
+        happens to be on disk.
+
+        Returns 404 (not 500) when the sim has never been anchored —
+        the EmbedDialog uses that as the "render the publish CTA"
+        signal.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Citation primitives for the on-chain Knowledge Asset.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        required: [ual, network, context_graph_id, assertion_name, published_at]
+                        properties:
+                          ual:
+                            type: string
+                            description: Universal Asset Locator (`urn:dkg:context-graph:…`).
+                          merkle_root:
+                            type: string
+                            description: Hex Merkle root committed on-chain.
+                          transaction_hash:
+                            type: string
+                            description: Hex transaction hash on the anchoring chain.
+                          block_number:
+                            type: [integer, "null"]
+                          finalized: { type: boolean }
+                          network:
+                            type: string
+                            enum: [testnet, mainnet]
+                          context_graph_id: { type: string }
+                          assertion_name: { type: string }
+                          reproduce_config_sha256:
+                            type: string
+                            description: |
+                              `sha256:<hex>` of the canonical
+                              `reproduce.json` bytes — the citation
+                              key a verifier re-hashes locally.
+                          explorer_url:
+                            type: string
+                            format: uri
+                            description: OriginTrail DKG explorer link for the UAL.
+                          published_at:
+                            type: string
+                            format: date-time
+                          schema_version: { type: string, enum: ["1"] }
+        "403":
+          description: Simulation is not published.
+        "404":
+          description: No DKG citation yet for this simulation.
+
+  /api/simulation/{simulation_id}/publish-dkg:
+    post:
+      tags: [Publish & Embed]
+      summary: Anchor a finished simulation on the OriginTrail DKG.
+      description: |
+        Walks the OriginTrail DKG v9/v10 WM → SWM → VM publish pipeline
+        on the operator's local daemon and returns the resulting UAL
+        + Merkle root + transaction hash + block number.
+
+        Idempotent: a successful publish persists
+        `<sim_dir>/dkg-citation.json` and subsequent calls return the
+        cached citation directly — no double-spend of TRAC or gas. The
+        on-disk file is the source of truth.
+
+        Steps the route walks server-side:
+
+          1. `POST /api/assertion/create`          (Working Memory)
+          2. `POST /api/assertion/{name}/write`    (append Turtle RDF)
+          3. `POST /api/assertion/{name}/promote`  (WM → SWM)
+          4. `POST /api/shared-memory/publish`     (SWM → Verified Memory)
+
+        Returns 503 when `DKG_*` env vars are unset, 502 on a daemon
+        error (chain failure, insufficient TRAC, name collision), 504
+        on connection refused / publish timeout, and 422 when the
+        simulation hasn't reached the prepared state. The publish
+        action requires the admin token because on-chain anchoring
+        costs TRAC + gas.
+      security:
+        - AdminToken: []
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+                  description: |
+                    Re-anchor even when a `dkg-citation.json` already
+                    exists. The v1 UI does not expose this; it is an
+                    escape hatch for operators who explicitly want to
+                    burn TRAC + gas on a fresh anchor after correcting
+                    upstream data.
+            example:
+              force: false
+      responses:
+        "200":
+          description: |
+            Publish succeeded (or a cached citation was returned for
+            an already-anchored sim).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      cached:
+                        type: boolean
+                        description: |
+                          `true` when the citation came from
+                          `dkg-citation.json` without contacting the
+                          daemon; `false` when freshly anchored.
+                      data:
+                        $ref: "#/components/schemas/DkgCitation"
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403":
+          description: Simulation is not published.
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422":
+          description: Simulation has not reached the prepared state — nothing to anchor yet.
+        "502":
+          description: |
+            DKG daemon returned an error (chain failure, validation
+            error, insufficient TRAC, name collision, etc.).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [false] }
+                  error: { type: string }
+                  stage:
+                    type: string
+                    enum: [create, write, promote, publish, unknown]
+                  daemon_status_code:
+                    type: integer
+                    description: The HTTP status the daemon returned.
+        "503": { $ref: "#/components/responses/AdminAuthNotConfigured" }
+        "504":
+          description: DKG daemon unreachable or publish timed out.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [false] }
+                  error: { type: string }
+                  stage:
+                    type: string
+                    enum: [create, write, promote, publish]
 
   # ────────────────────────────────────────────────────────────────────
   # Report Agent
@@ -2859,6 +3057,65 @@ components:
       required: [simulation_id]
       properties:
         simulation_id: { type: string }
+
+    DkgCitation:
+      type: object
+      description: |
+        Citation primitives for a simulation anchored on the OriginTrail
+        DKG. Persisted as `<sim_dir>/dkg-citation.json` after a
+        successful publish and returned by both
+        `GET /api/simulation/{simulation_id}/dkg-citation` and the 200
+        response of `POST /api/simulation/{simulation_id}/publish-dkg`.
+      required: [ual, network, context_graph_id, assertion_name, published_at, schema_version]
+      properties:
+        ual:
+          type: string
+          description: Universal Asset Locator (`urn:dkg:context-graph:…`).
+        merkle_root:
+          type: string
+          description: Hex Merkle root of the on-chain assertion.
+        transaction_hash:
+          type: string
+          description: Hex transaction hash on the anchoring chain.
+        block_number:
+          type: [integer, "null"]
+        finalized:
+          type: boolean
+          description: |
+            Daemon's signal that the on-chain transaction has reached
+            finality on the anchoring chain.
+        network:
+          type: string
+          enum: [testnet, mainnet]
+          description: |
+            Pure metadata — labels which chain the operator's daemon
+            was configured against so the SPA renders the right
+            explorer link. MiroShark does not pick the chain.
+        context_graph_id:
+          type: string
+        assertion_name:
+          type: string
+          description: |
+            DKG assertion name (`miroshark-sim-<simulation_id>`). The
+            collision-on-409 behaviour of `POST /api/assertion/create`
+            is the backstop to the on-disk idempotency guard.
+        reproduce_config_sha256:
+          type: string
+          description: |
+            `sha256:<hex>` of the canonical `reproduce.json` bytes. The
+            citation key — a verifier fetches the URL, re-hashes the
+            bytes, and compares to this literal (which is also embedded
+            in the Turtle RDF committed on-chain).
+        explorer_url:
+          type: string
+          format: uri
+          description: OriginTrail DKG explorer link for the UAL.
+        published_at:
+          type: string
+          format: date-time
+        schema_version:
+          type: string
+          enum: ["1"]
 
     SimulationEnvelope:
       allOf:

--- a/backend/tests/test_unit_notifications_config.py
+++ b/backend/tests/test_unit_notifications_config.py
@@ -52,17 +52,35 @@ def _payload(client):
     return body["data"]
 
 
+def _clear_dkg(monkeypatch):
+    """Reset the four DKG_* config attributes back to the unset shape.
+
+    The notifications probe reads DKG state via ``dkg_publisher.is_configured()``
+    which late-binds through ``Config`` — so a test that toggles DKG must
+    clear it both ways or earlier cases leak into later ones via attribute
+    state on the Config class.
+    """
+    from app.config import Config
+    monkeypatch.setattr(Config, "DKG_API_URL", "", raising=False)
+    monkeypatch.setattr(Config, "DKG_AUTH_TOKEN", "", raising=False)
+    monkeypatch.setattr(Config, "DKG_CONTEXT_GRAPH_ID", "", raising=False)
+    monkeypatch.setattr(Config, "DKG_NETWORK", "testnet", raising=False)
+
+
 def test_notifications_config_all_unset(monkeypatch, client):
     monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
     monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
+    _clear_dkg(monkeypatch)
 
     data = _payload(client)
     assert data == {
         "webhook_configured": False,
         "discord_configured": False,
         "slack_configured": False,
+        "dkg_configured": False,
+        "dkg_network": None,
     }
 
 
@@ -71,12 +89,15 @@ def test_notifications_config_discord_only(monkeypatch, client):
     monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
+    _clear_dkg(monkeypatch)
 
     data = _payload(client)
     assert data == {
         "webhook_configured": False,
         "discord_configured": True,
         "slack_configured": False,
+        "dkg_configured": False,
+        "dkg_network": None,
     }
 
 
@@ -88,12 +109,15 @@ def test_notifications_config_slack_only(monkeypatch, client):
     )
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
+    _clear_dkg(monkeypatch)
 
     data = _payload(client)
     assert data == {
         "webhook_configured": False,
         "discord_configured": False,
         "slack_configured": True,
+        "dkg_configured": False,
+        "dkg_network": None,
     }
 
 
@@ -105,12 +129,15 @@ def test_notifications_config_all_three_configured(monkeypatch, client):
     )
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "https://example.com/hook", raising=False)
+    _clear_dkg(monkeypatch)
 
     data = _payload(client)
     assert data == {
         "webhook_configured": True,
         "discord_configured": True,
         "slack_configured": True,
+        "dkg_configured": False,
+        "dkg_network": None,
     }
 
 
@@ -122,13 +149,58 @@ def test_notifications_config_blank_env_var_treated_as_unset(monkeypatch, client
     monkeypatch.setenv("SLACK_WEBHOOK_URL", "")
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "  ", raising=False)
+    _clear_dkg(monkeypatch)
 
     data = _payload(client)
     assert data == {
         "webhook_configured": False,
         "discord_configured": False,
         "slack_configured": False,
+        "dkg_configured": False,
+        "dkg_network": None,
     }
+
+
+def test_notifications_config_dkg_configured(monkeypatch, client):
+    """All three DKG_* required vars set → dkg_configured is True and
+    dkg_network reports whichever chain the operator labelled."""
+    monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    from app.config import Config
+    monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
+    monkeypatch.setattr(Config, "DKG_API_URL", "http://127.0.0.1:9200", raising=False)
+    monkeypatch.setattr(Config, "DKG_AUTH_TOKEN", "abc123def456", raising=False)
+    monkeypatch.setattr(Config, "DKG_CONTEXT_GRAPH_ID", "cg-miroshark", raising=False)
+    monkeypatch.setattr(Config, "DKG_NETWORK", "mainnet", raising=False)
+
+    data = _payload(client)
+    assert data == {
+        "webhook_configured": False,
+        "discord_configured": False,
+        "slack_configured": False,
+        "dkg_configured": True,
+        "dkg_network": "mainnet",
+    }
+
+
+def test_notifications_config_dkg_partial_treated_as_unconfigured(monkeypatch, client):
+    """Missing any one of the three required vars → not configured.
+    Catches the footgun where an operator sets DKG_API_URL but forgets
+    the token — the SPA should not surface a broken publish button."""
+    monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    from app.config import Config
+    monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
+    monkeypatch.setattr(Config, "DKG_API_URL", "http://127.0.0.1:9200", raising=False)
+    monkeypatch.setattr(Config, "DKG_AUTH_TOKEN", "", raising=False)
+    monkeypatch.setattr(Config, "DKG_CONTEXT_GRAPH_ID", "cg-miroshark", raising=False)
+    monkeypatch.setattr(Config, "DKG_NETWORK", "testnet", raising=False)
+
+    data = _payload(client)
+    assert data["dkg_configured"] is False
+    # Network metadata is suppressed when the integration isn't usable —
+    # showing "testnet" with no daemon would be misleading.
+    assert data["dkg_network"] is None
 
 
 def test_notifications_config_no_store_cache_header(monkeypatch, client):

--- a/docs/DKG.md
+++ b/docs/DKG.md
@@ -1,0 +1,240 @@
+# OriginTrail DKG citation surface
+
+MiroShark can anchor a finished simulation's citation surface on the
+**OriginTrail Decentralized Knowledge Graph (DKG)** as a cryptographically
+verifiable Knowledge Asset. The returned UAL (Universal Asset Locator),
+Merkle root, and transaction hash become a permanent, blockchain-anchored
+citation key — the same provenance property Stripe gives a charge or a
+DOI gives a paper, but for a MiroShark simulation result.
+
+This is the **citation primitive** the share-surface stack always wanted:
+`reproduce.json` makes a sim reproducible, the share card makes it
+shareable, and the DKG anchor makes it **un-rewritable**. A researcher
+quoting your Aave risk sim can point at the UAL and anyone can verify
+the underlying claims have not been edited since publication.
+
+The integration is **optional and opt-in**: empty env vars → the feature
+hides itself entirely (no button, no probe). Set the four `DKG_*` vars
+and the EmbedDialog grows a "Publish to DKG" button.
+
+## TL;DR — what you get
+
+* **One-click anchor** in the share dialog of any public simulation.
+* On success: `urn:dkg:context-graph:…` UAL + `0x…` Merkle root + `0x…`
+  transaction hash + block number + a link to the DKG explorer.
+* **Idempotent.** A second click on the same sim returns the existing
+  citation from disk without re-hitting the daemon (no double-spend of
+  TRAC or gas).
+* **Citation verification.** The on-chain Merkle root commits to a
+  Turtle RDF document that includes the SHA-256 of the sim's
+  `reproduce.json` bytes. A verifier fetches the URL, re-hashes the
+  bytes, and compares — match = the sim has not been altered since
+  anchoring.
+
+## One-time setup
+
+You need three things: a running DKG daemon, a funded wallet on the
+target chain (testnet or mainnet), and a Context Graph to publish into.
+
+### 1. Install + run the DKG daemon
+
+```bash
+# OriginTrail's TypeScript daemon — Node 22+ required
+npm install -g @origintrail-official/dkg
+
+# Initialize: creates ~/.dkg/config.yaml, auto-funds a wallet on the
+# testnet faucet. Use ``--no-fund`` to bring your own wallet.
+dkg init
+
+# Start the daemon — runs on http://127.0.0.1:9200
+dkg start
+```
+
+The daemon picks up your chain config from `~/.dkg/config.yaml`. The
+default points at Base Sepolia (testnet); switch to Base mainnet
+manually if you want real durability. MiroShark doesn't pick the chain
+— it just labels the citation with whichever chain the daemon is
+configured against (this is what `DKG_NETWORK` controls below; it's
+metadata for the explorer URL, nothing more).
+
+### 2. Create a Context Graph for MiroShark sims
+
+A Context Graph is a scoped, topic-bounded subgraph within the DKG.
+One MiroShark instance publishes all its sims into one Context Graph.
+
+```bash
+dkg context-graph create miroshark
+# → prints the new Context Graph ID; copy it.
+```
+
+### 3. Grab the auth token
+
+```bash
+dkg auth show
+# → prints the Bearer token the daemon expects on every API call.
+```
+
+### 4. Wire MiroShark up
+
+Paste into `.env`:
+
+```bash
+# OriginTrail DKG (optional — leave blank to disable the feature)
+DKG_API_URL=http://127.0.0.1:9200
+DKG_AUTH_TOKEN=<the token from `dkg auth show`>
+DKG_CONTEXT_GRAPH_ID=<the id from `dkg context-graph create`>
+DKG_NETWORK=testnet            # or "mainnet" — explorer label only
+```
+
+Restart MiroShark (or save through the Settings modal — env reads are
+late-bound). The next time you open the share dialog of a public sim,
+the **OriginTrail DKG citation** card appears.
+
+If any of the three required vars is blank the feature hides entirely
+and `GET /api/config/notifications` reports `dkg_configured: false`.
+`DKG_NETWORK` defaults to `testnet` and is never required.
+
+## How it works (one publish, four daemon calls)
+
+The OriginTrail DKG v9/v10 daemon uses a three-tier memory model that
+maps onto the publish flow:
+
+```
+1. POST /api/assertion/create            # Working Memory (private draft)
+2. POST /api/assertion/{name}/write      # append Turtle RDF
+3. POST /api/assertion/{name}/promote    # WM → Shared Working Memory
+4. POST /api/shared-memory/publish       # SWM → Verified Memory (on-chain)
+```
+
+Step 4 returns:
+
+```json
+{
+  "ual": "urn:dkg:context-graph:…",
+  "merkleRoot": "0x…",
+  "transactionHash": "0x…",
+  "blockNumber": 12345,
+  "finalized": true
+}
+```
+
+MiroShark persists these as `<sim_dir>/dkg-citation.json` so a re-click
+on the button returns the cached citation directly. The four-step
+pipeline is implemented in
+[`backend/app/services/dkg_publisher.py`](../backend/app/services/dkg_publisher.py).
+
+### What goes in the Knowledge Asset
+
+The Turtle RDF document committed on-chain is a minimal but complete
+representation of the simulation:
+
+```turtle
+@prefix mir: <https://miroshark.io/ns/sim#> .
+@prefix schema: <https://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:miroshark:sim:sim_abc123> a mir:Simulation ;
+  schema:identifier "sim_abc123" ;
+  schema:name """Will the SEC approve a spot AAVE ETF by EOY?""" ;
+  mir:agentCount 248 ;
+  mir:totalRounds 24 ;
+  mir:twitterEnabled true ;
+  mir:redditEnabled true ;
+  mir:polymarketEnabled true ;
+  mir:bullishPercent "62.0"^^xsd:decimal ;
+  mir:neutralPercent "13.0"^^xsd:decimal ;
+  mir:bearishPercent "25.0"^^xsd:decimal ;
+  mir:qualityHealth "Excellent" ;
+  mir:lineageKind "original" ;
+  mir:reproduceConfigSha256 "sha256:7c9f…" ;
+  mir:reproduceConfigUrl <https://your-host/api/simulation/sim_abc123/reproduce.json> ;
+  mir:shareUrl <https://your-host/share/sim_abc123> ;
+  mir:publishedAt "2026-05-15T12:00:00Z"^^xsd:dateTime .
+```
+
+The `mir:reproduceConfigSha256` literal is the actual citation key. The
+Merkle root the DKG returns is a cryptographic commitment over the
+entire Turtle document — so anchoring the Turtle on-chain
+transitively anchors the reproduce.json hash. The reproduce.json blob
+is already byte-stable (see [`backend/app/services/repro_export.py`](../backend/app/services/repro_export.py)),
+so two exports of the same finished sim produce the same hash.
+
+## HTTP endpoints
+
+| Method | Path                                            | Auth        | Returns                                                |
+| ------ | ----------------------------------------------- | ----------- | ------------------------------------------------------ |
+| GET    | `/api/simulation/<id>/dkg-citation`             | Public      | Persisted citation; 404 if not yet anchored            |
+| POST   | `/api/simulation/<id>/publish-dkg`              | Admin token | Triggers WM→SWM→VM publish; returns the citation       |
+| GET    | `/api/config/notifications`                     | Public      | `{dkg_configured, dkg_network, …}` presence booleans   |
+
+The publish endpoint requires `Authorization: Bearer $MIROSHARK_ADMIN_TOKEN`
+because anchoring on-chain costs TRAC + gas — the same admin gate the
+`webhook-retry` endpoint uses for the same reason.
+
+Response codes:
+
+* `200` — publish succeeded (or cached citation returned)
+* `403` — simulation not published (call `POST /publish` first)
+* `404` — simulation not found
+* `422` — sim hasn't reached the prepared state (nothing to anchor)
+* `502` — DKG daemon returned an error (chain failure, insufficient
+  TRAC, name collision, etc.)
+* `503` — `DKG_*` env vars not configured on this deployment
+* `504` — DKG daemon unreachable / publish timed out
+
+## Verifying a citation
+
+Once a sim is anchored, anyone with the UAL can verify:
+
+```bash
+# 1. Read the assertion from any DKG node
+curl -s "https://your-host/api/simulation/sim_abc123/dkg-citation" \
+  | jq .data
+
+# 2. Fetch the reproduce.json bytes
+curl -s "https://your-host/api/simulation/sim_abc123/reproduce.json" > repro.json
+
+# 3. SHA-256 the bytes
+shasum -a 256 repro.json
+# → 7c9f6e… repro.json
+
+# 4. Compare to the on-chain literal
+# Open the DKG explorer URL from the citation and confirm the
+# mir:reproduceConfigSha256 value matches.
+```
+
+A mismatch means the simulation parameters have been altered since
+anchoring — by design, the on-chain Merkle root cannot be silently
+rewritten.
+
+## Cost model
+
+* **Testnet** (Base Sepolia, default): TRAC + gas are auto-funded from
+  the faucet. Free for development.
+* **Mainnet** (Base): real TRAC token + ETH gas per publish. A typical
+  Knowledge Asset publish currently costs single-digit cents in gas
+  plus a small TRAC stake. Costs vary with network conditions — see
+  [OriginTrail's pricing docs](https://docs.origintrail.io/) for
+  current numbers.
+
+MiroShark's idempotent on-disk citation file means re-clicking the
+button on the same sim **does not** spend gas again. To force a
+re-anchor (e.g. after a sim was corrected), pass `force: true` in the
+POST body — the v1 UI doesn't expose this; it's an escape hatch for
+operators who know what they're asking for.
+
+## Disabling
+
+Comment out (or remove) `DKG_API_URL` / `DKG_AUTH_TOKEN` /
+`DKG_CONTEXT_GRAPH_ID` in `.env` and restart. The card disappears, the
+public probe reports `dkg_configured: false`, and existing
+`dkg-citation.json` files stay on disk (still served by
+`GET /dkg-citation` if the operator re-enables the feature later).
+
+## See also
+
+* [OriginTrail/dkg-v9 — official daemon repo](https://github.com/OriginTrail/dkg-v9)
+* [OriginTrail DKG documentation](https://docs.origintrail.io/)
+* [`backend/app/services/dkg_publisher.py`](../backend/app/services/dkg_publisher.py)
+* [`backend/app/services/repro_export.py`](../backend/app/services/repro_export.py) — the reproduce.json builder whose bytes get hashed
+* [Notifications](NOTIFICATIONS.md) — sibling channels (Webhook, Discord, Slack)

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -822,7 +822,8 @@ export const getSitemapConfig = () => {
 /**
  * Fetch the notification-channel config — tells the SPA which of the
  * three terminal-state notification channels (generic webhook, Discord
- * rich embed, Slack Block Kit) are wired up on this deployment. Only
+ * rich embed, Slack Block Kit) are wired up on this deployment, plus
+ * whether the OriginTrail DKG citation surface is reachable. Only
  * presence booleans cross the wire; the underlying URLs (which often
  * carry an opaque secret in the path) stay server-side.
  *
@@ -831,12 +832,58 @@ export const getSitemapConfig = () => {
  *     webhook_configured: boolean,
  *     discord_configured: boolean,
  *     slack_configured:   boolean,
+ *     dkg_configured:     boolean,
+ *     dkg_network:        "testnet" | "mainnet" | null,
  *   }
  *
  * @returns {Promise}
  */
 export const getNotificationsConfig = () => {
   return service.get('/api/config/notifications')
+}
+
+/**
+ * Read the persisted OriginTrail DKG citation for a published sim.
+ * Returns 404 when the sim has never been anchored — same publish gate
+ * as the reproduce.json endpoint. No daemon call.
+ *
+ * Response shape (under `data`):
+ *   {
+ *     ual: "urn:dkg:context-graph:…",
+ *     merkle_root: "0x…",
+ *     transaction_hash: "0x…",
+ *     block_number: number | null,
+ *     finalized: boolean,
+ *     network: "testnet" | "mainnet",
+ *     context_graph_id: string,
+ *     assertion_name: string,
+ *     reproduce_config_sha256: "sha256:…",
+ *     explorer_url: string,
+ *     published_at: ISO8601 string,
+ *   }
+ *
+ * @param {string} simulationId
+ */
+export const getDkgCitation = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/dkg-citation`)
+}
+
+/**
+ * Anchor a finished simulation's citation surface on the OriginTrail
+ * DKG. Requires admin auth (the publish action has on-chain cost
+ * implications: TRAC + gas). Idempotent — the second call returns the
+ * cached citation without re-anchoring.
+ *
+ * Same response shape as ``getDkgCitation`` for the success case, with
+ * an additional ``cached: boolean`` field at the top level signalling
+ * whether the daemon was contacted.
+ *
+ * @param {string} simulationId
+ * @param {{ force?: boolean }} [opts]
+ */
+export const publishToDkg = (simulationId, opts = {}) => {
+  const body = opts.force ? { force: true } : {}
+  return service.post(`/api/simulation/${simulationId}/publish-dkg`, body)
 }
 
 /**

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -732,6 +732,139 @@
               </div>
             </div>
 
+            <!-- OriginTrail DKG citation — the on-chain provenance
+                 surface. Opt-in: rendered only when DKG_* env vars are
+                 wired up on this deployment. The "Publish to DKG"
+                 button walks the WM→SWM→VM publish pipeline on the
+                 operator's local DKG node, hashes the reproduce.json
+                 bytes (citation key), and returns the UAL + Merkle
+                 root + transaction hash so the simulation gets a
+                 blockchain-anchored citation key. Idempotent — once
+                 anchored, subsequent dialog opens read the cached
+                 citation from disk without re-hitting the daemon. -->
+            <div
+              v-if="isPublic && notifConfig.dkg_configured"
+              class="transcript-section dkg-section"
+            >
+              <div class="transcript-head dkg-head">
+                <span class="transcript-icon">⛓️</span>
+                <div class="transcript-head-body">
+                  <div class="transcript-title">
+                    {{ $tr('OriginTrail DKG citation', 'OriginTrail DKG 引用') }}
+                    <span
+                      v-if="notifConfig.dkg_network"
+                      class="lineage-count-chip"
+                      :class="`dkg-network-chip-${notifConfig.dkg_network}`"
+                    >
+                      {{ notifConfig.dkg_network === 'mainnet'
+                          ? $tr('mainnet', '主网')
+                          : $tr('testnet', '测试网') }}
+                    </span>
+                  </div>
+                  <div class="transcript-sub">
+                    {{ $tr('Anchor the scenario, agent count, consensus, quality, and reproduce.json hash on the OriginTrail DKG as a cryptographically verifiable Knowledge Asset. The returned UAL + Merkle root + transaction hash become a permanent citation key — same provenance property a DOI gives a paper.', '将情景、智能体数、共识、质量与 reproduce.json 哈希作为可加密验证的知识资产锚定到 OriginTrail DKG。返回的 UAL + Merkle 根 + 交易哈希就是永久引用键 — 提供与论文 DOI 同等的来源证明。') }}
+                  </div>
+                </div>
+              </div>
+
+              <div class="dkg-body">
+                <!-- Already anchored — show the citation primitives -->
+                <div v-if="dkgCitation && dkgCitation.ual" class="dkg-card">
+                  <div class="dkg-row">
+                    <span class="dkg-row-label">UAL</span>
+                    <code
+                      class="dkg-row-value dkg-row-mono"
+                      :title="dkgCitation.ual"
+                    >{{ formatUalShort(dkgCitation.ual) }}</code>
+                    <button
+                      class="snippet-copy-btn dkg-copy"
+                      type="button"
+                      @click="copy('dkgUal')"
+                    >
+                      {{ copied === 'dkgUal' ? '✓' : $tr('Copy', '复制') }}
+                    </button>
+                  </div>
+                  <div v-if="dkgCitation.merkle_root" class="dkg-row">
+                    <span class="dkg-row-label">{{ $tr('Merkle root', 'Merkle 根') }}</span>
+                    <code
+                      class="dkg-row-value dkg-row-mono"
+                      :title="dkgCitation.merkle_root"
+                    >{{ formatHashShort(dkgCitation.merkle_root) }}</code>
+                    <button
+                      class="snippet-copy-btn dkg-copy"
+                      type="button"
+                      @click="copy('dkgMerkle')"
+                    >
+                      {{ copied === 'dkgMerkle' ? '✓' : $tr('Copy', '复制') }}
+                    </button>
+                  </div>
+                  <div v-if="dkgCitation.transaction_hash" class="dkg-row">
+                    <span class="dkg-row-label">{{ $tr('Transaction', '交易') }}</span>
+                    <code
+                      class="dkg-row-value dkg-row-mono"
+                      :title="dkgCitation.transaction_hash"
+                    >{{ formatHashShort(dkgCitation.transaction_hash) }}</code>
+                    <span v-if="typeof dkgCitation.block_number === 'number'" class="dkg-row-meta">
+                      {{ $tr('block', '区块') }} #{{ dkgCitation.block_number }}
+                    </span>
+                  </div>
+                  <div v-if="dkgCitation.reproduce_config_sha256" class="dkg-row">
+                    <span class="dkg-row-label">{{ $tr('Config hash', '配置哈希') }}</span>
+                    <code
+                      class="dkg-row-value dkg-row-mono"
+                      :title="dkgCitation.reproduce_config_sha256"
+                    >{{ formatHashShort(dkgCitation.reproduce_config_sha256) }}</code>
+                  </div>
+                  <div class="dkg-actions">
+                    <a
+                      v-if="dkgCitation.explorer_url"
+                      class="repro-download"
+                      :href="dkgCitation.explorer_url"
+                      target="_blank"
+                      rel="noopener"
+                    >
+                      {{ $tr('Open on DKG explorer ↗', '在 DKG 浏览器中打开 ↗') }}
+                    </a>
+                    <span v-if="dkgCitation.finalized" class="dkg-finalized-badge">
+                      ✓ {{ $tr('Finalized', '已最终确认') }}
+                    </span>
+                  </div>
+                  <div class="repro-note">
+                    {{ $tr('A verifier fetches reproduce.json, SHA-256s the bytes, and compares to the on-chain config hash. Match = the simulation parameters have not been altered since anchoring.', '验证者获取 reproduce.json,计算 SHA-256 后与链上配置哈希比对。匹配则证明该模拟参数自锚定后未被篡改。') }}
+                  </div>
+                </div>
+
+                <!-- Not yet anchored — show the publish CTA -->
+                <div v-else-if="!dkgLoading" class="dkg-card dkg-card-empty">
+                  <div class="dkg-empty-text">
+                    {{ $tr('No on-chain citation yet for this simulation.', '该模拟尚未生成链上引用。') }}
+                  </div>
+                  <div class="dkg-actions">
+                    <button
+                      class="repro-download dkg-publish-btn"
+                      type="button"
+                      :disabled="dkgPublishing"
+                      @click="publishDkg"
+                    >
+                      <span v-if="dkgPublishing">
+                        {{ $tr('Anchoring on-chain…', '正在上链…') }}
+                      </span>
+                      <span v-else>
+                        ⛓️ {{ $tr('Publish to DKG', '发布至 DKG') }}
+                      </span>
+                    </button>
+                  </div>
+                  <div class="repro-note">
+                    {{ $tr('Requires the local DKG daemon to be running (dkg start) and a funded wallet. Anchoring costs TRAC + gas on the configured chain.', '需要本地 DKG 守护进程已启动(dkg start)及一个已充值的钱包。上链需消耗所选链的 TRAC 与 gas 费。') }}
+                  </div>
+                </div>
+
+                <div v-if="dkgError" class="webhook-log-message" :class="dkgErrorClass">
+                  {{ dkgError }}
+                </div>
+              </div>
+            </div>
+
             <!-- Lineage navigator — closes the navigation gap PR #75
                  (reproducibility config) left behind. The
                  `parent_simulation_id` pointer existed on disk but was
@@ -1397,6 +1530,8 @@ import {
   submitSimulationOutcome,
   getWebhookLog,
   retryWebhookDelivery,
+  getDkgCitation,
+  publishToDkg,
 } from '../api/simulation'
 import { tr } from '../i18n'
 
@@ -2097,6 +2232,8 @@ const notifConfig = ref({
   webhook_configured: false,
   discord_configured: false,
   slack_configured: false,
+  dkg_configured: false,
+  dkg_network: null,
 })
 const notifConfigLoaded = ref(false)
 const loadNotificationsConfig = async () => {
@@ -2108,12 +2245,16 @@ const loadNotificationsConfig = async () => {
       webhook_configured: !!data.webhook_configured,
       discord_configured: !!data.discord_configured,
       slack_configured: !!data.slack_configured,
+      dkg_configured: !!data.dkg_configured,
+      dkg_network: data.dkg_network || null,
     }
   } catch {
     notifConfig.value = {
       webhook_configured: false,
       discord_configured: false,
       slack_configured: false,
+      dkg_configured: false,
+      dkg_network: null,
     }
   } finally {
     notifConfigLoaded.value = true
@@ -2183,6 +2324,8 @@ const copy = async (which) => {
   else if (which === 'reproCurl') text = reproCurlSnippet.value
   else if (which === 'notebookUrl') text = notebookDownloadUrl.value
   else if (which === 'notebookCurl') text = notebookCurlSnippet.value
+  else if (which === 'dkgUal') text = dkgCitation.value?.ual || ''
+  else if (which === 'dkgMerkle') text = dkgCitation.value?.merkle_root || ''
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)
@@ -2455,6 +2598,126 @@ const retryWebhook = async () => {
   }
 }
 
+// ---- DKG citation state -------------------------------------------------
+//
+// The OriginTrail DKG citation card is an opt-in surface: it lives only
+// when ``notifConfig.dkg_configured`` is true. State machine:
+//   1. mount → loadDkgCitation() probes for an existing on-chain anchor
+//   2. citation present → render UAL + Merkle + tx + explorer link
+//   3. citation absent → render "Publish to DKG" button
+//   4. click → publishDkg() walks WM→SWM→VM on the daemon, ~15-120s
+//   5. on success → citation populated, button hidden
+const dkgCitation = ref(null)
+const dkgLoading = ref(false)
+const dkgPublishing = ref(false)
+const dkgError = ref('')
+const dkgErrorClass = ref('')
+
+const loadDkgCitation = async () => {
+  if (!props.simulationId) return
+  if (!notifConfig.value.dkg_configured) return
+  if (!isPublic.value) return
+  dkgLoading.value = true
+  dkgError.value = ''
+  try {
+    const res = await getDkgCitation(props.simulationId)
+    if (res?.success && res.data) {
+      dkgCitation.value = res.data
+    } else {
+      dkgCitation.value = null
+    }
+  } catch (err) {
+    const status = err?.response?.status
+    // 404 just means "no anchor yet" — the common pre-publish state,
+    // never an error to surface. Anything else (403, 5xx) leaves the
+    // citation as null and the card renders the publish CTA.
+    if (status !== 404) {
+      // Soft-failure: don't paint a red error before the user has
+      // even clicked anything. The publish attempt itself will surface
+      // any real daemon issue.
+    }
+    dkgCitation.value = null
+  } finally {
+    dkgLoading.value = false
+  }
+}
+
+const publishDkg = async () => {
+  if (!props.simulationId || dkgPublishing.value) return
+  if (!notifConfig.value.dkg_configured) return
+  if (!isPublic.value) return
+  dkgPublishing.value = true
+  dkgError.value = ''
+  dkgErrorClass.value = ''
+  try {
+    const res = await publishToDkg(props.simulationId)
+    if (res?.success && res.data?.ual) {
+      dkgCitation.value = res.data
+      dkgError.value = res?.cached
+        ? tr('Already anchored — returned existing citation.', '已锚定 — 返回现有引用。')
+        : tr('Published to DKG. Citation anchored on-chain.', '已发布至 DKG,引用已上链。')
+      dkgErrorClass.value = 'webhook-log-message-ok'
+    } else {
+      dkgError.value = res?.error || tr('Could not publish to DKG.', '无法发布至 DKG。')
+      dkgErrorClass.value = 'webhook-log-message-error'
+    }
+  } catch (err) {
+    const status = err?.response?.status
+    const serverErr = err?.response?.data?.error
+    if (status === 401) {
+      dkgError.value = tr(
+        'Admin token does not match — set Authorization: Bearer $MIROSHARK_ADMIN_TOKEN at your reverse proxy to publish to DKG.',
+        '管理员 token 不匹配 — 请在反向代理处设置 Authorization: Bearer $MIROSHARK_ADMIN_TOKEN 才能发布至 DKG。',
+      )
+    } else if (status === 503) {
+      dkgError.value = serverErr || tr(
+        'DKG publishing is not configured on this deployment.',
+        '该部署未配置 DKG 发布。',
+      )
+    } else if (status === 504) {
+      dkgError.value = serverErr || tr(
+        'DKG daemon unreachable or publish timed out. Check that the local DKG node is running.',
+        '无法访问 DKG 守护进程或发布超时,请确认本地 DKG 节点已运行。',
+      )
+    } else if (status === 502) {
+      dkgError.value = serverErr || tr(
+        'DKG daemon returned an error. Check the node logs and TRAC balance.',
+        'DKG 守护进程返回错误,请检查节点日志与 TRAC 余额。',
+      )
+    } else if (status === 422) {
+      dkgError.value = serverErr || tr(
+        'Simulation has not reached the prepared state — nothing to anchor yet.',
+        '模拟尚未到达可发布状态,暂无可锚定的数据。',
+      )
+    } else {
+      dkgError.value = serverErr || err?.message || tr('Could not publish to DKG.', '无法发布至 DKG。')
+    }
+    dkgErrorClass.value = 'webhook-log-message-error'
+  } finally {
+    dkgPublishing.value = false
+  }
+}
+
+const _resetDkgState = () => {
+  dkgCitation.value = null
+  dkgLoading.value = false
+  dkgPublishing.value = false
+  dkgError.value = ''
+  dkgErrorClass.value = ''
+}
+
+const formatUalShort = (ual) => {
+  if (!ual || typeof ual !== 'string') return ''
+  if (ual.length <= 48) return ual
+  return `${ual.slice(0, 28)}…${ual.slice(-16)}`
+}
+
+const formatHashShort = (hash) => {
+  if (!hash || typeof hash !== 'string') return ''
+  if (hash.length <= 18) return hash
+  return `${hash.slice(0, 10)}…${hash.slice(-6)}`
+}
+
 const _resetWebhookLogState = () => {
   webhookLogExpanded.value = false
   webhookLogEntries.value = []
@@ -2476,6 +2739,7 @@ watch(() => props.open, async (val) => {
   replayLoaded.value = false
   _resetOutcomeForm()
   _resetWebhookLogState()
+  _resetDkgState()
   // Refresh public state when reopened — reflects external flips.
   try {
     const res = await getEmbedSummary(props.simulationId)
@@ -2499,7 +2763,11 @@ watch(() => props.open, async (val) => {
   // Pull the notification-channel config — cheap (three env reads
   // server-side, no Neo4j) so reading on each dialog open lets the
   // chips reflect a Settings save without requiring a hard refresh.
-  loadNotificationsConfig()
+  await loadNotificationsConfig()
+  // Probe for an existing DKG citation. Only meaningful when the
+  // deployment has DKG_* env vars wired up *and* the sim is public —
+  // the load helper short-circuits on either gate so this is cheap.
+  loadDkgCitation()
   // Bust the share-card image cache so the preview reloads with whatever
   // state the simulation is in right now (resolution may have landed
   // since the dialog was last opened).
@@ -2566,6 +2834,10 @@ watch(isPublic, () => {
   } else {
     lineagePayload.value = null
   }
+  // DKG citation probe flips on the same publish gate. The load helper
+  // short-circuits when the sim is private or the deployment isn't
+  // configured for DKG, so we can always call it.
+  loadDkgCitation()
 })
 </script>
 
@@ -4796,5 +5068,125 @@ watch(isPublic, () => {
 .embed-dialog-leave-to .embed-dialog {
   transform: translateY(8px) scale(0.98);
   opacity: 0;
+}
+
+/* ---- OriginTrail DKG citation card -------------------------------------
+ *
+ * Visually slots between the Jupyter notebook export and the lineage
+ * navigator. The card reuses the same vertical-stack pattern as the
+ * reproducibility config block (head + body + actions + note) so it
+ * lands in the dialog without a new visual idiom.
+ */
+.dkg-section {
+  margin-top: 18px;
+}
+
+.dkg-body {
+  padding: 12px 14px 14px;
+}
+
+.dkg-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.dkg-card-empty {
+  align-items: flex-start;
+  background: #ffffff;
+  border-style: dashed;
+}
+
+.dkg-empty-text {
+  color: #475569;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.dkg-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.dkg-row-label {
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  min-width: 96px;
+}
+
+.dkg-row-value {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 12.5px;
+  color: #0f172a;
+  word-break: break-all;
+}
+
+.dkg-row-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  padding: 3px 6px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+}
+
+.dkg-row-meta {
+  font-size: 11.5px;
+  color: #64748b;
+}
+
+.dkg-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.dkg-copy {
+  flex: 0 0 auto;
+}
+
+.dkg-publish-btn {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #ffffff;
+  border: none;
+}
+
+.dkg-publish-btn:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.dkg-publish-btn:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.dkg-finalized-badge {
+  color: #15803d;
+  background: #dcfce7;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.dkg-network-chip-testnet {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.dkg-network-chip-mainnet {
+  background: #dcfce7;
+  color: #166534;
 }
 </style>


### PR DESCRIPTION
## Summary

- Optional, env-var-gated integration with the **OriginTrail Decentralized Knowledge Graph** (v9/v10) — one click in the share dialog anchors a finished public sim as a Knowledge Asset and returns a UAL + Merkle root + transaction hash + block number. The on-chain hash binds to the byte-stable `reproduce.json`, so a verifier can re-hash and prove the simulation parameters have not been altered since anchoring.
- Closes the citation gap the share-surface stack always implied: `reproduce.json` made a sim reproducible, the share card made it shareable, this makes it **un-rewritable**. Survives the MiroShark host going away — same provenance property a DOI gives a paper.
- Fully optional. Empty `DKG_*` env vars hide the feature entirely (no probe, no button). Configured ones light up a card with the publish CTA. Idempotent on disk — a re-click returns the cached citation without re-spending TRAC + gas.

## What changed

| Area | File | What it does |
|---|---|---|
| Service | `backend/app/services/dkg_publisher.py` (new) | Stdlib-only publisher. Walks `assertion/create → write → promote → shared-memory/publish` on the local DKG daemon. Composes Turtle RDF from the existing `reproduce.json` blob + webhook payload (one source of truth across surfaces). Persists `<sim_dir>/dkg-citation.json` atomically. |
| Routes | `backend/app/api/simulation.py` | `GET /<id>/dkg-citation` (public read) + `POST /<id>/publish-dkg` (admin-token, triggers anchor). Daemon failures map to 502/503/504 with stage info so the SPA renders a useful error. |
| Probe | `backend/app/api/notifications.py` | `/api/config/notifications` now exposes `dkg_configured` + `dkg_network`. Auth token never leaves the backend. |
| Config | `backend/app/config.py` | Four env vars: `DKG_API_URL` / `DKG_AUTH_TOKEN` / `DKG_CONTEXT_GRAPH_ID` (required to enable) + `DKG_NETWORK` (default `testnet`, explorer-URL metadata only). |
| UI | `frontend/src/components/EmbedDialog.vue` + `frontend/src/api/simulation.js` | New citation card between the Jupyter notebook export and the lineage navigator. Testnet/mainnet chip, UAL + Merkle + tx with copy buttons, explorer link, publish CTA. |
| Docs | `docs/DKG.md` (new) + `README.md` | Setup walkthrough, payload schema, endpoint table, verification recipe, cost model. README feature row + docs index entry. |

## How the publish works

The OriginTrail DKG daemon uses a three-tier memory model — MiroShark walks it on every fresh publish:

```
1. POST /api/assertion/create            # Working Memory  (private draft)
2. POST /api/assertion/{name}/write      # append Turtle RDF
3. POST /api/assertion/{name}/promote    # WM → Shared Working Memory
4. POST /api/shared-memory/publish       # SWM → Verified Memory (on-chain)
```

Step 4 returns `{ual, merkleRoot, transactionHash, blockNumber, finalized}`. We persist this and key off the on-disk file for idempotency.

## What gets anchored

A minimal RDF representation of the sim — same shape the share card / webhook / Discord embed use, so on-chain claims match notification claims byte-for-byte:

- scenario, agent count, total rounds, platform toggles
- final consensus (bullish / neutral / bearish %) + quality health
- resolution outcome (if any)
- lineage (original / fork / counterfactual + parent UAL pointer)
- `mir:reproduceConfigSha256` — SHA-256 of the bytewise-stable `reproduce.json` bytes
- `mir:reproduceConfigUrl` + `mir:shareUrl` + `mir:shareCardUrl`

## Test plan

- [ ] Without `DKG_*` env vars: `/api/config/notifications` returns `dkg_configured: false`, EmbedDialog hides the card entirely.
- [ ] With `DKG_*` set but no daemon running: clicking publish surfaces a 504 "DKG daemon unreachable" message; no citation file written.
- [ ] With daemon running on testnet: clicking publish walks the four-step pipeline, persists `<sim_dir>/dkg-citation.json`, card flips to show UAL + Merkle root + tx hash + explorer link.
- [ ] Second click on the same sim: returns the cached citation without re-hitting the daemon (verify with daemon logs).
- [ ] Private sim: `POST /publish-dkg` returns 403, button is hidden in the dialog (gated on `isPublic`).
- [ ] Empty admin token: `POST /publish-dkg` returns 401 with the "set Authorization: Bearer …" hint.
- [ ] Open the explorer URL — confirm the on-chain Knowledge Asset shows the `mir:reproduceConfigSha256` literal matching what `shasum -a 256 reproduce.json` returns locally.
- [ ] Switch `DKG_NETWORK` between `testnet` and `mainnet` — chip + explorer URL update; no other code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)