### PR TITLE
feat: add Noelclaw to ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -21,6 +21,7 @@ These are the projects we know of that run MiroShark, extend it, or integrate wi
 | Crucible Sim | [crucible-sim](https://github.com/wshuyi/crucible-sim) |
 | Echo | [@BuiltByEcho](https://x.com/BuiltByEcho) · [builtbyecho.xyz](https://www.builtbyecho.xyz/) |
 | Monitor | [monitor-the-situation-bags](https://github.com/Zoidberg-eternal/monitor-the-situation-bags) |
+| Noelclaw | [@noelclawfun](https://x.com/noelclawfun) · [noelclaw.com](https://noelclaw.com) · [mcp](https://github.com/noelclaw/mcp) |
 | Nookplot | [nookplot.com](https://nookplot.com/?view=network) |
 | RootAI | [@Root_Edge](https://x.com/Root_Edge) · [rootai.wtf](https://rootai.wtf) |
 | Signa | [@Signa_Agent](https://x.com/Signa_Agent) · [signa-miroshark-skills](https://github.com/codexvritra/signa-miroshark-skills) |


### PR DESCRIPTION
## What

Adds Noelclaw to the MiroShark ecosystem table.

## How Noelclaw uses MiroShark

Noelclaw is a crypto AI platform delivered as an MCP server (`@noelclaw/mcp` on npm). Two of its tools — `miroshark_simulate` and `miroshark_status` — wrap the full MiroShark simulation flow:

1. `/api/simulation/ask` — converts a plain-English scenario into a seed document
2. `/api/graph/ontology/generate` → `/api/graph/build` — builds the knowledge graph
3. `/api/simulation/create` → `/api/simulation/prepare` — creates and prepares agents
4. `/api/simulation/start` → polls `/api/simulation/{id}/run-status` — runs and tracks progress

Users can trigger a full MiroShark simulation from any Claude/Cursor/Windsurf session via a single tool call.

## Compliance

- [x] Publicly identifies as using MiroShark
- [x] Single row, alphabetically placed (Monitor → **Noelclaw** → Nookplot)
- [x] X handle + website + GitHub link provided
- [x] Not a stock fork — it's an MCP integration layer on top of the engine