### PR TITLE
feat: per-agent belief sparklines surface

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -5575,6 +5575,83 @@ def get_peak_round(simulation_id: str):
         }), 500
 
 
+@simulation_bp.route('/<simulation_id>/agents/sparklines', methods=['GET'])
+def get_agent_sparklines(simulation_id: str):
+    """Per-agent belief sparklines for a published simulation.
+
+    The agent-level companion to the aggregate surfaces. ``chart.svg``
+    and the embed-summary draw what the *swarm* concluded round by round;
+    ``peak-round`` collapses that into inflection points. This surface
+    exposes the layer underneath — *each individual agent's* belief path
+    as a scalar position per round, the series a 40×15px SVG sparkline
+    draws. Researchers studying convergence ("which agent anchored the
+    consensus? did one cohort align before another?") get the data
+    without parsing the transcript.
+
+    Pure derivation — each per-agent scalar is the same
+    ``_avg_position`` mean of per-topic ``belief_positions`` every other
+    surface averages, and the final stance uses the same ±0.2 threshold,
+    so an agent tagged "bullish" here is "bullish" in the transcript.
+    Agent names come from ``reddit_profiles.json``.
+
+    Same publish gate as every other share surface (``is_public=true``).
+    Returns ``404`` when no agent holds a usable belief position yet so a
+    consumer can tell a "not ready" sim (404) apart from a "private" one
+    (403). Cached for 5 minutes — matches the chart.svg / trajectory /
+    peak-round cadence.
+    """
+    from ..services import agent_sparklines_service
+    from ..services import surface_stats
+    from flask import Response
+
+    locale = get_locale(request)
+    try:
+        try:
+            summary = _build_embed_summary_payload(simulation_id)
+        except LookupError as exc:
+            return jsonify({"success": False, "error": str(exc)}), 404
+
+        if not summary.get("is_public"):
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Simulation is not published. POST /api/simulation/<id>/publish to enable.",
+                    "该模拟未发布,请通过 POST /api/simulation/<id>/publish 启用。",
+                    locale,
+                ),
+            }), 403
+
+        sim_dir = os.path.join(Config.WONDERWALL_SIMULATION_DATA_DIR, simulation_id)
+        payload = agent_sparklines_service.build_agent_sparklines(sim_dir)
+        if payload is None:
+            return jsonify({
+                "success": False,
+                "error": _t(
+                    "Per-agent sparklines not available yet — the simulation has no per-agent trajectory data.",
+                    "尚无可用的单智能体迷你趋势图 — 模拟还没有单智能体轨迹数据。",
+                    locale,
+                ),
+            }), 404
+
+        payload["simulation_id"] = simulation_id
+
+        body = json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        response = Response(body, mimetype="application/json; charset=utf-8")
+        response.headers["Cache-Control"] = "public, max-age=300"
+        response.headers["Content-Disposition"] = (
+            f'inline; filename="miroshark-{simulation_id[:12]}-agent-sparklines.json"'
+        )
+        surface_stats.increment_surface_stat(sim_dir, "agent_sparklines")
+        return response
+
+    except Exception as e:
+        logger.error(f"agent-sparklines: failed for {simulation_id}: {e}\n{traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "error": str(e),
+        }), 500
+
+
 @simulation_bp.route('/<simulation_id>/polymarket.json', methods=['GET'])
 def get_polymarket_json(simulation_id: str):
     """Polymarket-shaped binary-market prediction for a completed sim.

--- a/backend/app/services/agent_sparklines_service.py
+++ b/backend/app/services/agent_sparklines_service.py
@@ -1,0 +1,279 @@
+"""Per-agent belief sparklines — the agent-level trajectory surface.
+
+``chart.svg`` and the embed-summary draw the *aggregate* belief curve:
+what the swarm concluded, round by round. ``peak-round`` collapses that
+aggregate into inflection points. Neither exposes the layer underneath —
+*each individual agent's* belief path. A researcher studying swarm
+convergence ("did the financial-analyst agents align before the retail
+ones? which agent anchored the consensus?") had no surface for it short
+of parsing ``transcript.md`` by hand.
+
+This module reads the same ``trajectory.json`` snapshots every other
+surface shares and projects them the other way: instead of bucketing all
+agents into one per-round percentage, it tracks **one scalar belief
+position per agent per round**. The result is a list of per-agent
+sparkline series the frontend renders as compact 40×15px SVG polylines,
+each colored by the agent's final stance.
+
+Design notes
+------------
+
+* **Same data, same threshold, transposed.** The per-agent scalar is the
+  mean of that agent's per-topic ``belief_positions`` for the round —
+  the exact ``_avg_position`` every other surface averages before
+  bucketing. An agent whose final position is ``> +0.2`` is "bullish"
+  here and "bullish" in the transcript; the ``±0.2`` threshold is shared
+  so labels never drift across surfaces.
+* **Names from the profile files.** ``belief_positions`` is keyed by
+  integer ``user_id``; the human-readable name comes from
+  ``reddit_profiles.json`` (then ``polymarket_profiles.json``), the same
+  lookup the transcript renderer uses. An id with no profile row falls
+  back to ``"Agent <id>"`` so a sparkline is never anonymous.
+* **Deterministic order.** Agents are sorted most-bullish-first by final
+  position, ties broken by ``agent_id`` ascending — so the rendered list
+  reads top-to-bottom from the strongest bull to the strongest bear, and
+  the same simulation always serializes in the same order.
+* **``has_per_agent_data`` is a real signal.** It is ``true`` only when
+  at least one agent has a 2-point trajectory — i.e. there are enough
+  rounds to draw a line. A single-round simulation returns the agents
+  (each a single dot) with the flag ``false`` so the frontend can show a
+  "needs ≥2 rounds" note instead of a row of meaningless dots.
+* **Pure stdlib.** ``json`` + ``os``. Same dependency posture as every
+  other export module.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+
+TRAJECTORY_FILENAME = "trajectory.json"
+
+# Same ±0.2 stance threshold the embed-summary, share card, transcript,
+# trajectory.csv, chart.svg, and peak-round surfaces all use. A per-agent
+# final position bucketed here MUST match how the same agent is labelled
+# everywhere else, so the constant is pinned rather than configurable.
+STANCE_THRESHOLD = 0.2
+
+# Canonical stance colors — identical to chart_svg.py / badge_service.py
+# so a "bullish" sparkline is the same green as a "bullish" chart line.
+STANCE_COLORS: dict[str, str] = {
+    "bullish": "#22c55e",
+    "neutral": "#6b7280",
+    "bearish": "#ef4444",
+}
+
+
+# ── On-disk readers ────────────────────────────────────────────────────────
+
+
+def _safe_load_json(path: str) -> Any:
+    """Read JSON, returning ``None`` on missing / corrupt input.
+
+    Never raises — the route handler must resolve a malformed artifact to
+    a clean 404 ("no data yet"), never a 500.
+    """
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def _load_profile_names(sim_dir: str) -> dict[int, str]:
+    """``user_id → display name`` lookup for the simulation's agents.
+
+    Reads ``reddit_profiles.json`` first (every run produces it), then
+    ``polymarket_profiles.json`` as a secondary source. Mirrors the
+    transcript renderer's lookup so an agent's name is identical across
+    both surfaces. First write wins, so reddit_profiles takes precedence.
+    """
+    out: dict[int, str] = {}
+    for filename in ("reddit_profiles.json", "polymarket_profiles.json"):
+        data = _safe_load_json(os.path.join(sim_dir, filename))
+        if not isinstance(data, list):
+            continue
+        for row in data:
+            if not isinstance(row, dict):
+                continue
+            try:
+                uid = int(row.get("user_id"))
+            except (TypeError, ValueError):
+                continue
+            name = (row.get("name") or row.get("username") or "").strip()
+            if not name:
+                continue
+            out.setdefault(uid, name)
+    return out
+
+
+# ── Stance helpers ─────────────────────────────────────────────────────────
+
+
+def _avg_position(positions: Any) -> Optional[float]:
+    """Mean of an agent's per-topic belief positions for one round.
+
+    ``positions`` is the ``{topic: float}`` dict from one agent's entry in
+    a snapshot's ``belief_positions``. Non-numeric / boolean values are
+    filtered out; returns ``None`` when no usable value remains so the
+    caller can skip the agent for that round.
+    """
+    if not isinstance(positions, dict) or not positions:
+        return None
+    values = [
+        float(v)
+        for v in positions.values()
+        if isinstance(v, (int, float)) and not isinstance(v, bool)
+    ]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _classify_stance(value: float) -> str:
+    """Bucket a continuous belief position into bullish/neutral/bearish.
+
+    Mirrors the ±0.2 threshold every other surface uses so the per-agent
+    label here matches the agent's label in the transcript and gallery.
+    """
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "neutral"
+    if v > STANCE_THRESHOLD:
+        return "bullish"
+    if v < -STANCE_THRESHOLD:
+        return "bearish"
+    return "neutral"
+
+
+# ── Trajectory assembly ────────────────────────────────────────────────────
+
+
+def load_agent_trajectories(sim_dir: str) -> list[dict[str, Any]]:
+    """Project ``trajectory.json`` into a per-agent belief-position series.
+
+    Walks every snapshot, computes each agent's scalar position
+    (``_avg_position``) for the rounds in which it holds a belief, and
+    groups those points by ``agent_id``. Each returned dict is::
+
+        {"agent_id": <int>, "trajectory": [{"round": <int>,
+                                            "position": <float>}, ...]}
+
+    Points are sorted ascending by round so the sparkline draws
+    left-to-right in time even if a runner ever writes snapshots out of
+    order. Agents with no usable position in any round are omitted.
+    Returns ``[]`` on missing / corrupt trajectory data so the route can
+    emit a 404.
+    """
+    trajectory = _safe_load_json(os.path.join(sim_dir, TRAJECTORY_FILENAME))
+    snapshots = trajectory.get("snapshots") if isinstance(trajectory, dict) else None
+    if not isinstance(snapshots, list):
+        return []
+
+    # agent_id → list of (round, position) points.
+    series: dict[int, list[dict[str, Any]]] = {}
+    for snap in snapshots:
+        if not isinstance(snap, dict):
+            continue
+        try:
+            round_num = int(snap.get("round_num"))
+        except (TypeError, ValueError):
+            continue
+        positions = snap.get("belief_positions")
+        if not isinstance(positions, dict):
+            continue
+        for agent_id_raw, agent_positions in positions.items():
+            try:
+                agent_id = int(agent_id_raw)
+            except (TypeError, ValueError):
+                continue
+            avg = _avg_position(agent_positions)
+            if avg is None:
+                continue
+            series.setdefault(agent_id, []).append(
+                {"round": round_num, "position": round(avg, 3)}
+            )
+
+    out: list[dict[str, Any]] = []
+    for agent_id, points in series.items():
+        points.sort(key=lambda p: p["round"])
+        out.append({"agent_id": agent_id, "trajectory": points})
+    return out
+
+
+def build_agent_sparklines(sim_dir: str) -> Optional[dict[str, Any]]:
+    """Assemble the full sparklines payload for a simulation directory.
+
+    Returns ``None`` when no agent holds a usable belief position in any
+    round (the route translates that to a 404 — "no per-agent trajectory
+    data yet"), distinguishing a not-ready sim from a private one (403).
+
+    On success returns::
+
+        {
+          "schema_version": "1",
+          "agent_count": <int>,
+          "round_count": <int>,
+          "has_per_agent_data": <bool>,
+          "agents": [
+            {"agent_id": <int>, "name": <str>, "final_stance": <str>,
+             "final_position": <float>, "color": <hex>,
+             "trajectory": [{"round": <int>, "position": <float>}, ...]},
+            ...
+          ]
+        }
+
+    Agents are ordered most-bullish-first by final position (ties broken
+    by ``agent_id``). ``round_count`` is the number of distinct rounds
+    that carry per-agent data; ``has_per_agent_data`` is ``true`` only
+    when at least one agent has a 2-point trajectory (enough to draw a
+    line).
+    """
+    trajectories = load_agent_trajectories(sim_dir)
+    if not trajectories:
+        return None
+
+    names = _load_profile_names(sim_dir)
+
+    agents: list[dict[str, Any]] = []
+    all_rounds: set[int] = set()
+    max_points = 0
+    for entry in trajectories:
+        agent_id = entry["agent_id"]
+        points = entry["trajectory"]
+        if not points:
+            continue
+        max_points = max(max_points, len(points))
+        for p in points:
+            all_rounds.add(p["round"])
+        final_position = points[-1]["position"]
+        stance = _classify_stance(final_position)
+        agents.append(
+            {
+                "agent_id": agent_id,
+                "name": names.get(agent_id, f"Agent {agent_id}"),
+                "final_stance": stance,
+                "final_position": final_position,
+                "color": STANCE_COLORS[stance],
+                "trajectory": points,
+            }
+        )
+
+    if not agents:
+        return None
+
+    # Most-bullish-first; ties broken by agent_id so the order is stable.
+    agents.sort(key=lambda a: (-a["final_position"], a["agent_id"]))
+
+    return {
+        "schema_version": "1",
+        "agent_count": len(agents),
+        "round_count": len(all_rounds),
+        "has_per_agent_data": max_points >= 2,
+        "agents": agents,
+    }

--- a/backend/app/services/surface_stats.py
+++ b/backend/app/services/surface_stats.py
@@ -51,7 +51,8 @@ Schema::
       "cite_bib": 0,
       "polymarket_json": 0,
       "oembed": 0,
-      "peak_round": 0
+      "peak_round": 0,
+      "agent_sparklines": 0
     }
 
 The ``read_surface_stats`` helper returns the same dict with every key
