### PR TITLE
feat: peak-round belief analytics — machine-readable inflection points

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -5490,6 +5490,91 @@ def get_signal_json(simulation_id: str):
         }), 500
 
 
+@simulation_bp.route('/<simulation_id>/peak-round', methods=['GET'])
+def get_peak_round(simulation_id: str):
+    """Peak-round belief analytics for a published simulation.
+
+    The analytical counterpart to ``trajectory.csv`` (raw per-round
+    data) and ``chart.svg`` (the visual). Collapses the whole belief
+    trajectory into a single O(n) summary of inflection points: the
+    round each stance reached its maximum (``bullish`` / ``neutral`` /
+    ``bearish`` → ``{round, pct}``), the ``most_volatile_round`` (the
+    round with the largest summed round-over-round swing), the
+    ``max_swing_pct`` value itself, and ``total_rounds``.
+
+    Pure derivation — the per-round percentages come from the same
+    ``compute_stance_split`` (±0.2 threshold) that ``trajectory.csv``
+    uses, so "bullish peaked at 71% on round 4" here matches row 4 of
+    the CSV. The only new information is the *shape*: a machine-readable
+    inflection summary a quant tool or research script can read without
+    parsing 100 rows of trajectory.
+
+    Same publish gate as every other share surface (``is_public=true``).
+    Returns ``404`` when the simulation has no trajectory data yet so a
+    consumer can tell a "not ready" sim (404) apart from a "private"
+    sim (403).
+    """
+    from ..services import peak_round as peak_round_service
+    from ..services import surface_stats
+    from flask import Response
+
+    locale = get_locale(request)
+    try:
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                    "该模拟未发布,请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
+            }), 403
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        rounds = peak_round_service.load_trajectory_rounds(sim_dir)
+        peaks = peak_round_service.compute_peak_rounds(rounds)
+        if peaks is None:
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Peak-round analytics not available yet — the simulation has no trajectory data.",
+                    "尚无可用的峰值回合分析 — 模拟还没有轨迹数据。",
+                    locale,
+                ),
+            }), 404
+
+        peaks["simulation_id"] = simulation_id
+
+        # Pretty-printed + sorted keys so ``curl > peak-round.json``
+        # produces a diff-friendly file. The underlying numbers are a
+        # pure read of the trajectory, but we don't claim bytewise
+        # determinism (key order aside) — same posture as signal.json.
+        payload = json.dumps(peaks, indent=2, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        response = Response(payload, mimetype="application/json; charset=utf-8")
+        # 5-minute cache — matches the chart.svg / trajectory / signal
+        # cadence; a live sim's peaks shift round-to-round, so a short
+        # cache lets analytical tools see fresh inflection points while
+        # crawlers don't re-scan the trajectory on every hit.
+        response.headers["Cache-Control"] = "public, max-age=300"
+        response.headers["Content-Disposition"] = (
+            f'inline; filename="miroshark-{simulation_id[:12]}-peak-round.json"'
+        )
+        surface_stats.increment_surface_stat(sim_dir, "peak_round")
+        return response
+
+    except Exception as e:
+        logger.error(f"peak-round: failed for {simulation_id}: {e}\n{traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500
+
+
 @simulation_bp.route('/<simulation_id>/polymarket.json', methods=['GET'])
 def get_polymarket_json(simulation_id: str):
     """Polymarket-shaped binary-market prediction for a completed sim.

--- a/backend/app/services/peak_round.py
+++ b/backend/app/services/peak_round.py
@@ -1,0 +1,187 @@
+"""Peak-round belief analytics — machine-readable inflection points.
+
+``trajectory.csv`` (PR-era fifth surface) hands an analyst the raw
+per-round belief split; ``chart.svg`` draws the same numbers as a vector
+line. Neither answers the two questions a quant operator actually asks
+first — *"which round did bullish peak?"* and *"which round had the
+biggest swing?"* — without parsing every row. This module collapses the
+whole trajectory into a single O(n) summary:
+
+  {
+    "schema_version": "1",
+    "simulation_id": "<id>",
+    "bullish":  {"round": <int>, "pct": <float>},
+    "neutral":  {"round": <int>, "pct": <float>},
+    "bearish":  {"round": <int>, "pct": <float>},
+    "most_volatile_round": <int>,
+    "max_swing_pct": <float>,
+    "total_rounds": <int>
+  }
+
+Design notes
+------------
+
+* **Pure derivation — same numbers as every other surface.** The
+  per-round bullish/neutral/bearish percentages come from
+  ``trajectory_export.compute_stance_split`` — the exact function
+  ``trajectory.csv`` uses, with the same ±0.2 stance threshold. A
+  "bullish peaked at 71% on round 4" here matches row 4 of the CSV
+  byte-for-byte; this surface adds *shape*, not new computation.
+* **First-occurrence peaks.** When two rounds tie for a stance's
+  maximum, the *earliest* round wins (strict ``>`` comparison). This
+  answers "when did bullish *first* reach its high" deterministically,
+  so a consumer can predict the output on a flat-topped trajectory.
+* **Volatility = summed absolute round-over-round delta.** For each
+  round after the first, ``|Δbullish| + |Δneutral| + |Δbearish|``
+  measures how much the whole distribution moved. The first round has
+  no predecessor, so its delta is zero. ``most_volatile_round`` is the
+  earliest round carrying the maximum swing; a fully flat (or
+  single-round) trajectory reports the first round with a ``0.0`` swing.
+* **Pure stdlib.** ``json`` + ``os`` for the on-disk read; no other
+  imports. Same dependency posture as every other export module.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+from .trajectory_export import compute_stance_split
+
+
+TRAJECTORY_FILENAME = "trajectory.json"
+
+# The three stance keys, in the canonical order used across every
+# surface. Iterating this rather than hard-coding three blocks keeps the
+# peak scan and the response shape in lock-step.
+_STANCES = ("bullish", "neutral", "bearish")
+
+
+def _safe_load_trajectory(sim_dir: str) -> Optional[dict]:
+    """Read ``trajectory.json`` from ``sim_dir``; ``None`` on any failure.
+
+    Never raises — a missing or corrupt trajectory file must resolve to
+    "no data yet" (the route translates that to a 404), not a 500.
+    """
+    if not sim_dir:
+        return None
+    path = os.path.join(sim_dir, TRAJECTORY_FILENAME)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_trajectory_rounds(sim_dir: str) -> list[dict[str, Any]]:
+    """Project ``trajectory.json`` into the per-round stance-split list.
+
+    Returns one dict per usable snapshot::
+
+        {"round": <int>, "bullish_pct": <float>,
+         "neutral_pct": <float>, "bearish_pct": <float>}
+
+    Snapshots without an integer ``round_num`` are skipped (mid-write
+    or malformed rows). The list is sorted ascending by round so the
+    volatility scan compares true neighbours even if a runner ever
+    writes snapshots out of order. Returns ``[]`` on missing / corrupt
+    trajectory data.
+    """
+    trajectory = _safe_load_trajectory(sim_dir)
+    if not trajectory:
+        return []
+
+    snapshots = trajectory.get("snapshots")
+    if not isinstance(snapshots, list):
+        return []
+
+    rounds: list[dict[str, Any]] = []
+    for snap in snapshots:
+        if not isinstance(snap, dict):
+            continue
+        try:
+            round_num = int(snap.get("round_num"))
+        except (TypeError, ValueError):
+            continue
+        split = compute_stance_split(snap.get("belief_positions"))
+        rounds.append(
+            {
+                "round": round_num,
+                "bullish_pct": split["bullish"],
+                "neutral_pct": split["neutral"],
+                "bearish_pct": split["bearish"],
+            }
+        )
+
+    rounds.sort(key=lambda r: r["round"])
+    return rounds
+
+
+def compute_peak_rounds(rounds: list[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Collapse the per-round list into the peak-round summary.
+
+    Returns ``None`` for empty input so the route handler can emit a
+    404 ("no trajectory data yet") rather than a misleading all-zero
+    payload. One O(n) pass tracks, per stance, the earliest round at
+    which it reached its maximum, and the round carrying the largest
+    summed absolute round-over-round delta.
+
+    All percentage values are rounded to two decimal places — one more
+    than the per-round CSV (which rounds to 1 dp) so a small swing
+    between two 1-dp values isn't lost to rounding in ``max_swing_pct``.
+    """
+    if not rounds:
+        return None
+
+    first = rounds[0]
+    # Seed each stance's peak with the first round so a single-round
+    # trajectory reports every peak at that round.
+    peaks: dict[str, dict[str, Any]] = {
+        stance: {"round": first["round"], "pct": first[f"{stance}_pct"]}
+        for stance in _STANCES
+    }
+
+    most_volatile_round = first["round"]
+    max_swing = 0.0
+    prev: Optional[dict[str, Any]] = None
+
+    for current in rounds:
+        for stance in _STANCES:
+            pct = current[f"{stance}_pct"]
+            if pct > peaks[stance]["pct"]:
+                peaks[stance] = {"round": current["round"], "pct": pct}
+
+        if prev is not None:
+            swing = (
+                abs(current["bullish_pct"] - prev["bullish_pct"])
+                + abs(current["neutral_pct"] - prev["neutral_pct"])
+                + abs(current["bearish_pct"] - prev["bearish_pct"])
+            )
+            if swing > max_swing:
+                max_swing = swing
+                most_volatile_round = current["round"]
+
+        prev = current
+
+    return {
+        "schema_version": "1",
+        "bullish": {
+            "round": peaks["bullish"]["round"],
+            "pct": round(peaks["bullish"]["pct"], 2),
+        },
+        "neutral": {
+            "round": peaks["neutral"]["round"],
+            "pct": round(peaks["neutral"]["pct"], 2),
+        },
+        "bearish": {
+            "round": peaks["bearish"]["round"],
+            "pct": round(peaks["bearish"]["pct"], 2),
+        },
+        "most_volatile_round": most_volatile_round,
+        "max_swing_pct": round(max_swing, 2),
+        "total_rounds": len(rounds),
+    }

--- a/backend/app/services/surface_stats.py
+++ b/backend/app/services/surface_stats.py
@@ -50,7 +50,8 @@ Schema::
       "badge_svg": 0,
       "cite_bib": 0,
       "polymarket_json": 0,
-      "oembed": 0
+      "oembed": 0,
+      "peak_round": 0
     }
 
 The ``read_surface_stats`` helper returns the same dict with every key
@@ -95,6 +96,7 @@ SURFACE_KEYS: frozenset[str] = frozenset(
         "cite_bib",
         "polymarket_json",
         "oembed",
+        "peak_round",
     }
 )
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1602,6 +1602,50 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/simulation/{simulation_id}/peak-round:
+    get:
+      tags: [Publish & Embed]
+      summary: Peak-round belief analytics for a published sim.
+      description: |
+        The analytical counterpart to `trajectory.csv` (raw per-round
+        data) and `chart.svg` (the visual). Collapses the whole belief
+        trajectory into a single O(n) summary of inflection points:
+        the round each stance reached its maximum (`bullish` /
+        `neutral` / `bearish` → `{round, pct}`), the
+        `most_volatile_round` (round with the largest summed
+        round-over-round swing), the `max_swing_pct` value itself, and
+        `total_rounds`.
+
+        Pure derivation — the per-round percentages come from the same
+        `compute_stance_split` (±0.2 threshold) that `trajectory.csv`
+        uses, so "bullish peaked at 71% on round 4" here matches row 4
+        of the CSV. The only new information is the *shape*: a
+        machine-readable inflection summary a quant tool or research
+        script can read without parsing every trajectory row.
+
+        Peak ties resolve to the *earliest* round (strict `>`
+        comparison), so the output is deterministic on a flat-topped
+        trajectory. `most_volatile_round` is likewise the earliest
+        round carrying the maximum swing; a single-round or fully flat
+        trajectory reports the first round with a `0.0` swing.
+
+        Same publish gate as every other share surface
+        (`is_public=true`). Returns `404` when the simulation has no
+        trajectory data yet so a consumer can tell a "not ready" sim
+        (404) apart from a "private" sim (403). Cached for 5 minutes —
+        matches the `chart.svg` / `trajectory` / `signal.json` cadence.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Peak-round analytics payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PeakRoundResponse"
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /api/simulation/{simulation_id}/polymarket.json:
     get:
       tags: [Publish & Embed]
@@ -4821,6 +4865,80 @@ components:
             determinism is not a property of this surface (unlike
             reproduce.json / notebook.ipynb whose bytes need to be
             citation-hashable).
+
+    StancePeak:
+      type: object
+      description: |
+        The round at which one stance (bullish / neutral / bearish)
+        reached its maximum share, and that maximum percentage. Ties
+        resolve to the earliest round.
+      required:
+        - round
+        - pct
+      properties:
+        round:
+          type: integer
+          description: Round number at which this stance peaked.
+        pct:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 100
+          description: Peak share for this stance, rounded to two decimal places.
+
+    PeakRoundResponse:
+      type: object
+      description: |
+        Machine-readable peak-round analytics returned by
+        `/api/simulation/{id}/peak-round`. A single O(n) summary of the
+        belief trajectory's inflection points, derived from the same
+        per-round stance split (`±0.2` threshold) `trajectory.csv` uses.
+
+        Schema is versioned via `schema_version`. v1 is the only
+        published version; future breaking changes bump the literal.
+      required:
+        - schema_version
+        - simulation_id
+        - bullish
+        - neutral
+        - bearish
+        - most_volatile_round
+        - max_swing_pct
+        - total_rounds
+      properties:
+        schema_version:
+          type: string
+          enum: ["1"]
+          description: Schema version literal — bumped on breaking changes.
+        simulation_id:
+          type: string
+          description: Echoed simulation id.
+        bullish:
+          $ref: "#/components/schemas/StancePeak"
+        neutral:
+          $ref: "#/components/schemas/StancePeak"
+        bearish:
+          $ref: "#/components/schemas/StancePeak"
+        most_volatile_round:
+          type: integer
+          description: |
+            The round carrying the largest summed absolute
+            round-over-round belief swing
+            (`|Δbullish| + |Δneutral| + |Δbearish|`). The first round
+            has no predecessor so its swing is zero; ties resolve to
+            the earliest round.
+        max_swing_pct:
+          type: number
+          format: float
+          minimum: 0
+          description: |
+            The swing value at `most_volatile_round`, rounded to two
+            decimal places. `0.0` for a single-round or fully flat
+            trajectory.
+        total_rounds:
+          type: integer
+          minimum: 1
+          description: Number of usable rounds in the trajectory.
 
     PolymarketPrediction:
       type: object

--- a/backend/tests/test_unit_peak_round.py
+++ b/backend/tests/test_unit_peak_round.py
@@ -1,0 +1,231 @@
+"""Unit tests for the peak-round belief analytics service + route wiring.
+
+Pure offline — no Flask app, no network, no simulation runner. Covers the
+contract the ``GET /api/simulation/<id>/peak-round`` endpoint depends on:
+
+  1. ``load_trajectory_rounds`` projects ``trajectory.json`` into the
+     per-round stance-split list, reusing the same ±0.2 threshold every
+     other surface uses.
+  2. ``compute_peak_rounds`` finds the earliest peak round per stance,
+     the most-volatile round, and the max swing.
+  3. Empty / missing trajectory data resolves to ``None`` (the route
+     translates that to a 404).
+  4. The route decorator, the publish gate, and the surface-stat
+     increment exist in ``app/api/simulation.py``.
+  5. ``peak_round`` is registered in the surface_stats schema.
+  6. ``openapi.yaml`` documents ``/peak-round`` and the
+     ``PeakRoundResponse`` schema so the drift test stays green.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from app.services import peak_round  # noqa: E402
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+def _write_trajectory(sim_dir: Path, snapshots: list[dict]) -> None:
+    (sim_dir / "trajectory.json").write_text(
+        json.dumps({"snapshots": snapshots}), encoding="utf-8"
+    )
+
+
+# ── load_trajectory_rounds ───────────────────────────────────────────────
+
+
+def test_load_returns_empty_on_missing_file(tmp_path: Path):
+    assert peak_round.load_trajectory_rounds(str(tmp_path)) == []
+
+
+def test_load_returns_empty_on_corrupt_file(tmp_path: Path):
+    (tmp_path / "trajectory.json").write_text("{not json", encoding="utf-8")
+    assert peak_round.load_trajectory_rounds(str(tmp_path)) == []
+
+
+def test_load_projects_stance_split_per_round(tmp_path: Path):
+    """One bullish, one bearish, one neutral agent ⇒ 33.3% each — same
+    ±0.2 threshold every other surface uses."""
+    _write_trajectory(tmp_path, [
+        {
+            "round_num": 1,
+            "belief_positions": {
+                "1": {"t": 0.5},    # bullish
+                "2": {"t": -0.5},   # bearish
+                "3": {"t": 0.0},    # neutral
+            },
+        },
+    ])
+    rounds = peak_round.load_trajectory_rounds(str(tmp_path))
+    assert len(rounds) == 1
+    assert rounds[0]["round"] == 1
+    assert rounds[0]["bullish_pct"] == pytest.approx(33.3, abs=0.1)
+    assert rounds[0]["neutral_pct"] == pytest.approx(33.3, abs=0.1)
+    assert rounds[0]["bearish_pct"] == pytest.approx(33.3, abs=0.1)
+
+
+def test_load_sorts_rounds_ascending_and_skips_unnumbered(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 3, "belief_positions": {"1": {"t": 0.5}}},
+        {"round_num": 1, "belief_positions": {"1": {"t": -0.5}}},
+        {"belief_positions": {"1": {"t": 0.5}}},  # no round_num — skipped
+        {"round_num": 2, "belief_positions": {"1": {"t": 0.0}}},
+    ])
+    rounds = peak_round.load_trajectory_rounds(str(tmp_path))
+    assert [r["round"] for r in rounds] == [1, 2, 3]
+
+
+# ── compute_peak_rounds ──────────────────────────────────────────────────
+
+
+def test_compute_returns_none_on_empty():
+    assert peak_round.compute_peak_rounds([]) is None
+
+
+def test_single_round_puts_every_peak_at_that_round():
+    rounds = [
+        {"round": 1, "bullish_pct": 60.0, "neutral_pct": 30.0, "bearish_pct": 10.0},
+    ]
+    result = peak_round.compute_peak_rounds(rounds)
+    assert result["bullish"] == {"round": 1, "pct": 60.0}
+    assert result["neutral"] == {"round": 1, "pct": 30.0}
+    assert result["bearish"] == {"round": 1, "pct": 10.0}
+    assert result["most_volatile_round"] == 1
+    assert result["max_swing_pct"] == 0.0
+    assert result["total_rounds"] == 1
+
+
+def test_multi_round_finds_correct_peak_round_per_stance():
+    rounds = [
+        {"round": 1, "bullish_pct": 20.0, "neutral_pct": 50.0, "bearish_pct": 30.0},
+        {"round": 2, "bullish_pct": 70.0, "neutral_pct": 20.0, "bearish_pct": 10.0},
+        {"round": 3, "bullish_pct": 40.0, "neutral_pct": 10.0, "bearish_pct": 50.0},
+    ]
+    result = peak_round.compute_peak_rounds(rounds)
+    assert result["bullish"] == {"round": 2, "pct": 70.0}
+    assert result["neutral"] == {"round": 1, "pct": 50.0}
+    assert result["bearish"] == {"round": 3, "pct": 50.0}
+    assert result["total_rounds"] == 3
+
+
+def test_peak_tie_resolves_to_earliest_round():
+    """Two rounds tie at the bullish max ⇒ the earlier round wins
+    (answers 'when did bullish *first* peak')."""
+    rounds = [
+        {"round": 1, "bullish_pct": 50.0, "neutral_pct": 25.0, "bearish_pct": 25.0},
+        {"round": 2, "bullish_pct": 50.0, "neutral_pct": 25.0, "bearish_pct": 25.0},
+    ]
+    result = peak_round.compute_peak_rounds(rounds)
+    assert result["bullish"]["round"] == 1
+
+
+def test_most_volatile_round_on_known_delta_sequence():
+    """Round 2 swing = |40-20|+|40-60|+|20-20| = 40.
+       Round 3 swing = |80-40|+|10-40|+|10-20| = 80 (the max)."""
+    rounds = [
+        {"round": 1, "bullish_pct": 20.0, "neutral_pct": 60.0, "bearish_pct": 20.0},
+        {"round": 2, "bullish_pct": 40.0, "neutral_pct": 40.0, "bearish_pct": 20.0},
+        {"round": 3, "bullish_pct": 80.0, "neutral_pct": 10.0, "bearish_pct": 10.0},
+    ]
+    result = peak_round.compute_peak_rounds(rounds)
+    assert result["most_volatile_round"] == 3
+    assert result["max_swing_pct"] == 80.0
+
+
+def test_max_swing_rounds_to_two_dp():
+    rounds = [
+        {"round": 1, "bullish_pct": 0.0, "neutral_pct": 100.0, "bearish_pct": 0.0},
+        {"round": 2, "bullish_pct": 33.33, "neutral_pct": 33.34, "bearish_pct": 33.33},
+    ]
+    result = peak_round.compute_peak_rounds(rounds)
+    # |33.33-0| + |33.34-100| + |33.33-0| = 33.33 + 66.66 + 33.33 = 133.32
+    assert result["max_swing_pct"] == 133.32
+
+
+def test_total_rounds_matches_input_length():
+    rounds = [
+        {"round": r, "bullish_pct": 10.0 * r, "neutral_pct": 5.0, "bearish_pct": 0.0}
+        for r in range(1, 6)
+    ]
+    result = peak_round.compute_peak_rounds(rounds)
+    assert result["total_rounds"] == 5
+
+
+def test_schema_version_is_one():
+    rounds = [{"round": 1, "bullish_pct": 50.0, "neutral_pct": 25.0, "bearish_pct": 25.0}]
+    assert peak_round.compute_peak_rounds(rounds)["schema_version"] == "1"
+
+
+# ── End-to-end: load → compute ────────────────────────────────────────────
+
+
+def test_load_then_compute_against_on_disk_trajectory(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"1": {"t": 0.5}, "2": {"t": -0.5}}},
+        {"round_num": 2, "belief_positions": {"1": {"t": 0.5}, "2": {"t": 0.5}}},
+    ])
+    rounds = peak_round.load_trajectory_rounds(str(tmp_path))
+    result = peak_round.compute_peak_rounds(rounds)
+    # Round 2 is fully bullish ⇒ bullish peaks there at 100%.
+    assert result["bullish"] == {"round": 2, "pct": 100.0}
+    assert result["total_rounds"] == 2
+
+
+# ── Static wiring guards ───────────────────────────────────────────────────
+
+
+def _read_simulation_api() -> str:
+    return (_BACKEND / "app" / "api" / "simulation.py").read_text(encoding="utf-8")
+
+
+def test_route_decorator_registered():
+    text = _read_simulation_api()
+    assert (
+        "@simulation_bp.route('/<simulation_id>/peak-round', methods=['GET'])" in text
+    ), "GET /<id>/peak-round route decorator missing from simulation.py"
+    assert "def get_peak_round" in text, (
+        "get_peak_round handler function missing from simulation.py"
+    )
+
+
+def test_route_enforces_publish_gate():
+    text = _read_simulation_api()
+    # The handler reuses the embed-summary publish lookup.
+    assert "_build_embed_summary_payload" in text
+    assert "is_public" in text
+
+
+def test_route_increments_peak_round_surface_stat():
+    text = _read_simulation_api()
+    assert '"peak_round"' in text, (
+        "simulation.py must increment the peak_round counter via "
+        "surface_stats.increment_surface_stat(..., \"peak_round\")"
+    )
+    assert "increment_surface_stat" in text
+
+
+def test_surface_stats_registers_peak_round_key():
+    from app.services import surface_stats
+
+    assert "peak_round" in surface_stats.SURFACE_KEYS
+
+
+def test_openapi_documents_peak_round_path_and_schema():
+    spec_text = (_BACKEND / "openapi.yaml").read_text(encoding="utf-8")
+    assert "/api/simulation/{simulation_id}/peak-round:" in spec_text, (
+        "openapi.yaml is missing the /peak-round path entry"
+    )
+    assert "PeakRoundResponse:" in spec_text, (
+        "openapi.yaml is missing the PeakRoundResponse schema"
+    )

