### PR TITLE
Add .x402books/wallets.json (MiroShark wallet declaration)

### DIFF
--- a/.x402books/wallets.json
+++ b/.x402books/wallets.json
@@ -1,0 +1,19 @@
+{
+  "agent": "MiroShark",
+  "xHandle": "@miroshark_",
+  "ecosystem": "Base",
+  "wallets": [
+    {
+      "address": "0x7753a770285b39308c426742BE81EEe2f6e80dC1",
+      "role": "treasury",
+      "chain": "base",
+      "notes": "Main protocol treasury"
+    },
+    {
+      "address": "0x6cab485fc28ec70d3845113b704d4824e4d2b24f",
+      "role": "deployer",
+      "chain": "base",
+      "notes": "Contract deployer"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.x402books/wallets.json` declaring MiroShark's wallets so Luca can verify and upgrade the registry confidence level.

- **treasury**: `0x7753a770285b39308c426742BE81EEe2f6e80dC1`
- **deployer**: `0x6cab485fc28ec70d3845113b704d4824e4d2b24f`

ecosystem: Base · xHandle: @miroshark_

🤖 Generated with [Claude Code](https://claude.com/claude-code)