@@ -97,6 +98,7 @@ SURFACE_KEYS: frozenset[str] = frozenset(
         "polymarket_json",
         "oembed",
         "peak_round",
+        "agent_sparklines",
     }
 )
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1646,6 +1646,52 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/simulation/{simulation_id}/agents/sparklines:
+    get:
+      tags: [Publish & Embed]
+      summary: Per-agent belief sparklines for a published sim.
+      description: |
+        The agent-level companion to `chart.svg` / the embed-summary
+        (which draw the *aggregate* swarm belief curve) and `peak-round`
+        (which collapses that curve into inflection points). This surface
+        exposes the layer underneath — *each individual agent's* belief
+        path as a scalar position per round, the series a 40×15px SVG
+        sparkline draws. Answers the swarm-convergence question a
+        researcher asks first ("which agent anchored the consensus? did
+        one cohort align before another?") without parsing the
+        transcript.
+
+        Pure derivation — each per-agent scalar is the same
+        `_avg_position` mean of per-topic `belief_positions` every other
+        surface averages, and the final stance uses the same `±0.2`
+        threshold, so an agent tagged "bullish" here is "bullish" in the
+        transcript. Agent names come from `reddit_profiles.json`; an id
+        with no profile row falls back to `"Agent <id>"`.
+
+        Agents are ordered most-bullish-first by final position (ties
+        broken by `agent_id`). `round_count` is the number of distinct
+        rounds carrying per-agent data; `has_per_agent_data` is `true`
+        only when at least one agent has a 2-point trajectory (enough to
+        draw a line) — a single-round sim returns the agents as single
+        dots with the flag `false`.
+
+        Same publish gate as every other share surface
+        (`is_public=true`). Returns `404` when no agent holds a usable
+        belief position yet, so a consumer can tell a "not ready" sim
+        (404) apart from a "private" sim (403). Cached for 5 minutes —
+        matches the `chart.svg` / `trajectory` / `peak-round` cadence.
+      parameters:
+        - $ref: "#/components/parameters/SimulationIdPath"
+      responses:
+        "200":
+          description: Per-agent sparklines payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentSparklinesResponse"
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /api/simulation/{simulation_id}/polymarket.json:
     get:
       tags: [Publish & Embed]
@@ -4939,6 +4985,114 @@ components:
           type: integer
           minimum: 1
           description: Number of usable rounds in the trajectory.
+
+    SparklinePoint:
+      type: object
+      description: One point on an agent's belief sparkline.
+      required:
+        - round
+        - position
+      properties:
+        round:
+          type: integer
+          description: Round number this position was recorded in.
+        position:
+          type: number
+          format: float
+          minimum: -1
+          maximum: 1
+          description: |
+            The agent's scalar belief position for the round — the mean
+            of its per-topic `belief_positions`, in roughly `[-1, 1]`,
+            rounded to three decimal places. `> +0.2` is bullish,
+            `< -0.2` is bearish, between is neutral.
+
+    AgentSparkline:
+      type: object
+      description: One agent's belief trajectory + final-stance metadata.
+      required:
+        - agent_id
+        - name
+        - final_stance
+        - final_position
+        - color
+        - trajectory
+      properties:
+        agent_id:
+          type: integer
+          description: The agent's integer user id.
+        name:
+          type: string
+          description: |
+            Display name from `reddit_profiles.json`
+            (then `polymarket_profiles.json`); `"Agent <id>"` when no
+            profile row exists.
+        final_stance:
+          type: string
+          enum: [bullish, neutral, bearish]
+          description: Stance bucket of the agent's last-round position (±0.2).
+        final_position:
+          type: number
+          format: float
+          minimum: -1
+          maximum: 1
+          description: The agent's position in the final round, rounded to 3 dp.
+        color:
+          type: string
+          description: |
+            Hex stance color matching every other surface — `#22c55e`
+            (bullish), `#6b7280` (neutral), `#ef4444` (bearish).
+        trajectory:
+          type: array
+          description: Per-round belief positions, sorted ascending by round.
+          items:
+            $ref: "#/components/schemas/SparklinePoint"
+
+    AgentSparklinesResponse:
+      type: object
+      description: |
+        Per-agent belief sparklines returned by
+        `/api/simulation/{id}/agents/sparklines`. The agent-level layer
+        under the aggregate `chart.svg` curve — one belief trajectory per
+        agent, derived from the same per-topic `belief_positions` and the
+        same `±0.2` stance threshold every other surface uses.
+
+        Agents are ordered most-bullish-first by `final_position` (ties
+        broken by `agent_id`). Schema is versioned via `schema_version`;
+        v1 is the only published version.
+      required:
+        - schema_version
+        - simulation_id
+        - agent_count
+        - round_count
+        - has_per_agent_data
+        - agents
+      properties:
+        schema_version:
+          type: string
+          enum: ["1"]
+          description: Schema version literal — bumped on breaking changes.
+        simulation_id:
+          type: string
+          description: Echoed simulation id.
+        agent_count:
+          type: integer
+          minimum: 1
+          description: Number of agents with at least one usable belief position.
+        round_count:
+          type: integer
+          minimum: 1
+          description: Number of distinct rounds carrying per-agent data.
+        has_per_agent_data:
+          type: boolean
+          description: |
+            `true` only when at least one agent has a 2-point trajectory
+            (enough to draw a line). A single-round simulation returns
+            the agents as single dots with this flag `false`.
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentSparkline"
 
     PolymarketPrediction:
       type: object

--- a/backend/tests/test_unit_agent_sparklines.py
+++ b/backend/tests/test_unit_agent_sparklines.py
@@ -1,0 +1,239 @@
+"""Unit tests for the per-agent belief sparklines service + route wiring.
+
+Pure offline — no Flask app, no network, no simulation runner. Covers the
+contract the ``GET /api/simulation/<id>/agents/sparklines`` endpoint
+depends on:
+
+  1. ``load_agent_trajectories`` groups ``trajectory.json`` per-agent
+     belief positions into per-agent point series, reusing the same
+     ``_avg_position`` mean every other surface uses.
+  2. ``build_agent_sparklines`` assembles the payload — final-stance
+     classification (±0.2 threshold), stance colors, most-bullish-first
+     ordering, ``has_per_agent_data`` flag, ``round_count``, and
+     profile-name resolution.
+  3. Empty / missing trajectory data resolves to ``None`` (the route
+     translates that to a 404).
+  4. The route decorator, the publish gate, and the surface-stat
+     increment exist in ``app/api/simulation.py``.
+  5. ``agent_sparklines`` is registered in the surface_stats schema.
+  6. ``openapi.yaml`` documents ``/agents/sparklines`` and the
+     ``AgentSparklinesResponse`` schema so the drift test stays green.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from app.services import agent_sparklines_service as svc  # noqa: E402
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+def _write_trajectory(sim_dir: Path, snapshots: list[dict]) -> None:
+    (sim_dir / "trajectory.json").write_text(
+        json.dumps({"snapshots": snapshots}), encoding="utf-8"
+    )
+
+
+def _write_profiles(sim_dir: Path, profiles: list[dict]) -> None:
+    (sim_dir / "reddit_profiles.json").write_text(
+        json.dumps(profiles), encoding="utf-8"
+    )
+
+
+# ── load_agent_trajectories ──────────────────────────────────────────────
+
+
+def test_load_returns_empty_on_missing_file(tmp_path: Path):
+    assert svc.load_agent_trajectories(str(tmp_path)) == []
+
+
+def test_load_returns_empty_on_corrupt_file(tmp_path: Path):
+    (tmp_path / "trajectory.json").write_text("{not json", encoding="utf-8")
+    assert svc.load_agent_trajectories(str(tmp_path)) == []
+
+
+def test_load_groups_points_per_agent_sorted_by_round(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 2, "belief_positions": {"1": {"t": 0.4}, "2": {"t": -0.3}}},
+        {"round_num": 1, "belief_positions": {"1": {"t": 0.1}, "2": {"t": -0.5}}},
+    ])
+    trajs = svc.load_agent_trajectories(str(tmp_path))
+    by_id = {t["agent_id"]: t for t in trajs}
+    assert set(by_id) == {1, 2}
+    # Points are sorted ascending by round even though snapshots were not.
+    assert [p["round"] for p in by_id[1]["trajectory"]] == [1, 2]
+    assert by_id[1]["trajectory"][0]["position"] == 0.1
+    assert by_id[1]["trajectory"][1]["position"] == 0.4
+
+
+def test_load_skips_rounds_without_belief_for_an_agent(tmp_path: Path):
+    """An agent absent from one round's belief_positions just has fewer
+    points — the sparkline connects the rounds it does have."""
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"1": {"t": 0.5}, "2": {"t": -0.5}}},
+        {"round_num": 2, "belief_positions": {"1": {"t": 0.6}}},  # agent 2 absent
+    ])
+    by_id = {t["agent_id"]: t for t in svc.load_agent_trajectories(str(tmp_path))}
+    assert [p["round"] for p in by_id[1]["trajectory"]] == [1, 2]
+    assert [p["round"] for p in by_id[2]["trajectory"]] == [1]
+
+
+def test_load_averages_multi_topic_positions(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"1": {"a": 0.2, "b": 0.6}}},
+    ])
+    by_id = {t["agent_id"]: t for t in svc.load_agent_trajectories(str(tmp_path))}
+    # (0.2 + 0.6) / 2 = 0.4
+    assert by_id[1]["trajectory"][0]["position"] == 0.4
+
+
+# ── build_agent_sparklines ────────────────────────────────────────────────
+
+
+def test_build_returns_none_on_empty(tmp_path: Path):
+    assert svc.build_agent_sparklines(str(tmp_path)) is None
+
+
+def test_build_returns_none_when_no_numeric_positions(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"1": {"t": "nope"}}},
+    ])
+    assert svc.build_agent_sparklines(str(tmp_path)) is None
+
+
+def test_build_classifies_final_stance_and_color(tmp_path: Path):
+    """Final stance comes from the LAST round's position, using ±0.2."""
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"1": {"t": -0.1}, "2": {"t": 0.1}, "3": {"t": 0.0}}},
+        {"round_num": 2, "belief_positions": {"1": {"t": 0.5}, "2": {"t": -0.5}, "3": {"t": 0.0}}},
+    ])
+    payload = svc.build_agent_sparklines(str(tmp_path))
+    by_id = {a["agent_id"]: a for a in payload["agents"]}
+    assert by_id[1]["final_stance"] == "bullish"
+    assert by_id[1]["color"] == "#22c55e"
+    assert by_id[2]["final_stance"] == "bearish"
+    assert by_id[2]["color"] == "#ef4444"
+    assert by_id[3]["final_stance"] == "neutral"
+    assert by_id[3]["color"] == "#6b7280"
+
+
+def test_build_orders_most_bullish_first(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"1": {"t": -0.4}, "2": {"t": 0.8}, "3": {"t": 0.1}}},
+    ])
+    payload = svc.build_agent_sparklines(str(tmp_path))
+    assert [a["agent_id"] for a in payload["agents"]] == [2, 3, 1]
+    # Final positions descend.
+    finals = [a["final_position"] for a in payload["agents"]]
+    assert finals == sorted(finals, reverse=True)
+
+
+def test_build_order_ties_break_by_agent_id(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"3": {"t": 0.5}, "1": {"t": 0.5}, "2": {"t": 0.5}}},
+    ])
+    payload = svc.build_agent_sparklines(str(tmp_path))
+    assert [a["agent_id"] for a in payload["agents"]] == [1, 2, 3]
+
+
+def test_build_resolves_profile_names(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"7": {"t": 0.5}, "9": {"t": -0.5}}},
+    ])
+    _write_profiles(tmp_path, [
+        {"user_id": 7, "name": "Skeptical Trader"},
+    ])
+    payload = svc.build_agent_sparklines(str(tmp_path))
+    by_id = {a["agent_id"]: a for a in payload["agents"]}
+    assert by_id[7]["name"] == "Skeptical Trader"
+    # No profile row ⇒ deterministic fallback, never anonymous.
+    assert by_id[9]["name"] == "Agent 9"
+
+
+def test_build_has_per_agent_data_false_for_single_round(tmp_path: Path):
+    """One round ⇒ each agent is a single dot; the flag is false so the
+    frontend can show a 'needs ≥2 rounds' note instead of dots."""
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"1": {"t": 0.5}}},
+    ])
+    payload = svc.build_agent_sparklines(str(tmp_path))
+    assert payload["has_per_agent_data"] is False
+    assert payload["round_count"] == 1
+    assert payload["agent_count"] == 1
+
+
+def test_build_has_per_agent_data_true_for_multi_round(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"1": {"t": 0.2}}},
+        {"round_num": 2, "belief_positions": {"1": {"t": 0.5}}},
+        {"round_num": 3, "belief_positions": {"1": {"t": 0.6}}},
+    ])
+    payload = svc.build_agent_sparklines(str(tmp_path))
+    assert payload["has_per_agent_data"] is True
+    assert payload["round_count"] == 3
+    assert payload["agent_count"] == 1
+    assert len(payload["agents"][0]["trajectory"]) == 3
+
+
+def test_build_schema_version_is_one(tmp_path: Path):
+    _write_trajectory(tmp_path, [
+        {"round_num": 1, "belief_positions": {"1": {"t": 0.5}}},
+    ])
+    assert svc.build_agent_sparklines(str(tmp_path))["schema_version"] == "1"
+
+
+# ── Static wiring guards ───────────────────────────────────────────────────
+
+
+def _read_simulation_api() -> str:
+    return (_BACKEND / "app" / "api" / "simulation.py").read_text(encoding="utf-8")
+
+
+def test_route_decorator_registered():
+    text = _read_simulation_api()
+    assert (
+        "@simulation_bp.route('/<simulation_id>/agents/sparklines', methods=['GET'])" in text
+    ), "GET /<id>/agents/sparklines route decorator missing from simulation.py"
+    assert "def get_agent_sparklines" in text, (
+        "get_agent_sparklines handler function missing from simulation.py"
+    )
+
+
+def test_route_enforces_publish_gate():
+    text = _read_simulation_api()
+    assert "_build_embed_summary_payload" in text
+    assert "is_public" in text
+
+
+def test_route_increments_agent_sparklines_surface_stat():
+    text = _read_simulation_api()
+    assert '"agent_sparklines"' in text, (
+        "simulation.py must increment the agent_sparklines counter via "
+        "surface_stats.increment_surface_stat(..., \"agent_sparklines\")"
+    )
+    assert "increment_surface_stat" in text
+
+
+def test_surface_stats_registers_agent_sparklines_key():
+    from app.services import surface_stats
+
+    assert "agent_sparklines" in surface_stats.SURFACE_KEYS
+
+
+def test_openapi_documents_agent_sparklines_path_and_schema():
+    spec_text = (_BACKEND / "openapi.yaml").read_text(encoding="utf-8")
+    assert "/api/simulation/{simulation_id}/agents/sparklines:" in spec_text, (
+        "openapi.yaml is missing the /agents/sparklines path entry"
+    )
+    assert "AgentSparklinesResponse:" in spec_text, (
+        "openapi.yaml is missing the AgentSparklinesResponse schema"
+    )

