### PR TITLE
launcher: skip local Neo4j startup when .env points at Aura

### DIFF
--- a/miroshark
+++ b/miroshark
@@ -188,6 +188,11 @@ ensure_env() {
 ensure_neo4j() {
     header "Neo4j"
 
+    if grep -qE '^NEO4J_URI=neo4j\+s://' "$SCRIPT_DIR/.env" 2>/dev/null; then
+        success "Remote Neo4j (Aura) configured in .env — skipping local startup"
+        return 0
+    fi
+
     if check_port "$NEO4J_BOLT_PORT"; then
         success "Neo4j already running on port $NEO4J_BOLT_PORT"
         return 0


### PR DESCRIPTION
## Context

The README documents Neo4j AuraDB as a zero-install path:

> **Option 1: Neo4j Aura (Free Cloud)** — Sign up at neo4j.com/aura, create a free instance, copy credentials to `.env`

But the `miroshark` launcher's `ensure_neo4j()` hardcodes a localhost startup flow: it probes for the `neo4j` CLI, falls back to Docker, and fails the dependency check if neither is present — even when `.env` points at a remote `neo4j+s://...` URI. On an Aura-only machine (no local Neo4j, no Docker), the launcher refuses to start despite the backend being perfectly capable of connecting to Aura via the credentials in `.env`.

## Fix

A 5-line early-return at the top of `ensure_neo4j()`: if `.env` contains `NEO4J_URI=neo4j+s://...`, skip local startup entirely and let the backend's dotenv loader handle the connection. Local-Neo4j users are untouched (their URI starts with `neo4j://` / `bolt://` and the existing CLI/Docker path runs as before).

## Verification

Tested end-to-end against a live AuraDB Free instance: with `NEO4J_URI=neo4j+s://<id>.databases.neo4j.io` in `.env`, the launcher now skips the local-startup block and the backend connects to Aura on first run.

## Test plan

- [x] `.env` with `neo4j+s://` URI → launcher skips local Neo4j startup
- [x] Backend connects to Aura successfully on first run
- [ ] `.env` with `neo4j://` or `bolt://` URI → existing local-startup path unchanged (CLI or Docker)