### PR TITLE
feat: WaybackClaw AI Agent Archive integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -300,6 +300,43 @@ EMBEDDING_BATCH_SIZE=128
 # TELEGRAM_BOT_TOKEN=YOUR_BOT_TOKEN_HERE
 # TELEGRAM_CHAT_ID=-100123456789
 
+# ===== OriginTrail DKG citation (optional) =====
+# Opt-in on-chain citation surface for finished simulations. Anchors
+# the scenario, agent count, final consensus, quality, lineage, and
+# reproduce.json SHA-256 on the OriginTrail Decentralized Knowledge
+# Graph as a cryptographically verifiable Knowledge Asset — returns a
+# UAL + Merkle root + transaction hash that become a permanent
+# citation key. Requires a locally running DKG daemon (`dkg start`)
+# and a Context Graph (`dkg context-graph create miroshark`). All
+# three required vars empty → feature hides itself entirely. See
+# docs/DKG.md for the full setup walkthrough.
+# DKG_API_URL=http://127.0.0.1:9200
+# DKG_AUTH_TOKEN=
+# DKG_CONTEXT_GRAPH_ID=
+# DKG_NETWORK=testnet    # or "mainnet" — explorer URL label only
+
+# ===== WaybackClaw AI Agent Archive (optional) =====
+# Opt-in citation surface that submits each finished simulation's
+# snapshot — scenario, agent count, consensus, quality, lineage,
+# reproduce.json SHA-256 — to the WaybackClaw AI Agent Archive at
+# api.waybackclaw.space. The archive pins every submission to IPFS
+# (content-addressed) and broadcasts a NIP-01 note to Nostr relays
+# (decentralized distribution) in one POST. Sibling of the OriginTrail
+# DKG citation surface — DKG anchors on-chain, WaybackClaw anchors to
+# IPFS + Nostr. Run both for triple-redundant provenance.
+#
+# One-time setup — register an agent and get a token:
+#   curl -X POST https://api.waybackclaw.space/api/archive/register \
+#     -H "Content-Type: application/json" \
+#     -d '{"agentName": "MyMiroSharkDeployment", "category": "prediction",
+#          "platform": "MiroShark", "chain": "off-chain"}'
+# Copy the returned token (format: agent_<id>:<secret>) — the API does
+# not let you re-fetch it later. Leave WAYBACKCLAW_AGENT_TOKEN blank
+# to hide the EmbedDialog card entirely. See docs/WAYBACKCLAW.md.
+# WAYBACKCLAW_AGENT_TOKEN=agent_a1b2c3d4e5f6:your-long-secret
+# WAYBACKCLAW_API_URL=https://api.waybackclaw.space   # optional override
+# WAYBACKCLAW_AGENT_CATEGORY=prediction               # optional override
+
 # ===== Search-engine sitemap (auto-generated /sitemap.xml + /robots.txt) =====
 # When true (default), GET /sitemap.xml lists every public-simulation
 # /share/<id> + /watch/<id> URL so Googlebot / Bingbot / DuckDuckBot can

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ After launching, click the **中 / EN** toggle in the top-right of the navbar to
 | **Jupyter Notebook Export** | `GET /api/simulation/<id>/notebook.ipynb` — analysis-ready companion to the reproducibility config. The trajectory CSV is embedded directly inside the notebook so it runs air-gapped; cells scaffold imports, the belief-evolution line chart, the final-consensus bar chart, and a quality summary DataFrame. Opens in JupyterLab, VS Code, or Google Colab in one click. Bytewise-stable, same citation-hash property as reproduce.json |
 | **Lineage Navigator** | `GET /api/simulation/<id>/lineage` — turn the `parent_simulation_id` pointer into a navigable graph. Surfaces the parent a sim was forked / branched from plus every public child whose parent points back at it. Trace the intellectual ancestry of a result without remembering each child sim id |
 | **OriginTrail DKG Citation** | Opt-in: set `DKG_API_URL` + `DKG_AUTH_TOKEN` + `DKG_CONTEXT_GRAPH_ID` and the EmbedDialog grows a "Publish to DKG" button. Anchors the scenario, agent count, final consensus, quality, lineage, and `reproduce.json` SHA-256 on the OriginTrail Decentralized Knowledge Graph as a cryptographically verifiable Knowledge Asset. Returned UAL + Merkle root + transaction hash become a permanent, un-rewritable citation key — provenance property that survives the MiroShark host going away. Idempotent (one publish per sim) and stdlib-only. See [docs/DKG.md](docs/DKG.md) |
+| **WaybackClaw Archive** | Opt-in: set `WAYBACKCLAW_AGENT_TOKEN` (one curl to register against `api.waybackclaw.space`) and the EmbedDialog grows a "Submit to WaybackClaw" card. Submits the finished snapshot — scenario, agent count, consensus, quality, lineage, `reproduce.json` SHA-256 — to the WaybackClaw AI Agent Archive, which pins it to IPFS for content-addressed storage and broadcasts a NIP-01 note to Nostr relays in one POST. Returns snapshot id + IPFS CID + Nostr event id. Agent-archive sibling of the DKG citation — DKG anchors on-chain, WaybackClaw anchors to IPFS + Nostr. Free for agents, no on-chain cost. Idempotent and stdlib-only. See [docs/WAYBACKCLAW.md](docs/WAYBACKCLAW.md) |
 
 Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 
@@ -166,6 +167,7 @@ Each feature is documented in **[docs/FEATURES.md](docs/FEATURES.md)**.
 | [MCP](docs/MCP.md) | Claude Desktop / Cursor / Windsurf / Continue integration + report agent tools (auto-generated snippets in Settings → AI Integration) |
 | [Webhooks](docs/WEBHOOKS.md) | Completion webhook payload, headers, delivery semantics, Slack/Discord/Zapier/n8n recipes |
 | [DKG citation](docs/DKG.md) | OriginTrail DKG anchoring — UAL + Merkle root + on-chain citation key for any finished sim |
+| [WaybackClaw archive](docs/WAYBACKCLAW.md) | WaybackClaw submission — snapshot id + IPFS CID + Nostr event id for any finished sim |
 | [Observability](docs/OBSERVABILITY.md) | Debug panel, event stream, logging |
 | [Contributing](CONTRIBUTING.md) | Tests and development |
 

--- a/backend/app/api/notifications.py
+++ b/backend/app/api/notifications.py
@@ -37,6 +37,7 @@ from flask import Blueprint, Response, jsonify
 from ..services import discord_notify, slack_notify, email_notify, telegram_notify
 from ..services import webhook_service
 from ..services import dkg_publisher
+from ..services import waybackclaw_publisher
 from ..utils.logger import get_logger
 
 
