### PR TITLE
feat: oEmbed provider — auto-unfurl share links on Notion / Ghost / Substack / WordPress

### DIFF
--- a/backend/app/api/share.py
+++ b/backend/app/api/share.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import html
 import os
+from urllib.parse import quote, urlparse
 from flask import Blueprint, Response, request
 
 from ..config import Config
@@ -56,6 +57,7 @@ def _render_landing_html(
     spa_url: str,
     card_url: str,
     frame_meta: dict | None = None,
+    oembed_block: str = "",
 ) -> str:
     """Build the static HTML returned to scrapers + browsers.
 
@@ -154,6 +156,7 @@ def _render_landing_html(
         f"<meta name=\"twitter:description\" content=\"{desc_e}\">\n"
         f"<meta name=\"twitter:image\" content=\"{card_e}\">\n"
         f"{frame_block}"
+        f"{oembed_block}"
         "\n"
         f"<meta http-equiv=\"refresh\" content=\"0; url={spa_e}\">\n"
         f"<link rel=\"canonical\" href=\"{spa_e}\">\n"
@@ -255,6 +258,26 @@ def share_landing(simulation_id: str):
         except Exception:
             frame_meta = None
 
+    # oEmbed discovery links. Emitted only for published sims — same
+    # gating posture as the OG / Frame tags so a private sim's scenario
+    # never leaks. Writing platforms (Notion, Ghost, Substack, WordPress)
+    # read these <link> tags and call back to /oembed for a rich card.
+    # Both the JSON and XML format variants are advertised; the endpoint
+    # honours ?format= and the consumer picks whichever it prefers.
+    oembed_block = ""
+    if is_public:
+        share_self_url = f"{base}/share/{simulation_id}"
+        encoded = quote(share_self_url, safe="")
+        oembed_title = _esc((scenario or "MiroShark Simulation")[:60])
+        json_href = _esc(f"{base}/oembed?url={encoded}&format=json")
+        xml_href = _esc(f"{base}/oembed?url={encoded}&format=xml")
+        oembed_block = (
+            f"<link rel=\"alternate\" type=\"application/json+oembed\" "
+            f"href=\"{json_href}\" title=\"{oembed_title}\">\n"
+            f"<link rel=\"alternate\" type=\"text/xml+oembed\" "
+            f"href=\"{xml_href}\" title=\"{oembed_title}\">\n"
+        )
+
     body = _render_landing_html(
         simulation_id=simulation_id,
         scenario=scenario if is_public else "",
@@ -262,10 +285,168 @@ def share_landing(simulation_id: str):
         spa_url=spa_url,
         card_url=card_url,
         frame_meta=frame_meta,
+        oembed_block=oembed_block,
     )
 
     response = Response(body, mimetype="text/html; charset=utf-8")
     # OG scrapers cache aggressively — keep the cache short so newly
     # published sims show their card without long delays.
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return response
+
+
+def _resolve_oembed_base_url() -> str:
+    """Canonical origin for the absolute URLs inside an oEmbed payload.
+
+    Same strategy as the feed / sitemap modules — prefer the operator-set
+    ``Config.PUBLIC_BASE_URL`` (single source of truth across surfaces),
+    falling back to the request host with ``X-Forwarded-Proto`` /
+    ``X-Forwarded-Host`` honoured for reverse-proxy deployments. Returns a
+    value with no trailing slash.
+    """
+    explicit = (Config.PUBLIC_BASE_URL or "").strip()
+    if explicit:
+        return explicit.rstrip("/")
+
+    base = (request.host_url or "").rstrip("/")
+    forwarded_proto = request.headers.get("X-Forwarded-Proto")
+    forwarded_host = request.headers.get("X-Forwarded-Host")
+    if forwarded_host:
+        proto = forwarded_proto or ("https" if request.is_secure else "http")
+        base = f"{proto}://{forwarded_host}"
+    return base
+
+
+def _oembed_allowed_hosts(base_url: str) -> set:
+    """Hosts an inbound oEmbed ``url`` is allowed to belong to.
+
+    A consumer hands us the canonical share URL it scraped the discovery
+    tag from; we only describe sims hosted on *this* deployment. The set
+    is the union of the resolved canonical host, the raw request host, and
+    any ``X-Forwarded-Host`` — so the gate passes behind a proxy and on a
+    bare ``PUBLIC_BASE_URL``-less dev server alike, but a foreign domain
+    is rejected (the endpoint can't be aimed at another site).
+    """
+    hosts: set = set()
+    for candidate in (base_url, request.host_url):
+        if candidate:
+            netloc = urlparse(candidate).netloc.lower()
+            if netloc:
+                hosts.add(netloc)
+    forwarded_host = request.headers.get("X-Forwarded-Host")
+    if forwarded_host:
+        hosts.add(forwarded_host.strip().lower())
+    return hosts
+
+
+@share_bp.route('/oembed', methods=['GET'])
+def oembed_provider():
+    """oEmbed 1.0 provider — auto-unfurl for MiroShark share URLs.
+
+    Mounted at the **root** (no ``/api`` prefix) so the discovery tag in
+    the share page points at a clean ``/oembed?url=`` endpoint. A consumer
+    (Notion, Ghost, Substack, WordPress, …) that finds the
+    ``<link rel="alternate" type="application/json+oembed">`` tag on a
+    ``/share/<id>`` page calls back here with the share URL and renders
+    the returned ``rich`` embed inline.
+
+    Query params:
+
+      * ``url`` (required) — the MiroShark share URL the consumer scraped.
+        Must resolve to a sim hosted on this deployment; a foreign domain
+        or a URL with no recognisable sim path returns ``404``.
+      * ``format`` (optional, ``json`` default) — ``json`` or ``xml``. Any
+        other value returns ``501`` per the oEmbed spec.
+
+    Same publish gate as the share landing tags: a private or missing sim
+    is answered with ``404`` (indistinguishable from a non-existent one)
+    so the endpoint never confirms a private sim exists.
+    """
+    from ..services import oembed_service
+    from ..services import surface_stats
+
+    locale = get_locale(request)
+
+    fmt = (request.args.get("format") or "json").strip().lower()
+    if fmt not in ("json", "xml"):
+        # oEmbed spec: a requested format the provider can't supply is a
+        # 501 Not Implemented, not a 400.
+        return Response(
+            _t(
+                "Unsupported oEmbed format — use 'json' or 'xml'.",
+                "不支持的 oEmbed 格式 — 请使用 'json' 或 'xml'。",
+                locale,
+            ),
+            status=501,
+            mimetype="text/plain; charset=utf-8",
+        )
+
+    url = (request.args.get("url") or "").strip()
+    if not url:
+        return Response(
+            _t(
+                "Missing required 'url' query parameter.",
+                "缺少必需的 'url' 查询参数。",
+                locale,
+            ),
+            status=400,
+            mimetype="text/plain; charset=utf-8",
+        )
+
+    base = _resolve_oembed_base_url()
+    allowed_hosts = _oembed_allowed_hosts(base)
+
+    not_found = Response(
+        _t(
+            "No published MiroShark simulation found for that URL.",
+            "未找到与该 URL 对应的已发布 MiroShark 模拟。",
+            locale,
+        ),
+        status=404,
+        mimetype="text/plain; charset=utf-8",
+    )
+
+    sim_id = oembed_service.parse_sim_id_from_url(url, allowed_hosts=allowed_hosts)
+    if not sim_id:
+        return not_found
+
+    try:
+        validate_simulation_id(sim_id)
+    except ValueError:
+        return not_found
+
+    # Publish gate — never raise on a peripheral lookup; an unpublished or
+    # missing sim falls through to the shared 404.
+    scenario = ""
+    is_public = False
+    try:
+        manager = SimulationManager()
+        state = manager.get_simulation(sim_id)
+        if state:
+            is_public = bool(getattr(state, "is_public", False))
+            if is_public:
+                config = manager.get_simulation_config(sim_id)
+                if config:
+                    scenario = (config.get("simulation_requirement") or "").strip()
+    except Exception:
+        is_public = False
+
+    if not is_public:
+        return not_found
+
+    payload = oembed_service.build_oembed_payload(scenario, sim_id, base)
+
+    sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, sim_id)
+    surface_stats.increment_surface_stat(sim_dir, "oembed")
+
+    if fmt == "xml":
+        body = oembed_service.oembed_to_xml(payload)
+        response = Response(body, mimetype="text/xml; charset=utf-8")
+    else:
+        import json as _json
+
+        body = _json.dumps(payload, indent=2, ensure_ascii=False)
+        response = Response(body, mimetype="application/json; charset=utf-8")
+
     response.headers["Cache-Control"] = "public, max-age=300"
     return response

--- a/backend/app/services/oembed_service.py
+++ b/backend/app/services/oembed_service.py
@@ -1,0 +1,207 @@
+"""oEmbed 1.0 provider for MiroShark simulation share URLs.
+
+Implements the discovery half of the `oEmbed spec <https://oembed.com>`_
+so a paste of a MiroShark ``/share/<id>`` link auto-unfurls into a rich
+sim card on any oEmbed consumer — Notion, Ghost, Substack, WordPress, and
+the long tail of CMS / note-taking tools that all implement the same
+protocol.
+
+The share page already emits Open Graph / Twitter / Farcaster-Frame meta
+tags, which cover the *social* platforms (Twitter/X, Discord, Slack,
+LinkedIn, Warpcast). Those platforms read meta tags. The *writing*
+platforms — where researchers and analysts actually publish — read an
+``<link rel="alternate" type="application/json+oembed">`` discovery tag
+instead, then call back to this endpoint for a structured embed payload.
+Before this surface, a MiroShark link pasted into a Notion page or a
+Substack draft rendered as a bare URL; with it, every organic citation
+becomes a rich preview card with no user action.
+
+This module is the pure, Flask-free core: URL → ``sim_id`` parsing with
+host allow-listing, payload construction, and JSON↔XML serialization.
+The route handler in ``app/api/share.py`` owns the publish gate, the
+surface-stat increment, and the request/response plumbing.
+
+Design notes
+------------
+
+* **Pure stdlib.** ``re`` + ``urllib.parse`` + ``xml.etree.ElementTree``
+  + ``html``. No new dependencies — the same posture as every other
+  surface module (signal.json, polymarket.json, badge.svg, …).
+* **A protocol, not a new renderer.** The ``thumbnail_url`` points at the
+  existing ``/api/simulation/<id>/share-card.png`` surface and the
+  ``html`` iframe at the existing ``/embed/<id>`` SPA route. oEmbed adds
+  a *discovery protocol* over surfaces that already ship; it renders
+  nothing new itself.
+* **Host allow-listing, never fetching.** ``parse_sim_id_from_url`` never
+  dereferences the URL. It extracts a ``sim_id`` only from a path that
+  lives on a host this deployment owns (the caller passes the allow-list
+  in). A foreign-host ``url``, a bare path with no host, or a URL with no
+  recognisable sim path all yield ``None`` so the route can answer 404 —
+  the endpoint can't be coerced into describing content it doesn't host.
+* **Type ``rich``.** A MiroShark embed is an interactive iframe, not a
+  static photo or a raw video file, so the oEmbed ``type`` is ``rich``
+  with an ``html`` iframe payload, per the spec's rich-type contract.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import Iterable, Optional
+from urllib.parse import urlparse
+from xml.etree import ElementTree as ET
+
+
+# oEmbed version this provider speaks. Required top-level field per the
+# 1.0 spec; consumers key their parsing on it.
+OEMBED_VERSION = "1.0"
+
+# A MiroShark embed is an interactive iframe → the rich type. Photo /
+# video types would require a static asset URL we don't expose.
+OEMBED_TYPE = "rich"
+
+PROVIDER_NAME = "MiroShark"
+
+# Fixed embed geometry. Matches the 800×500 iframe the EmbedDialog hands
+# out and the 1200×630 OG share-card thumbnail every other surface uses.
+EMBED_WIDTH = 800
+EMBED_HEIGHT = 500
+THUMBNAIL_WIDTH = 1200
+THUMBNAIL_HEIGHT = 630
+
+# Consumers may cache the embed this long (seconds). Matches the
+# 5-minute Cache-Control the share page and signal.json already set.
+CACHE_AGE_SECONDS = 300
+
+# oEmbed title field cap. Long scenario prompts are truncated with an
+# ellipsis so the unfurled card title stays a headline, not a paragraph.
+_TITLE_MAX = 100
+
+# Sim-id path matcher. Accepts the three public URL shapes that reference
+# a single simulation:
+#   * /share/<id>            — the canonical paste-able landing URL
+#   * /embed/<id>            — the iframe SPA route
+#   * /simulation/<id>/...   — the SPA deep link (e.g. /simulation/<id>/start)
+# The id char class mirrors ``validate_simulation_id`` (alphanumeric, dot,
+# hyphen, underscore); the 4–64 length bound rejects a bare ``..`` and
+# keeps the match tight. The route handler still runs the captured id
+# through ``validate_simulation_id`` for path-traversal defense in depth.
+_SIM_PATH_RE = re.compile(r"/(?:share|embed|simulation)/([A-Za-z0-9_.\-]{4,64})")
+
+
+def _host_of(url: str) -> Optional[str]:
+    """Return the lower-cased ``host[:port]`` of an absolute URL, or ``None``.
+
+    Requires both a scheme and a netloc so a bare path (``/share/x``) or a
+    scheme-relative string is treated as un-validatable — without a host
+    we can't prove the URL belongs to this deployment, so the caller
+    rejects it.
+    """
+    if not isinstance(url, str) or not url.strip():
+        return None
+    try:
+        parsed = urlparse(url.strip())
+    except Exception:
+        return None
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return parsed.netloc.lower()
+
+
+def parse_sim_id_from_url(
+    url: str,
+    allowed_hosts: Optional[Iterable[str]] = None,
+) -> Optional[str]:
+    """Extract a simulation id from a MiroShark URL, or ``None``.
+
+    ``url`` must be an absolute URL whose host is in ``allowed_hosts``
+    (when supplied) — a foreign domain returns ``None`` so the oEmbed
+    endpoint can't be pointed at someone else's site. When
+    ``allowed_hosts`` is ``None`` the host check is skipped (used by the
+    pure unit tests); the route handler always supplies it.
+
+    The path must contain a recognised sim surface (``/share/<id>``,
+    ``/embed/<id>``, or ``/simulation/<id>``). Returns the captured id —
+    never validated for filesystem safety here; the caller does that.
+    """
+    host = _host_of(url)
+    if host is None:
+        return None
+
+    if allowed_hosts is not None:
+        normalized = {h.strip().lower() for h in allowed_hosts if h and h.strip()}
+        if host not in normalized:
+            return None
+
+    parsed = urlparse(url.strip())
+    match = _SIM_PATH_RE.search(parsed.path or "")
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _truncate_title(scenario: Optional[str]) -> str:
+    """Collapse a scenario prompt into an oEmbed ``title`` ≤ ``_TITLE_MAX``.
+
+    Falls back to a generic title when the scenario is empty (a published
+    sim with no recorded requirement still gets a usable card). The result
+    is always at most ``_TITLE_MAX`` characters including the ellipsis.
+    """
+    title = (scenario or "").strip()
+    if not title:
+        return "MiroShark Simulation"
+    if len(title) > _TITLE_MAX:
+        title = title[: _TITLE_MAX - 1].rstrip() + "…"
+    return title
+
+
+def build_oembed_payload(scenario: Optional[str], sim_id: str, base_url: str) -> dict:
+    """Build the oEmbed ``rich`` payload for a published simulation.
+
+    ``base_url`` is the deployment's canonical origin (no trailing slash);
+    the ``thumbnail_url`` and iframe ``src`` are absolute so the embed
+    works when rendered on a third-party domain. The iframe ``src`` is
+    HTML-attribute-escaped because the ``html`` field is injected verbatim
+    into the consumer's page — ``sim_id`` is validated upstream and
+    ``base_url`` is operator-controlled, but escaping keeps the surface
+    safe even if a proxy header ever smuggles a quote into the host.
+    """
+    base = (base_url or "").rstrip("/")
+    iframe_src = html.escape(f"{base}/embed/{sim_id}", quote=True)
+
+    return {
+        "version": OEMBED_VERSION,
+        "type": OEMBED_TYPE,
+        "provider_name": PROVIDER_NAME,
+        "provider_url": base,
+        "title": _truncate_title(scenario),
+        "thumbnail_url": f"{base}/api/simulation/{sim_id}/share-card.png",
+        "thumbnail_width": THUMBNAIL_WIDTH,
+        "thumbnail_height": THUMBNAIL_HEIGHT,
+        "width": EMBED_WIDTH,
+        "height": EMBED_HEIGHT,
+        "html": (
+            f'<iframe src="{iframe_src}" width="{EMBED_WIDTH}" '
+            f'height="{EMBED_HEIGHT}" frameborder="0" '
+            f'allowfullscreen></iframe>'
+        ),
+        "cache_age": CACHE_AGE_SECONDS,
+    }
+
+
+def oembed_to_xml(payload: dict) -> str:
+    """Serialize an oEmbed payload dict to the spec's XML representation.
+
+    The oEmbed spec defines both a JSON and an XML format; a consumer
+    selects one via the discovery ``<link type>`` or a ``?format=`` query
+    param. The XML form is a flat ``<oembed>`` element with one child per
+    field. ``ElementTree`` escapes every text node (so the ``html``
+    iframe field is emitted as entity-escaped text the consumer
+    un-escapes) and we prepend an explicit declaration for determinism.
+    """
+    root = ET.Element("oembed")
+    for key, value in payload.items():
+        child = ET.SubElement(root, key)
+        child.text = str(value)
+    body = ET.tostring(root, encoding="unicode")
+    return '<?xml version="1.0" encoding="utf-8" standalone="yes"?>\n' + body

--- a/backend/app/services/surface_stats.py
+++ b/backend/app/services/surface_stats.py
@@ -49,7 +49,8 @@ Schema::
       "archive_zip": 0,
       "badge_svg": 0,
       "cite_bib": 0,
-      "polymarket_json": 0
+      "polymarket_json": 0,
+      "oembed": 0
     }
 
 The ``read_surface_stats`` helper returns the same dict with every key