--- a/backend/tests/test_unit_surface_stats.py
+++ b/backend/tests/test_unit_surface_stats.py
@@ -84,6 +84,7 @@ def test_surface_keys_includes_every_serve_handler():
         "cite_bib",
         "polymarket_json",
         "oembed",
+        "peak_round",
     }
     assert set(surface_stats.SURFACE_KEYS) == expected
 
@@ -285,6 +286,7 @@ def test_surface_stats_route_decorator_registered():
         "chart_svg",
         "signal_json",
         "archive_zip",
+        "peak_round",
     ],
 )
 def test_serve_handlers_increment_their_surface_key(surface_key: str):

--- a/docs/API.md
+++ b/docs/API.md
@@ -68,6 +68,7 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `GET` | `/api/simulation/<id>/interaction-network` | Agent-to-agent graph |
 | `GET` | `/api/simulation/<id>/demographics` | Archetype distribution |
 | `GET` | `/api/simulation/<id>/quality` | Run health diagnostics |
+| `GET` | `/api/simulation/<id>/peak-round` | Machine-readable belief inflection points — the round each stance (`bullish` / `neutral` / `bearish`) peaked (`{round, pct}`), the `most_volatile_round` (largest summed round-over-round swing), `max_swing_pct`, and `total_rounds`. Pure O(n) derivation from the same ±0.2 stance split `trajectory.csv` uses; peak ties resolve to the earliest round. Publish-gated; `404` until trajectory data exists. Cached 5 minutes. `curl -s "https://your-host/api/simulation/<id>/peak-round"` |
 | `POST` | `/api/simulation/compare` | Side-by-side belief comparison |
 
 ## Interaction

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -263,6 +263,38 @@ The Embed dialog exposes a `📡 Trading signal (JSON)` section beneath the traj
 
 Closes the gap between *"a sim produces data"* and *"a sim produces a signal"* — the last mile a quant audience needed before MiroShark output could land directly in an automation rather than a notebook.
 
