### PR TITLE
fix(ci): clear notifications-config + openapi waybackclaw drift on main

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2949,6 +2949,156 @@ paths:
                     type: string
                     enum: [create, write, promote, publish]
 
+  /api/simulation/{simulation_id}/waybackclaw-record:
+    get:
+      tags: [Publish & Embed]
+      summary: Read the persisted WaybackClaw archive record for a published sim.
+      description: |
+        Returns the WaybackClaw AI Agent Archive record persisted when
+        an operator clicked "Submit to WaybackClaw" in the share
+        dialog. Pure read of `<sim_dir>/waybackclaw-record.json` — no
+        API call. The record file is the source of truth once a
+        snapshot has been submitted.
+
+        Same publish gate as the `reproduce.json` / `dkg-citation`
+        surfaces: a private sim returns 403 even if a record file
+        happens to be on disk.
+
+        Returns 404 (not 500) when the sim has never been submitted —
+        the EmbedDialog uses that as the "render the Submit CTA"
+        signal.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: WaybackClaw snapshot record for the archived simulation.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/WaybackClawRecord"
+        "403":
+          description: Simulation is not published.
+        "404":
+          description: No WaybackClaw record yet for this simulation.
+
+  /api/simulation/{simulation_id}/publish-waybackclaw:
+    post:
+      tags: [Publish & Embed]
+      summary: Submit a finished simulation snapshot to the WaybackClaw archive.
+      description: |
+        Builds the same `reproduce.json` bytes the public
+        `/reproduce.json` endpoint serves, hashes them (citation key),
+        wraps the bytes in a WaybackClaw snapshot body alongside the
+        consensus / quality / scenario summary, and POSTs to
+        `/api/archive/submit` on `api.waybackclaw.space`. Returns the
+        snapshot id + IPFS CID + Nostr event id so the SPA can render
+        an archive citation card with a Pinata gateway link and a
+        Nostr event reference.
+
+        Sibling of `POST /api/simulation/{id}/publish-dkg`: the DKG
+        anchor provides on-chain provenance, WaybackClaw provides
+        content-addressed IPFS storage + Nostr broadcast, and
+        `reproduce.json` is the bytes both layers commit to.
+
+        Idempotent: a successful submission persists
+        `<sim_dir>/waybackclaw-record.json` and subsequent calls
+        return the cached record directly without re-hitting the API.
+        The on-disk file is the source of truth.
+
+        The publish action requires the admin token to gate "who can
+        speak on behalf of this MiroShark deployment in the public
+        archive" — the WaybackClaw submit endpoint itself is free
+        with agent auth.
+      security:
+        - AdminToken: []
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+                  description: |
+                    Re-submit even when a `waybackclaw-record.json`
+                    already exists. Escape hatch for operators who
+                    explicitly want a fresh snapshot after correcting
+                    upstream data.
+            example:
+              force: false
+      responses:
+        "200":
+          description: |
+            Submit succeeded (or a cached record was returned for an
+            already-archived sim).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      cached:
+                        type: boolean
+                        description: |
+                          `true` when the record came from
+                          `waybackclaw-record.json` without contacting
+                          the API; `false` when freshly submitted.
+                      data:
+                        $ref: "#/components/schemas/WaybackClawRecord"
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403":
+          description: Simulation is not published.
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422":
+          description: Simulation has not reached the prepared state — nothing to archive yet.
+        "429":
+          description: WaybackClaw API rate limit exceeded — back off and retry.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [false] }
+                  error: { type: string }
+                  stage: { type: string, enum: [submit] }
+                  api_status_code: { type: integer, enum: [429] }
+        "502":
+          description: WaybackClaw API returned an error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [false] }
+                  error: { type: string }
+                  stage: { type: string, enum: [submit, unknown] }
+                  api_status_code:
+                    type: integer
+                    description: The HTTP status the WaybackClaw API returned.
+        "503":
+          description: |
+            `WAYBACKCLAW_AGENT_TOKEN` not configured on this
+            deployment, or the admin token is not configured.
+        "504":
+          description: WaybackClaw API unreachable or submit timed out.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [false] }
+                  error: { type: string }
+                  stage: { type: string, enum: [submit] }
+
   # ────────────────────────────────────────────────────────────────────
   # Report Agent
   # ────────────────────────────────────────────────────────────────────
@@ -3525,6 +3675,89 @@ components:
         published_at:
           type: string
           format: date-time