@@ -93,6 +94,7 @@ SURFACE_KEYS: frozenset[str] = frozenset(
         "badge_svg",
         "cite_bib",
         "polymarket_json",
+        "oembed",
     }
 )
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1962,6 +1962,71 @@ paths:
               schema: { type: string }
         "400": { $ref: "#/components/responses/BadRequest" }
 
+  /oembed:
+    get:
+      tags: [Publish & Embed]
+      summary: oEmbed 1.0 provider — auto-unfurl for MiroShark share URLs.
+      description: |
+        Mounted at the **root** (no `/api` prefix). Implements the
+        discovery half of the [oEmbed 1.0 spec](https://oembed.com) so a
+        paste of a `/share/<id>` link auto-unfurls into a rich sim card on
+        the *writing* platforms — Notion, Ghost, Substack, WordPress — that
+        read an `<link rel="alternate" type="application/json+oembed">`
+        discovery tag rather than Open Graph meta. The share landing page
+        emits that discovery tag for published sims; a consumer follows it
+        here with the share `url` and renders the returned embed inline.
+
+        Returns a `type: "rich"` payload: the `/api/simulation/<id>/share-card.png`
+        thumbnail (1200×630) and an 800×500 iframe over the `/embed/<id>`
+        SPA route. oEmbed adds a discovery *protocol* over surfaces that
+        already ship — it renders nothing new itself.
+
+        `format` selects the JSON (default) or XML representation. A
+        foreign-host `url`, a URL with no recognisable sim path, an
+        unpublished sim, and a missing sim all return `404` — the endpoint
+        only describes published sims hosted on this deployment and never
+        confirms a private sim exists. Honors `X-Forwarded-Proto` /
+        `X-Forwarded-Host`.
+      parameters:
+        - name: url
+          in: query
+          required: true
+          description: |
+            The canonical MiroShark share URL the consumer scraped the
+            discovery tag from (e.g. `https://your-host/share/<id>`). Must
+            resolve to a sim hosted on this deployment.
+          schema: { type: string, format: uri }
+        - name: format
+          in: query
+          required: false
+          description: Response representation. `json` (default) or `xml`.
+          schema: { type: string, enum: [json, xml], default: json }
+      responses:
+        "200":
+          description: oEmbed `rich` payload (JSON or XML per `format`).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/OEmbedResponse" }
+            text/xml:
+              schema: { type: string }
+        "400":
+          description: Missing required `url` query parameter.
+          content:
+            text/plain:
+              schema: { type: string }
+        "404":
+          description: |
+            No published sim found for that URL — foreign domain,
+            unrecognised path, unpublished sim, or missing sim.
+          content:
+            text/plain:
+              schema: { type: string }
+        "501":
+          description: Requested `format` is not supported (use json or xml).
+          content:
+            text/plain:
+              schema: { type: string }
+
   /watch/{simulation_id}:
     get:
       tags: [Publish & Embed]
@@ -3599,6 +3664,39 @@ components:
           schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
   schemas:
+
+    OEmbedResponse:
+      type: object
+      description: |
+        oEmbed 1.0 `rich`-type payload returned by `GET /oembed`. A
+        consumer renders the `html` iframe inline and the `thumbnail_url`
+        as the preview image. JSON shape shown here; the `?format=xml`
+        variant carries the same fields as a flat `<oembed>` element.
+      required: [version, type, provider_name, title, html]
+      properties:
+        version: { type: string, enum: ["1.0"] }
+        type: { type: string, enum: [rich] }
+        provider_name: { type: string, example: MiroShark }
+        provider_url: { type: string, format: uri }
+        title:
+          type: string
+          description: Scenario prompt, truncated to 100 chars with an ellipsis.
+        thumbnail_url:
+          type: string
+          format: uri
+          description: Absolute URL of the 1200×630 share-card PNG.
+        thumbnail_width: { type: integer, example: 1200 }
+        thumbnail_height: { type: integer, example: 630 }
+        width: { type: integer, example: 800 }
+        height: { type: integer, example: 500 }
+        html:
+          type: string
+          description: An 800×500 iframe over the `/embed/<id>` SPA route.
+          example: '<iframe src="https://your-host/embed/sim_abc" width="800" height="500" frameborder="0" allowfullscreen></iframe>'
+        cache_age:
+          type: integer
+          description: Seconds a consumer may cache the embed.
+          example: 300
 
     SuccessEnvelope:
       type: object

--- a/backend/tests/test_unit_oembed.py
+++ b/backend/tests/test_unit_oembed.py
@@ -1,0 +1,220 @@
+"""Unit tests for the oEmbed provider service + route wiring.
+
+Pure offline — no Flask app, no network, no simulation runner, no on-disk
+state. Covers the contract the `GET /oembed` endpoint depends on:
+
+  1. ``parse_sim_id_from_url`` extracts a sim id from each recognised
+     URL shape (``/share/<id>``, ``/embed/<id>``, ``/simulation/<id>``).
+  2. Host allow-listing rejects a foreign domain and a host-less URL.
+  3. ``build_oembed_payload`` produces a spec-shaped ``rich`` payload:
+     version ``"1.0"``, provider ``MiroShark``, share-card thumbnail,
+     ``/embed/<id>`` iframe, title capped at 100 chars.
+  4. ``oembed_to_xml`` emits well-formed XML that round-trips through an
+     XML parser with the same fields.
+  5. The route decorator, the publish gate, the surface-stat increment,
+     and the discovery-link injection exist in ``app/api/share.py``.
+  6. ``oembed`` is registered in the surface_stats schema.
+  7. ``openapi.yaml`` documents ``/oembed`` and the ``OEmbedResponse``
+     schema so the drift test stays green.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from app.services import oembed_service  # noqa: E402
+
+
+_ALLOWED = {"miroshark.example.com"}
+
+
+# ── parse_sim_id_from_url ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://miroshark.example.com/share/sim_abc123", "sim_abc123"),
+        ("https://miroshark.example.com/embed/sim_abc123", "sim_abc123"),
+        ("https://miroshark.example.com/simulation/sim_abc123/start", "sim_abc123"),
+        ("https://miroshark.example.com/share/sim_abc123?ref=notion", "sim_abc123"),
+    ],
+)
+def test_parse_extracts_sim_id_from_known_shapes(url: str, expected: str):
+    assert oembed_service.parse_sim_id_from_url(url, allowed_hosts=_ALLOWED) == expected
+
+
+def test_parse_rejects_foreign_domain():
+    """A share-shaped path on a host we don't own must not resolve — the
+    endpoint can't be aimed at someone else's site."""
+    foreign = "https://evil.example.org/share/sim_abc123"
+    assert oembed_service.parse_sim_id_from_url(foreign, allowed_hosts=_ALLOWED) is None
+
+
+def test_parse_rejects_hostless_url():
+    """A bare path has no host to validate against — reject it."""
+    assert oembed_service.parse_sim_id_from_url("/share/sim_abc123", allowed_hosts=_ALLOWED) is None
+
+
+def test_parse_rejects_url_with_no_sim_path():
+    """A valid-host URL that doesn't point at a sim surface returns None."""
+    assert oembed_service.parse_sim_id_from_url(
+        "https://miroshark.example.com/explore", allowed_hosts=_ALLOWED
+    ) is None
+
+
+def test_parse_skips_host_check_when_allowlist_is_none():
+    """With no allow-list supplied the host gate is skipped (pure path
+    extraction) — the route always supplies one."""
+    assert oembed_service.parse_sim_id_from_url(
+        "https://anything.test/share/sim_xyz1", allowed_hosts=None
+    ) == "sim_xyz1"
+
+
+def test_parse_matches_host_with_port():
+    """Dev / proxy hosts carry a port — the match is exact incl. port."""
+    assert oembed_service.parse_sim_id_from_url(
+        "http://localhost:5000/share/sim_local1", allowed_hosts={"localhost:5000"}
+    ) == "sim_local1"
+
+
+def test_parse_rejects_empty_and_non_string():
+    assert oembed_service.parse_sim_id_from_url("", allowed_hosts=_ALLOWED) is None
+    assert oembed_service.parse_sim_id_from_url(None, allowed_hosts=_ALLOWED) is None  # type: ignore[arg-type]
+
+
+# ── build_oembed_payload ───────────────────────────────────────────────────
+
+
+def test_payload_has_rich_type_and_required_fields():
+    payload = oembed_service.build_oembed_payload(
+        "Will BTC break 100k by Q3?", "sim_abc123", "https://miroshark.example.com"
+    )
+    assert payload["version"] == "1.0"
+    assert payload["type"] == "rich"
+    assert payload["provider_name"] == "MiroShark"
+    assert payload["provider_url"] == "https://miroshark.example.com"
+    assert payload["cache_age"] == 300
+
+
+def test_payload_thumbnail_and_iframe_point_at_existing_surfaces():
+    payload = oembed_service.build_oembed_payload(
+        "scenario", "sim_abc123", "https://miroshark.example.com"
+    )
+    assert payload["thumbnail_url"] == (
+        "https://miroshark.example.com/api/simulation/sim_abc123/share-card.png"
+    )
+    assert payload["thumbnail_width"] == 1200
+    assert payload["thumbnail_height"] == 630
+    assert "<iframe" in payload["html"]
+    assert "/embed/sim_abc123" in payload["html"]
+    assert 'width="800"' in payload["html"]
+    assert 'height="500"' in payload["html"]
+
+
+def test_payload_strips_trailing_slash_on_base():
+    payload = oembed_service.build_oembed_payload(
+        "scenario", "sim_abc123", "https://miroshark.example.com/"
+    )
+    assert "//api/simulation" not in payload["thumbnail_url"]
+    assert payload["thumbnail_url"].startswith("https://miroshark.example.com/api/")
+
+
+def test_payload_title_capped_at_100_chars():
+    long_scenario = "A" * 250
+    payload = oembed_service.build_oembed_payload(
+        long_scenario, "sim_abc123", "https://miroshark.example.com"
+    )
+    assert len(payload["title"]) <= 100
+    assert payload["title"].endswith("…")
+
+
+def test_payload_empty_scenario_gets_fallback_title():
+    payload = oembed_service.build_oembed_payload(
+        "", "sim_abc123", "https://miroshark.example.com"
+    )
+    assert payload["title"] == "MiroShark Simulation"
+
+
+# ── oembed_to_xml ──────────────────────────────────────────────────────────
+
+
+def test_xml_is_well_formed_and_round_trips():
+    payload = oembed_service.build_oembed_payload(
+        "scenario", "sim_abc123", "https://miroshark.example.com"
+    )
+    xml = oembed_service.oembed_to_xml(payload)
+    assert xml.startswith("<?xml")
+
+    # Strip the declaration so ElementTree parses the body.
+    body = xml.split("?>", 1)[1].strip()
+    root = ET.fromstring(body)
+    assert root.tag == "oembed"
+
+    fields = {child.tag: child.text for child in root}
+    assert fields["version"] == "1.0"
+    assert fields["type"] == "rich"
+    assert fields["provider_name"] == "MiroShark"
+    # The iframe markup is carried as escaped text the consumer un-escapes.
+    assert "<iframe" in (fields["html"] or "")
+
+
+# ── Static wiring guards ───────────────────────────────────────────────────
+
+
+def _read_share_api() -> str:
+    return (_BACKEND / "app" / "api" / "share.py").read_text(encoding="utf-8")
+
+
+def test_route_decorator_registered_on_share_bp():
+    text = _read_share_api()
+    assert "@share_bp.route('/oembed'" in text or '@share_bp.route("/oembed"' in text, (
+        "share.py must register the /oembed route on share_bp"
+    )
+
+
+def test_route_enforces_publish_gate():
+    text = _read_share_api()
+    assert "is_public" in text
+    # The oEmbed handler reuses the manager-based publish lookup.
+    assert "get_simulation_config" in text
+
+
+def test_route_increments_oembed_surface_stat():
+    text = _read_share_api()
+    assert '"oembed"' in text, (
+        "share.py must increment the oembed counter via "
+        "surface_stats.increment_surface_stat(..., \"oembed\")"
+    )
+    assert "increment_surface_stat" in text
+
+
+def test_share_page_injects_discovery_links():
+    text = _read_share_api()
+    assert "application/json+oembed" in text, (
+        "the share page <head> must emit the JSON oEmbed discovery <link>"
+    )
+    assert "text/xml+oembed" in text, (
+        "the share page <head> must emit the XML oEmbed discovery <link>"
+    )
+
+
+def test_surface_stats_registers_oembed_key():
+    from app.services import surface_stats
+
+    assert "oembed" in surface_stats.SURFACE_KEYS
+
+
+def test_openapi_documents_oembed_path_and_schema():
+    spec_text = (_BACKEND / "openapi.yaml").read_text(encoding="utf-8")
+    assert "/oembed:" in spec_text, "openapi.yaml is missing the /oembed path entry"
+    assert "OEmbedResponse:" in spec_text, "openapi.yaml is missing the OEmbedResponse schema"

--- a/backend/tests/test_unit_surface_stats.py
+++ b/backend/tests/test_unit_surface_stats.py
@@ -83,6 +83,7 @@ def test_surface_keys_includes_every_serve_handler():
         "badge_svg",
         "cite_bib",
         "polymarket_json",
+        "oembed",
     }
     assert set(surface_stats.SURFACE_KEYS) == expected
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -104,7 +104,8 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `GET` | `/api/simulation/<id>/lineage` | Lineage graph slice — parent the sim was forked / branched from + every public child whose `parent_simulation_id` points back at it. Closes the navigation gap the reproduction config left open |
 | `GET` | `/api/simulation/<id>/webhook-log` | Recent outbound-webhook delivery attempts (last 10 + total count). Admin-token gated |
 | `POST` | `/api/simulation/<id>/webhook-retry` | Re-fire the completion webhook for a finished sim. Admin-token gated |
