### PR TITLE
UI: tighten button consistency, contrast, and typography

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Young+Serif&family=Space+Mono:wght@400;700&family=Geist:wght@400;500;600;700;800;900&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800;900&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/icon.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon.png" />

--- a/frontend/src/components/BeliefDriftChart.vue
+++ b/frontend/src/components/BeliefDriftChart.vue
@@ -452,7 +452,7 @@ onBeforeUnmount(() => {
   text-align: center;
 }
 
-.bd-error-state { color: #dc2626; }
+.bd-error-state { color: #ef4444; }
 
 .bd-hint {
   font-size: 11px;

--- a/frontend/src/components/CounterfactualBranchPanel.vue
+++ b/frontend/src/components/CounterfactualBranchPanel.vue
@@ -397,13 +397,20 @@ onMounted(() => {
 }
 
 .cf-submit {
-  background: var(--color-black);
-  color: var(--color-white);
-  border-color: var(--color-black);
+  background: linear-gradient(180deg, #6a4ad6 0%, #4922b8 45%, #2a118a 55%, #4f2dc4 100%);
+  color: #f8f5ff;
+  border-color: rgba(167, 139, 250, 0.5);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    0 10px 24px -10px rgba(139, 92, 246, 0.55);
 }
 
 .cf-submit:hover:not(:disabled) {
-  opacity: 0.9;
+  background: linear-gradient(180deg, #7d5ee8 0%, #5728d4 45%, #3414a3 55%, #5e3bde 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    0 14px 30px -10px rgba(139, 92, 246, 0.7);
 }
 
 .cf-submit:disabled,

--- a/frontend/src/components/DebugPanel.vue
+++ b/frontend/src/components/DebugPanel.vue
@@ -500,7 +500,7 @@ onUnmounted(() => {
   max-height: 70vh;
   background: #f4f1ff;
   color: #E0E0E0;
-  font-family: 'Space Mono', 'Courier New', monospace;
+  font-family: 'Geist Mono', 'Courier New', monospace;
   font-size: 11px;
   border-top: 3px solid var(--color-orange, #a78bfa);
   border-left: 3px solid var(--color-orange, #a78bfa);

--- a/frontend/src/components/GraphPanel.vue
+++ b/frontend/src/components/GraphPanel.vue
@@ -775,7 +775,7 @@ const renderGraph = () => {
     .attr('dominant-baseline', 'middle')
     .style('cursor', 'pointer')
     .style('pointer-events', 'all')
-    .style('font-family', "'Space Mono', 'Courier New', monospace")
+    .style('font-family', "'Geist Mono', 'Courier New', monospace")
     .style('display', showEdgeLabels.value ? 'block' : 'none')
     .on('click', (event, d) => {
       event.stopPropagation()
@@ -887,7 +887,7 @@ const renderGraph = () => {
     .attr('dy', 4)
     .attr('data-entity-type', d => d.type)
     .style('pointer-events', 'none')
-    .style('font-family', "'Space Mono', 'Courier New', monospace")
+    .style('font-family', "'Geist Mono', 'Courier New', monospace")
 
   simulation.on('tick', () => {
     // Update curve paths

--- a/frontend/src/components/HistoryDatabase.vue
+++ b/frontend/src/components/HistoryDatabase.vue
@@ -1289,14 +1289,19 @@ onUnmounted(() => {
 .project-card {
   position: absolute;
   width: 280px;
-  background: linear-gradient(180deg, rgba(40,30,70,0.65) 0%, rgba(18,12,38,0.85) 100%);
+  /* Opaque dark base under the violet sheen so stacked cards in the deck
+     fully occlude the ones behind them — without it the translucent
+     gradient let the back card's text bleed through (double-exposure). */
+  background-color: #0a0618;
+  background-image: linear-gradient(180deg, rgba(40,30,70,0.85) 0%, rgba(18,12,38,0.92) 100%);
   border: 1px solid rgba(167,139,250,0.18);
   border-radius: 12px;
   padding: 14px;
   cursor: pointer;
   box-shadow:
     inset 0 1px 0 rgba(255,255,255,0.08),
-    inset 0 -1px 0 rgba(0,0,0,0.4);
+    inset 0 -1px 0 rgba(0,0,0,0.4),
+    0 18px 40px -20px rgba(0,0,0,0.85);
   transition: border-color 0.3s ease, transform 700ms cubic-bezier(0.23, 1, 0.32, 1), opacity 700ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 180ms ease;
 }
 
@@ -2021,7 +2026,7 @@ onUnmounted(() => {
   border-radius: 4px;
   cursor: pointer;
   font-size: 11px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   transition: all 0.15s;
   flex-shrink: 0;
 }
@@ -2036,7 +2041,7 @@ onUnmounted(() => {
   border-radius: 9999px;
   cursor: pointer;
   font-size: 11px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   transition: all 0.15s;
 }
 .compare-select-btn:hover { border-color: #a78bfa; color: #a78bfa; }
@@ -2365,7 +2370,7 @@ onUnmounted(() => {
 .resolve-outcome-btn.yes {
   border-color: rgba(34,197,94,0.5);
   background: rgba(34,197,94,0.06);
-  color: #16a34a;
+  color: #22c55e;
 }
 .resolve-outcome-btn.yes:hover:not(:disabled) {
   background: rgba(34,197,94,0.15);
@@ -2374,7 +2379,7 @@ onUnmounted(() => {
 .resolve-outcome-btn.no {
   border-color: rgba(239,68,68,0.5);
   background: rgba(239,68,68,0.06);
-  color: #dc2626;
+  color: #ef4444;
 }
 .resolve-outcome-btn.no:hover:not(:disabled) {
   background: rgba(239,68,68,0.15);
@@ -2428,12 +2433,12 @@ onUnmounted(() => {
 }
 .resolve-value { font-family: var(--font-mono); font-size: 12px; font-weight: 600; }
 .outcome-badge { padding: 2px 8px; border: 1px solid currentColor; }
-.outcome-badge.yes { color: #16a34a; background: rgba(34,197,94,0.08); border-color: rgba(34,197,94,0.4); }
-.outcome-badge.no  { color: #dc2626; background: rgba(239,68,68,0.08); border-color: rgba(239,68,68,0.4); }
+.outcome-badge.yes { color: #22c55e; background: rgba(34,197,94,0.08); border-color: rgba(34,197,94,0.4); }
+.outcome-badge.no  { color: #ef4444; background: rgba(239,68,68,0.08); border-color: rgba(239,68,68,0.4); }
 .resolve-confidence { font-size: 10px; font-weight: 400; margin-left: 4px; opacity: 0.7; }
 .accuracy-value { font-size: 12px; }
-.accuracy-value.correct { color: #16a34a; }
-.accuracy-value.wrong   { color: #dc2626; }
+.accuracy-value.correct { color: #22c55e; }
+.accuracy-value.wrong   { color: #ef4444; }
 .accuracy-value.split   { color: #a78bfa; }
 .resolve-notes {
   font-size: 11px;

--- a/frontend/src/components/InteractionNetwork.vue
+++ b/frontend/src/components/InteractionNetwork.vue
@@ -757,7 +757,7 @@ onBeforeUnmount(() => {
   text-align: center;
 }
 
-.net-error-state { color: #dc2626; }
+.net-error-state { color: #ef4444; }
 
 .net-hint {
   font-size: 11px;

--- a/frontend/src/components/NetworkPanel.vue
+++ b/frontend/src/components/NetworkPanel.vue
@@ -317,7 +317,7 @@ const renderGraph = () => {
     .attr('dx', d => radiusScale(d.actionCount) + 4)
     .attr('dy', 4)
     .style('pointer-events', 'none')
-    .style('font-family', "'Space Mono', 'Courier New', monospace")
+    .style('font-family', "'Geist Mono', 'Courier New', monospace")
 
   // Action overlay layer (on top of everything)
   actionLayer = g.append('g').attr('class', 'action-layer')
@@ -468,7 +468,7 @@ const showRoundActions = (roundNum) => {
         .attr('font-size', '8px')
         .attr('font-weight', '700')
         .attr('fill', color)
-        .style('font-family', "'Space Mono', monospace")
+        .style('font-family', "'Geist Mono', monospace")
         .style('pointer-events', 'none')
         .style('text-transform', 'uppercase')
         .style('letter-spacing', '0.5px')
@@ -481,7 +481,7 @@ const showRoundActions = (roundNum) => {
           .attr('y', 14 + (li + 1) * lineHeight)
           .attr('font-size', '10px')
           .attr('fill', 'rgba(250,250,250,0.8)')
-          .style('font-family', "'Space Mono', monospace")
+          .style('font-family', "'Geist Mono', monospace")
           .style('pointer-events', 'none')
       })
 

--- a/frontend/src/components/PolymarketChart.vue
+++ b/frontend/src/components/PolymarketChart.vue
@@ -105,13 +105,13 @@
                   <line
                     :x1="ML" :y1="yScale(pct / 100)"
                     :x2="W - MR" :y2="yScale(pct / 100)"
-                    stroke="rgba(10,10,10,0.08)" stroke-width="1"
+                    stroke="rgba(244,241,255,0.08)" stroke-width="1"
                     :stroke-dasharray="pct === 50 ? '' : '2,3'"
                   />
                   <text
                     :x="W - MR + 8" :y="yScale(pct / 100) + 4"
-                    fill="rgba(10,10,10,0.45)" font-size="10"
-                    font-family="'Space Mono', ui-monospace, monospace"
+                    fill="rgba(244,241,255,0.45)" font-size="10"
+                    font-family="'Geist Mono', ui-monospace, monospace"
                   >{{ pct }}%</text>
                 </g>
 
@@ -151,7 +151,7 @@
                   <line
                     :x1="xScale(hoverPoint)" :y1="MT"
                     :x2="xScale(hoverPoint)" :y2="H - MB"
-                    stroke="rgba(10,10,10,0.25)" stroke-width="1" stroke-dasharray="2,3"
+                    stroke="rgba(244,241,255,0.25)" stroke-width="1" stroke-dasharray="2,3"
                   />
                   <circle
                     :cx="xScale(hoverPoint)"
@@ -408,7 +408,7 @@ const _buildExportCanvas = async () => {
 
   // ── Measure title height so the header sizes to its content ──
   // Fonts: Young Serif 44px for the title, Space Mono for everything else.
-  const titleFont = '700 44px "Young Serif", Georgia, serif'
+  const titleFont = '700 44px "Geist", Georgia, serif'
   const titleLineHeight = 54
   const measureCanvas = document.createElement('canvas')
   const measureCtx = measureCanvas.getContext('2d')
@@ -435,7 +435,7 @@ const _buildExportCanvas = async () => {
 
     // ── Big orange price ──
     ctx.fillStyle = priceColor
-    ctx.font = '700 56px "Space Mono", "JetBrains Mono", ui-monospace, monospace'
+    ctx.font = '700 56px "Geist Mono", "JetBrains Mono", ui-monospace, monospace'
     ctx.textBaseline = 'alphabetic'
     const priceBaseline = y + 46
     ctx.fillText(priceStr, PX, priceBaseline)
@@ -443,12 +443,12 @@ const _buildExportCanvas = async () => {
 
     // "CHANCE YES" label next to the price
     ctx.fillStyle = 'rgba(10, 10, 10, 0.5)'
-    ctx.font = '400 13px "Space Mono", "JetBrains Mono", ui-monospace, monospace'
+    ctx.font = '400 13px "Geist Mono", "JetBrains Mono", ui-monospace, monospace'
     ctx.fillText(`CHANCE ${outcomeLabel}`, PX + priceWidth + 18, priceBaseline - 4)
 
     // Delta pill, right-aligned to keep from colliding with the label
     if (deltaStr) {
-      ctx.font = '700 15px "Space Mono", "JetBrains Mono", ui-monospace, monospace'
+      ctx.font = '700 15px "Geist Mono", "JetBrains Mono", ui-monospace, monospace'
       const dw = ctx.measureText(deltaStr).width + 24
       const dh = 32
       const dx = W - PX - dw
@@ -471,13 +471,13 @@ const _buildExportCanvas = async () => {
       const cx = PX + i * colW
       // Label (uppercase small)
       ctx.fillStyle = 'rgba(10, 10, 10, 0.45)'
-      ctx.font = '700 10px "Space Mono", "JetBrains Mono", ui-monospace, monospace'
+      ctx.font = '700 10px "Geist Mono", "JetBrains Mono", ui-monospace, monospace'
       ctx.textAlign = 'left'
       ctx.textBaseline = 'top'
       ctx.fillText(s.k, cx, y)
       // Value
       ctx.fillStyle = '#f4f1ff'
-      ctx.font = '700 14px "Space Mono", "JetBrains Mono", ui-monospace, monospace'
+      ctx.font = '700 14px "Geist Mono", "JetBrains Mono", ui-monospace, monospace'
       ctx.fillText(s.v, cx, y + 16)
     })
   }
@@ -750,12 +750,12 @@ onBeforeUnmount(() => {
 
 .pm-market-resolved {
   margin-left: auto;
-  padding: 2px 6px;
-  background: var(--color-black);
-  color: var(--color-white);
+  padding: 2px 8px;
+  background: rgba(167, 139, 250, 0.18);
+  color: #cbb6ff;
   font-size: 9px;
   letter-spacing: 1px;
-  border-radius: 0;
+  border-radius: 9999px;
   text-transform: uppercase;
 }
 

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -1146,7 +1146,7 @@ const saveSettings = async () => {
   border: 2px solid rgba(244, 241, 255,0.1);
   background: #1a0f3a;
   padding: 8px 11px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 13px;
   color: #f4f1ff;
   outline: none;
@@ -1162,7 +1162,7 @@ const saveSettings = async () => {
   border: 2px solid rgba(244, 241, 255,0.1);
   background: #1a0f3a;
   padding: 8px 11px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 13px;
   color: #f4f1ff;
   outline: none;
@@ -1184,7 +1184,7 @@ const saveSettings = async () => {
   border: 2px solid rgba(244, 241, 255,0.1);
   background: #1a0f3a;
   padding: 8px 12px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 14px;
   cursor: pointer;
   transition: all 0.1s;
@@ -1234,18 +1234,24 @@ const saveSettings = async () => {
 }
 
 .test-btn {
-  border: 2px solid rgba(244, 241, 255,0.12);
-  background: transparent;
-  padding: 8px 16px;
-  font-family: 'Space Mono', monospace;
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  background: linear-gradient(180deg, rgba(50, 38, 86, 0.5) 0%, rgba(18, 12, 38, 0.7) 100%);
+  color: rgba(244, 241, 255, 0.88);
+  padding: 9px 18px;
+  font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 2px;
   text-transform: uppercase;
   cursor: pointer;
-  transition: all 0.1s;
+  transition: border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
 }
-.test-btn:hover:not(:disabled) { border-color: #a78bfa; color: #a78bfa; }
+.test-btn:hover:not(:disabled) {
+  border-color: rgba(167, 139, 250, 0.7);
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px -12px rgba(139, 92, 246, 0.6);
+}
 .test-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 
 .test-result {
@@ -1265,7 +1271,7 @@ const saveSettings = async () => {
   border: none;
   padding: 0 0 10px 0;
   cursor: pointer;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
 }
 .chevron {
   font-size: 16px;
@@ -1325,7 +1331,7 @@ const saveSettings = async () => {
   border: 2px solid rgba(244, 241, 255,0.1);
   background: transparent;
   padding: 10px 20px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 2px;
@@ -1341,7 +1347,7 @@ const saveSettings = async () => {
   background: #f4f1ff;
   color: #110a26;
   padding: 10px 20px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 2px;
@@ -1361,7 +1367,7 @@ const saveSettings = async () => {
 }
 
 .webhook-test-result {
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 11px;
   letter-spacing: 0.5px;
 }
@@ -1410,7 +1416,7 @@ const saveSettings = async () => {
   color: #110a26;
   border: none;
   padding: 6px 12px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 11px;
   letter-spacing: 1px;
   text-transform: uppercase;
@@ -1467,7 +1473,7 @@ const saveSettings = async () => {
   border-bottom: 2px solid transparent;
   margin-bottom: -2px;
   padding: 8px 12px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 11px;
   letter-spacing: 1px;
   text-transform: uppercase;
@@ -1501,7 +1507,7 @@ const saveSettings = async () => {
 }
 
 .ai-client-file-path {
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   color: #f4f1ff;
   background: #110a26;
   padding: 1px 5px;
@@ -1517,7 +1523,7 @@ const saveSettings = async () => {
   color: #110a26;
   padding: 14px 16px;
   margin: 0;
-  font-family: 'Space Mono', 'Courier New', monospace;
+  font-family: 'Geist Mono', 'Courier New', monospace;
   font-size: 12px;
   line-height: 1.45;
   overflow-x: auto;
@@ -1538,7 +1544,7 @@ const saveSettings = async () => {
   color: #f4f1ff;
   border: 1px solid rgba(250,250,250,0.2);
   padding: 4px 10px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 10px;
   letter-spacing: 1px;
   text-transform: uppercase;
@@ -1564,7 +1570,7 @@ const saveSettings = async () => {
   border: 2px dashed rgba(244, 241, 255,0.1);
   padding: 8px 12px;
   margin-top: 14px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 11px;
   letter-spacing: 1px;
   text-transform: uppercase;
@@ -1601,7 +1607,7 @@ const saveSettings = async () => {
 .ai-tool-name {
   color: #a78bfa;
   font-weight: 700;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
 }
 
 .ai-tool-desc {

--- a/frontend/src/components/Step2EnvSetup.vue
+++ b/frontend/src/components/Step2EnvSetup.vue
@@ -1628,7 +1628,7 @@ onUnmounted(() => {
   padding: 8px;
   background: transparent;
   border: 2px solid rgba(10,10,10,0.08);
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 2px;

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -1975,7 +1975,7 @@ onUnmounted(() => {
 }
 
 .tooltip-title {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 11px;
   font-weight: 600;
   color: rgba(244, 241, 255,0.4);
@@ -2011,7 +2011,7 @@ onUnmounted(() => {
 }
 
 .platform-name {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 9px;
   font-weight: 700;
   color: #f4f1ff;
@@ -2040,7 +2040,7 @@ onUnmounted(() => {
 }
 
 .stat-label {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 7px;
   color: rgba(244, 241, 255,0.4);
   font-weight: 600;
@@ -2049,14 +2049,14 @@ onUnmounted(() => {
 }
 
 .stat-value {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 10px;
   font-weight: 600;
   color: rgba(244, 241, 255,0.7);
 }
 
 .stat-total, .stat-unit {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 8px;
   color: rgba(244, 241, 255,0.4);
   font-weight: 400;
@@ -2215,20 +2215,20 @@ onUnmounted(() => {
 }
 
 .filter-name {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 12px;
   font-weight: 600;
   color: rgba(244, 241, 255,0.7);
 }
 
 .filter-count {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 10px;
   color: rgba(244, 241, 255,0.4);
 }
 
 .filter-clear {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -2286,7 +2286,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 16px;
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 11px;
   color: rgba(244, 241, 255,0.5);
   background: var(--color-gray, #1a0f3a);
@@ -2295,7 +2295,7 @@ onUnmounted(() => {
 }
 
 .total-count {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-weight: 600;
   color: rgba(244, 241, 255,0.7);
   text-transform: uppercase;
@@ -2312,7 +2312,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 4px;
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
 }
 
 .breakdown-divider { color: rgba(244, 241, 255,0.2); }
@@ -2469,7 +2469,7 @@ onUnmounted(() => {
 }
 
 .agent-name {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 13px;
   font-weight: 600;
   color: #f4f1ff;
@@ -2537,13 +2537,13 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 12px;
   flex-wrap: wrap;
 }
 
 .trade-direction {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 10px;
   font-weight: 700;
   padding: 1px 6px;
@@ -2563,7 +2563,7 @@ onUnmounted(() => {
 }
 
 .market-ref {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 10px;
   color: rgba(244, 241, 255,0.4);
   margin-top: 2px;
@@ -2608,7 +2608,7 @@ onUnmounted(() => {
 }
 
 .search-query {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   background: rgba(10,10,10,0.06);
   padding: 0 4px;
 }
@@ -2619,7 +2619,7 @@ onUnmounted(() => {
   justify-content: flex-end;
   font-size: 10px;
   color: rgba(244, 241, 255,0.2);
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
 }
 
 /* Waiting State */
@@ -2633,7 +2633,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 16px;
   color: rgba(244, 241, 255,0.2);
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 3px;
@@ -2736,7 +2736,7 @@ onUnmounted(() => {
 
 .log-time { color: rgba(196,181,253,0.5); min-width: 75px; }
 .log-msg { color: rgba(228,222,255,0.75); word-break: break-all; }
-.mono { font-family: var(--font-mono, 'Space Mono', monospace); }
+.mono { font-family: var(--font-mono, 'Geist Mono', monospace); }
 
 /* Loading spinner for button — adapts to whichever button hosts it. */
 .loading-spinner-small {
@@ -2791,7 +2791,7 @@ onUnmounted(() => {
 }
 
 .article-drawer-title {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 2px;
@@ -2862,7 +2862,7 @@ onUnmounted(() => {
 .article-loading-label {
   text-align: center;
   color: rgba(244, 241, 255,0.35);
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 11px;
   letter-spacing: 1px;
   text-transform: uppercase;
@@ -2908,7 +2908,7 @@ onUnmounted(() => {
 }
 
 .article-error-msg {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 12px;
   color: #e53e3e;
   text-align: center;
@@ -2955,7 +2955,7 @@ onUnmounted(() => {
   margin-left: 4px;
   padding: 1px 6px;
   background: rgba(167, 139, 250, 0.18);
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 9px;
   letter-spacing: 1px;
   color: #a78bfa;
@@ -2969,7 +2969,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 2px;
@@ -2991,7 +2991,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 0;
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   background: var(--background, #110a26);
 }
 
@@ -3036,7 +3036,7 @@ onUnmounted(() => {
   border: 1px solid rgba(167,139,250,0.28);
   border-radius: 10px;
   background: linear-gradient(180deg, rgba(22,16,46,0.85) 0%, rgba(8,5,22,0.95) 100%);
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 12px;
   color: #f4f1ff;
   resize: none;
@@ -3075,7 +3075,7 @@ onUnmounted(() => {
   background: #a78bfa;
   border: none;
   color: #fff;
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 11px;
   letter-spacing: 1px;
   cursor: pointer;
@@ -3094,7 +3094,7 @@ onUnmounted(() => {
 .director-error {
   margin-top: 8px;
   font-size: 11px;
-  color: #dc2626;
+  color: #ef4444;
   letter-spacing: 0.5px;
 }
 
@@ -3224,7 +3224,7 @@ onUnmounted(() => {
 }
 
 .director-banner-text {
-  font-family: var(--font-mono, 'Space Mono', monospace);
+  font-family: var(--font-mono, 'Geist Mono', monospace);
   font-size: 10px;
   color: #b45309;
   letter-spacing: 0.5px;

--- a/frontend/src/components/WhatIfPanel.vue
+++ b/frontend/src/components/WhatIfPanel.vue
@@ -104,12 +104,12 @@
               <line
                 :x1="ML" :y1="yS(pct)"
                 :x2="W - MR" :y2="yS(pct)"
-                stroke="rgba(10,10,10,0.06)" stroke-width="1"
+                stroke="rgba(244,241,255,0.06)" stroke-width="1"
               />
               <text
                 :x="ML - 5" :y="yS(pct) + 4"
-                fill="rgba(10,10,10,0.35)" font-size="9"
-                font-family="'Space Mono', monospace" text-anchor="end"
+                fill="rgba(244,241,255,0.35)" font-size="9"
+                font-family="'Geist Mono', monospace" text-anchor="end"
               >{{ pct }}%</text>
             </g>
 
@@ -117,7 +117,7 @@
             <line
               :x1="ML" :y1="yS(50)"
               :x2="W - MR" :y2="yS(50)"
-              stroke="rgba(10,10,10,0.18)" stroke-width="1"
+              stroke="rgba(244,241,255,0.18)" stroke-width="1"
               stroke-dasharray="2,3"
             />
 
@@ -125,7 +125,7 @@
             <path
               :d="originalPath"
               fill="none"
-              stroke="rgba(10,10,10,0.35)"
+              stroke="rgba(244,241,255,0.35)"
               stroke-width="1.5"
               stroke-dasharray="5,3"
             />
@@ -143,7 +143,7 @@
               v-if="origEnd"
               :cx="origEnd.x" :cy="origEnd.y"
               r="3"
-              fill="rgba(10,10,10,0.35)"
+              fill="rgba(244,241,255,0.35)"
             />
             <circle
               v-if="cfEnd"
@@ -158,13 +158,13 @@
               <line
                 :x1="xS(origData.consensus_round)" :y1="MT"
                 :x2="xS(origData.consensus_round)" :y2="H - MB"
-                stroke="rgba(10,10,10,0.3)" stroke-width="1"
+                stroke="rgba(244,241,255,0.3)" stroke-width="1"
                 stroke-dasharray="3,3"
               />
               <text
                 :x="xS(origData.consensus_round) + 4" :y="MT + 10"
-                fill="rgba(10,10,10,0.45)" font-size="9"
-                font-family="'Space Mono', monospace"
+                fill="rgba(244,241,255,0.45)" font-size="9"
+                font-family="'Geist Mono', monospace"
               >{{ $tr('orig r', '原 r') }}{{ origData.consensus_round }}</text>
             </g>
             <g v-if="cfData?.consensus_round != null && cfData.consensus_round !== origData?.consensus_round">
@@ -177,7 +177,7 @@
               <text
                 :x="xS(cfData.consensus_round) + 4" :y="MT + 22"
                 fill="#c4b5fd" font-size="9"
-                font-family="'Space Mono', monospace"
+                font-family="'Geist Mono', monospace"
               >{{ $tr('cf r', '反 r') }}{{ cfData.consensus_round }}</text>
             </g>
 
@@ -186,13 +186,13 @@
               v-for="r in xTicks"
               :key="'xt' + r"
               :x="xS(r)" :y="H - MB + 13"
-              fill="rgba(10,10,10,0.35)" font-size="9"
-              font-family="'Space Mono', monospace" text-anchor="middle"
+              fill="rgba(244,241,255,0.35)" font-size="9"
+              font-family="'Geist Mono', monospace" text-anchor="middle"
             >{{ r }}</text>
             <text
               :x="ML + (W - ML - MR) / 2" :y="H - 2"
-              fill="rgba(10,10,10,0.3)" font-size="9"
-              font-family="'Space Mono', monospace" text-anchor="middle"
+              fill="rgba(244,241,255,0.3)" font-size="9"
+              font-family="'Geist Mono', monospace" text-anchor="middle"
             >{{ $tr('Round — bullish %', '轮次 — 看涨 %') }}</text>
           </svg>
 
@@ -534,7 +534,7 @@ onBeforeUnmount(() => {
   justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
-  border-bottom: 1px solid rgba(10,10,10,0.08);
+  border-bottom: 1px solid rgba(244,241,255,0.08);
   flex-shrink: 0;
 }
 
@@ -566,7 +566,7 @@ onBeforeUnmount(() => {
 /* ── Export button — mirrors .export-btn ── */
 .wi-export-btn {
   background: none;
-  border: 1px solid rgba(10,10,10,0.15);
+  border: 1px solid rgba(244,241,255,0.15);
   color: rgba(244, 241, 255,0.5);
   padding: 4px 10px;
   font-family: var(--font-mono);
@@ -586,7 +586,7 @@ onBeforeUnmount(() => {
   font-size: 11px;
   line-height: 1.5;
   color: rgba(244, 241, 255,0.5);
-  border-bottom: 1px solid rgba(10,10,10,0.05);
+  border-bottom: 1px solid rgba(244,241,255,0.05);
   letter-spacing: 0.3px;
 }
 
@@ -619,7 +619,7 @@ onBeforeUnmount(() => {
 
 .wi-picker {
   padding: 12px 16px;
-  border-bottom: 1px solid rgba(10,10,10,0.05);
+  border-bottom: 1px solid rgba(244,241,255,0.05);
 }
 
 .wi-picker-header {
@@ -660,14 +660,14 @@ onBeforeUnmount(() => {
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
-  border: 1px solid rgba(10,10,10,0.12);
+  border: 1px solid rgba(244,241,255,0.12);
   cursor: pointer;
   font-size: 11px;
   color: rgba(244, 241, 255,0.7);
   transition: background-color 0.12s, border-color 0.12s;
 }
 .wi-agent-card:hover:not(.disabled) {
-  background: rgba(10,10,10,0.02);
+  background: rgba(244,241,255,0.02);
   border-color: rgba(167, 139, 250, 0.35);
 }
 .wi-agent-card.selected {
@@ -709,9 +709,9 @@ onBeforeUnmount(() => {
 
 /* ── Recompute — primary CTA, matches .action-btn.primary (black filled) ── */
 .wi-recompute {
-  background: var(--color-black);
-  color: var(--color-white);
-  border: 2px solid var(--color-black);
+  background: linear-gradient(180deg, #6a4ad6 0%, #4922b8 45%, #2a118a 55%, #4f2dc4 100%);
+  color: #f8f5ff;
+  border: 1px solid rgba(167, 139, 250, 0.5);
   padding: 8px 16px;
   font-family: var(--font-mono);
   font-size: 11px;
@@ -721,9 +721,19 @@ onBeforeUnmount(() => {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  transition: opacity 0.15s ease;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    0 10px 24px -10px rgba(139, 92, 246, 0.55);
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
 }
-.wi-recompute:hover:not(:disabled) { opacity: 0.9; }
+.wi-recompute:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: linear-gradient(180deg, #7d5ee8 0%, #5728d4 45%, #3414a3 55%, #5e3bde 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    0 14px 30px -10px rgba(139, 92, 246, 0.7);
+}
 .wi-recompute:disabled {
   opacity: 0.3;
   cursor: not-allowed;
@@ -747,8 +757,8 @@ onBeforeUnmount(() => {
 }
 
 .wi-chart-wrap {
-  background: rgba(10,10,10,0.02);
-  border: 1px solid rgba(10,10,10,0.06);
+  background: rgba(244,241,255,0.02);
+  border: 1px solid rgba(244,241,255,0.06);
   padding: 10px 6px 4px;
 }
 
@@ -789,7 +799,7 @@ onBeforeUnmount(() => {
   flex-direction: column;
   gap: 8px;
   padding: 12px 14px;
-  border: 1px solid rgba(10,10,10,0.08);
+  border: 1px solid rgba(244,241,255,0.08);
   background: var(--color-white);
 }
 
@@ -859,7 +869,7 @@ onBeforeUnmount(() => {
 }
 .wi-impact-badge.impact-minimal {
   color: rgba(244, 241, 255,0.45);
-  background: rgba(10,10,10,0.04);
+  background: rgba(244,241,255,0.04);
   border-color: rgba(244, 241, 255,0.12);
 }
 
@@ -868,7 +878,7 @@ onBeforeUnmount(() => {
   line-height: 1.55;
   color: rgba(244, 241, 255,0.75);
   padding-top: 8px;
-  border-top: 1px solid rgba(10,10,10,0.06);
+  border-top: 1px solid rgba(244,241,255,0.06);
   letter-spacing: 0.2px;
 }
 

--- a/frontend/src/utils/chartExport.js
+++ b/frontend/src/utils/chartExport.js
@@ -33,8 +33,8 @@ function _loadLogo() {
 export function buildTitledHeader({ title, subtitle = '', width }) {
   const PX = 32
   const TITLE_LH = 44
-  const TITLE_FONT = '700 36px "Young Serif", Georgia, serif'
-  const SUBTITLE_FONT = '400 13px "Space Mono", "JetBrains Mono", ui-monospace, monospace'
+  const TITLE_FONT = '700 36px "Geist", Georgia, serif'
+  const SUBTITLE_FONT = '400 13px "Geist Mono", "JetBrains Mono", ui-monospace, monospace'
 
   // Pre-measure title to size the header
   const measureCanvas = document.createElement('canvas')
@@ -100,9 +100,9 @@ async function _ensureFontsReady() {
     if (document.fonts?.ready) await document.fonts.ready
     if (document.fonts?.load) {
       await Promise.all([
-        document.fonts.load('700 42px "Young Serif"'),
-        document.fonts.load('700 24px "Space Mono"'),
-        document.fonts.load('400 13px "Space Mono"'),
+        document.fonts.load('700 42px "Geist"'),
+        document.fonts.load('700 24px "Geist Mono"'),
+        document.fonts.load('400 13px "Geist Mono"'),
       ])
     }
   } catch (_) {
@@ -214,7 +214,7 @@ export async function renderSvgToCanvas(svgEl, {
 
   // Big wordmark — "SIMULATED BY MIROSHARK"
   ctx.fillStyle = '#0A0A0A'
-  ctx.font = '700 24px "Space Mono", "JetBrains Mono", ui-monospace, monospace'
+  ctx.font = '700 24px "Geist Mono", "JetBrains Mono", ui-monospace, monospace'
   ctx.textBaseline = 'middle'
   ctx.textAlign = 'left'
   // Letter spacing ~2px, implemented manually because canvas lacks the CSS
@@ -230,7 +230,7 @@ export async function renderSvgToCanvas(svgEl, {
   // Fallback title in the footer (only if there's no dedicated header zone)
   if (!drawHeader && title) {
     ctx.fillStyle = 'rgba(10, 10, 10, 0.9)'
-    ctx.font = '700 13px "Space Mono", "JetBrains Mono", ui-monospace, monospace'
+    ctx.font = '700 13px "Geist Mono", "JetBrains Mono", ui-monospace, monospace'
     ctx.textAlign = 'center'
     const titleStr = title.length > 60 ? title.slice(0, 57) + '…' : title
     ctx.fillText(titleStr, width / 2, midY)
@@ -239,7 +239,7 @@ export async function renderSvgToCanvas(svgEl, {
   // Subtitle / provenance (right)
   if (subtitle) {
     ctx.fillStyle = 'rgba(10, 10, 10, 0.4)'
-    ctx.font = '400 12px "Space Mono", "JetBrains Mono", ui-monospace, monospace'
+    ctx.font = '400 12px "Geist Mono", "JetBrains Mono", ui-monospace, monospace'
     ctx.textAlign = 'right'
     const subStr = subtitle.length > 44 ? subtitle.slice(0, 41) + '…' : subtitle
     ctx.fillText(subStr, width - 24, midY)

--- a/frontend/src/views/ComparisonView.vue
+++ b/frontend/src/views/ComparisonView.vue
@@ -651,7 +651,7 @@ const downloadComparison = () => {
 }
 .metric-card.sim-a { border-top: 3px solid #a78bfa; }
 .metric-card.sim-b { border-top: 3px solid #c4b5fd; }
-.metric-sim-id { font-size: 11px; color: #555; margin-bottom: 12px; font-family: 'Space Mono', monospace; }
+.metric-sim-id { font-size: 11px; color: #555; margin-bottom: 12px; font-family: 'Geist Mono', monospace; }
 .metric-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
 .metric-item { display: flex; flex-direction: column; gap: 4px; }
 .metric-val { font-size: 20px; color: #110a26; font-weight: bold; }
@@ -670,7 +670,7 @@ const downloadComparison = () => {
 .lb-col {}
 .lb-header {
   font-size: 11px;
-  font-family: 'Space Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   margin-bottom: 8px;
   padding-bottom: 6px;
   border-bottom: 1px solid #2A2A2A;
@@ -711,7 +711,7 @@ const downloadComparison = () => {
 /* Markets */
 .markets-compare { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
 .market-col { }
-.market-col-header { font-size: 11px; font-family: 'Space Mono', monospace; margin-bottom: 8px; }
+.market-col-header { font-size: 11px; font-family: 'Geist Mono', monospace; margin-bottom: 8px; }
 .market-row { display: flex; align-items: center; gap: 8px; padding: 6px 0; font-size: 11px; }
 .market-id { color: #555; width: 60px; flex-shrink: 0; }
 .market-bar-wrap { flex: 1; height: 8px; background: #1A1A1A; border-radius: 4px; overflow: hidden; }

--- a/frontend/src/views/ExploreView.vue
+++ b/frontend/src/views/ExploreView.vue
@@ -957,9 +957,10 @@ onMounted(refresh)
   display: inline-flex;
   align-items: baseline;
   gap: 6px;
-  padding: 6px 12px;
-  background: var(--color-gray);
-  border: var(--border-light);
+  padding: 6px 14px;
+  background: linear-gradient(180deg, rgba(50, 38, 86, 0.5) 0%, rgba(18, 12, 38, 0.7) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 9999px;
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.5px;
@@ -977,9 +978,10 @@ onMounted(refresh)
 }
 
 .refresh-btn {
-  padding: 6px 12px;
-  background: transparent;
-  border: var(--border-medium);
+  padding: 6px 14px;
+  background: linear-gradient(180deg, rgba(50, 38, 86, 0.45) 0%, rgba(18, 12, 38, 0.65) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 9999px;
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.5px;
@@ -1029,10 +1031,19 @@ onMounted(refresh)
 .gallery-error,
 .gallery-empty {
   padding: var(--space-2xl) var(--space-lg);
-  border: var(--border-medium);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.5rem;
   text-align: center;
   max-width: 540px;
   margin: var(--space-xl) auto;
+  background: linear-gradient(180deg, rgba(40, 30, 70, 0.55) 0%, rgba(18, 12, 38, 0.7) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.45),
+    0 20px 48px -16px rgba(0, 0, 0, 0.8),
+    0 0 60px -20px rgba(139, 92, 246, 0.25);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
 }
 
 .error-icon,
@@ -1057,26 +1068,63 @@ onMounted(refresh)
   margin-bottom: var(--space-md);
 }
 
+/* Primary CTA pill — same purple-gradient treatment as the marketing
+   site's .metal-cta, sized down for in-page actions. */
 .error-retry,
 .empty-cta {
-  display: inline-block;
-  padding: 10px 20px;
-  background: var(--color-orange);
-  color: var(--color-white);
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 12px 26px;
   border: none;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, #6a4ad6 0%, #4922b8 45%, #2a118a 55%, #4f2dc4 100%);
+  color: #f8f5ff;
   font-family: var(--font-mono);
   font-size: 13px;
+  font-weight: 700;
   letter-spacing: 1px;
   text-transform: uppercase;
   text-decoration: none;
   cursor: pointer;
-  transition: var(--transition-fast);
+  overflow: hidden;
+  isolation: isolate;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.5),
+    0 12px 28px -8px rgba(139, 92, 246, 0.6),
+    0 0 60px -10px rgba(167, 139, 250, 0.4);
+  transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 200ms ease, background 200ms ease;
+}
+
+.error-retry::before,
+.empty-cta::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.4) 0%, rgba(255, 255, 255, 0.08) 40%, transparent 55%);
+  pointer-events: none;
 }
 
 .error-retry:hover,
 .empty-cta:hover {
-  background: var(--color-black);
+  transform: translateY(-2px);
+  background: linear-gradient(180deg, #7d5ee8 0%, #5728d4 45%, #3414a3 55%, #5e3bde 100%);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.5),
+    0 20px 40px -10px rgba(139, 92, 246, 0.75),
+    0 0 80px -10px rgba(167, 139, 250, 0.6);
 }
+
+.error-retry:active,
+.empty-cta:active { transform: translateY(0); }
 
 /* ── Grid ── */
 .gallery-grid {
@@ -1087,17 +1135,27 @@ onMounted(refresh)
 }
 
 .gallery-card {
-  background: var(--color-white);
-  border: var(--border-light);
+  position: relative;
+  background: linear-gradient(180deg, rgba(40, 30, 70, 0.6) 0%, rgba(18, 12, 38, 0.78) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.1rem;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  transition: var(--transition-medium);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 16px 40px -18px rgba(0, 0, 0, 0.8);
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
   animation: fade-in 0.4s ease-out;
 }
 
 .gallery-card:hover {
-  border-color: var(--color-orange);
-  transform: translateY(-2px);
+  border-color: rgba(167, 139, 250, 0.5);
+  transform: translateY(-3px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 22px 50px -16px rgba(0, 0, 0, 0.85),
+    0 0 70px -18px rgba(139, 92, 246, 0.45);
 }
 
 .card-resolved {
@@ -1168,53 +1226,57 @@ onMounted(refresh)
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 9px;
+  padding: 3px 10px;
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
   font-weight: 600;
-  border-radius: 2px;
+  border-radius: 9999px;
 }
 
+/* Signal palette — bullish = cool violet, bearish = warm fuchsia,
+   matching the marketing site's --signal-up / --signal-down. Light
+   text on a translucent tint keeps contrast high on the near-black bg
+   (the old dark green/red was unreadable). */
 .pill-bullish {
-  background: rgba(196, 181, 253, 0.15);
-  color: #2a8545;
+  background: rgba(167, 139, 250, 0.18);
+  color: #cbb6ff;
 }
 
 .pill-bearish {
-  background: rgba(255, 68, 68, 0.14);
-  color: #c52d2d;
+  background: rgba(240, 171, 252, 0.16);
+  color: #f5c2ff;
 }
 
 .pill-neutral {
   background: rgba(244, 241, 255, 0.08);
-  color: rgba(244, 241, 255, 0.7);
+  color: rgba(244, 241, 255, 0.78);
 }
 
 .pill-quality-excellent {
-  background: rgba(196, 181, 253, 0.15);
-  color: #2a8545;
+  background: rgba(167, 139, 250, 0.2);
+  color: #cbb6ff;
 }
 
 .pill-quality-good {
-  background: rgba(196, 181, 253, 0.1);
-  color: #2a8545;
+  background: rgba(167, 139, 250, 0.12);
+  color: #c4b5fd;
 }
 
 .pill-quality-fair {
-  background: rgba(255, 179, 71, 0.18);
-  color: #a66414;
+  background: rgba(252, 211, 77, 0.14);
+  color: #fcd34d;
 }
 
 .pill-quality-poor {
-  background: rgba(255, 68, 68, 0.14);
-  color: #c52d2d;
+  background: rgba(240, 171, 252, 0.14);
+  color: #f0abfc;
 }
 
 .pill-quality-unknown {
   background: rgba(244, 241, 255, 0.06);
-  color: rgba(244, 241, 255, 0.5);
+  color: rgba(244, 241, 255, 0.55);
 }
 
 .pill-resolved {
@@ -1224,7 +1286,7 @@ onMounted(refresh)
 
 .pill-status {
   background: rgba(244, 241, 255, 0.06);
-  color: rgba(244, 241, 255, 0.55);
+  color: rgba(244, 241, 255, 0.6);
 }
 
 /* Verified-prediction pills — slightly stronger visual weight than the
@@ -1249,16 +1311,16 @@ a.pill-verified:hover {
 }
 
 .pill-verified-incorrect {
-  background: rgba(255, 68, 68, 0.18);
-  color: #c52d2d;
-  outline: 1px solid rgba(255, 68, 68, 0.35);
+  background: rgba(240, 171, 252, 0.16);
+  color: #f5c2ff;
+  outline: 1px solid rgba(240, 171, 252, 0.4);
   outline-offset: -1px;
 }
 
 .pill-verified-partial {
-  background: rgba(255, 179, 71, 0.22);
-  color: #8a4a0a;
-  outline: 1px solid rgba(255, 179, 71, 0.5);
+  background: rgba(252, 211, 77, 0.18);
+  color: #fde68a;
+  outline: 1px solid rgba(252, 211, 77, 0.45);
   outline-offset: -1px;
 }
 
@@ -1274,7 +1336,7 @@ a.pill-verified:hover {
 }
 
 .card-verified-partial {
-  border-left: 3px solid #f59e0b;
+  border-left: 3px solid var(--color-amber);
 }
 
 /* Filter chip in the stats row — toggles `?verified=1`. Active state
@@ -1284,9 +1346,10 @@ a.pill-verified:hover {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 12px;
-  background: transparent;
-  border: var(--border-medium);
+  padding: 6px 14px;
+  background: linear-gradient(180deg, rgba(50, 38, 86, 0.45) 0%, rgba(18, 12, 38, 0.65) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 9999px;
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.5px;
@@ -1355,7 +1418,7 @@ a.pill-verified:hover {
   height: 6px;
   background: rgba(244, 241, 255, 0.06);
   overflow: hidden;
-  border-radius: 3px;
+  border-radius: 9999px;
 }
 
 .bar-seg { height: 100%; transition: width 0.2s ease; }
@@ -1402,36 +1465,49 @@ a.pill-verified:hover {
 
 .action-btn {
   flex: 1;
-  padding: 8px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 9px 14px;
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 1px;
   text-transform: uppercase;
   text-decoration: none;
   text-align: center;
-  border: var(--border-light);
-  background: transparent;
-  color: rgba(244, 241, 255, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 9999px;
+  background: linear-gradient(180deg, rgba(70, 55, 120, 0.4) 0%, rgba(20, 14, 42, 0.62) 100%);
+  color: rgba(244, 241, 255, 0.82);
   cursor: pointer;
-  transition: var(--transition-fast);
+  transition: transform 180ms ease, border-color 180ms ease, color 180ms ease, box-shadow 180ms ease, background 180ms ease;
   font-weight: 600;
 }
 
 .action-view:hover {
-  background: var(--color-black);
-  color: var(--color-white);
-  border-color: var(--color-black);
+  transform: translateY(-1px);
+  border-color: rgba(167, 139, 250, 0.55);
+  color: #ffffff;
+  box-shadow: 0 10px 24px -12px rgba(139, 92, 246, 0.6);
 }
 
 .action-fork {
-  background: var(--color-orange);
-  color: var(--color-white);
-  border-color: var(--color-orange);
+  background: linear-gradient(180deg, #6a4ad6 0%, #4922b8 45%, #2a118a 55%, #4f2dc4 100%);
+  color: #f8f5ff;
+  border-color: rgba(167, 139, 250, 0.5);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    0 10px 24px -10px rgba(139, 92, 246, 0.55);
 }
 
 .action-fork:hover:not(:disabled) {
-  background: var(--color-black);
-  border-color: var(--color-black);
+  transform: translateY(-1px);
+  background: linear-gradient(180deg, #7d5ee8 0%, #5728d4 45%, #3414a3 55%, #5e3bde 100%);
+  border-color: rgba(196, 181, 253, 0.7);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    0 16px 32px -10px rgba(139, 92, 246, 0.7);
 }
 
 .action-fork:disabled {
@@ -1443,7 +1519,7 @@ a.pill-verified:hover {
   margin-top: 6px;
   font-family: var(--font-mono);
   font-size: 11px;
-  color: #c52d2d;
+  color: #f0abfc;
   line-height: 1.4;
 }
 
@@ -1456,22 +1532,24 @@ a.pill-verified:hover {
 
 .load-more-btn {
   padding: 12px 32px;
-  background: transparent;
-  border: var(--border-medium);
+  background: linear-gradient(180deg, rgba(50, 38, 86, 0.45) 0%, rgba(18, 12, 38, 0.65) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 9999px;
   font-family: var(--font-mono);
   font-size: 13px;
   letter-spacing: 1px;
   text-transform: uppercase;
   color: rgba(244, 241, 255, 0.75);
   cursor: pointer;
-  transition: var(--transition-fast);
+  transition: transform 180ms ease, border-color 180ms ease, color 180ms ease, box-shadow 180ms ease;
   font-weight: 600;
 }
 
 .load-more-btn:hover:not(:disabled) {
-  background: var(--color-black);
-  color: var(--color-white);
-  border-color: var(--color-black);
+  transform: translateY(-1px);
+  border-color: rgba(167, 139, 250, 0.55);
+  color: #ffffff;
+  box-shadow: 0 14px 30px -12px rgba(139, 92, 246, 0.6);
 }
 
 .load-more-btn:disabled {
@@ -1509,8 +1587,14 @@ a.pill-verified:hover {
   gap: var(--space-sm) var(--space-md);
   margin-top: var(--space-lg);
   padding: var(--space-md);
-  background: var(--color-gray);
-  border: var(--border-light);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.1rem;
+  background: linear-gradient(180deg, rgba(40, 30, 70, 0.55) 0%, rgba(18, 12, 38, 0.7) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 16px 40px -20px rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .search-wrap {
@@ -1533,22 +1617,25 @@ a.pill-verified:hover {
 .search-input {
   flex: 1;
   width: 100%;
-  padding: 10px 36px 10px 36px;
-  background: var(--color-white);
-  border: var(--border-light);
+  padding: 10px 36px 10px 38px;
+  background: linear-gradient(180deg, rgba(22, 16, 46, 0.9) 0%, rgba(8, 5, 22, 0.95) 100%);
+  border: 1px solid rgba(167, 139, 250, 0.22);
+  border-radius: 9999px;
   font-family: var(--font-mono);
   font-size: 13px;
   color: var(--foreground);
   letter-spacing: 0.3px;
-  transition: var(--transition-fast);
+  transition: border-color 180ms ease, box-shadow 180ms ease;
   -webkit-appearance: none;
   appearance: none;
 }
 
+.search-input::placeholder { color: rgba(228, 222, 255, 0.45); }
+
 .search-input:focus {
   outline: none;
-  border-color: var(--color-orange);
-  background: var(--color-white);
+  border-color: rgba(167, 139, 250, 0.65);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.2);
 }
 
 .search-input::-webkit-search-decoration,
@@ -1597,16 +1684,17 @@ a.pill-verified:hover {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 5px 11px;
-  background: var(--color-white);
-  border: var(--border-light);
+  padding: 5px 12px;
+  background: linear-gradient(180deg, rgba(50, 38, 86, 0.5) 0%, rgba(18, 12, 38, 0.7) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 9999px;
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  color: rgba(244, 241, 255, 0.65);
+  color: rgba(244, 241, 255, 0.7);
   cursor: pointer;
-  transition: var(--transition-fast);
+  transition: border-color 160ms ease, color 160ms ease, background 160ms ease;
   font-weight: 600;
 }
 
@@ -1642,9 +1730,9 @@ a.pill-verified:hover {
   line-height: 1;
 }
 
-.glyph-bullish { color: #2a8545; }
-.glyph-bearish { color: #c52d2d; }
-.glyph-neutral { color: rgba(244, 241, 255, 0.55); }
+.glyph-bullish { color: #c4b5fd; }
+.glyph-bearish { color: #f0abfc; }
+.glyph-neutral { color: rgba(244, 241, 255, 0.6); }
 
 .chip-active .chip-glyph {
   color: var(--color-white);
@@ -1697,9 +1785,10 @@ a.pill-verified:hover {
 }
 
 .reset-btn {
-  padding: 5px 12px;
+  padding: 5px 14px;
   background: transparent;
   border: 1px dashed rgba(244, 241, 255, 0.25);
+  border-radius: 9999px;
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.5px;


### PR DESCRIPTION
Continues the marketing-site design-system port, focused on the surfaces that still diverged. Verified visually with Chrome DevTools; `npm run build` passes.

## Explore page (least-ported surface) — full restyle
- Flat **"RUN A SIMULATION"** rectangle, card Open/Fork buttons, and every secondary control (consensus/quality chips, search, sort, refresh, load-more, reset, RSS/verified) → consistent **fully-round pills**.
- Gallery cards, filter bar, and empty/error states → **rounded glossy panels**.
- Bullish/bearish & quality signals: dark green `#2a8545` / red `#c52d2d` (unreadable on the near-black bg) → in-palette **violet/fuchsia**, matching the reference system's `--signal-up`/`--signal-down`.

## Contrast + button consistency across components
- Inverted "light button/badge" traps (`var(--color-black)` resolves to light) → purple-gradient pills (CounterfactualBranchPanel, WhatIfPanel) and a tinted dark badge (PolymarketChart).
- Settings **TEST CONNECTION**: black-on-dark text → legible light pill (also fixed a stray retired-font literal).
- Dark-on-dark error/outcome text (`#16a34a` / `#dc2626`) → bright legible variants (HistoryDatabase, Step3Simulation, InteractionNetwork, BeliefDriftChart).
- On-screen SVG chart gridlines/axis labels lightened so they're visible on the dark surface — the share-card **canvas** is left intentionally dark.

## Home
- Stacked simulation-records deck given an opaque base so the front card no longer lets the back card's text bleed through (the "double-exposure" glitch).

## Typography
- Repointed **73 stray hardcoded `Space Mono` / `Young Serif` literals** (including the share-card canvas in `chartExport.js`) to **Geist / Geist Mono**, and dropped both retired families from the Google Fonts link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)