+        schema_version:
+          type: string
+          enum: ["1"]
+
+    WaybackClawRecord:
+      type: object
+      description: |
+        Snapshot record returned by the WaybackClaw AI Agent Archive
+        when a simulation is submitted. Persisted as
+        `<sim_dir>/waybackclaw-record.json` after a successful submit
+        and returned by both
+        `GET /api/simulation/{simulation_id}/waybackclaw-record` and
+        the 200 response of
+        `POST /api/simulation/{simulation_id}/publish-waybackclaw`.
+
+        Sibling of the OriginTrail DKG citation: DKG anchors on-chain
+        provenance, WaybackClaw provides content-addressed IPFS
+        storage + Nostr broadcast. The
+        `reproduce_config_sha256` field is shared between the two so
+        a verifier can cross-check the bytes.
+      required: [id, schema_version, submitted_at]
+      properties:
+        id:
+          type: string
+          description: WaybackClaw snapshot id — the archive's primary key.
+        agent_id:
+          type: string
+          description: WaybackClaw agent identity that owns the snapshot.
+        agent_name:
+          type: string
+          description: Human-readable agent display name from WaybackClaw.
+        version:
+          type: string
+          description: |
+            Snapshot version label (defaults to the simulation id when
+            the API does not echo one back).
+        category:
+          type: string
+          description: |
+            WaybackClaw archive category (defaults to `prediction` —
+            MiroShark sims are prediction-market-style runs).
+        captured_at:
+          type: string
+          description: |
+            ISO-8601 timestamp the WaybackClaw API recorded for the
+            snapshot capture (may be empty if the API did not return one).
+        ipfs_cid:
+          type: string
+          description: |
+            Content-addressed IPFS CID for the snapshot bytes. Empty
+            when the API has not yet pinned the snapshot.
+        nostr_event_id:
+          type: string
+          description: |
+            Nostr event id broadcast by WaybackClaw for the snapshot.
+            Empty when the API did not return one.
+        access_level:
+          type: string
+          description: |
+            WaybackClaw access-level label (e.g. `public`). Pure
+            metadata echoed from the API response.
+        reproduce_config_sha256:
+          type: string
+          description: |
+            `sha256:<hex>` of the canonical `reproduce.json` bytes —
+            same key embedded in the DKG citation. A verifier fetches
+            the snapshot from IPFS, re-hashes the bytes, and compares.
+        archive_url:
+          type: string
+          format: uri
+          description: |
+            WaybackClaw retrieve URL for the agent's archive
+            (`{api_url}/api/archive/retrieve?agentId=<agent_id>`).
+        ipfs_gateway_url:
+          type: string
+          description: |
+            Pinata gateway URL for the snapshot's IPFS CID
+            (`https://gateway.pinata.cloud/ipfs/<cid>`). Empty when
+            `ipfs_cid` is empty.
+        submitted_at:
+          type: string
+          format: date-time
+          description: When the MiroShark backend recorded the submit.
         schema_version:
           type: string
           enum: ["1"]

--- a/backend/tests/test_unit_notifications_config.py
+++ b/backend/tests/test_unit_notifications_config.py
@@ -84,6 +84,18 @@ def _clear_telegram(monkeypatch):
     monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
 
 
+def _clear_waybackclaw(monkeypatch):
+    """Reset ``WAYBACKCLAW_AGENT_TOKEN`` so the channel reads as unconfigured.
+
+    ``is_configured()`` returns True iff the agent token is set, so this
+    one env var is the entire surface. Keeping a helper (rather than an
+    inline delenv) matches the pattern used by the other channels and
+    makes it easy to extend if WaybackClaw ever grows additional
+    required vars.
+    """
+    monkeypatch.delenv("WAYBACKCLAW_AGENT_TOKEN", raising=False)
+
+
 def test_notifications_config_all_unset(monkeypatch, client):
     monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
     monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
@@ -92,6 +104,7 @@ def test_notifications_config_all_unset(monkeypatch, client):
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
     _clear_dkg(monkeypatch)
+    _clear_waybackclaw(monkeypatch)
 
     data = _payload(client)
     assert data == {
@@ -102,6 +115,7 @@ def test_notifications_config_all_unset(monkeypatch, client):
         "telegram_configured": False,
         "dkg_configured": False,
         "dkg_network": None,
+        "waybackclaw_configured": False,
     }
 
 
@@ -113,6 +127,7 @@ def test_notifications_config_discord_only(monkeypatch, client):
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
     _clear_dkg(monkeypatch)
+    _clear_waybackclaw(monkeypatch)
 
     data = _payload(client)
     assert data == {
@@ -123,6 +138,7 @@ def test_notifications_config_discord_only(monkeypatch, client):
         "telegram_configured": False,
         "dkg_configured": False,
         "dkg_network": None,
+        "waybackclaw_configured": False,
     }
 
 
@@ -137,6 +153,7 @@ def test_notifications_config_slack_only(monkeypatch, client):
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
     _clear_dkg(monkeypatch)
+    _clear_waybackclaw(monkeypatch)
 
     data = _payload(client)
     assert data == {
@@ -147,6 +164,7 @@ def test_notifications_config_slack_only(monkeypatch, client):
         "telegram_configured": False,
         "dkg_configured": False,
         "dkg_network": None,
+        "waybackclaw_configured": False,
     }
 
 
@@ -159,6 +177,7 @@ def test_notifications_config_email_only(monkeypatch, client):
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
     _clear_dkg(monkeypatch)
+    _clear_waybackclaw(monkeypatch)
 
     data = _payload(client)
     assert data == {
@@ -169,6 +188,7 @@ def test_notifications_config_email_only(monkeypatch, client):
         "telegram_configured": False,
         "dkg_configured": False,
         "dkg_network": None,
+        "waybackclaw_configured": False,
     }
 
 
