### PR TITLE
Add ECOSYSTEM.md

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,41 @@
+<p align="center">
+  <img src="miroshark-nobg.png" alt="MiroShark" width="80" />
+</p>
+
+<h1 align="center">Ecosystem</h1>
+
+<p align="center">
+  Projects, agents, and products building on top of MiroShark.
+</p>
+
+---
+
+## Building on MiroShark
+
+These are the projects we know of that run MiroShark, extend it, or integrate with the engine. The list is curated from operator self-disclosures and public mentions — it isn't exhaustive, and not every fork is listed here.
+
+| Project | Links |
+|---------|-------|
+| AntFleet | [@AntFleetDev](https://x.com/AntFleetDev) · [miroshark-bench](https://github.com/AntFleet/miroshark-bench) |
+| Blue Agent | [@blueagent_](https://x.com/blueagent_) · [blue-agent](https://github.com/madebyshun/blue-agent) |
+| Crucible Sim | [crucible-sim](https://github.com/wshuyi/crucible-sim) |
+| Echo | [@BuiltByEcho](https://x.com/BuiltByEcho) · [builtbyecho.xyz](https://www.builtbyecho.xyz/) |
+| Monitor | [monitor-the-situation-bags](https://github.com/Zoidberg-eternal/monitor-the-situation-bags) |
+| Nookplot | [nookplot.com](https://nookplot.com/?view=network) |
+| RootAI | [@Root_Edge](https://x.com/Root_Edge) · [rootai.wtf](https://rootai.wtf) |
+| Signa | [@Signa_Agent](https://x.com/Signa_Agent) · [signa-miroshark-skills](https://github.com/codexvritra/signa-miroshark-skills) |
+| Supercompact | [supercompact-for-miroshark](https://github.com/JohnTammi/supercompact-for-miroshark) |
+| Xerg | [@xerg_AI](https://x.com/xerg_AI) · [xerg.ai](https://xerg.ai/) |
+
+---
+
+## Add your project
+
+Building on top of MiroShark? Open a PR adding a row to the table above.
+
+Guidelines:
+
+- Project should publicly identify as built on / using / extending MiroShark.
+- One row per project. Keep rows alphabetized by project name.
+- Provide at least an X handle or a public link. A short website link is welcome alongside the X handle.
+- Stock forks that mainly re-run the engine without an extension or product on top do not belong here. This page is for products, agents, and integrations *built with* MiroShark.


### PR DESCRIPTION
## Summary
- Adds an `ECOSYSTEM.md` page listing projects, agents, and products built on top of MiroShark.
- Seeds the table with 10 projects already publicly identifying as building on / extending MiroShark, alphabetized.
- Includes an "Add your project" section with PR guidelines so contributors can self-add.

## Why
A single canonical index of MiroShark-powered work makes it easier to discover what people are building on the engine and gives operators a clear way to surface their projects.

## Notes for review
- Page references `miroshark-nobg.png`, which already exists at the repo root.
- Happy to trim/adjust the project list or the guideline copy — flag anything you'd like changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)