### PR TITLE
Fix reranker hang on Apple Silicon (steer off MPS backend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,11 @@ NEO4J_PASSWORD=CHANGE_ME_GENERATE_A_RANDOM_PASSWORD
 RERANKER_ENABLED=true
 RERANKER_MODEL=BAAI/bge-reranker-v2-m3
 RERANKER_CANDIDATES=30
+# Torch device for the reranker. Blank = auto: CUDA if available, else CPU.
+# MPS (Apple-Silicon GPU) is intentionally avoided in auto mode — torch can hang
+# compiling Metal shader pipelines for this cross-encoder, stalling retrieval.
+# Set to cpu / cuda / mps to override.
+RERANKER_DEVICE=
 
 # ===== Graph-traversal Retrieval =====
 # Zep/Graphiti-style BFS: picks top-K entity hits as seeds, expands along

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -70,6 +70,11 @@ class Config:
     # Number of candidates to pull from hybrid fusion before reranking.
     # Must be >= final limit. Larger = better recall before rerank, slower inference.
     RERANKER_CANDIDATES = int(os.environ.get('RERANKER_CANDIDATES', '30'))
+    # Torch device for the reranker. Blank = auto (CUDA if available, else CPU).
+    # MPS (Apple-Silicon GPU) is intentionally avoided in auto mode — torch can
+    # hang compiling Metal shader pipelines for this cross-encoder. Set to
+    # 'cpu', 'cuda', or 'mps' to override.
+    RERANKER_DEVICE = os.environ.get('RERANKER_DEVICE', '').strip()
 
     # Graph-traversal retrieval (Zep/Graphiti-style BFS from seed entities).
     # A third retrieval strategy alongside vector + BM25 — catches multi-hop

--- a/backend/app/storage/reranker_service.py
+++ b/backend/app/storage/reranker_service.py
@@ -42,6 +42,25 @@ class RerankerService:
     def model_name(self) -> str:
         return self._model_name_override or Config.RERANKER_MODEL
 
+    @staticmethod
+    def _select_device() -> str:
+        """Pick a torch device for the cross-encoder.
+
+        Honors an explicit ``RERANKER_DEVICE`` override; otherwise prefers CUDA
+        and falls back to CPU. MPS (Apple-Silicon GPU) is intentionally skipped
+        in auto mode — torch can hang indefinitely compiling Metal shader
+        pipelines for this cross-encoder, pegging a core and stalling retrieval.
+        """
+        if Config.RERANKER_DEVICE:
+            return Config.RERANKER_DEVICE
+        try:
+            import torch
+            if torch.cuda.is_available():
+                return "cuda"
+        except Exception:
+            pass
+        return "cpu"
+
     def _ensure_loaded(self) -> bool:
         """Load the cross-encoder lazily. Returns False on failure."""
         if self._model is not None:
@@ -57,8 +76,11 @@ class RerankerService:
 
             try:
                 from sentence_transformers import CrossEncoder
-                logger.info(f"Loading cross-encoder reranker: {self.model_name}")
-                self._model = CrossEncoder(self.model_name, max_length=512)
+                device = self._select_device()
+                logger.info(
+                    f"Loading cross-encoder reranker: {self.model_name} (device={device})"
+                )
+                self._model = CrossEncoder(self.model_name, max_length=512, device=device)
                 logger.info(f"Reranker ready: {self.model_name}")
                 return True
             except Exception as e:


### PR DESCRIPTION
## Problem

On macOS / Apple Silicon, with the default `RERANKER_ENABLED=true`, simulations hang during the **prepare** phase right after persona generation. No further OpenRouter calls happen, and one CPU core sits pegged at ~100% indefinitely.

Root cause: the cross-encoder reranker (`BAAI/bge-reranker-v2-m3`) is loaded via `CrossEncoder(...)` with **no device argument**, so sentence-transformers auto-selects torch's **MPS (Metal) backend**. The first rerank then hangs inside:

```
at::native::mps::..._bitwise_op_out_mps
  -> MetalShaderLibrary::getLibraryPipelineState
    -> std::__hash_table::__do_rehash   # spins forever
```

i.e. torch wedges compiling a Metal shader pipeline. The pegged native thread is the ~100% CPU; the main thread parks in `time.sleep()` and the rest of the pipeline blocks behind it.

## Fix

Select the reranker's device explicitly instead of letting sentence-transformers auto-pick:

- New `RERANKER_DEVICE` env var (blank = auto).
- Auto mode prefers **CUDA** if available, else **CPU**. **MPS is intentionally skipped** in auto mode.
- Fully overridable (`RERANKER_DEVICE=mps` to opt back in).

This keeps the reranker **enabled and working out of the box** — CPU on Macs, CUDA on NVIDIA hosts — rather than forcing users to discover `RERANKER_ENABLED=false`.

### Changes
- `backend/app/config.py` — add `RERANKER_DEVICE` (blank = auto)
- `backend/app/storage/reranker_service.py` — `_select_device()` helper; pass `device=` to `CrossEncoder`
- `.env.example` — document `RERANKER_DEVICE`

## Test

Loading + reranking through the patched service on an M-series Mac:

```
device auto-selected -> cpu
Loading cross-encoder reranker: BAAI/bge-reranker-v2-m3 (device=cpu)
Reranker ready: BAAI/bge-reranker-v2-m3
rerank OK in 6.6s, scores=[0.077, 0.0, 0.591]   # football docs > recipe doc
RESULT: PASS
```

No hang; ranking is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)