### PR TITLE
gitignore: collapse explicit .env profile list into .env.* wildcard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,8 @@ design-system/
 
 # Environment variables (protect sensitive information)
 .env
-.env.local
-.env.*.local
-.env.development
-.env.test
-.env.production
+.env.*
+!.env.example
 
 # Python
 __pycache__/


### PR DESCRIPTION
Closes #101.

Per your recommendation in #101 — replaces the explicit per-profile list with a single wildcard + tracked-template exception:

```diff
 # Environment variables (protect sensitive information)
 .env
-.env.local
-.env.*.local
-.env.development
-.env.test
-.env.production
+.env.*
+!.env.example
```

## Why this matters

The explicit allowlist (`.env.local`, `.env.test`, `.env.production`, …) silently grows every time someone invents a new profile — `.env.aura`, `.env.staging`, `.env.qa`. The `.env.*` wildcard absorbs all of them; `!.env.example` keeps the canonical template tracked.

Same pattern Next.js and Vite recommend for exactly this reason.

## Verification

Ran the pre-push check from your #101 review:

```bash
$ git ls-files | grep -E '^\.env'
.env.example
```

`.env.example` is the only currently-tracked file under the `.env*` pattern. The `!.env.example` exception keeps it tracked under the new wildcard; `git check-ignore` confirms `.env.production` / `.env.aura` / etc. are correctly ignored.

## Test plan

- [x] `.gitignore` diff matches your recommended snippet exactly
- [x] `git ls-files | grep -E '^\.env'` returns only `.env.example`
- [x] `git check-ignore .env.example` → not ignored (kept tracked)
- [x] `git check-ignore .env.production` → ignored by `.env.*` rule
- [x] `git check-ignore .env.aura` → ignored by `.env.*` rule (future-proof profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)