+## Peak-Round Analytics
+
+`trajectory.csv` hands an analyst the raw per-round belief split; `chart.svg` draws the same numbers as a line. Neither answers the two questions a quant operator asks first — *"which round did bullish peak?"* and *"which round had the biggest swing?"* — without parsing every row. `GET /api/simulation/<id>/peak-round` collapses the whole trajectory into a single O(n) summary of inflection points.
+
+Returns a stable v1-schema JSON document:
+
+```json
+{
+  "schema_version": "1",
+  "simulation_id": "<sim_id>",
+  "bullish": { "round": 4, "pct": 71.4 },
+  "neutral": { "round": 1, "pct": 55.0 },
+  "bearish": { "round": 9, "pct": 48.2 },
+  "most_volatile_round": 4,
+  "max_swing_pct": 38.6,
+  "total_rounds": 12
+}
+```
+
+- **`bullish` / `neutral` / `bearish`** — `{round, pct}` for the round each stance reached its maximum share. Ties resolve to the *earliest* round (strict `>` comparison), so the output is deterministic on a flat-topped trajectory — it answers "when did bullish *first* peak."
+- **`most_volatile_round`** — the round carrying the largest summed absolute round-over-round belief swing (`|Δbullish| + |Δneutral| + |Δbearish|`). The first round has no predecessor so its swing is zero; ties resolve to the earliest round.
+- **`max_swing_pct`** — the swing value at `most_volatile_round`, rounded to two decimal places. `0.0` for a single-round or fully flat trajectory.
+- **`total_rounds`** — number of usable rounds in the trajectory.
+
+Pure derivation. The per-round percentages come from the same `trajectory_export.compute_stance_split` (±0.2 threshold) that `trajectory.csv` uses, so "bullish peaked at 71.4% on round 4" here matches row 4 of the CSV. The only new information is the *shape*: a machine-readable inflection summary, not a re-computation. Stdlib-only (`json` + `os`); `peak_round.py` is ~190 LoC with no new dependencies.
+
+Same publish gate as every other share surface (`is_public=true`). Returns `404` when the simulation has no trajectory data yet so a consumer can tell a "not ready" sim (404) apart from a "private" sim (403). Cached for 5 minutes — matches the `chart.svg` / `trajectory` / `signal.json` cadence.
+
+The Embed dialog exposes a `📊 Peak beliefs (JSON)` section beneath the trading-signal row: a live preview (bullish / bearish peaks, the most-volatile round, total rounds), a copyable URL, and a paste-ready `curl` snippet. The `peak_round` counter joins the surface-stats schema so an operator can see how often the analytical summary is pulled independently of the raw CSV.
+
+Completes the analytical quadrant alongside `trajectory.csv` (raw data), `chart.svg` (visual), and `signal.json` (final-state action primitive) — the inflection-point view those three left implicit.
+
 ## Polymarket-Ready Prediction JSON
 
 The first share surface adapted for a specific external integrator. `signal.json` emits a generic action primitive (`direction` + `confidence_pct` + `risk_tier`); `GET /api/simulation/<id>/polymarket.json` re-shapes that primitive into the binary YES / NO probability envelope a Polymarket trading bot expects between *"simulation result"* and *"actionable market signal"*.

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -695,6 +695,52 @@ export const getPolymarketJson = async (simulationId) => {
 }
 
 /**
+ * Build the absolute URL of the peak-round belief analytics endpoint for
+ * a published simulation. The analytical counterpart to trajectory.csv
+ * (raw per-round data) and chart.svg (the visual): a single O(n) summary
+ * of the belief trajectory's inflection points.
+ *
+ * Returns a v1-schema JSON document with `bullish` / `neutral` /
+ * `bearish` (`{round, pct}` — the round each stance peaked),
+ * `most_volatile_round` (round with the largest summed round-over-round
+ * swing), `max_swing_pct`, and `total_rounds`.
+ *
+ * Same publish gate as every other share surface. Returns 404 when the
+ * simulation has no trajectory data yet.
+ *
+ * @param {string} simulationId
+ * @param {string} [origin]
+ * @returns {string}
+ */
+export const getPeakRoundUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/api/simulation/${simulationId}/peak-round`
+}
+
+/**
+ * Fetch the peak-round analytics payload for a published simulation.
+ *
+ * Returns the parsed JSON document on 200, `null` on 404 (no trajectory
+ * data yet) or 403 (sim not published), and throws on transport errors.
+ *
+ * @param {string} simulationId
+ * @returns {Promise<object|null>}
+ */
+export const getPeakRound = async (simulationId) => {
+  const res = await fetch(getPeakRoundUrl(simulationId), {
+    credentials: 'omit',
+    cache: 'no-store',
+  })
+  if (res.status === 403 || res.status === 404) {
+    return null
+  }
+  if (!res.ok) {
+    throw new Error(`peak-round fetch failed: ${res.status}`)
+  }
+  return res.json()
+}
+
+/**
  * Build the absolute URL of the oEmbed provider endpoint for a published
  * simulation's share URL. The discovery half of the oEmbed 1.0 spec —
  * writing platforms (Notion, Ghost, Substack, WordPress) that find the

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -686,6 +686,91 @@
               </div>
             </div>
 
+            <!-- Peak-round belief analytics — the analytical counterpart
+                 to trajectory.csv (raw per-round data) and chart.svg
+                 (the visual). Collapses the whole trajectory into a
+                 single O(n) inflection-point summary: when each stance
+                 peaked + the most volatile round. Same publish gate as
+                 every other surface; pure stdlib, zero new deps. -->
+            <div class="transcript-section signal-section">
+              <div class="transcript-head">
+                <span class="transcript-icon">📊</span>
+                <div class="transcript-head-body">
+                  <div class="transcript-title">
+                    {{ $tr('Peak beliefs (JSON)', '峰值信念(JSON)') }}
+                    <span v-if="peakPayload" class="signal-direction-badge signal-direction-bullish">
+                      {{ $tr('Most volatile: round', '最波动:回合') }} {{ peakPayload.most_volatile_round }}
+                    </span>
+                  </div>
+                  <div class="transcript-sub">
+                    {{ $tr('Machine-readable inflection points — the round each stance (bullish / neutral / bearish) peaked, the most volatile round, and the maximum round-over-round swing. The analytical summary quant tools need alongside trajectory.csv, in one O(n) pass.', '机器可读的拐点 — 每种立场(看涨 / 中性 / 看跌)达到峰值的回合、最波动的回合,以及最大的回合间摆动幅度。量化工具在 trajectory.csv 之外需要的分析摘要,一次 O(n) 遍历即可获得。') }}
+                  </div>
+                </div>
+              </div>
+
+              <div v-if="isPublic && peakPayload" class="signal-preview">
+                <div class="signal-row">
+                  <span class="signal-label">{{ $tr('Bullish peak', '看涨峰值') }}</span>
+                  <span class="signal-value signal-direction-bullish">
+                    {{ peakPayload.bullish.pct }}% · {{ $tr('round', '回合') }} {{ peakPayload.bullish.round }}
+                  </span>
+                </div>
+                <div class="signal-row">
+                  <span class="signal-label">{{ $tr('Bearish peak', '看跌峰值') }}</span>
+                  <span class="signal-value signal-direction-bearish">
+                    {{ peakPayload.bearish.pct }}% · {{ $tr('round', '回合') }} {{ peakPayload.bearish.round }}
+                  </span>
+                </div>
+                <div class="signal-row">
+                  <span class="signal-label">{{ $tr('Most volatile', '最波动') }}</span>
+                  <span class="signal-value">
+                    {{ $tr('round', '回合') }} {{ peakPayload.most_volatile_round }} (±{{ peakPayload.max_swing_pct }}%)
+                  </span>
+                </div>
+                <div class="signal-row signal-row-breakdown">
+                  <span class="signal-label">{{ $tr('Total rounds', '总回合数') }}</span>
+                  <span class="signal-value">{{ peakPayload.total_rounds }}</span>
+                </div>
+              </div>
+              <div v-else-if="isPublic && peakLoading" class="signal-loading">
+                {{ $tr('Loading peak beliefs…', '加载峰值信念中…') }}
+              </div>
+              <div v-else-if="isPublic && peakError" class="signal-empty">
+                {{ peakError }}
+              </div>
+              <div v-else-if="!isPublic" class="signal-empty">
+                {{ $tr('Publish the simulation to enable peak-round analytics.', '发布模拟以启用峰值回合分析。') }}
+              </div>
+
+              <div class="snippet-block transcript-snippet">
+                <div class="snippet-head">
+                  <span class="snippet-label">{{ $tr('Peak-round URL', '峰值回合 URL') }}</span>
+                  <button
+                    class="snippet-copy-btn"
+                    @click="copy('peakUrl')"
+                    :disabled="!isPublic"
+                  >
+                    {{ copied === 'peakUrl' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy URL', '复制 URL') }}
+                  </button>
+                </div>
+                <pre class="snippet-code"><code>{{ peakRoundUrl || '—' }}</code></pre>
+              </div>
+
+              <div class="snippet-block transcript-snippet">
+                <div class="snippet-head">
+                  <span class="snippet-label">{{ $tr('curl snippet', 'curl 片段') }}</span>
+                  <button
+                    class="snippet-copy-btn"
+                    @click="copy('peakCurl')"
+                    :disabled="!isPublic"
+                  >
+                    {{ copied === 'peakCurl' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy snippet', '复制代码片段') }}
+                  </button>
+                </div>
+                <pre class="snippet-code"><code>{{ peakCurlSnippet }}</code></pre>
+              </div>
+            </div>
+
             <!-- Polymarket-shaped prediction JSON — the first share
                  surface adapted for a specific external integrator
                  (a Polymarket trading bot). Reshapes the signal.json
@@ -2265,6 +2350,8 @@ import {
   getBadgeUrl,
   getSignalJsonUrl,
   getSignalJson,
+  getPeakRoundUrl,
+  getPeakRound,
   getPolymarketJsonUrl,
   getPolymarketJson,
   getArchiveZipUrl,
@@ -2523,6 +2610,51 @@ const loadSignal = async () => {
     signalError.value = err?.message || tr('Signal fetch failed', '信号获取失败')
   } finally {
     signalLoading.value = false
+  }
+}
+
+// ── Peak-round analytics state ─────────────────────────────────────────
+// The analytical counterpart to trajectory.csv / chart.svg: a single
+// O(n) summary of the belief trajectory's inflection points. Same
+// publish gate as signal.json; 404 means "no trajectory data yet".
+
+const peakPayload = ref(null)
+const peakLoading = ref(false)
+const peakError = ref('')
+
+const peakRoundUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  return getPeakRoundUrl(props.simulationId, origin.value)
+})
+
+const peakCurlSnippet = computed(() => {
+  const url = peakRoundUrl.value || 'https://your-host/api/simulation/<id>/peak-round'
+  return `curl -s "${url}"`
+})
+
+const loadPeakRound = async () => {
+  if (!props.simulationId || !isPublic.value) {
+    peakPayload.value = null
+    return
+  }
+  peakLoading.value = true
+  peakError.value = ''
+  try {
+    const payload = await getPeakRound(props.simulationId)
+    if (payload && typeof payload === 'object') {
+      peakPayload.value = payload
+    } else {
+      peakPayload.value = null
+      peakError.value = tr(
+        'Peak-round analytics not available yet — the simulation has no trajectory data.',
+        '尚无可用的峰值回合分析 — 模拟还没有轨迹数据。',
+      )
+    }
+  } catch (err) {
+    peakPayload.value = null
+    peakError.value = err?.message || tr('Peak-round fetch failed', '峰值回合获取失败')
+  } finally {
+    peakLoading.value = false
   }
 }
 
@@ -3338,6 +3470,8 @@ const copy = async (which) => {
   else if (which === 'badgeHtml') text = badgeHtmlSnippet.value
   else if (which === 'signalUrl') text = signalJsonUrl.value
   else if (which === 'signalCurl') text = signalCurlSnippet.value
+  else if (which === 'peakUrl') text = peakRoundUrl.value
+  else if (which === 'peakCurl') text = peakCurlSnippet.value
   else if (which === 'polymarketUrl') text = polymarketJsonUrl.value
   else if (which === 'polymarketCurl') text = polymarketCurlSnippet.value
   else if (which === 'archiveUrl') text = archiveZipUrl.value
@@ -3928,6 +4062,9 @@ watch(() => props.open, async (val) => {
   // tiny payload (~250 bytes), and the preview row needs the parsed
   // payload to render the direction / confidence / risk-tier chips.
   loadSignal()
+  // Peak-round analytics sits on the same publish gate; load alongside
+  // so the inflection-point preview renders without a manual refresh.
+  loadPeakRound()
   // Polymarket prediction sits on the same gate as signal.json; load
   // alongside so the YES/NO preview row renders without a manual refresh.
   loadPolymarket()
@@ -3974,6 +4111,8 @@ watch(isPublic, () => {
   loadThread()
   // Same publish-gate flip applies to the trading signal — re-fetch.
   loadSignal()
+  // Same publish-gate flip applies to peak-round analytics — re-fetch.
+  loadPeakRound()
   // Polymarket prediction sits on the same gate; re-fetch alongside.
   loadPolymarket()
   // Same flip applies to the archive bundle — re-HEAD so the bundle


### PR DESCRIPTION
## What

Adds `GET /api/simulation/<id>/peak-round` — the analytical counterpart to `trajectory.csv` (raw per-round data) and `chart.svg` (the visual). It collapses the whole belief trajectory into a single O(n) summary of inflection points:

```json
{
  "schema_version": "1",
  "simulation_id": "<id>",
  "bullish": { "round": 4, "pct": 71.4 },
  "neutral": { "round": 1, "pct": 55.0 },
  "bearish": { "round": 9, "pct": 48.2 },
  "most_volatile_round": 4,
  "max_swing_pct": 38.6,
  "total_rounds": 12
}
```

- **`bullish` / `neutral` / `bearish`** — `{round, pct}` for the round each stance reached its maximum share. Ties resolve to the **earliest** round (strict `>`), so the output is deterministic on a flat-topped trajectory — it answers "when did bullish *first* peak."
- **`most_volatile_round`** — the round with the largest summed absolute round-over-round swing (`|Δbullish| + |Δneutral| + |Δbearish|`); the first round has no predecessor so its swing is zero.
- **`max_swing_pct`** — the swing value at `most_volatile_round` (2 dp); `0.0` for a single-round / flat trajectory.
- **`total_rounds`** — number of usable rounds.

## Why

`trajectory.csv` gives the raw numbers; `chart.svg` shows the picture. Neither answers the two questions a quant operator asks first — *"which round did bullish peak?"* and *"which round had the biggest swing?"* — without parsing every row. This is the machine-readable inflection summary that completes the analytical quadrant alongside `signal.json`. Re-eligible idea from the 2026-05-16 and 2026-05-24 repo-actions batches (unbuilt until now).

## How it works

**Pure derivation, zero new computation.** Per-round percentages come from the same `trajectory_export.compute_stance_split` (±0.2 stance threshold) that `trajectory.csv` uses, so "bullish peaked at 71.4% on round 4" here matches row 4 of the CSV byte-for-byte. The new module reads `trajectory.json`, projects each snapshot to a stance split, and does one O(n) pass tracking each stance's earliest peak round and the max round-over-round swing.

## Changes

- `backend/app/services/peak_round.py` — `load_trajectory_rounds` + `compute_peak_rounds` (pure stdlib, reuses `compute_stance_split`)
- `backend/app/api/simulation.py` — publish-gated `GET /<id>/peak-round` route + surface-stat increment, mirroring the `signal.json` handler (404 = no trajectory yet, 403 = unpublished)
- `backend/app/services/surface_stats.py` — new `peak_round` surface key
- `backend/openapi.yaml` — `/peak-round` path + `PeakRoundResponse` / `StancePeak` schemas
- `backend/tests/test_unit_peak_round.py` — 19 offline unit tests + static wiring guards; `test_unit_surface_stats.py` updated for the new key
- `frontend/src/api/simulation.js` — `getPeakRoundUrl` / `getPeakRound` helpers
- `frontend/src/components/EmbedDialog.vue` — 📊 Peak beliefs (JSON) section beneath the trading-signal row
- `docs/API.md` + `docs/FEATURES.md` — documentation

Zero new dependencies.

---
*Built autonomously by Aeon*