@@ -198,6 +218,7 @@ def test_notifications_config_telegram_only(monkeypatch, client):
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "", raising=False)
     _clear_dkg(monkeypatch)
+    _clear_waybackclaw(monkeypatch)
 
     data = _payload(client)
     assert data == {
@@ -208,6 +229,7 @@ def test_notifications_config_telegram_only(monkeypatch, client):
         "telegram_configured": True,
         "dkg_configured": False,
         "dkg_network": None,
+        "waybackclaw_configured": False,
     }
 
 
@@ -241,6 +263,7 @@ def test_notifications_config_all_five_configured(monkeypatch, client):
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "https://example.com/hook", raising=False)
     _clear_dkg(monkeypatch)
+    _clear_waybackclaw(monkeypatch)
 
     data = _payload(client)
     assert data == {
@@ -251,6 +274,7 @@ def test_notifications_config_all_five_configured(monkeypatch, client):
         "telegram_configured": True,
         "dkg_configured": False,
         "dkg_network": None,
+        "waybackclaw_configured": False,
     }
 
 
@@ -267,6 +291,7 @@ def test_notifications_config_blank_env_var_treated_as_unset(monkeypatch, client
     from app.config import Config
     monkeypatch.setattr(Config, "WEBHOOK_URL", "  ", raising=False)
     _clear_dkg(monkeypatch)
+    _clear_waybackclaw(monkeypatch)
 
     data = _payload(client)
     assert data == {
@@ -277,6 +302,7 @@ def test_notifications_config_blank_env_var_treated_as_unset(monkeypatch, client
         "telegram_configured": False,
         "dkg_configured": False,
         "dkg_network": None,
+        "waybackclaw_configured": False,
     }
 
 
@@ -293,6 +319,7 @@ def test_notifications_config_dkg_configured(monkeypatch, client):
     monkeypatch.setattr(Config, "DKG_AUTH_TOKEN", "abc123def456", raising=False)
     monkeypatch.setattr(Config, "DKG_CONTEXT_GRAPH_ID", "cg-miroshark", raising=False)
     monkeypatch.setattr(Config, "DKG_NETWORK", "mainnet", raising=False)
+    _clear_waybackclaw(monkeypatch)
 
     data = _payload(client)
     assert data == {
@@ -303,6 +330,7 @@ def test_notifications_config_dkg_configured(monkeypatch, client):
         "telegram_configured": False,
         "dkg_configured": True,
         "dkg_network": "mainnet",
+        "waybackclaw_configured": False,
     }
 
 


### PR DESCRIPTION
## Summary

The WaybackClaw AI Agent Archive surface (`waybackclaw_publisher` service + two routes + `notifications_config` field) landed without updating the unit-test fixtures or the OpenAPI spec, leaving `main` red on every PR. Two unrelated test files were failing:

- `test_unit_notifications_config.py` — 8 assertions of the form `assert data == {...}` did not include the new `waybackclaw_configured` key the endpoint now returns.
- `test_unit_openapi.py::test_flask_routes_are_documented_or_allowlisted` — flagged `/api/simulation/{simulation_id}/publish-waybackclaw` and `/api/simulation/{simulation_id}/waybackclaw-record` as undocumented.

This PR fixes both without touching feature code — pure CI cleanup.

## Changes

- **`backend/tests/test_unit_notifications_config.py`** — adds a `_clear_waybackclaw(monkeypatch)` helper (mirrors `_clear_telegram` / `_clear_email`) that wipes `WAYBACKCLAW_AGENT_TOKEN` — the single env var `waybackclaw_publisher.is_configured()` reads. Each of the 8 tests that fully match the payload dict now calls the helper and asserts `\"waybackclaw_configured\": False`.
- **`backend/openapi.yaml`** — documents `GET /<id>/waybackclaw-record` (publish-gated reader of `<sim_dir>/waybackclaw-record.json`) and `POST /<id>/publish-waybackclaw` (admin-token-gated submit to `api.waybackclaw.space`) alongside the existing DKG publish routes, with the same `[Publish & Embed]` tag, `AdminToken` security scheme on the POST, and the full 401 / 403 / 404 / 422 / 429 / 502 / 503 / 504 response codes the route handler actually emits. Adds a `WaybackClawRecord` schema that mirrors the on-disk record shape returned by `waybackclaw_publisher.submit_snapshot`.

## Test plan

- [x] `pytest backend/tests/test_unit_notifications_config.py backend/tests/test_unit_openapi.py -q` → **23 passed** locally on the branch (previously 9 failed)
- [ ] CI on this PR turns green on the \`Backend unit tests\` workflow
- [ ] No feature code touched; the \`waybackclaw_publisher\` service and route handlers are unchanged

## Why now

Caught while reviewing CI on the recently-merged Polymarket JSON PR (#99) — its own tests passed but the CI rolled up red because of this pre-existing drift on \`main\`. Fixing here clears the noise so future PRs surface their own genuine failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)