### PR TITLE
fix(ecosystem): add Sparkleware to machine-readable catalog

### DIFF
--- a/backend/app/services/ecosystem_catalog.py
+++ b/backend/app/services/ecosystem_catalog.py
@@ -181,6 +181,14 @@ _CATALOG: List[Dict[str, Any]] = [
         "repo": "https://github.com/codexvritra/signa-miroshark-skills",
     },
     {
+        "name": "Sparkleware",
+        "url": "https://sparkleware.fun",
+        "description": "Discovery registry that indexes MiroShark-on-Aeon skill packs and bundles them into an installable kit.",
+        "category": "integration",
+        "x_handle": "sparklewarefun",
+        "repo": None,
+    },
+    {
         "name": "SyntheticsAI",
         "url": "https://syntheticuser.org",
         "description": "Synthetic-user pipeline that runs MiroShark sims as the underlying behavioural engine.",


### PR DESCRIPTION
#144 added the Sparkleware row to `ECOSYSTEM.md` but not to the `ecosystem_catalog.py` literal, so the drift-guard unit test `test_catalog_names_match_ecosystem_md` started failing on `main`. This adds the matching catalog entry (category: `integration`) to restore sync.

Verified locally: `pytest tests/test_unit_ecosystem_catalog.py` → 18 passed.