--- a/backend/tests/test_unit_surface_stats.py
+++ b/backend/tests/test_unit_surface_stats.py
@@ -85,6 +85,7 @@ def test_surface_keys_includes_every_serve_handler():
         "polymarket_json",
         "oembed",
         "peak_round",
+        "agent_sparklines",
     }
     assert set(surface_stats.SURFACE_KEYS) == expected
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -69,6 +69,7 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 | `GET` | `/api/simulation/<id>/demographics` | Archetype distribution |
 | `GET` | `/api/simulation/<id>/quality` | Run health diagnostics |
 | `GET` | `/api/simulation/<id>/peak-round` | Machine-readable belief inflection points — the round each stance (`bullish` / `neutral` / `bearish`) peaked (`{round, pct}`), the `most_volatile_round` (largest summed round-over-round swing), `max_swing_pct`, and `total_rounds`. Pure O(n) derivation from the same ±0.2 stance split `trajectory.csv` uses; peak ties resolve to the earliest round. Publish-gated; `404` until trajectory data exists. Cached 5 minutes. `curl -s "https://your-host/api/simulation/<id>/peak-round"` |
+| `GET` | `/api/simulation/<id>/agents/sparklines` | Per-agent belief sparklines — for each agent, a `{round, position}` series the frontend draws as a compact SVG line, plus `final_stance` / `final_position` / `color`. The agent-level layer under `chart.svg`'s aggregate curve. Same `_avg_position` mean + ±0.2 threshold every surface uses; agent names from `reddit_profiles.json`. Agents ordered most-bullish-first; `has_per_agent_data` is `false` for single-round sims. Publish-gated; `404` until per-agent data exists. Cached 5 minutes. `curl -s "https://your-host/api/simulation/<id>/agents/sparklines"` |
 | `POST` | `/api/simulation/compare` | Side-by-side belief comparison |
 
 ## Interaction

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -295,6 +295,48 @@ The Embed dialog exposes a `📊 Peak beliefs (JSON)` section beneath the tradin
 
 Completes the analytical quadrant alongside `trajectory.csv` (raw data), `chart.svg` (visual), and `signal.json` (final-state action primitive) — the inflection-point view those three left implicit.
 
