### PR TITLE
Fix report section crash on a null agent interview response

### DIFF
--- a/backend/app/services/graph_tools.py
+++ b/backend/app/services/graph_tools.py
@@ -1382,7 +1382,11 @@ class GraphToolsService:
     @staticmethod
     def _clean_tool_call_response(response: str) -> str:
         """Clean JSON tool call wrappers in Agent responses and extract actual content"""
-        if not response or not response.strip().startswith('{'):
+        if not response:
+            # Coerce None / empty to "" — callers feed this straight into re.sub,
+            # and the simulation API can return an explicit "response": null.
+            return ""
+        if not response.strip().startswith('{'):
             return response
         text = response.strip()
         if 'tool_name' not in text[:80]:


### PR DESCRIPTION
## Problem

Report generation fails a section with:

```
(Section generation error: expected string or bytes-like object, got 'NoneType')
```

When the report agent's ReAct loop calls the **`interview_agents`** tool in single-platform mode, the cleaned response is assigned straight into `combined_responses` and then run through `re.sub(...)`:

```python
platform_response = self._clean_tool_call_response(platform_result.get("response", ""))
...
combined_responses = platform_response
clean_text = re.sub(r'#{1,6}\s+', '', combined_responses)   # <- boom if None
```

Two things combine to make `combined_responses` `None`:

1. `platform_result.get("response", "")` returns `None` when the running-simulation API sends an explicit `"response": null` — `dict.get(key, default)` only uses the default for a **missing** key, not a present-but-`null` one.
2. `_clean_tool_call_response` returned its argument unchanged for falsy input (`if not response ...: return response`), so `None` passed straight through.

`re.sub` on `None` then raises `TypeError`, which the section worker reports as the section error.

## Fix

Make `_clean_tool_call_response` always return a string — coerce `None`/empty to `""`:

```python
if not response:
    return ""
if not response.strip().startswith('{'):
    return response
```

This covers all three call sites (twitter / reddit / single-platform). The dual-platform path was already safe (builds `combined_responses` via an f-string), and the LLM-fallback interview path guards its own response (`if not response_text: ...`), so this was the one unguarded site.

## Test

```
None           -> type=str  re.sub OK -> ''
empty          -> type=str  re.sub OK -> ''
plain text     -> type=str  re.sub OK -> 'Germany will dominate the group stage.'
json wrapper   -> type=str  re.sub OK -> 'Brazil are favourites'
```

`None`/empty now return `""` (regex-safe); JSON-wrapper content extraction is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)