### PR TITLE
Add HivemindOS to ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -20,7 +20,7 @@ These are the projects we know of that run MiroShark, extend it, or integrate wi
 | Blue Agent | [@blueagent_](https://x.com/blueagent_) · [blue-agent](https://github.com/madebyshun/blue-agent) |
 | Crucible Sim | [crucible-sim](https://github.com/wshuyi/crucible-sim) |
 | Echo | [@BuiltByEcho](https://x.com/BuiltByEcho) · [builtbyecho.xyz](https://www.builtbyecho.xyz/) |
-| HivemindOS | [website](https://hivemindos.liamvisionary.com) · [@thehivemindos](https://x.com/thehivemindos) · [@0xliamvisionary](https://x.com/0xliamvisionary) · [repo](https://github.com/LiamVisionary/hivemindos) · [Bankr launch](https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3) |
+| HivemindOS | [website](https://hivemindos.liamvisionary.com) · [@thehivemindos](https://x.com/thehivemindos) · [repo](https://github.com/LiamVisionary/hivemindos) |
 | Monitor | [monitor-the-situation-bags](https://github.com/Zoidberg-eternal/monitor-the-situation-bags) |
 | Noelclaw | [@noelclawfun](https://x.com/noelclawfun) · [noelclaw.com](https://noelclaw.com) · [mcp](https://github.com/noelclaw/mcp) |
 | Nookplot | [nookplot.com](https://nookplot.com/?view=network) |

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -20,6 +20,7 @@ These are the projects we know of that run MiroShark, extend it, or integrate wi
 | Blue Agent | [@blueagent_](https://x.com/blueagent_) · [blue-agent](https://github.com/madebyshun/blue-agent) |
 | Crucible Sim | [crucible-sim](https://github.com/wshuyi/crucible-sim) |
 | Echo | [@BuiltByEcho](https://x.com/BuiltByEcho) · [builtbyecho.xyz](https://www.builtbyecho.xyz/) |
+| HivemindOS | [repo](https://github.com/LiamVisionary/hivemindos) · [Bankr launch](https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3) |
 | Monitor | [monitor-the-situation-bags](https://github.com/Zoidberg-eternal/monitor-the-situation-bags) |
 | Noelclaw | [@noelclawfun](https://x.com/noelclawfun) · [noelclaw.com](https://noelclaw.com) · [mcp](https://github.com/noelclaw/mcp) |
 | Nookplot | [nookplot.com](https://nookplot.com/?view=network) |

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -20,7 +20,7 @@ These are the projects we know of that run MiroShark, extend it, or integrate wi
 | Blue Agent | [@blueagent_](https://x.com/blueagent_) · [blue-agent](https://github.com/madebyshun/blue-agent) |
 | Crucible Sim | [crucible-sim](https://github.com/wshuyi/crucible-sim) |
 | Echo | [@BuiltByEcho](https://x.com/BuiltByEcho) · [builtbyecho.xyz](https://www.builtbyecho.xyz/) |
-| HivemindOS | [repo](https://github.com/LiamVisionary/hivemindos) · [Bankr launch](https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3) |
+| HivemindOS | [website](https://hivemindos.liamvisionary.com) · [@thehivemindos](https://x.com/thehivemindos) · [@0xliamvisionary](https://x.com/0xliamvisionary) · [repo](https://github.com/LiamVisionary/hivemindos) · [Bankr launch](https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3) |
 | Monitor | [monitor-the-situation-bags](https://github.com/Zoidberg-eternal/monitor-the-situation-bags) |
 | Noelclaw | [@noelclawfun](https://x.com/noelclawfun) · [noelclaw.com](https://noelclaw.com) · [mcp](https://github.com/noelclaw/mcp) |
 | Nookplot | [nookplot.com](https://nookplot.com/?view=network) |


### PR DESCRIPTION
## Summary

Adds HivemindOS to the MiroShark ecosystem list.

HivemindOS includes MiroShark companion integration for scenario rehearsal and swarm simulation workflows from its local-first dashboard.

## Links

- Website: https://hivemindos.liamvisionary.com
- X: https://x.com/thehivemindos
- Dev X: https://x.com/0xliamvisionary
- Repo: https://github.com/LiamVisionary/hivemindos
- Bankr launch: https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3

## Verification

- Checked the ecosystem table remains alphabetized.