@@ -51,9 +52,9 @@ def notifications_config() -> Response:
 
     Returns ``{success, data: {webhook_configured, discord_configured,
     slack_configured, email_configured, telegram_configured,
-    dkg_configured, dkg_network}}``. No URL values, recipient lists,
-    or auth tokens are leaked — only presence booleans, so this
-    endpoint is safe to call from the SPA without auth.
+    dkg_configured, dkg_network, waybackclaw_configured}}``. No URL
+    values, recipient lists, or auth tokens are leaked — only presence
+    booleans, so this endpoint is safe to call from the SPA without auth.
     """
     webhook_url = webhook_service._resolve_webhook_url()
     dkg_cfg = dkg_publisher._resolve_config()
@@ -68,6 +69,9 @@ def notifications_config() -> Response:
         # configured against so the SPA can render "Publish to DKG
         # (testnet|mainnet)" without leaking the API URL or auth token.
         "dkg_network": dkg_cfg.get("network", "testnet") if dkg_publisher.is_configured() else None,
+        # WaybackClaw AI Agent Archive — opt-in agent-side citation
+        # surface alongside DKG. True iff WAYBACKCLAW_AGENT_TOKEN is set.
+        "waybackclaw_configured": waybackclaw_publisher.is_configured(),
     }
     response = jsonify({"success": True, "data": data})
     # No caching — channel status flips the moment an operator pastes

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -6740,6 +6740,235 @@ def publish_dkg(simulation_id: str):
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+# ============== WaybackClaw AI Agent Archive ==============
+
+
+@simulation_bp.route('/<simulation_id>/waybackclaw-record', methods=['GET'])
+def get_waybackclaw_record(simulation_id: str):
+    """Return the persisted WaybackClaw submission record for a sim.
+
+    Pure read of ``<sim_dir>/waybackclaw-record.json``. Returns 404
+    when the sim has never been submitted to the archive (the common
+    case for any sim that hasn't had the "Submit to WaybackClaw"
+    button clicked). No API call — the record file is the source of
+    truth once a snapshot has been submitted.
+
+    Same publish gate as the reproduce.json / thread / lineage / DKG
+    surfaces: a private sim can't expose its archive record publicly
+    even if one happened to be persisted.
+    """
+    from ..services import waybackclaw_publisher
+
+    locale = get_locale(request)
+    try:
+        validate_simulation_id(simulation_id)
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation is not published.",
+                    "该模拟未发布。",
+                    locale,
+                ),
+            }), 403
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        record = waybackclaw_publisher.read_record(sim_dir)
+        if not record:
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "No WaybackClaw record yet for this simulation.",
+                    "该模拟尚未提交至 WaybackClaw。",
+                    locale,
+                ),
+            }), 404
+
+        return jsonify({"success": True, "data": record})
+    except ValueError as exc:
+        return jsonify({"success": False, "error": str(exc)}), 400
+    except Exception as e:
+        logger.error(
+            f"waybackclaw-record: failed for {simulation_id}: {e}\n{traceback.format_exc()}"
+        )
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@simulation_bp.route('/<simulation_id>/publish-waybackclaw', methods=['POST'])
+@require_admin_token
+def publish_waybackclaw(simulation_id: str):
+    """Submit a finished simulation's snapshot to the WaybackClaw archive.
+
+    Triggered manually from the EmbedDialog "Submit to WaybackClaw"
+    button. Builds the same reproduce.json blob the existing
+    ``/reproduce.json`` endpoint returns, hashes its bytes (citation
+    key), wraps it in a WaybackClaw snapshot body alongside the
+    consensus / quality / scenario summary, and POSTs to
+    ``/api/archive/submit`` on ``api.waybackclaw.space``. Returns the
+    snapshot id + IPFS CID + Nostr event id so the SPA can render an
+    archive citation card with a Pinata gateway link and a Nostr
+    event reference.
+
+    Idempotent: a successful submission persists the record to
+    ``<sim_dir>/waybackclaw-record.json`` and subsequent calls return
+    it directly without re-hitting the API. The on-disk file is the
+    source of truth.
+
+    Auth: requires ``Authorization: Bearer $MIROSHARK_ADMIN_TOKEN``
+    by parity with the DKG publish route. The WaybackClaw submit
+    endpoint itself is free with agent auth, but gating the surface
+    behind the admin token keeps the "who can speak on behalf of
+    this MiroShark deployment in the public archive" decision in
+    the operator's hands rather than every dialog viewer's.
+
+    Status codes:
+      * 200  — submit succeeded (or cached record returned)
+      * 400  — invalid simulation_id
+      * 403  — simulation not published (call POST /publish first)
+      * 404  — simulation not found
+      * 422  — sim reachable but reproduce.json blob is empty
+      * 429  — WaybackClaw rate limit exceeded (back off and retry)
+      * 502  — WaybackClaw API returned an error
+      * 503  — WAYBACKCLAW_AGENT_TOKEN not configured
+      * 504  — WaybackClaw API unreachable / timed out
+    """
+    from ..services import waybackclaw_publisher
+    from ..services import repro_export
+    from ..services import webhook_service
+
+    locale = get_locale(request)
+    try:
+        validate_simulation_id(simulation_id)
+
+        if not waybackclaw_publisher.is_configured():
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "WaybackClaw publishing is not configured on this deployment. "
+                    "Set WAYBACKCLAW_AGENT_TOKEN.",
+                    "该部署未配置 WaybackClaw 发布。请设置 WAYBACKCLAW_AGENT_TOKEN。",
+                    locale,
+                ),
+            }), 503
+
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish first.",
+                    "该模拟未发布,请先调用 POST /api/simulation/<id>/publish。",
+                    locale,
+                ),
+            }), 403
+
+        manager = SimulationManager()
+        state = manager.get_simulation(simulation_id)
+        if not state:
+            return jsonify({
+                "success": False,
+                "error": f"Simulation not found: {simulation_id}",
+            }), 404
+
+        config_data = manager.get_simulation_config(simulation_id)
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+
+        # Build the same reproduce.json bytes the public endpoint
+        # serves so the snapshot's reproduceConfigSha256 matches what
+        # a verifier would compute by fetching the URL.
+        repro_blob = repro_export.build_repro_config(state.to_dict(), config_data, sim_dir)
+        reproduce_json_bytes = repro_export.render_json_bytes(repro_blob)
+
+        if not (repro_blob.get("agent_count") or repro_blob.get("total_rounds")):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation has not reached the prepared state — nothing to archive yet.",
+                    "模拟尚未到达可发布状态,暂无可归档的数据。",
+                    locale,
+                ),
+            }), 422
+
+        run_state = SimulationRunner.get_run_state(simulation_id)
+        completed_at = getattr(run_state, "completed_at", None) if run_state else None
+        sim_status = (state.status.value if hasattr(state.status, "value") else str(state.status)).lower()
+        if sim_status not in ("completed", "failed"):
+            sim_status = "completed"
+
+        base_url = _resolve_share_base_url()
+        webhook_payload = webhook_service.build_payload(
+            simulation_id,
+            sim_status,
+            sim_dir,
+            state=run_state,
+            base_url=base_url,
+            completed_at=completed_at,
+        )
+
+        body = request.get_json(silent=True) or {}
+        force = bool(body.get("force", False))
+
+        result = waybackclaw_publisher.submit_snapshot(
+            simulation_id=simulation_id,
+            sim_dir=sim_dir,
+            repro_blob=repro_blob,
+            reproduce_json_bytes=reproduce_json_bytes,
+            webhook_payload=webhook_payload,
+            base_url=base_url,
+            force=force,
+        )
+
+        if not result.get("ok"):
+            stage = result.get("stage") or "unknown"
+            status_code = result.get("status_code") or 0
+            # Map API failures to sensible HTTP semantics:
+            # * 0 from transport (DNS / refused / timeout) → 504
+            # * 429 from API (rate limit) → 429
+            # * 4xx / 5xx from API → 502
+            # * not_configured → 503 (already handled above; defensive)
+            if stage == "not_configured":
+                http_status = 503
+            elif status_code == 0:
+                http_status = 504
+            elif status_code == 429:
+                http_status = 429
+            else:
+                http_status = 502
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    f"WaybackClaw submit failed at stage '{stage}': {result.get('error', 'unknown')}",
+                    f"WaybackClaw 提交在阶段 '{stage}' 失败:{result.get('error', '未知')}",
+                    locale,
+                ),
+                "stage": stage,
+                "api_status_code": status_code,
+            }), http_status
+
+        return jsonify({
+            "success": True,
+            "data": result.get("record"),
+            "cached": bool(result.get("cached")),
+        })
+
+    except ValueError as exc:
+        return jsonify({"success": False, "error": str(exc)}), 400
+    except Exception as e:
+        logger.error(
+            f"publish-waybackclaw: failed for {simulation_id}: {e}\n{traceback.format_exc()}"
+        )
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
 # ============== Public Gallery ==============
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -223,6 +223,36 @@ class Config:
     DKG_CONTEXT_GRAPH_ID = os.environ.get('DKG_CONTEXT_GRAPH_ID', '')
     DKG_NETWORK = (os.environ.get('DKG_NETWORK', 'testnet') or 'testnet').strip().lower()
 
+    # WaybackClaw AI Agent Archive publishing.
+    # Optional integration that submits a finished simulation's snapshot
+    # (scenario, agent count, consensus, quality, lineage, reproduce.json
+    # hash) to the WaybackClaw archive at ``api.waybackclaw.space``. The
+    # archive pins every snapshot to IPFS and broadcasts a NIP-01 note to
+    # Nostr relays, so a submission yields a content-addressed IPFS CID +
+    # a censorship-resistant Nostr event id alongside the archive's
+    # internal snapshot id. The pair is the agent-archive sibling of the
+    # OriginTrail DKG citation surface.
+    #
+    # Required:
+    #   * ``WAYBACKCLAW_AGENT_TOKEN`` — agent token issued by
+    #     ``POST /api/archive/register``. Format: ``agent_<id>:<secret>``.
+    #     Empty → integration disabled, ``/api/config/notifications``
+    #     reports ``waybackclaw_configured: false``, the EmbedDialog
+    #     hides the card.
+    # Optional:
+    #   * ``WAYBACKCLAW_API_URL`` — override the API endpoint (defaults
+    #     to ``https://api.waybackclaw.space``). Useful for staging
+    #     deployments or a self-hosted fork.
+    #   * ``WAYBACKCLAW_AGENT_CATEGORY`` — WaybackClaw taxonomy slot
+    #     for this deployment's snapshots (defaults to ``prediction``,
+    #     which fits a multi-agent swarm running prediction-market-style
+    #     consensus runs).
+    WAYBACKCLAW_API_URL = os.environ.get('WAYBACKCLAW_API_URL', '').rstrip('/')
+    WAYBACKCLAW_AGENT_TOKEN = os.environ.get('WAYBACKCLAW_AGENT_TOKEN', '')
+    WAYBACKCLAW_AGENT_CATEGORY = (
+        os.environ.get('WAYBACKCLAW_AGENT_CATEGORY', '') or ''
+    ).strip().lower()
+
     # Whether ``GET /sitemap.xml`` is served and ``robots.txt`` advertises
     # it. Default ``true`` — the public sitemap is the search-engine
     # discovery surface for the public-simulation gallery, and a

--- a/backend/app/services/waybackclaw_publisher.py
+++ b/backend/app/services/waybackclaw_publisher.py
@@ -1,0 +1,634 @@
+"""WaybackClaw archive publishing — agent snapshot surface for finished simulations.
+
+Submits a finished, published simulation as a **snapshot** to the
+WaybackClaw AI Agent Archive (``api.waybackclaw.space``). Each
+snapshot captures the scenario, agent count, total rounds, platforms,
+final consensus, quality health, lineage, and the SHA-256 of the
+canonical ``reproduce.json`` blob — packaged as a versioned record
+under the deployment's registered MiroShark agent identity.
+
+A successful submission returns a ``{id, ipfsCid, nostrEventId, …}``
+envelope that becomes the sibling of the OriginTrail DKG citation:
+the DKG anchor provides on-chain provenance, WaybackClaw provides
+content-addressed IPFS storage + Nostr broadcast on the agent-archive
+side, and ``reproduce.json`` is the bytes both layers commit to.
+
+Design notes
+------------
+
+* **Optional + env-var-gated.** ``WAYBACKCLAW_AGENT_TOKEN`` empty →
+  the module is a no-op. ``WAYBACKCLAW_API_URL`` defaults to the
+  hosted endpoint, ``WAYBACKCLAW_AGENT_CATEGORY`` defaults to
+  ``prediction`` (MiroShark sims are prediction-market-style runs).
+* **One HTTP call.** WaybackClaw exposes a single
+  ``POST /api/archive/submit`` for snapshots — no multi-step
+  WM→SWM→VM pipeline like the DKG daemon. Auth is a long-lived
+  bearer token issued via ``POST /api/archive/register``.
+* **Free for agents.** Submission carries no payment requirement
+  beyond the token. No ``X-PAYMENT`` header is sent; we let the
+  server's free-tier write path handle the request.
+* **Idempotent on disk.** A successful submission persists
+  ``<sim_dir>/waybackclaw-record.json`` and the route handler
+  returns the cached envelope without re-hitting the API on
+  subsequent clicks (matches the DKG flow). ``force=True`` is
+  plumbed through for re-submission after a sim correction.
+* **Stdlib only.** ``urllib.request`` for HTTP, ``hashlib`` for
+  the ``reproduce.json`` SHA-256, ``json`` for serialization.
+* **Never raises.** Failures surface as structured dicts so the
+  route handler can map them to sensible HTTP semantics
+  (502 / 504 / 503 / 429) instead of a generic 500.
+
+The submit payload
+------------------
+
+A minimal but complete snapshot describing the simulation, with a
+metadata blob carrying the reproducible citation primitives::
+
+    {
+      "version": "<simulation_id>",
+      "capabilities": ["swarm-simulation", "twitter", "reddit", "polymarket"],
+      "category": "prediction",
+      "modelFamily": "MiroShark",
+      "description": "<scenario>",
+      "metadata": {
+        "agentCount": 248,
+        "totalRounds": 24,
+        "bullishPercent": 62.0,
+        "neutralPercent": 13.0,
+        "bearishPercent": 25.0,
+        "qualityHealth": "Excellent",
+        "lineageKind": "original",
+        "reproduceConfigSha256": "sha256:7c9f…",
+        "reproduceConfigUrl": "https://host/api/simulation/<id>/reproduce.json",
+        "shareUrl": "https://host/share/<id>",
+        "shareCardUrl": "https://host/api/simulation/<id>/share-card.png",
+        "platform": "MiroShark",
+        "chain": "off-chain",
+        "publishedAt": "2026-05-22T12:00:00Z"
+      }
+    }
+
+The ``metadata.reproduceConfigSha256`` literal is the citation key —
+a verifier fetches the ``reproduceConfigUrl`` bytes, re-hashes them,
+and compares to the stored hash. WaybackClaw also pins the JSON
+record itself to IPFS (returning ``ipfsCid``), so the snapshot is
+content-addressed end-to-end without the operator running any
+infrastructure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..utils.logger import get_logger
+
+logger = get_logger("miroshark.waybackclaw")
+
+
+# ---- HTTP defaults ---------------------------------------------------------
+
+WAYBACKCLAW_USER_AGENT = "MiroShark-WaybackClaw/1.0"
+
+# Fast probe for the public ``GET /health`` check. The health endpoint
+# is always free + auth-free; we use it for the notifications-config
+# reachability probe.
+WAYBACKCLAW_PROBE_TIMEOUT_SECONDS = 4.0
+
+# Snapshot submissions land on the SQLite write path immediately, but
+# the API spawns async daemon threads for IPFS pinning + Nostr
+# publishing before returning the envelope with ``ipfsCid`` /
+# ``nostrEventId`` populated. 30s is conservative; under load the
+# IPFS pin can stretch past the default 10s urlopen timeout.
+WAYBACKCLAW_SUBMIT_TIMEOUT_SECONDS = 30.0
+
+
+# ---- Persistence -----------------------------------------------------------
+
+WAYBACKCLAW_RECORD_FILENAME = "waybackclaw-record.json"
+
+
+# ---- Config (late-binding so Settings modal changes take effect) ----------
+
+# WaybackClaw's hosted production endpoint. Operators can override via
+# ``WAYBACKCLAW_API_URL`` (private deployment, staging, self-hosted
+# fork) — same shape as the DKG_API_URL knob.
+WAYBACKCLAW_DEFAULT_API_URL = "https://api.waybackclaw.space"
+
+# Sensible default category for MiroShark snapshots. The WaybackClaw
+# taxonomy includes ``prediction`` (oracle / prediction-market style),
+# which is the right home for a multi-agent swarm sim with a final
+# consensus distribution. Operators can override per deployment.
+WAYBACKCLAW_DEFAULT_CATEGORY = "prediction"
+
+
+def _resolve_config() -> Dict[str, str]:
+    """Read WAYBACKCLAW_* env vars at call time via the ``Config`` class.
+
+    Late-binding mirrors webhook_service / dkg_publisher so an operator
+    pasting values into a future Settings modal sees them take effect
+    immediately without a server restart.
+    """
+    try:
+        from ..config import Config
+        return {
+            "api_url": (
+                (getattr(Config, "WAYBACKCLAW_API_URL", "") or WAYBACKCLAW_DEFAULT_API_URL)
+                .strip()
+                .rstrip("/")
+            ),
+            "agent_token": (getattr(Config, "WAYBACKCLAW_AGENT_TOKEN", "") or "").strip(),
+            "category": (
+                (getattr(Config, "WAYBACKCLAW_AGENT_CATEGORY", "") or WAYBACKCLAW_DEFAULT_CATEGORY)
+                .strip()
+                .lower()
+            ),
+        }
+    except Exception:
+        return {
+            "api_url": WAYBACKCLAW_DEFAULT_API_URL,
+            "agent_token": "",
+            "category": WAYBACKCLAW_DEFAULT_CATEGORY,
+        }
+
+
+def is_configured() -> bool:
+    """True iff ``WAYBACKCLAW_AGENT_TOKEN`` is set.
+
+    ``WAYBACKCLAW_API_URL`` has a sensible production default and is
+    never required. ``WAYBACKCLAW_AGENT_CATEGORY`` is metadata only.
+    The agent token is the single required secret — it carries both
+    identity and authorization in the
+    ``Bearer <agentId>:<secret>`` format the WaybackClaw API expects.
+    """
+    cfg = _resolve_config()
+    return bool(cfg["agent_token"])
+
+
+def mask_token(token: str) -> str:
+    """Show the leading agent id prefix of a token for log lines / UI.
+
+    Tokens look like ``agent_abc123:long-secret``. We surface the
+    agent-id half (safe, semi-public — it's effectively a username)
+    and mask the secret half completely. Mirrors
+    :func:`dkg_publisher.mask_token`.
+    """
+    if not token:
+        return ""
+    stripped = token.strip()
+    if ":" in stripped:
+        agent_part, _, _ = stripped.partition(":")
+        return f"{agent_part}:***"
+    if len(stripped) <= 6:
+        return "***"
+    return f"{stripped[:6]}***"
+
+
+# ---- HTTP transport --------------------------------------------------------
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    body: Optional[Dict[str, Any]] = None,
+    timeout: float,
+    agent_token: str,
+    api_url: str,
+) -> Tuple[bool, int, Any]:
+    """Issue one WaybackClaw API HTTP call.
+
+    Returns ``(ok, status_code, payload)``:
+      * ``ok`` — True for 2xx, False otherwise.
+      * ``status_code`` — 0 if the request never reached the server
+        (DNS / connection refused / timeout).
+      * ``payload`` — parsed JSON response when possible, otherwise
+        the raw body text or an error message on transport failure.
+
+    Never raises — submission happens inside a user-facing request
+    handler and must surface the failure as data so the frontend can
+    render a sensible error message instead of a generic 500.
+    """
+    url = f"{api_url}{path}"
+    headers: Dict[str, str] = {
+        "User-Agent": WAYBACKCLAW_USER_AGENT,
+        "Accept": "application/json",
+    }
+    if agent_token:
+        # The API accepts ``X-Agent-Token: Bearer <agentId>:<secret>``
+        # per the WaybackClaw docs. We also forward the same token via
+        # ``Authorization`` for clients / proxies that strip the
+        # custom header. Belt-and-suspenders, no behavioural change.
+        bearer = agent_token if agent_token.lower().startswith("bearer ") else f"Bearer {agent_token}"
+        headers["X-Agent-Token"] = bearer
+        headers["Authorization"] = bearer
+
+    data: Optional[bytes] = None
+    if body is not None:
+        try:
+            data = json.dumps(body).encode("utf-8")
+        except Exception as exc:
+            return False, 0, f"could not serialize request body: {exc}"
+        headers["Content-Type"] = "application/json; charset=utf-8"
+
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = resp.getcode() or 0
+            raw = resp.read()
+            payload = _parse_body(raw)
+            ok = 200 <= status < 300
+            return ok, status, payload
+    except urllib.error.HTTPError as exc:
+        try:
+            raw = exc.read() or b""
+        except Exception:
+            raw = b""
+        payload = _parse_body(raw)
+        return False, exc.code or 0, payload
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        return False, 0, f"URL error: {reason}"
+    except Exception as exc:
+        return False, 0, f"{type(exc).__name__}: {exc}"
+
+
+def _parse_body(raw: bytes) -> Any:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except Exception:
+        try:
+            return raw.decode("utf-8", errors="replace")
+        except Exception:
+            return None
+
+
+# ---- Health probe ---------------------------------------------------------
+
+
+def health_check() -> Dict[str, Any]:
+    """Probe the API via ``GET /health``. Always returns a dict.
+
+    Used by the notifications-config probe to render a "reachable"
+    badge in the EmbedDialog before the user clicks publish. The
+    health endpoint is auth-free so we send it without a token to
+    keep the probe useful even on a deployment that hasn't pasted
+    the agent token in yet.
+    """
+    cfg = _resolve_config()
+    ok, status, payload = _request(
+        "GET",
+        "/health",
+        timeout=WAYBACKCLAW_PROBE_TIMEOUT_SECONDS,
+        agent_token="",
+        api_url=cfg["api_url"],
+    )
+    return {
+        "ok": ok,
+        "configured": is_configured(),
+        "status_code": status,
+        "response": payload if ok else None,
+        "error": None if ok else (payload if isinstance(payload, str) else "unreachable"),
+    }
+
+
+# ---- Record file ----------------------------------------------------------
+
+
+def record_path(sim_dir: str) -> str:
+    return os.path.join(sim_dir or "", WAYBACKCLAW_RECORD_FILENAME)
+
+
+def read_record(sim_dir: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Return the persisted submission record, or ``None`` if absent.
+
+    Cheap read used by the EmbedDialog to render the existing
+    snapshot badge without forcing another submission. Never raises.
+    """
+    if not sim_dir:
+        return None
+    path = record_path(sim_dir)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            obj = json.load(fh)
+        if isinstance(obj, dict):
+            return obj
+    except Exception:
+        return None
+    return None
+
+
+_RECORD_WRITE_LOCK = threading.Lock()
+
+
+def _write_record(sim_dir: str, payload: Dict[str, Any]) -> None:
+    """Persist the submission record atomically via tempfile + os.replace.
+
+    Mirrors the dkg-citation on-disk atomic-write pattern.
+    """
+    if not sim_dir:
+        return
+    try:
+        os.makedirs(sim_dir, exist_ok=True)
+    except OSError as exc:
+        logger.warning(f"waybackclaw-record: could not ensure sim_dir for {sim_dir}: {exc}")
+        return
+    path = record_path(sim_dir)
+    tmp_path = path + ".tmp"
+    with _RECORD_WRITE_LOCK:
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2, sort_keys=True)
+            os.replace(tmp_path, path)
+        except OSError as exc:
+            logger.warning(f"waybackclaw-record: write failed for {sim_dir}: {exc}")
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
+
+
+# ---- Snapshot payload assembly --------------------------------------------
+
+
+def _sha256_hex(payload_bytes: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload_bytes).hexdigest()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _derive_capabilities(repro_blob: Dict[str, Any]) -> List[str]:
+    """Translate enabled platforms into WaybackClaw capability tags.
+
+    Capabilities are free-form short strings on the WaybackClaw API;
+    we pick a stable set of MiroShark-flavoured ones so the archive's
+    capability index has useful aggregates for searches like "find
+    every prediction agent that simulates a Polymarket-style market".
+    """
+    caps: List[str] = ["swarm-simulation", "multi-agent", "consensus-tracking"]
+    platforms = repro_blob.get("platforms") or {}
+    if isinstance(platforms, dict):
+        if platforms.get("twitter"):
+            caps.append("twitter")
+        if platforms.get("reddit"):
+            caps.append("reddit")
+        if platforms.get("polymarket"):
+            caps.append("polymarket")
+    return caps
+
+
+def build_submission(
+    *,
+    simulation_id: str,
+    repro_blob: Dict[str, Any],
+    reproduce_json_bytes: bytes,
+    webhook_payload: Dict[str, Any],
+    base_url: str,
+    category: str,
+) -> Tuple[Dict[str, Any], str]:
+    """Compose the WaybackClaw snapshot submission body.
+
+    Returns ``(body, reproduce_sha256)``. The hash is the citation
+    key — a verifier fetches ``metadata.reproduceConfigUrl``, SHA-256s
+    the bytes, and compares against the literal stored in the
+    snapshot's metadata (and pinned content-addressed via IPFS).
+
+    ``webhook_payload`` is reused as the source of the consensus +
+    quality + scenario summary so the on-archive claim matches the
+    notification claim byte-for-byte.
+    """
+    repro_sha = _sha256_hex(reproduce_json_bytes)
+
+    scenario = (
+        webhook_payload.get("scenario")
+        or repro_blob.get("scenario")
+        or f"MiroShark simulation {simulation_id}"
+    )
+
+    agent_count = int(repro_blob.get("agent_count") or webhook_payload.get("agent_count") or 0)
+    total_rounds = int(repro_blob.get("total_rounds") or webhook_payload.get("total_rounds") or 0)
+
+    metadata: Dict[str, Any] = {
+        "simulationId": simulation_id,
+        "agentCount": agent_count,
+        "totalRounds": total_rounds,
+        "reproduceConfigSha256": repro_sha,
+        "platform": "MiroShark",
+        # MiroShark sims aren't on-chain — the metadata layer's
+        # ``chain`` field maps to the consensus venue for tokenized
+        # agents in the WaybackClaw taxonomy, so labelling the runs
+        # ``off-chain`` is accurate and avoids implying a chain
+        # affinity the runner doesn't have.
+        "chain": "off-chain",
+        "framework": "MiroShark",
+        "publishedAt": _now_iso(),
+    }
+
+    consensus = webhook_payload.get("final_consensus")
+    if isinstance(consensus, dict):
+        if "bullish" in consensus:
+            metadata["bullishPercent"] = round(float(consensus.get("bullish") or 0.0), 1)
+        if "neutral" in consensus:
+            metadata["neutralPercent"] = round(float(consensus.get("neutral") or 0.0), 1)
+        if "bearish" in consensus:
+            metadata["bearishPercent"] = round(float(consensus.get("bearish") or 0.0), 1)
+
+    quality_health = webhook_payload.get("quality_health")
+    if quality_health:
+        metadata["qualityHealth"] = quality_health
+
+    resolution_outcome = webhook_payload.get("resolution_outcome")
+    if resolution_outcome:
+        metadata["resolutionOutcome"] = resolution_outcome
+
+    created_at = webhook_payload.get("created_at")
+    if created_at:
+        metadata["createdAt"] = created_at
+    completed_at = webhook_payload.get("completed_at")
+    if completed_at:
+        metadata["completedAt"] = completed_at
+
+    lineage = repro_blob.get("lineage") or {}
+    if isinstance(lineage, dict):
+        kind = lineage.get("kind") or "original"
+        metadata["lineageKind"] = kind
+        parent_id = lineage.get("parent_simulation_id")
+        if parent_id:
+            metadata["parentSimulationId"] = parent_id
+        cf = lineage.get("counterfactual") or {}
+        if isinstance(cf, dict):
+            if cf.get("trigger_round"):
+                metadata["counterfactualTriggerRound"] = int(cf.get("trigger_round") or 0)
+            if cf.get("label"):
+                metadata["counterfactualLabel"] = cf.get("label")
+
+    platforms = repro_blob.get("platforms") or {}
+    if isinstance(platforms, dict):
+        metadata["twitterEnabled"] = bool(platforms.get("twitter", False))
+        metadata["redditEnabled"] = bool(platforms.get("reddit", False))
+        metadata["polymarketEnabled"] = bool(platforms.get("polymarket", False))
+
+    if base_url:
+        base = base_url.rstrip("/")
+        metadata["reproduceConfigUrl"] = f"{base}/api/simulation/{simulation_id}/reproduce.json"
+        metadata["shareUrl"] = f"{base}/share/{simulation_id}"
+        metadata["shareCardUrl"] = f"{base}/api/simulation/{simulation_id}/share-card.png"
+
+    body: Dict[str, Any] = {
+        # The snapshot ``version`` field is free-form; using the
+        # simulation id keeps the archive's per-agent version history
+        # 1:1 with MiroShark's own sim ids so a viewer can match
+        # archive entries back to ``/share/<id>`` URLs without
+        # cross-referencing.
+        "version": simulation_id,
+        "capabilities": _derive_capabilities(repro_blob),
+        "category": category,
+        "modelFamily": "MiroShark",
+        "description": scenario,
+        "metadata": metadata,
+    }
+    return body, repro_sha
+
+
+# ---- Submission flow ------------------------------------------------------
+
+
+def submit_snapshot(
+    *,
+    simulation_id: str,
+    sim_dir: str,
+    repro_blob: Dict[str, Any],
+    reproduce_json_bytes: bytes,
+    webhook_payload: Dict[str, Any],
+    base_url: str,
+    force: bool = False,
+) -> Dict[str, Any]:
+    """Submit a simulation snapshot to the WaybackClaw archive.
+
+    Idempotent: a successful submission persists the response envelope
+    to ``<sim_dir>/waybackclaw-record.json`` and is returned directly
+    on subsequent calls unless ``force=True``.
+
+    Returns one of these shapes:
+
+      * ``{ok: True, record: {…}, cached: True}`` — record already on
+        disk, no API call made.
+      * ``{ok: True, record: {…}, cached: False}`` — fresh submission.
+      * ``{ok: False, status_code: int, stage: str, error: str}`` —
+        submission failed. Stage values: ``"not_configured"``,
+        ``"submit"``.
+
+    Never raises.
+    """
+    if not is_configured():
+        return {
+            "ok": False,
+            "status_code": 0,
+            "stage": "not_configured",
+            "error": "WAYBACKCLAW_AGENT_TOKEN not set",
+        }
+
+    if not force:
+        existing = read_record(sim_dir)
+        if existing and existing.get("id"):
+            return {"ok": True, "record": existing, "cached": True}
+
+    cfg = _resolve_config()
+    body, repro_sha = build_submission(
+        simulation_id=simulation_id,
+        repro_blob=repro_blob,
+        reproduce_json_bytes=reproduce_json_bytes,
+        webhook_payload=webhook_payload,
+        base_url=base_url,
+        category=cfg["category"],
+    )
+
+    masked = mask_token(cfg["agent_token"])
+    logger.info(
+        f"waybackclaw-submit: starting {simulation_id} → {cfg['api_url']} "
+        f"category={cfg['category']} token={masked}"
+    )
+
+    ok, status, payload = _request(
+        "POST",
+        "/api/archive/submit",
+        body=body,
+        timeout=WAYBACKCLAW_SUBMIT_TIMEOUT_SECONDS,
+        agent_token=cfg["agent_token"],
+        api_url=cfg["api_url"],
+    )
+    if not ok:
+        return _fail("submit", status, payload)
+
+    if not isinstance(payload, dict):
+        return _fail("submit", status, f"unexpected response shape: {payload!r}")
+
+    # The WaybackClaw API wraps everything in ``{success, data, timestamp}``.
+    # Unwrap when present, fall back to the raw payload for resilience
+    # against a future shape change.
+    envelope = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+
+    snapshot_id = envelope.get("id") or ""
+    if not snapshot_id:
+        return _fail("submit", status, f"API returned no snapshot id: {payload!r}")
+
+    record: Dict[str, Any] = {
+        "id": snapshot_id,
+        "agent_id": envelope.get("agentId") or "",
+        "agent_name": envelope.get("agentName") or "",
+        "version": envelope.get("version") or simulation_id,
+        "category": envelope.get("category") or cfg["category"],
+        "captured_at": envelope.get("capturedAt") or "",
+        "ipfs_cid": envelope.get("ipfsCid") or "",
+        "nostr_event_id": envelope.get("nostrEventId") or "",
+        "access_level": envelope.get("accessLevel") or "",
+        "reproduce_config_sha256": repro_sha,
+        "archive_url": f"{cfg['api_url']}/api/archive/retrieve?agentId={envelope.get('agentId') or ''}".rstrip(),
+        "ipfs_gateway_url": (
+            f"https://gateway.pinata.cloud/ipfs/{envelope.get('ipfsCid')}"
+            if envelope.get("ipfsCid") else ""
+        ),
+        "submitted_at": _now_iso(),
+        "schema_version": "1",
+    }
+
+    _write_record(sim_dir, record)
+    logger.info(
+        f"waybackclaw-submit: ok {simulation_id} → {snapshot_id} "
+        f"(ipfs={record['ipfs_cid'][:10] if record['ipfs_cid'] else 'n/a'}…, "
+        f"nostr={record['nostr_event_id'][:10] if record['nostr_event_id'] else 'n/a'}…)"
+    )
+    return {"ok": True, "record": record, "cached": False}
+
+
+def _fail(stage: str, status: int, payload: Any) -> Dict[str, Any]:
+    """Shape a submission failure into the structured response."""
+    if isinstance(payload, dict):
+        try:
+            err_text = json.dumps(payload, ensure_ascii=False)
+        except Exception:
+            err_text = str(payload)
+    else:
+        err_text = str(payload) if payload is not None else ""
+    if len(err_text) > 800:
+        err_text = err_text[:797].rstrip() + "…"
+    logger.warning(f"waybackclaw-submit: stage={stage} status={status} error={err_text}")
+    return {
+        "ok": False,
+        "status_code": status,
+        "stage": stage,
+        "error": err_text or f"WaybackClaw API returned status {status}",
+    }

--- a/docs/WAYBACKCLAW.md
+++ b/docs/WAYBACKCLAW.md
@@ -1,0 +1,228 @@
+# WaybackClaw archive submission
+
+MiroShark can submit a finished simulation's snapshot to the
+**WaybackClaw AI Agent Archive** (`api.waybackclaw.space`). Each
+submission is indexed by the archive, pinned to IPFS via Pinata for
+content-addressed storage, and broadcast to Nostr relays as a NIP-01
+text note — three independent persistence layers in one POST.
+
+The returned snapshot id + IPFS CID + Nostr event id become the
+agent-side sibling of the OriginTrail DKG citation. The DKG anchor
+gives on-chain provenance; WaybackClaw gives content-addressed storage
++ a live event stream other agents can subscribe to without an API key.
+Both layers commit to the same `reproduce.json` bytes, so a verifier
+can fetch the file, SHA-256 it, and compare to either side.
+
+The integration is **optional and opt-in**: leave
+`WAYBACKCLAW_AGENT_TOKEN` blank → the feature hides itself entirely
+(no card, no probe). Set the token and the EmbedDialog grows a
+"Submit to WaybackClaw" card next to the OriginTrail DKG card.
+
+## TL;DR — what you get
+
+* **One-click submission** in the share dialog of any public simulation.
+* On success: `snap_…` snapshot id + IPFS CID (`Qm…`) + Nostr event
+  id + an IPFS gateway link.
+* **Idempotent.** A second click on the same sim returns the cached
+  record from disk without re-hitting the API.
+* **Free for agents.** Submission is a free-tier write — no payment
+  header, no on-chain cost. WaybackClaw rate-limits by reputation
+  tier (see `https://api.waybackclaw.space` docs).
+* **Three durability layers.** SQLite index (fast queries), IPFS pin
+  (immutable + content-addressed), Nostr broadcast (decentralized
+  distribution). Any one layer surviving keeps the snapshot retrievable.
+
+## One-time setup
+
+You need one thing: a WaybackClaw agent token. Registration is a
+single curl call.
+
+### 1. Register a WaybackClaw agent
+
+```bash
+curl -X POST https://api.waybackclaw.space/api/archive/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentName": "MyMiroSharkDeployment",
+    "category": "prediction",
+    "platform": "MiroShark",
+    "chain": "off-chain"
+  }'
+```
+
+The response carries a token of the form
+`agent_a1b2c3d4e5f6:Rz9x…long-secret…`. **Copy it now** — the
+WaybackClaw API does not let you re-fetch it later.
+
+### 2. Wire MiroShark up
+
+Paste into `.env`:
+
+```bash
+# WaybackClaw archive (optional — leave blank to disable the feature)
+WAYBACKCLAW_AGENT_TOKEN=agent_a1b2c3d4e5f6:Rz9x...your-secret
+# Optional overrides (sensible defaults; leave blank for the common case)
+# WAYBACKCLAW_API_URL=https://api.waybackclaw.space
+# WAYBACKCLAW_AGENT_CATEGORY=prediction
+```
+
+Restart MiroShark (or save through the Settings modal — env reads are
+late-bound). The next time you open the share dialog of a public sim,
+the **WaybackClaw archive** card appears.
+
+If `WAYBACKCLAW_AGENT_TOKEN` is blank the feature hides entirely and
+`GET /api/config/notifications` reports `waybackclaw_configured: false`.
+
+## How it works (one API call)
+
+WaybackClaw's snapshot submission is a single POST — no multi-step
+write-promote-publish flow like the OriginTrail DKG daemon. MiroShark
+builds the body from the same `reproduce.json` blob the public
+`/reproduce.json` endpoint serves, so the on-archive
+`reproduceConfigSha256` matches what a verifier would compute from
+the URL byte-for-byte.
+
+```
+POST /api/archive/submit
+X-Agent-Token: Bearer agent_…:secret
+Content-Type: application/json
+```
+
+The submission body:
+
+```json
+{
+  "version": "sim_abc123",
+  "capabilities": ["swarm-simulation", "multi-agent", "consensus-tracking", "twitter", "polymarket"],
+  "category": "prediction",
+  "modelFamily": "MiroShark",
+  "description": "Will the SEC approve a spot AAVE ETF by EOY?",
+  "metadata": {
+    "simulationId": "sim_abc123",
+    "agentCount": 248,
+    "totalRounds": 24,
+    "bullishPercent": 62.0,
+    "neutralPercent": 13.0,
+    "bearishPercent": 25.0,
+    "qualityHealth": "Excellent",
+    "lineageKind": "original",
+    "reproduceConfigSha256": "sha256:7c9f…",
+    "reproduceConfigUrl": "https://your-host/api/simulation/sim_abc123/reproduce.json",
+    "shareUrl": "https://your-host/share/sim_abc123",
+    "shareCardUrl": "https://your-host/api/simulation/sim_abc123/share-card.png",
+    "publishedAt": "2026-05-22T12:00:00Z"
+  }
+}
+```
+
+The API responds with the snapshot envelope plus, once the async pin
++ broadcast threads finish, the `ipfsCid` and `nostrEventId` fields:
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "snap_abc123def456",
+    "agentId": "mymirosharkdeployment",
+    "agentName": "MyMiroSharkDeployment",
+    "version": "sim_abc123",
+    "category": "prediction",
+    "capturedAt": "2026-05-22T12:00:00.000Z",
+    "ipfsCid": "QmX7b...k9f",
+    "nostrEventId": "a1b2c3d4...",
+    "accessLevel": "agent"
+  }
+}
+```
+
+MiroShark persists these (alongside the local
+`reproduceConfigSha256`) as `<sim_dir>/waybackclaw-record.json`, so a
+re-click on the button returns the cached record directly. The
+submission flow is implemented in
+[`backend/app/services/waybackclaw_publisher.py`](../backend/app/services/waybackclaw_publisher.py).
+
+## HTTP endpoints
+
+| Method | Path                                            | Auth        | Returns                                                |
+| ------ | ----------------------------------------------- | ----------- | ------------------------------------------------------ |
+| GET    | `/api/simulation/<id>/waybackclaw-record`       | Public      | Persisted record; 404 if not yet submitted             |
+| POST   | `/api/simulation/<id>/publish-waybackclaw`      | Admin token | Submits the snapshot; returns the record               |
+| GET    | `/api/config/notifications`                     | Public      | `{waybackclaw_configured, …}` presence booleans        |
+
+The publish endpoint requires `Authorization: Bearer $MIROSHARK_ADMIN_TOKEN`
+by parity with `publish-dkg`. The WaybackClaw write path itself is
+free with agent auth, but gating "who can speak for this MiroShark
+deployment in the public archive" behind the admin token keeps that
+decision in the operator's hands rather than every dialog viewer's.
+
+Response codes:
+
+* `200` — submit succeeded (or cached record returned)
+* `403` — simulation not published (call `POST /publish` first)
+* `404` — simulation not found
+* `422` — sim hasn't reached the prepared state (nothing to archive)
+* `429` — WaybackClaw rate limit exceeded (back off and retry)
+* `502` — WaybackClaw API returned an error
+* `503` — `WAYBACKCLAW_AGENT_TOKEN` not configured on this deployment
+* `504` — WaybackClaw API unreachable / submit timed out
+
+## Verifying a record
+
+Once a sim is submitted, anyone with the snapshot id can verify:
+
+```bash
+# 1. Read the persisted record from MiroShark
+curl -s "https://your-host/api/simulation/sim_abc123/waybackclaw-record" \
+  | jq .data
+
+# 2. Fetch the reproduce.json bytes
+curl -s "https://your-host/api/simulation/sim_abc123/reproduce.json" > repro.json
+
+# 3. SHA-256 the bytes
+shasum -a 256 repro.json
+# → 7c9f6e… repro.json
+
+# 4. Compare to the WaybackClaw-stored value
+#    The reproduce_config_sha256 field on the record above must match.
+
+# 5. (Optional) Re-fetch the content-addressed snapshot from IPFS
+curl -s "https://gateway.pinata.cloud/ipfs/<ipfs_cid_from_step_1>" | jq .
+```
+
+A mismatch means the simulation parameters have been altered since
+submission — by design, the IPFS-pinned blob cannot be silently
+rewritten without changing the CID.
+
+## What WaybackClaw adds on top of DKG
+
+| Property                         | DKG (OriginTrail) | WaybackClaw                    |
+| -------------------------------- | ----------------- | ------------------------------ |
+| Storage                          | RDF assertion     | JSON snapshot                  |
+| Immutability                     | On-chain Merkle   | IPFS content-addressed CID     |
+| Distribution                     | Pull (explorer)   | Push (Nostr relays)            |
+| Cost per write                   | TRAC + gas        | Free (agent token)             |
+| Cost per read                    | Free              | Free (redacted) / WBC (full)   |
+| Setup                            | Run a local daemon| Single curl to register        |
+| Subscriber discovery             | Indexer required  | Any Nostr relay client         |
+
+Run **both** to get the strongest provenance story: the DKG anchor
+binds the citation to a blockchain Merkle root, WaybackClaw binds it
+to a content-addressed CID and a Nostr event id. Triple-redundant —
+no single layer needs to survive for the citation to verify.
+
+## Disabling
+
+Remove `WAYBACKCLAW_AGENT_TOKEN` from `.env` and restart. The card
+disappears, the public probe reports `waybackclaw_configured: false`,
+and existing `waybackclaw-record.json` files stay on disk (still
+served by `GET /waybackclaw-record` if the operator re-enables the
+feature later).
+
+## See also
+
+* [WaybackClaw API documentation](https://api.waybackclaw.space) — full
+  endpoint reference, taxonomy, and reputation tiers
+* [`backend/app/services/waybackclaw_publisher.py`](../backend/app/services/waybackclaw_publisher.py)
+* [`backend/app/services/repro_export.py`](../backend/app/services/repro_export.py) — the reproduce.json builder whose bytes get hashed
+* [DKG.md](DKG.md) — the on-chain provenance sibling
+* [Notifications](NOTIFICATIONS.md) — webhook / Discord / Slack / Telegram / email sibling channels

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -1110,6 +1110,54 @@ export const publishToDkg = (simulationId, opts = {}) => {
 }
 
 /**
+ * Read the persisted WaybackClaw archive submission for a published
+ * sim. Returns 404 when the sim has never been submitted — same
+ * publish gate as reproduce.json / dkg-citation. No API call to
+ * api.waybackclaw.space; the on-disk record is the source of truth.
+ *
+ * Response shape (under `data`):
+ *   {
+ *     id: "snap_…",
+ *     agent_id: string,
+ *     agent_name: string,
+ *     version: string,
+ *     category: string,
+ *     captured_at: ISO8601 string,
+ *     ipfs_cid: string,
+ *     nostr_event_id: string,
+ *     access_level: string,
+ *     reproduce_config_sha256: "sha256:…",
+ *     archive_url: string,
+ *     ipfs_gateway_url: string,
+ *     submitted_at: ISO8601 string,
+ *   }
+ *
+ * @param {string} simulationId
+ */
+export const getWaybackclawRecord = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/waybackclaw-record`)
+}
+
+/**
+ * Submit a finished simulation's snapshot to the WaybackClaw AI Agent
+ * Archive. Requires admin auth (parity with the DKG publish route —
+ * gates "who can speak for this MiroShark deployment in the public
+ * archive"). Idempotent — the second call returns the cached record
+ * without re-submitting.
+ *
+ * Same response shape as ``getWaybackclawRecord`` for the success
+ * case, with an additional ``cached: boolean`` field at the top level
+ * signalling whether the API was contacted.
+ *
+ * @param {string} simulationId
+ * @param {{ force?: boolean }} [opts]
+ */
+export const publishToWaybackclaw = (simulationId, opts = {}) => {
+  const body = opts.force ? { force: true } : {}
+  return service.post(`/api/simulation/${simulationId}/publish-waybackclaw`, body)
+}
+
+/**
  * Branch a simulation with a narrative injection at a specific round.
  * The new simulation is READY and shares the parent's agent population;
  * when the runner hits trigger_round it auto-promotes the injection into

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -1348,6 +1348,150 @@
               </div>
             </div>
 
+            <!-- WaybackClaw AI Agent Archive — the agent-side citation
+                 sibling of the DKG card. Opt-in: rendered only when
+                 WAYBACKCLAW_AGENT_TOKEN is set on this deployment.
+                 The "Submit to WaybackClaw" button POSTs a snapshot
+                 (scenario, agent count, consensus, quality,
+                 reproduce.json hash) to api.waybackclaw.space, which
+                 pins it to IPFS and broadcasts a NIP-01 note to Nostr
+                 relays before returning the snapshot id + IPFS CID +
+                 Nostr event id. Idempotent — once submitted, subsequent
+                 dialog opens read the cached record from disk without
+                 re-hitting the API. Free for agents (no on-chain cost). -->
+            <div
+              v-if="isPublic && notifConfig.waybackclaw_configured"
+              class="transcript-section dkg-section"
+            >
+              <div class="transcript-head dkg-head">
+                <span class="transcript-icon">🗄️</span>
+                <div class="transcript-head-body">
+                  <div class="transcript-title">
+                    {{ $tr('WaybackClaw archive', 'WaybackClaw 归档') }}
+                    <span class="lineage-count-chip dkg-network-chip-testnet">
+                      {{ $tr('IPFS + Nostr', 'IPFS + Nostr') }}
+                    </span>
+                  </div>
+                  <div class="transcript-sub">
+                    {{ $tr('Submit the snapshot (scenario, agent count, consensus, quality, reproduce.json hash) to the WaybackClaw AI Agent Archive. The archive pins the record to IPFS for content-addressed storage and broadcasts it to Nostr relays for real-time distribution — an open, agent-readable history of this MiroShark deployment.', '将快照(情景、智能体数、共识、质量、reproduce.json 哈希)提交至 WaybackClaw AI Agent 归档。归档会将记录固定到 IPFS 以实现内容寻址存储,并广播到 Nostr 中继以实现实时分发 — 为该 MiroShark 部署构建一份开放、可被其他智能体读取的历史记录。') }}
+                  </div>
+                </div>
+              </div>
+
+              <div class="dkg-body">
+                <!-- Already submitted — show the snapshot primitives -->
+                <div v-if="wbcRecord && wbcRecord.id" class="dkg-card">
+                  <div class="dkg-row">
+                    <span class="dkg-row-label">{{ $tr('Snapshot', '快照') }}</span>
+                    <code
+                      class="dkg-row-value dkg-row-mono"
+                      :title="wbcRecord.id"
+                    >{{ wbcRecord.id }}</code>
+                    <button
+                      class="snippet-copy-btn dkg-copy"
+                      type="button"
+                      @click="copy('wbcId')"
+                    >
+                      {{ copied === 'wbcId' ? '✓' : $tr('Copy', '复制') }}
+                    </button>
+                  </div>
+                  <div v-if="wbcRecord.agent_name" class="dkg-row">
+                    <span class="dkg-row-label">{{ $tr('Agent', '智能体') }}</span>
+                    <code class="dkg-row-value dkg-row-mono">
+                      {{ wbcRecord.agent_name }}<span v-if="wbcRecord.agent_id"> · {{ wbcRecord.agent_id }}</span>
+                    </code>
+                  </div>
+                  <div v-if="wbcRecord.ipfs_cid" class="dkg-row">
+                    <span class="dkg-row-label">IPFS CID</span>
+                    <code
+                      class="dkg-row-value dkg-row-mono"
+                      :title="wbcRecord.ipfs_cid"
+                    >{{ formatHashShort(wbcRecord.ipfs_cid) }}</code>
+                    <button
+                      class="snippet-copy-btn dkg-copy"
+                      type="button"
+                      @click="copy('wbcIpfs')"
+                    >
+                      {{ copied === 'wbcIpfs' ? '✓' : $tr('Copy', '复制') }}
+                    </button>
+                  </div>
+                  <div v-if="wbcRecord.nostr_event_id" class="dkg-row">
+                    <span class="dkg-row-label">Nostr</span>
+                    <code
+                      class="dkg-row-value dkg-row-mono"
+                      :title="wbcRecord.nostr_event_id"
+                    >{{ formatHashShort(wbcRecord.nostr_event_id) }}</code>
+                    <button
+                      class="snippet-copy-btn dkg-copy"
+                      type="button"
+                      @click="copy('wbcNostr')"
+                    >
+                      {{ copied === 'wbcNostr' ? '✓' : $tr('Copy', '复制') }}
+                    </button>
+                  </div>
+                  <div v-if="wbcRecord.reproduce_config_sha256" class="dkg-row">
+                    <span class="dkg-row-label">{{ $tr('Config hash', '配置哈希') }}</span>
+                    <code
+                      class="dkg-row-value dkg-row-mono"
+                      :title="wbcRecord.reproduce_config_sha256"
+                    >{{ formatHashShort(wbcRecord.reproduce_config_sha256) }}</code>
+                  </div>
+                  <div class="dkg-actions">
+                    <a
+                      v-if="wbcRecord.ipfs_gateway_url"
+                      class="repro-download"
+                      :href="wbcRecord.ipfs_gateway_url"
+                      target="_blank"
+                      rel="noopener"
+                    >
+                      {{ $tr('Open on IPFS gateway ↗', '在 IPFS 网关中打开 ↗') }}
+                    </a>
+                    <a
+                      v-if="wbcRecord.archive_url"
+                      class="repro-download"
+                      :href="wbcRecord.archive_url"
+                      target="_blank"
+                      rel="noopener"
+                    >
+                      {{ $tr('View agent in archive ↗', '在归档中查看智能体 ↗') }}
+                    </a>
+                  </div>
+                  <div class="repro-note">
+                    {{ $tr('A verifier fetches reproduce.json, SHA-256s the bytes, and compares to the config hash stored in the snapshot metadata. The IPFS CID makes the record itself content-addressed, and the Nostr event id gives any relay subscriber an independent witness of the submission.', '验证者获取 reproduce.json,计算 SHA-256 后与快照元数据中的配置哈希比对。IPFS CID 使记录本身可通过内容寻址访问,Nostr 事件 ID 让任意中继订阅者获得对该提交的独立见证。') }}
+                  </div>
+                </div>
+
+                <!-- Not yet submitted — show the submit CTA -->
+                <div v-else-if="!wbcLoading" class="dkg-card dkg-card-empty">
+                  <div class="dkg-empty-text">
+                    {{ $tr('Not yet submitted to the WaybackClaw archive.', '尚未提交至 WaybackClaw 归档。') }}
+                  </div>
+                  <div class="dkg-actions">
+                    <button
+                      class="repro-download dkg-publish-btn"
+                      type="button"
+                      :disabled="wbcSubmitting"
+                      @click="publishWaybackclaw"
+                    >
+                      <span v-if="wbcSubmitting">
+                        {{ $tr('Submitting…', '正在提交…') }}
+                      </span>
+                      <span v-else>
+                        🗄️ {{ $tr('Submit to WaybackClaw', '提交至 WaybackClaw') }}
+                      </span>
+                    </button>
+                  </div>
+                  <div class="repro-note">
+                    {{ $tr('Free for agents — no on-chain cost. The archive pins the snapshot to IPFS and broadcasts to Nostr.', '智能体提交免费 — 无链上费用。归档会将快照固定到 IPFS 并广播到 Nostr。') }}
+                  </div>
+                </div>
+
+                <div v-if="wbcError" class="webhook-log-message" :class="wbcErrorClass">
+                  {{ wbcError }}
+                </div>
+              </div>
+            </div>
+
             <!-- Lineage navigator — closes the navigation gap PR #75
                  (reproducibility config) left behind. The
                  `parent_simulation_id` pointer existed on disk but was
@@ -2032,6 +2176,8 @@ import {
   retryWebhookDelivery,
   getDkgCitation,
   publishToDkg,
+  getWaybackclawRecord,
+  publishToWaybackclaw,
   getFrameMetadata,
   buildWarpcastComposeUrl,
 } from '../api/simulation'
@@ -2936,6 +3082,7 @@ const notifConfig = ref({
   email_configured: false,
   dkg_configured: false,
   dkg_network: null,
+  waybackclaw_configured: false,
 })
 const notifConfigLoaded = ref(false)
 const loadNotificationsConfig = async () => {
@@ -2950,6 +3097,7 @@ const loadNotificationsConfig = async () => {
       email_configured: !!data.email_configured,
       dkg_configured: !!data.dkg_configured,
       dkg_network: data.dkg_network || null,
+      waybackclaw_configured: !!data.waybackclaw_configured,
     }
   } catch {
     notifConfig.value = {
@@ -2959,6 +3107,7 @@ const loadNotificationsConfig = async () => {
       email_configured: false,
       dkg_configured: false,
       dkg_network: null,
+      waybackclaw_configured: false,
     }
   } finally {
     notifConfigLoaded.value = true
@@ -3043,6 +3192,9 @@ const copy = async (which) => {
   else if (which === 'notebookCurl') text = notebookCurlSnippet.value
   else if (which === 'dkgUal') text = dkgCitation.value?.ual || ''
   else if (which === 'dkgMerkle') text = dkgCitation.value?.merkle_root || ''
+  else if (which === 'wbcId') text = wbcRecord.value?.id || ''
+  else if (which === 'wbcIpfs') text = wbcRecord.value?.ipfs_cid || ''
+  else if (which === 'wbcNostr') text = wbcRecord.value?.nostr_event_id || ''
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)
@@ -3423,6 +3575,113 @@ const _resetDkgState = () => {
   dkgErrorClass.value = ''
 }
 
+// ---- WaybackClaw archive state -----------------------------------------
+//
+// The WaybackClaw card is the agent-archive sibling of the DKG card:
+// opt-in (gated by ``notifConfig.waybackclaw_configured``), follows the
+// same load-on-mount → submit-on-click → cached-thereafter state
+// machine. Free for agents — no on-chain cost — so the publish CTA is
+// simpler than the DKG one (no TRAC / gas balance to worry about).
+const wbcRecord = ref(null)
+const wbcLoading = ref(false)
+const wbcSubmitting = ref(false)
+const wbcError = ref('')
+const wbcErrorClass = ref('')
+
+const loadWaybackclawRecord = async () => {
+  if (!props.simulationId) return
+  if (!notifConfig.value.waybackclaw_configured) return
+  if (!isPublic.value) return
+  wbcLoading.value = true
+  wbcError.value = ''
+  try {
+    const res = await getWaybackclawRecord(props.simulationId)
+    if (res?.success && res.data) {
+      wbcRecord.value = res.data
+    } else {
+      wbcRecord.value = null
+    }
+  } catch (err) {
+    const status = err?.response?.status
+    if (status !== 404) {
+      // Soft-failure same as DKG — leave the card showing the
+      // submit CTA. The submit attempt itself surfaces real errors.
+    }
+    wbcRecord.value = null
+  } finally {
+    wbcLoading.value = false
+  }
+}
+
+const publishWaybackclaw = async () => {
+  if (!props.simulationId || wbcSubmitting.value) return
+  if (!notifConfig.value.waybackclaw_configured) return
+  if (!isPublic.value) return
+  wbcSubmitting.value = true
+  wbcError.value = ''
+  wbcErrorClass.value = ''
+  try {
+    const res = await publishToWaybackclaw(props.simulationId)
+    if (res?.success && res.data?.id) {
+      wbcRecord.value = res.data
+      wbcError.value = res?.cached
+        ? tr('Already submitted — returned existing record.', '已提交 — 返回现有归档记录。')
+        : tr('Submitted to WaybackClaw. Snapshot archived.', '已提交至 WaybackClaw,快照已归档。')
+      wbcErrorClass.value = 'webhook-log-message-ok'
+    } else {
+      wbcError.value = res?.error || tr('Could not submit to WaybackClaw.', '无法提交至 WaybackClaw。')
+      wbcErrorClass.value = 'webhook-log-message-error'
+    }
+  } catch (err) {
+    const status = err?.response?.status
+    const serverErr = err?.response?.data?.error
+    if (status === 401) {
+      wbcError.value = tr(
+        'Admin token does not match — set Authorization: Bearer $MIROSHARK_ADMIN_TOKEN to submit to WaybackClaw.',
+        '管理员 token 不匹配 — 请设置 Authorization: Bearer $MIROSHARK_ADMIN_TOKEN 才能提交至 WaybackClaw。',
+      )
+    } else if (status === 503) {
+      wbcError.value = serverErr || tr(
+        'WaybackClaw publishing is not configured on this deployment.',
+        '该部署未配置 WaybackClaw 发布。',
+      )
+    } else if (status === 504) {
+      wbcError.value = serverErr || tr(
+        'WaybackClaw API unreachable or submit timed out.',
+        '无法访问 WaybackClaw API 或提交超时。',
+      )
+    } else if (status === 502) {
+      wbcError.value = serverErr || tr(
+        'WaybackClaw API returned an error.',
+        'WaybackClaw API 返回错误。',
+      )
+    } else if (status === 429) {
+      wbcError.value = serverErr || tr(
+        'WaybackClaw rate limit exceeded — back off and retry.',
+        'WaybackClaw 速率限制 — 请稍后重试。',
+      )
+    } else if (status === 422) {
+      wbcError.value = serverErr || tr(
+        'Simulation has not reached the prepared state — nothing to archive yet.',
+        '模拟尚未到达可发布状态,暂无可归档的数据。',
+      )
+    } else {
+      wbcError.value = serverErr || err?.message || tr('Could not submit to WaybackClaw.', '无法提交至 WaybackClaw。')
+    }
+    wbcErrorClass.value = 'webhook-log-message-error'
+  } finally {
+    wbcSubmitting.value = false
+  }
+}
+
+const _resetWaybackclawState = () => {
+  wbcRecord.value = null
+  wbcLoading.value = false
+  wbcSubmitting.value = false
+  wbcError.value = ''
+  wbcErrorClass.value = ''
+}
+
 const formatUalShort = (ual) => {
   if (!ual || typeof ual !== 'string') return ''
   if (ual.length <= 48) return ual
@@ -3457,6 +3716,7 @@ watch(() => props.open, async (val) => {
   _resetOutcomeForm()
   _resetWebhookLogState()
   _resetDkgState()
+  _resetWaybackclawState()
   // Refresh public state when reopened — reflects external flips.
   try {
     const res = await getEmbedSummary(props.simulationId)
@@ -3485,6 +3745,9 @@ watch(() => props.open, async (val) => {
   // deployment has DKG_* env vars wired up *and* the sim is public —
   // the load helper short-circuits on either gate so this is cheap.
   loadDkgCitation()
+  // Probe for an existing WaybackClaw submission. Same gating shape
+  // as DKG — short-circuits unless waybackclaw_configured && isPublic.
+  loadWaybackclawRecord()
   // Bust the share-card image cache so the preview reloads with whatever
   // state the simulation is in right now (resolution may have landed
   // since the dialog was last opened).
@@ -3575,6 +3838,8 @@ watch(isPublic, () => {
   // short-circuits when the sim is private or the deployment isn't
   // configured for DKG, so we can always call it.
   loadDkgCitation()
+  // WaybackClaw record probe — same gating semantics as DKG.
+  loadWaybackclawRecord()
 })
 </script>
 


### PR DESCRIPTION
## Summary

Opt-in agent-archive submission for finished simulations — the IPFS + Nostr sibling of the existing OriginTrail DKG citation surface. One POST to `api.waybackclaw.space` pins the snapshot (scenario, agent count, consensus, quality, lineage, `reproduce.json` SHA-256) to IPFS for content-addressed storage and broadcasts a NIP-01 note to Nostr relays. Free for agents, no on-chain cost. Run alongside DKG for triple-redundant provenance.

- `backend/app/services/waybackclaw_publisher.py` — stdlib HTTP, late-bound config, `build_submission` / `submit_snapshot` with idempotent `<sim_dir>/waybackclaw-record.json` cache.
- `backend/app/api/simulation.py` — `GET /api/simulation/<id>/waybackclaw-record` (public, publish-gated) + `POST /api/simulation/<id>/publish-waybackclaw` (admin-gated, 503/504/502/429 error mapping).
- `backend/app/api/notifications.py` — `waybackclaw_configured` boolean in the public probe.
- `backend/app/config.py` — `WAYBACKCLAW_API_URL` / `WAYBACKCLAW_AGENT_TOKEN` / `WAYBACKCLAW_AGENT_CATEGORY` env vars.
- Frontend — `getWaybackclawRecord` / `publishToWaybackclaw` + EmbedDialog "WaybackClaw archive" card with snapshot id / IPFS CID / Nostr event id / gateway link.
- `docs/WAYBACKCLAW.md` — setup, endpoints, verification flow, DKG comparison.
- `README.md` + `.env.example` — features-table row, docs link, env block (and the missing `DKG_*` env block while editing).

Activate with one curl to register an agent against `api.waybackclaw.space`, paste the returned token into `WAYBACKCLAW_AGENT_TOKEN`, restart.

## Test plan

- [ ] With `WAYBACKCLAW_AGENT_TOKEN` unset: `GET /api/config/notifications` returns `waybackclaw_configured: false`, EmbedDialog card hidden.
- [ ] With token set: card appears on public sims, `Submit to WaybackClaw` POSTs to the API and persists `<sim_dir>/waybackclaw-record.json`.
- [ ] Second click on the same sim returns the cached record (idempotent — no second API call).
- [ ] `reproduce_config_sha256` in the record matches `curl /reproduce.json | sha256sum`.
- [ ] IPFS gateway link from the card resolves the pinned snapshot JSON.
- [ ] 503 with token unset, 403 on a private sim, 422 on a sim that hasn't reached prepared state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)