-| `GET` | `/share/<id>` | Public OG-tag landing page (auto-redirects to SPA) |
+| `GET` | `/share/<id>` | Public OG-tag landing page (auto-redirects to SPA). Also emits `application/json+oembed` + `text/xml+oembed` discovery `<link>` tags for published sims |
+| `GET` | `/oembed?url=<share-url>&format=<json\|xml>` | oEmbed 1.0 provider — auto-unfurls a pasted `/share/<id>` link into a `type: "rich"` card (share-card thumbnail + `/embed/<id>` iframe) on Notion, Ghost, Substack, WordPress, and other oEmbed consumers. `format` defaults to `json`; unsupported format → `501`. Foreign-domain / unpublished / missing URL → `404`. Honors `X-Forwarded-*` |
 | `GET` | `/watch/<id>` | Live spectator-watch page — minimal full-viewport broadcast view, polls every 15 s, OG / Twitter-card unfurl |
 | `GET` | `/sitemap.xml` | Auto-generated sitemap (sitemaps.org 0.9) listing every public sim's `/share/<id>` + `/watch/<id>` URLs. `404` when `ENABLE_SITEMAP=false`. Cached 1 h |
 | `GET` | `/robots.txt` | Crawler directives — `Disallow: /api/`, `Allow: /share/` etc., advertises `Sitemap:` when enabled. Cached 1 h |
