### PR TITLE
docs: document the locale-negotiation protocol on the HTTP API surface

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -6,6 +6,27 @@ Base URL is `http://localhost:5001` in dev. Every endpoint returns JSON unless o
 
 > **Interactive docs:** the running backend serves Swagger UI at `/api/docs` and the OpenAPI 3.1 spec at `/api/openapi.yaml` (or `/api/openapi.json`). Point [`openapi-generator`](https://openapi-generator.tech/) at the spec to produce a Python / TypeScript / Go SDK in one command.
 
+## Localization
+
+Every endpoint resolves an active locale per request. Order of precedence:
+
+1. `?lang=` query parameter (use on share-surface URLs that need to be locale-pinned in their canonical form — `/share/<id>`, `cite.bib`, `badge.svg`, `chart.svg`)
+2. `X-MiroShark-Locale` request header (what the bundled SPA sends on every API call)
+3. `Accept-Language` request header (standard fallback for off-the-shelf HTTP clients)
+4. `en` (default)
+
+Supported locales: `en`, `zh-CN`. Unknown tags fall back to `en` silently — `?lang=fr` on the current build returns the English payload, not a 400.
+
+What gets localized: API error messages (`{"success": false, "error": "..."}`), preset template `name` / `description` metadata, RSS / Atom feed copy, and the report agent's narration. Raw simulation data (posts, trades, agent stances) is never translated.
+
+```bash
+# SPA-style: header-driven
+curl -s -H "X-MiroShark-Locale: zh-CN" "https://your-host/api/templates/list"
+
+# Share-surface-style: query-pinned for stable canonical URLs
+curl -s "https://your-host/share/<id>?lang=zh-CN"
+```
+
 ## Setup & Discovery
 
 | Method | Path | Purpose |

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -6,6 +6,27 @@
 
 > **交互式文档:** 运行中的后端会在 `/api/docs` 暴露 Swagger UI,在 `/api/openapi.yaml`(或 `/api/openapi.json`)暴露 OpenAPI 3.1 规范。把 [`openapi-generator`](https://openapi-generator.tech/) 指向这份规范,一行命令就能生成 Python / TypeScript / Go SDK。
 
+## 本地化
+
+每个端点都会按请求解析一个活动 locale。优先级顺序:
+
+1. `?lang=` 查询参数(用于需要在规范 URL 中锁定 locale 的分享面 — `/share/<id>`、`cite.bib`、`badge.svg`、`chart.svg`)
+2. `X-MiroShark-Locale` 请求头(自带 SPA 在每次 API 调用上都会发送)
+3. `Accept-Language` 请求头(用于现成 HTTP 客户端的标准回退)
+4. `en`(默认)
+
+支持的 locale:`en`、`zh-CN`。未知 tag 静默回退到 `en` — 当前构建上 `?lang=fr` 返回英文负载,而不是 400。
+
+会被本地化的内容:API 错误消息(`{"success": false, "error": "..."}`)、预设模板的 `name` / `description` 元数据、RSS / Atom 订阅源文本、报告智能体的叙述。原始模拟数据(发帖、交易、智能体立场)不会被翻译。
+
+```bash
+# SPA 风格:头驱动
+curl -s -H "X-MiroShark-Locale: zh-CN" "https://your-host/api/templates/list"
+
+# 分享面风格:用查询参数锁定稳定的规范 URL
+curl -s "https://your-host/share/<id>?lang=zh-CN"
+```
+
 ## 配置与发现
 
 | 方法 | 路径 | 用途 |


### PR DESCRIPTION
## Summary
Every backend endpoint already resolves an active locale per request via `?lang=` > `X-MiroShark-Locale` > `Accept-Language` > `en` (`backend/app/utils/i18n.py::get_locale`). The bundled SPA sends the header on every API call ([`frontend/src/api/index.js`](https://github.com/aaronjmars/MiroShark/blob/main/frontend/src/api/index.js#L19-L20)), and `apply_i18n` / `_t()` localize error messages, template `name`/`description` metadata, RSS / Atom feed copy, and the report agent's narration.

None of that was discoverable from `docs/API.md`. An SDK author running `openapi-generator` against the spec, or a third-party integrator pulling `/api/templates/list` or `/api/feed.atom`, had no way to opt into the `zh-CN` payload. Issue [#95](https://github.com/aaronjmars/MiroShark/issues/95) (French locale interest) references this protocol without any docs entry a translator could follow.

## Changes
- `docs/API.md` — new `## Localization` section right after the Interactive-docs note, before the endpoint tables. Documents the 4-step precedence, supported locales (`en`, `zh-CN`), what is and isn't localized, and two example curls (header-driven for SPA-style consumers, `?lang=` for share-surface canonical URLs).
- `docs/API.zh-CN.md` — mirror section in Chinese, same ordering and example block.

Docs-only; no spec, code, or test touched. The drift test in `backend/tests/test_unit_openapi.py` is untouched (it only walks `openapi.yaml` vs Flask routes, not Markdown).

## Context
Highest-impact-per-line entry point I could find on the repo's current loose-ends list:

- Aaron's reply on #95 names exactly this protocol as the negotiation contract a French-locale PR has to honor (`X-MiroShark-Locale` header, `Accept-Language` fallback, `?lang=` for share surfaces). Documenting it where API consumers actually look (`docs/API.md`) is a 0-risk prerequisite that makes the eventual `fr` PR — or any third-party SDK pulling the spec — land cleaner.
- The protocol's existing single docstring lives in `backend/app/utils/i18n.py` — readable only to someone already inside the repo. Third-party SDK builders pointing `openapi-generator` at `/api/openapi.yaml` never see it.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)