### PR TITLE
Fix report section crash on intermittent null LLM content

### DIFF
--- a/backend/app/services/report_agent.py
+++ b/backend/app/services/report_agent.py
@@ -2901,8 +2901,8 @@ class ReportAgent:
             response = self.llm.chat(
                 messages=messages,
                 temperature=0.5
-            )
-            
+            ) or ""
+
             # Parse tool calls
             tool_calls = self._parse_tool_calls(response)
             
@@ -2941,8 +2941,8 @@ class ReportAgent:
         final_response = self.llm.chat(
             messages=messages,
             temperature=0.5
-        )
-        
+        ) or ""
+
         # Clean response
         clean_response = re.sub(r'<tool_call>.*?</tool_call>', '', final_response, flags=re.DOTALL)
         clean_response = re.sub(r'\[TOOL_CALL\].*?\)', '', clean_response)

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -365,6 +365,13 @@ class LLMClient:
             raise
 
         content = response.choices[0].message.content
+        # Reasoning-capable models (e.g. Gemini 3 Flash) intermittently return
+        # None content on a turn. Guard before the regex and return None so
+        # callers' empty-response handling (e.g. the report ReAct loop's retry)
+        # engages instead of crashing on a NoneType regex.
+        if content is None:
+            self._emit_llm_event(messages, None, t0, response=response, temperature=temperature)
+            return None
         # Some models (e.g., MiniMax M2.5) include <think> reasoning content in the content field, which needs to be removed
         content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
 
@@ -394,6 +401,10 @@ class LLMClient:
             max_tokens=max_tokens,
             response_format={"type": "json_object"}
         )
+        # chat() returns None on an empty/null-content response — surface a
+        # clear error rather than crashing on None.strip().
+        if response is None:
+            raise ValueError("LLM returned an empty response")
         # Clean up markdown code block markers
         cleaned_response = response.strip()
         cleaned_response = re.sub(r'^```(?:json)?\s*\n?', '', cleaned_response, flags=re.IGNORECASE)


### PR DESCRIPTION
## Problem

Report sections fail with:

```
(Section generation error: expected string or bytes-like object, got 'NoneType')
```

`LLMClient.chat()` ran the `<think>`-stripping regex directly on the response content:

```python
content = response.choices[0].message.content
content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()   # 💥 if content is None
```

Reasoning-capable models — notably `google/gemini-3-flash-preview`, the default **Smart** model used for report generation — **intermittently** return `message.content = None` on a turn. `re.sub` on `None` then raises *inside* `chat()`, before any tool runs, so a section dies in ~1s. (Confirmed empirically: the same prompt usually returns content, occasionally `None`.)

The report ReAct loop is already written to handle this — it checks `if response is None:` and retries — but the crash pre-empts that retry, failing the whole section. This is the root cause behind the `NoneType` section errors (complements #111, which fixed a separate null site in the `interview_agents` tool).

## Fix

- **`chat()`**: guard `None` content before the regex and **return `None`** — the "empty content" contract the callers' retry logic already expects — instead of crashing.
- **`chat_json()`**: raise a clear `ValueError` on `None` rather than crashing on `None.strip()`.
- **report agent interactive `chat()`**: coerce `chat()` results with `or ""` before the regex (that path has no retry loop).

## Test

- Reproduced intermittent `content=None` from `google/gemini-3-flash-preview` directly.
- After the fix, regenerating the report completes; sections that previously hit `NoneType` now generate (the loop retries the occasional null turn) instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)