@@ -187,6 +188,22 @@ if sig["confidence_tier"] in ("confident", "high-conviction") and sig["risk_tier
 ```
 
 Stricter publish gate than `signal.json`: only sims with `status == "completed"` emit a payload. A 404 means the simulation is still running or has no recorded rounds — a bot should treat it as "not ready" and skip, not retry. The `confidence_tier` field is the four-bucket discrete scale (`speculative` / `moderate` / `confident` / `high-conviction`) bots use for position-sizing logic; the underlying `confidence_pct` is also returned for callers that want the continuous value. `yes_probability + no_probability == 1.0` within float tolerance — the invariant a Polymarket order-book consumer expects.
+
+### oEmbed auto-unfurl
+
+Most oEmbed consumers (Notion, Ghost, Substack, WordPress) discover the endpoint automatically from the `<link rel="alternate" type="application/json+oembed">` tag on the `/share/<id>` page — paste the share link and the rich card appears with no further setup. To query the provider directly:
+
+```bash
+curl -s "https://your-host/oembed?url=https://your-host/share/<id>" \
+  | jq '{type, title, thumbnail_url, html}'
+```
+
+```bash
+# XML representation (some consumers, Notion among them, probe the text/xml+oembed link)
+curl -s "https://your-host/oembed?url=https://your-host/share/<id>&format=xml"
+```
+
+Returns a `type: "rich"` payload — `thumbnail_url` is the 1200×630 share-card PNG and `html` is an 800×500 iframe over `/embed/<id>`. The `url` must be a share link on this deployment's own host; a foreign domain, an unpublished sim, or a missing sim all return `404`. An unsupported `format` returns `501` per the oEmbed spec.
 
 ### Search Engine Discoverability
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -206,6 +206,18 @@ The EmbedDialog surfaces a `🟣 Farcaster Frame` section: a lazy-loaded preview
 - **Frame meta tags:** `fc:frame`, `fc:frame:image`, `fc:frame:image:aspect_ratio`, `fc:frame:button:1`, `fc:frame:button:1:action`, `fc:frame:button:1:target` — emitted by `GET /share/<id>` for published sims, silently absent for private sims.
 - **Endpoint:** `GET /api/simulation/<id>/frame-metadata` → `{frame_version, image_url, image_aspect_ratio, share_url, buttons, has_trajectory, sim_title}`. Same publish gate as the chart SVG — 403 on unpublished sims, 200 with the share-card fallback for sims with no trajectory yet.
 
+## oEmbed Auto-Unfurl (Notion / Ghost / Substack / WordPress)
+
+The writing-platform distribution surface. Open Graph and Twitter tags cover the social platforms; Farcaster Frame v2 covers Warpcast. But the platforms where researchers and analysts actually *publish* — Notion, Ghost, Substack, WordPress — don't render from Open Graph alone; they implement the [oEmbed 1.0 spec](https://oembed.com) and look for a discovery `<link>` tag, then call back to the provider for a structured embed payload. Without it, a MiroShark link pasted into a Notion page or a Substack draft renders as a bare URL.
+
+`GET /oembed?url=<share-url>` is that provider. The share-page `<head>` now emits two discovery tags for published sims — `<link rel="alternate" type="application/json+oembed">` and the `text/xml+oembed` variant (some consumers, Notion among them, probe for the XML link) — both pointing at the root-mounted `/oembed` endpoint. A consumer that finds the tag calls back with the share URL and receives a `type: "rich"` payload: the 1200×630 share-card PNG as `thumbnail_url` and an 800×500 iframe over the existing `/embed/<id>` SPA route as `html`. Every organic citation becomes a rich preview card with no user action.
+
+oEmbed adds a *protocol*, not a renderer — the thumbnail and iframe both point at surfaces that already ship. Pure stdlib on the backend (`re` + `urllib.parse` + `xml.etree.ElementTree` in `app/services/oembed_service.py`), zero new dependencies. The endpoint never dereferences the inbound URL; it only extracts a sim id from a path on a host this deployment owns, so a foreign-domain `url` returns `404` and the surface can't be aimed at another site. Private and missing sims also return `404` (indistinguishable from each other), so the endpoint never confirms a private sim exists — the same gating posture as the OG / Frame tags.
+
+- **Endpoint:** `GET /oembed?url=<share-url>&format=<json|xml>` → oEmbed `rich` payload. `format` defaults to `json`; an unsupported format returns `501` per the spec. Mounted at the root (no `/api` prefix). Honors `X-Forwarded-Proto` / `X-Forwarded-Host`.
+- **Discovery tags:** `GET /share/<id>` emits `application/json+oembed` + `text/xml+oembed` `<link>` tags for published sims, silently absent for private sims.
+- **Counter:** the `oembed` key joins the surface-stats schema so an operator can see how many third-party unfurls the endpoint drove.
+
 ## Trajectory Chart SVG
 
 The scalable-vector companion to the trajectory CSV / JSONL data export. Where the CSV gives Pandas / Excel / Tableau / R the raw numbers, `GET /api/simulation/<id>/chart.svg` gives every other platform a ready-made image of the belief journey — bullish (`#22c55e`), neutral (`#6b7280`), bearish (`#ef4444`) polylines plotted against round number on a fixed `viewBox="0 0 800 400"`, with a 5-line y-axis grid, round-number x-axis labels, a three-swatch legend, and the scenario title.

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -695,6 +695,31 @@ export const getPolymarketJson = async (simulationId) => {
 }
 
 /**
+ * Build the absolute URL of the oEmbed provider endpoint for a published
+ * simulation's share URL. The discovery half of the oEmbed 1.0 spec —
+ * writing platforms (Notion, Ghost, Substack, WordPress) that find the
+ * `<link rel="alternate" type="application/json+oembed">` tag on a
+ * `/share/<id>` page call this endpoint to render a rich sim card inline
+ * instead of a bare link.
+ *
+ * Mounted at the root (no `/api` prefix). Returns a `type: "rich"`
+ * payload with the share-card thumbnail and an `/embed/<id>` iframe.
+ * `format` selects the JSON (default) or XML representation. A foreign
+ * `url`, an unpublished sim, or a missing sim all return 404.
+ *
+ * @param {string} simulationId
+ * @param {string} [origin]
+ * @param {('json'|'xml')} [format] - response representation, default 'json'
+ * @returns {string}
+ */
+export const getOEmbedUrl = (simulationId, origin, format = 'json') => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  const shareUrl = `${base}/share/${simulationId}`
+  const params = new URLSearchParams({ url: shareUrl, format })
+  return `${base}/oembed?${params.toString()}`
+}
+
+/**
  * Build the absolute URL of the simulation archive bundle — a single
  * ZIP containing every published share surface (share-card.png,
  * chart.svg, trajectory.csv / jsonl, transcript.md, thread.txt,


### PR DESCRIPTION
## What

A root-mounted `GET /oembed` provider that implements the [oEmbed 1.0](https://oembed.com) discovery spec, plus the discovery `<link>` tags on the `/share/<id>` page.

The share page already emits Open Graph / Twitter / Farcaster-Frame tags, which cover the *social* platforms. But the platforms where researchers and analysts actually **publish** — Notion, Ghost, Substack, WordPress — don't render from Open Graph; they implement oEmbed and look for a discovery `<link>` tag, then call back to the provider for a structured embed. Before this, a MiroShark link pasted into a Notion page or a Substack draft rendered as a bare URL.

With this PR live, a consumer that finds the discovery tag on a share page calls `GET /oembed?url=<share-url>` and receives a `type: "rich"` payload — the 1200×630 share-card PNG as `thumbnail_url` and an 800×500 iframe over the existing `/embed/<id>` SPA route as `html`. Every organic citation becomes a rich preview card with no user action.

## Why

From the 2026-05-24 repo-actions batch (idea #1, re-eligible from May 16, unbuilt). The "unfurl gap" for writing platforms was the highest-impact distribution play in the batch: ~80 LoC, pure stdlib, and it lights up auto-unfurl across the entire long tail of oEmbed consumers at once.

oEmbed adds a **protocol, not a renderer** — the thumbnail and iframe both point at surfaces that already ship.

## Changes

- **`backend/app/services/oembed_service.py`** (new) — pure, Flask-free core: `parse_sim_id_from_url` (host allow-listing + `/share`, `/embed`, `/simulation` path extraction), `build_oembed_payload` (rich-type payload), `oembed_to_xml` (spec XML variant). Pure stdlib (`re` + `urllib.parse` + `xml.etree.ElementTree` + `html`).
- **`backend/app/api/share.py`** — adds `GET /oembed` on `share_bp` (root-mounted): publish-gated, domain-validated, honors `?format=json|xml` (`501` on anything else), increments the `oembed` counter. Injects `application/json+oembed` + `text/xml+oembed` discovery `<link>` tags into the share-page `<head>` for **published** sims only (same gating as the OG / Frame tags).
- **`backend/app/services/surface_stats.py`** — registers the `oembed` surface counter.
- **`backend/tests/test_unit_oembed.py`** (new) — offline tests: URL parsing across the three shapes, foreign-domain + host-less rejection, payload shape (`rich`, version `1.0`, share-card thumbnail, `/embed` iframe, 100-char title cap), XML round-trip, and static guards for the route / publish gate / increment / discovery links / surface key / OpenAPI doc.
- **`frontend/src/api/simulation.js`** — `getOEmbedUrl(simulationId, origin, format)` helper.
- **`backend/openapi.yaml`** — documents `/oembed` (Publish & Embed tag) + the `OEmbedResponse` schema.
- **`docs/API.md`** / **`docs/FEATURES.md`** — endpoint table row, curl quickstart, and a feature section.

## Design notes

- **Host allow-listing, never fetching.** The endpoint never dereferences the inbound `url`; it only extracts a sim id from a path on a host this deployment owns. A foreign-domain `url` returns `404`, so the surface can't be aimed at another site.
- **Private/missing sims return `404`** (indistinguishable from each other) — the endpoint never confirms a private sim exists.
- **Spec-correct content types.** The discovery `<link>` advertises `application/json+oembed` (the standard link type); the HTTP response uses `application/json` / `text/xml` per the oEmbed 1.0 response contract. Both JSON and XML variants are served because some consumers (Notion among them) probe the XML link.
- **Zero new dependencies** — continues the stdlib-only surface pattern.

## Test plan

- [ ] `pytest backend/tests/test_unit_oembed.py` (offline)
- [ ] `pytest backend/tests/test_unit_surface_stats.py` (updated `expected` set)
- [ ] `pytest backend/tests/test_unit_openapi.py` (drift: `/oembed` now documented)
- [ ] Manual: publish a sim, paste its `/share/<id>` link into Notion / a WordPress block → renders a rich card

---
*Built autonomously by Aeon*