+## Per-Agent Belief Sparklines
+
+`chart.svg` and the embed-summary draw the *aggregate* belief curve — what the swarm concluded, round by round. `peak-round` collapses that aggregate into inflection points. Neither exposes the layer underneath: *each individual agent's* belief path. A researcher studying swarm convergence — *"which agent anchored the consensus? did the financial-analyst cohort align before the retail traders?"* — had no surface for it short of parsing `transcript.md` by hand. `GET /api/simulation/<id>/agents/sparklines` is the agent-level companion: one belief trajectory per agent.
+
+Returns a stable v1-schema JSON document:
+
+```json
+{
+  "schema_version": "1",
+  "simulation_id": "<sim_id>",
+  "agent_count": 24,
+  "round_count": 12,
+  "has_per_agent_data": true,
+  "agents": [
+    {
+      "agent_id": 7,
+      "name": "Skeptical Quant",
+      "final_stance": "bullish",
+      "final_position": 0.612,
+      "color": "#22c55e",
+      "trajectory": [
+        { "round": 1, "position": 0.05 },
+        { "round": 2, "position": 0.31 },
+        { "round": 3, "position": 0.612 }
+      ]
+    }
+  ]
+}
+```
+
+- **`agents`** — one entry per agent that holds a usable belief position, ordered most-bullish-first by `final_position` (ties broken by `agent_id`), so the list reads top-to-bottom from the strongest bull to the strongest bear.
+- **`trajectory`** — the agent's scalar belief position per round, sorted ascending by round. Each `position` is the mean of that agent's per-topic `belief_positions` (roughly `[-1, 1]`), rounded to three decimals — the exact `_avg_position` every other surface averages before bucketing.
+- **`final_stance` / `color`** — the stance of the agent's last-round position under the same ±0.2 threshold, plus the matching hex color (`#22c55e` bullish, `#6b7280` neutral, `#ef4444` bearish) so a sparkline is the same green as a bullish `chart.svg` line.
+- **`name`** — display name from `reddit_profiles.json` (then `polymarket_profiles.json`); `"Agent <id>"` when no profile row exists, so a sparkline is never anonymous.
+- **`has_per_agent_data`** — `true` only when at least one agent has a 2-point trajectory (enough to draw a line). A single-round simulation returns the agents as single dots with this flag `false`, so a consumer can show a "needs ≥2 rounds" note instead of a row of meaningless dots.
+
+Pure derivation, transposed: instead of bucketing all agents into one per-round percentage (the aggregate view), it tracks one scalar per agent per round. Stdlib-only (`json` + `os`); `agent_sparklines_service.py` has no new dependencies.
+
+Same publish gate as every other share surface (`is_public=true`). Returns `404` when no agent holds a usable belief position yet — a "not ready" sim (404) apart from a "private" sim (403). Cached for 5 minutes — matches the `chart.svg` / `trajectory` / `peak-round` cadence.
+
+The Embed dialog exposes a `🤖 Agent trajectories (JSON)` section beneath the peak-round row: a scrollable list of agents, each a name chip + an inline SVG sparkline (belief position over rounds, stroked in the agent's stance color) + the final-stance label, plus a copyable URL and a paste-ready `curl` snippet. The `agent_sparklines` counter joins the surface-stats schema so an operator can see how often the agent-level view is pulled.
+
 ## Polymarket-Ready Prediction JSON
 
 The first share surface adapted for a specific external integrator. `signal.json` emits a generic action primitive (`direction` + `confidence_pct` + `risk_tier`); `GET /api/simulation/<id>/polymarket.json` re-shapes that primitive into the binary YES / NO probability envelope a Polymarket trading bot expects between *"simulation result"* and *"actionable market signal"*.

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -741,6 +741,54 @@ export const getPeakRound = async (simulationId) => {
 }
 
 /**
+ * Build the absolute URL of the per-agent belief sparklines endpoint for
+ * a published simulation. The agent-level companion to chart.svg /
+ * embed-summary (which draw the aggregate swarm curve) and peak-round
+ * (which collapses that curve into inflection points).
+ *
+ * Returns a v1-schema JSON document with `agent_count`, `round_count`,
+ * `has_per_agent_data`, and an `agents` array — each entry an agent's
+ * `{agent_id, name, final_stance, final_position, color}` plus a
+ * `trajectory` of `{round, position}` points the frontend draws as a
+ * compact SVG sparkline. Agents are ordered most-bullish-first.
+ *
+ * Same publish gate as every other share surface. Returns 404 when no
+ * agent holds a usable belief position yet.
+ *
+ * @param {string} simulationId
+ * @param {string} [origin]
+ * @returns {string}
+ */
+export const getAgentSparklinesUrl = (simulationId, origin) => {
+  const base = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+  return `${base}/api/simulation/${simulationId}/agents/sparklines`
+}
+
+/**
+ * Fetch the per-agent sparklines payload for a published simulation.
+ *
+ * Returns the parsed JSON document on 200, `null` on 404 (no per-agent
+ * trajectory data yet) or 403 (sim not published), and throws on
+ * transport errors.
+ *
+ * @param {string} simulationId
+ * @returns {Promise<object|null>}
+ */
+export const getAgentSparklines = async (simulationId) => {
+  const res = await fetch(getAgentSparklinesUrl(simulationId), {
+    credentials: 'omit',
+    cache: 'no-store',
+  })
+  if (res.status === 403 || res.status === 404) {
+    return null
+  }
+  if (!res.ok) {
+    throw new Error(`agent-sparklines fetch failed: ${res.status}`)
+  }
+  return res.json()
+}
+
+/**
  * Build the absolute URL of the oEmbed provider endpoint for a published
  * simulation's share URL. The discovery half of the oEmbed 1.0 spec —
  * writing platforms (Notion, Ghost, Substack, WordPress) that find the

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -771,6 +771,107 @@
               </div>
             </div>
 
+            <!-- Per-agent belief sparklines — the agent-level companion
+                 to chart.svg (aggregate curve) and peak-round
+                 (inflection points). Each agent's belief position over
+                 rounds, drawn as a compact SVG polyline colored by final
+                 stance. Answers the swarm-convergence question ("which
+                 agent anchored the consensus? did one cohort align
+                 first?") without parsing the transcript. Same publish
+                 gate + pure-stdlib derivation as every other surface;
+                 zero new deps. -->
+            <div class="transcript-section signal-section sparklines-section">
+              <div class="transcript-head">
+                <span class="transcript-icon">🤖</span>
+                <div class="transcript-head-body">
+                  <div class="transcript-title">
+                    {{ $tr('Agent trajectories (JSON)', '智能体轨迹(JSON)') }}
+                    <span v-if="sparklinesPayload" class="signal-direction-badge signal-direction-bullish">
+                      {{ sparklinesPayload.agent_count }} {{ $tr('agents', '个智能体') }}
+                    </span>
+                  </div>
+                  <div class="transcript-sub">
+                    {{ $tr('Per-agent belief sparklines — each agent\'s position across rounds, colored by final stance (bullish / neutral / bearish). The agent-level layer under chart.svg\'s aggregate curve: which agent anchored the consensus, which cohort aligned first. Same ±0.2 threshold every surface uses.', '单智能体信念迷你趋势图 — 每个智能体在各回合的立场,按最终立场着色(看涨 / 中性 / 看跌)。chart.svg 聚合曲线之下的智能体层:哪个智能体锚定了共识,哪个群体最先对齐。与所有界面一致的 ±0.2 阈值。') }}
+                  </div>
+                </div>
+              </div>
+
+              <div v-if="isPublic && sparklinesPayload && sparklinesPayload.agents.length" class="sparklines-list">
+                <div
+                  v-for="agent in sparklinesPayload.agents"
+                  :key="agent.agent_id"
+                  class="sparkline-row"
+                >
+                  <span class="sparkline-name" :title="agent.name">{{ agent.name }}</span>
+                  <svg
+                    class="sparkline-svg"
+                    :viewBox="`0 0 ${SPARK_W} ${SPARK_H}`"
+                    :width="SPARK_W"
+                    :height="SPARK_H"
+                    preserveAspectRatio="none"
+                    role="img"
+                    :aria-label="`${agent.name}: ${agent.final_stance}`"
+                  >
+                    <line
+                      :x1="0" :y1="SPARK_H / 2" :x2="SPARK_W" :y2="SPARK_H / 2"
+                      class="sparkline-axis"
+                    />
+                    <polyline
+                      :points="sparklinePoints(agent.trajectory)"
+                      fill="none"
+                      :stroke="agent.color"
+                      stroke-width="1.3"
+                      stroke-linejoin="round"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                  <span class="sparkline-stance" :style="{ color: agent.color }">
+                    {{ agent.final_stance }}
+                  </span>
+                </div>
+                <div v-if="!sparklinesPayload.has_per_agent_data" class="sparkline-note">
+                  {{ $tr('Only one round of data — sparklines need ≥2 rounds to show a trend.', '只有一个回合的数据 — 迷你趋势图需要 ≥2 个回合才能显示趋势。') }}
+                </div>
+              </div>
+              <div v-else-if="isPublic && sparklinesLoading" class="signal-loading">
+                {{ $tr('Loading agent trajectories…', '加载智能体轨迹中…') }}
+              </div>
+              <div v-else-if="isPublic && sparklinesError" class="signal-empty">
+                {{ sparklinesError }}
+              </div>
+              <div v-else-if="!isPublic" class="signal-empty">
+                {{ $tr('Publish the simulation to enable agent trajectories.', '发布模拟以启用智能体轨迹。') }}
+              </div>
+
+              <div class="snippet-block transcript-snippet">
+                <div class="snippet-head">
+                  <span class="snippet-label">{{ $tr('Sparklines URL', '迷你趋势图 URL') }}</span>
+                  <button
+                    class="snippet-copy-btn"
+                    @click="copy('sparkUrl')"
+                    :disabled="!isPublic"
+                  >
+                    {{ copied === 'sparkUrl' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy URL', '复制 URL') }}
+                  </button>
+                </div>
+                <pre class="snippet-code"><code>{{ agentSparklinesUrl || '—' }}</code></pre>
+              </div>
+
+              <div class="snippet-block transcript-snippet">
+                <div class="snippet-head">
+                  <span class="snippet-label">{{ $tr('curl snippet', 'curl 片段') }}</span>
+                  <button
+                    class="snippet-copy-btn"
+                    @click="copy('sparkCurl')"
+                    :disabled="!isPublic"
+                  >
+                    {{ copied === 'sparkCurl' ? '✓ ' + $tr('Copied', '已复制') : $tr('Copy snippet', '复制代码片段') }}
+                  </button>
+                </div>
+                <pre class="snippet-code"><code>{{ sparklinesCurlSnippet }}</code></pre>
+              </div>
+            </div>
+
             <!-- Polymarket-shaped prediction JSON — the first share
                  surface adapted for a specific external integrator
                  (a Polymarket trading bot). Reshapes the signal.json
@@ -2352,6 +2453,8 @@ import {
   getSignalJson,
   getPeakRoundUrl,
   getPeakRound,
+  getAgentSparklinesUrl,
+  getAgentSparklines,
   getPolymarketJsonUrl,
   getPolymarketJson,
   getArchiveZipUrl,
@@ -2655,6 +2758,79 @@ const loadPeakRound = async () => {
     peakError.value = err?.message || tr('Peak-round fetch failed', '峰值回合获取失败')
   } finally {
     peakLoading.value = false
+  }
+}
+
+// ── Per-agent sparklines state ─────────────────────────────────────────
+// The agent-level companion to chart.svg / peak-round. Each agent's
+// belief position over rounds, drawn as a compact SVG polyline colored
+// by final stance. Same publish gate; 404 means "no per-agent
+// trajectory data yet".
+
+const sparklinesPayload = ref(null)
+const sparklinesLoading = ref(false)
+const sparklinesError = ref('')
+
+// Sparkline viewBox — small enough to render inline next to a name chip,
+// large enough that a multi-round trajectory reads as a curve.
+const SPARK_W = 60
+const SPARK_H = 16
+
+const agentSparklinesUrl = computed(() => {
+  if (!props.simulationId || !origin.value) return ''
+  return getAgentSparklinesUrl(props.simulationId, origin.value)
+})
+
+const sparklinesCurlSnippet = computed(() => {
+  const url = agentSparklinesUrl.value || 'https://your-host/api/simulation/<id>/agents/sparklines'
+  return `curl -s "${url}"`
+})
+
+// Project one agent's trajectory into an SVG polyline `points` string.
+// Belief position (clamped to [-1, 1]) maps to y so +1 sits at the top
+// and -1 at the bottom; round index maps to x across the full width. A
+// single-point trajectory renders a centered dot via two identical
+// coordinates so the <polyline> still paints.
+const sparklinePoints = (trajectory) => {
+  const pts = Array.isArray(trajectory) ? trajectory : []
+  if (pts.length === 0) return ''
+  const n = pts.length
+  const toXY = (p, i) => {
+    const x = n === 1 ? SPARK_W / 2 : (i / (n - 1)) * SPARK_W
+    const pos = Math.max(-1, Math.min(1, Number(p.position) || 0))
+    const y = (SPARK_H * (1 - pos)) / 2
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  }
+  if (n === 1) {
+    const xy = toXY(pts[0], 0)
+    return `${xy} ${xy}`
+  }
+  return pts.map(toXY).join(' ')
+}
+
+const loadAgentSparklines = async () => {
+  if (!props.simulationId || !isPublic.value) {
+    sparklinesPayload.value = null
+    return
+  }
+  sparklinesLoading.value = true
+  sparklinesError.value = ''
+  try {
+    const payload = await getAgentSparklines(props.simulationId)
+    if (payload && Array.isArray(payload.agents)) {
+      sparklinesPayload.value = payload
+    } else {
+      sparklinesPayload.value = null
+      sparklinesError.value = tr(
+        'Per-agent sparklines not available yet — the simulation has no per-agent trajectory data.',
+        '尚无可用的单智能体迷你趋势图 — 模拟还没有单智能体轨迹数据。',
+      )
+    }
+  } catch (err) {
+    sparklinesPayload.value = null
+    sparklinesError.value = err?.message || tr('Agent sparklines fetch failed', '单智能体迷你趋势图获取失败')
+  } finally {
+    sparklinesLoading.value = false
   }
 }
 
@@ -3472,6 +3648,8 @@ const copy = async (which) => {
   else if (which === 'signalCurl') text = signalCurlSnippet.value
   else if (which === 'peakUrl') text = peakRoundUrl.value
   else if (which === 'peakCurl') text = peakCurlSnippet.value
+  else if (which === 'sparkUrl') text = agentSparklinesUrl.value
+  else if (which === 'sparkCurl') text = sparklinesCurlSnippet.value
   else if (which === 'polymarketUrl') text = polymarketJsonUrl.value
   else if (which === 'polymarketCurl') text = polymarketCurlSnippet.value
   else if (which === 'archiveUrl') text = archiveZipUrl.value
@@ -4065,6 +4243,9 @@ watch(() => props.open, async (val) => {
   // Peak-round analytics sits on the same publish gate; load alongside
   // so the inflection-point preview renders without a manual refresh.
   loadPeakRound()
+  // Per-agent sparklines sit on the same publish gate; load alongside so
+  // the agent-trajectory rows render without a manual refresh.
+  loadAgentSparklines()
   // Polymarket prediction sits on the same gate as signal.json; load
   // alongside so the YES/NO preview row renders without a manual refresh.
   loadPolymarket()
@@ -4113,6 +4294,8 @@ watch(isPublic, () => {
   loadSignal()
   // Same publish-gate flip applies to peak-round analytics — re-fetch.
   loadPeakRound()
+  // Same publish-gate flip applies to per-agent sparklines — re-fetch.
+  loadAgentSparklines()
   // Polymarket prediction sits on the same gate; re-fetch alongside.
   loadPolymarket()
   // Same flip applies to the archive bundle — re-HEAD so the bundle
@@ -4945,6 +5128,67 @@ watch(isPublic, () => {
   margin-top: 10px;
   padding: 8px 12px;
   font-size: 13px;
+  color: #6b7280;
+  font-style: italic;
+}
+
+/* Per-agent sparklines — a scrollable list of agent rows, each a name
+   chip + inline SVG belief trajectory + final-stance label. Capped
+   height so a 100-agent swarm scrolls within the dialog instead of
+   pushing the snippet blocks off-screen. */
+.sparklines-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 10px;
+  padding: 8px 10px;
+  background: rgba(10, 10, 10, 0.03);
+  border-radius: 8px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.sparkline-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+}
+
+.sparkline-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #374151;
+  font-weight: 500;
+}
+
+.sparkline-svg {
+  flex: 0 0 auto;
+  display: block;
+}
+
+.sparkline-axis {
+  stroke: rgba(10, 10, 10, 0.12);
+  stroke-width: 0.5;
+}
+
+.sparkline-stance {
+  flex: 0 0 auto;
+  width: 56px;
+  text-align: right;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.sparkline-note {
+  margin-top: 4px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(10, 10, 10, 0.06);
+  font-size: 12px;
   color: #6b7280;
   font-style: italic;
 }


### PR DESCRIPTION
## What
Adds `GET /api/simulation/<id>/agents/sparklines` — the **agent-level companion** to `chart.svg` (aggregate belief curve) and `peak-round` (inflection points). For every agent it returns a `{round, position}` belief trajectory plus `final_stance` / `final_position` / `color`, ordered most-bullish-first. The Embed dialog renders these as compact inline SVG sparklines, each stroked in the agent's stance color.

```json
{
  "schema_version": "1",
  "simulation_id": "<id>",
  "agent_count": 24,
  "round_count": 12,
  "has_per_agent_data": true,
  "agents": [
    { "agent_id": 7, "name": "Skeptical Quant", "final_stance": "bullish",
      "final_position": 0.612, "color": "#22c55e",
      "trajectory": [ { "round": 1, "position": 0.05 }, { "round": 2, "position": 0.31 } ] }
  ]
}
```

## Why
`chart.svg` and the embed-summary draw what the *swarm* concluded; `peak-round` collapses that into inflection points. Neither exposes the layer underneath — *each individual agent's* belief path. A researcher studying swarm convergence ("which agent anchored the consensus? did one cohort align before another?") had no surface for it short of parsing `transcript.md` by hand. This is the last per-agent visualization gap (repo-actions idea, 2026-05-26 #1).

## How it works
Pure derivation, transposed: instead of bucketing all agents into one per-round percentage (the aggregate view), it tracks **one scalar per agent per round** — the same `_avg_position` mean of per-topic `belief_positions` every other surface averages, under the same ±0.2 stance threshold, so an agent tagged "bullish" here is "bullish" in the transcript. Agent names resolve from `reddit_profiles.json` (then `polymarket_profiles.json`), with an `"Agent <id>"` fallback. `has_per_agent_data` is `false` for single-round sims (a sparkline needs ≥2 points). Same publish gate, 5-minute cache, and surface-stats counter as every other share surface.

## Changes
- `backend/app/services/agent_sparklines_service.py` — new stdlib-only service: `load_agent_trajectories` groups per-agent points from `trajectory.json`; `build_agent_sparklines` assembles the payload (returns `None` → route 404 when no per-agent data).
- `backend/app/api/simulation.py` — publish-gated `GET /<id>/agents/sparklines` route; 5-min cache; increments the `agent_sparklines` surface stat.
- `backend/app/services/surface_stats.py` — register the `agent_sparklines` surface key.
- `backend/tests/test_unit_agent_sparklines.py` — 18 offline unit tests + static wiring/openapi-drift guards.
- `frontend/src/api/simulation.js` — `getAgentSparklinesUrl` + `getAgentSparklines`.
- `frontend/src/components/EmbedDialog.vue` — "🤖 Agent trajectories (JSON)" section: scrollable agent list with inline SVG sparklines, copyable URL + curl snippet.
- `backend/openapi.yaml`, `docs/API.md`, `docs/FEATURES.md` — document the surface (`AgentSparklinesResponse` / `AgentSparkline` / `SparklinePoint` schemas).

Zero new dependencies.

---
*Built autonomously by Aeon*