### PR TITLE
refactor: dedup shared helpers (utc-iso8601, avg_position, public-base-url) + fix transcript bool bug

### DIFF
--- a/backend/app/api/feed.py
+++ b/backend/app/api/feed.py
@@ -36,33 +36,12 @@ from ..services.feed import (
     select_public_cards,
 )
 from ..services import surface_stats
+from ..utils.base_url import resolve_public_base_url as _resolve_base_url
 from ..utils.i18n import get_locale
 from ..utils.logger import get_logger
 
 
 logger = get_logger("miroshark.api.feed")
-
-
-def _resolve_base_url() -> str:
-    """Build the absolute URL prefix used inside the feed XML.
-
-    Prefers ``Config.PUBLIC_BASE_URL`` (the operator-supplied canonical
-    deployment URL — same field the webhook payload + share-card use)
-    so a feed served from ``localhost`` but configured for a public host
-    still points at the public host. Falls back to the request's host
-    URL with X-Forwarded-Proto/Host honored when behind a reverse proxy.
-    """
-    explicit = (Config.PUBLIC_BASE_URL or "").strip()
-    if explicit:
-        return explicit.rstrip("/")
-
-    base = (request.host_url or "").rstrip("/")
-    forwarded_proto = request.headers.get("X-Forwarded-Proto")
-    forwarded_host = request.headers.get("X-Forwarded-Host")
-    if forwarded_host:
-        proto = forwarded_proto or ("https" if request.is_secure else "http")
-        base = f"{proto}://{forwarded_host}"
-    return base
 
 
 def _is_truthy(value: str) -> bool:

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -11,7 +11,6 @@ from flask import request, jsonify
 
 from . import settings_bp
 from ..config import Config
-from ..services import webhook_service  # noqa: F401 — kept for namespace-style access
 from ..services.webhook_service import (
     mask_url as mask_webhook_url,
     send_test_webhook,

--- a/backend/app/api/share.py
+++ b/backend/app/api/share.py
@@ -37,6 +37,7 @@ from flask import Blueprint, Response, request
 
 from ..config import Config
 from ..services.simulation_manager import SimulationManager
+from ..utils.base_url import resolve_public_base_url as _resolve_oembed_base_url
 from ..utils.i18n import get_locale, t as _t
 from ..utils.validation import validate_simulation_id
 
@@ -293,28 +294,6 @@ def share_landing(simulation_id: str):
     # published sims show their card without long delays.
     response.headers["Cache-Control"] = "public, max-age=300"
     return response
-
-
-def _resolve_oembed_base_url() -> str:
-    """Canonical origin for the absolute URLs inside an oEmbed payload.
-
-    Same strategy as the feed / sitemap modules — prefer the operator-set
-    ``Config.PUBLIC_BASE_URL`` (single source of truth across surfaces),
-    falling back to the request host with ``X-Forwarded-Proto`` /
-    ``X-Forwarded-Host`` honoured for reverse-proxy deployments. Returns a
-    value with no trailing slash.
-    """
-    explicit = (Config.PUBLIC_BASE_URL or "").strip()
-    if explicit:
-        return explicit.rstrip("/")
-
-    base = (request.host_url or "").rstrip("/")
-    forwarded_proto = request.headers.get("X-Forwarded-Proto")
-    forwarded_host = request.headers.get("X-Forwarded-Host")
-    if forwarded_host:
-        proto = forwarded_proto or ("https" if request.is_secure else "http")
-        base = f"{proto}://{forwarded_host}"
-    return base
 
 
 def _oembed_allowed_hosts(base_url: str) -> set:

--- a/backend/app/api/sitemap.py
+++ b/backend/app/api/sitemap.py
@@ -30,39 +30,18 @@ Neo4j / LLM calls.
 
 from __future__ import annotations
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, jsonify
 
 from ..config import Config
 from ..services.simulation_manager import SimulationManager
 from ..services import sitemap as sitemap_service
+from ..utils.base_url import resolve_public_base_url as _resolve_base_url
 from ..utils.logger import get_logger
 
 
 logger = get_logger("miroshark.api.sitemap")
 
 sitemap_bp = Blueprint("sitemap", __name__)
-
-
-def _resolve_base_url() -> str:
-    """Build the absolute URL prefix used inside the sitemap document.
-
-    Identical strategy to the feed module — prefer ``Config.PUBLIC_BASE_URL``
-    when the operator has set it (single source of truth across the
-    feed / webhook / share-card / sitemap surfaces) and fall back to
-    the request's host with ``X-Forwarded-Proto`` / ``X-Forwarded-Host``
-    honored for reverse-proxy deployments.
-    """
-    explicit = (Config.PUBLIC_BASE_URL or "").strip()
-    if explicit:
-        return explicit.rstrip("/")
-
-    base = (request.host_url or "").rstrip("/")
-    forwarded_proto = request.headers.get("X-Forwarded-Proto")
-    forwarded_host = request.headers.get("X-Forwarded-Host")
-    if forwarded_host:
-        proto = forwarded_proto or ("https" if request.is_secure else "http")
-        base = f"{proto}://{forwarded_host}"
-    return base
 
 
 @sitemap_bp.route("/sitemap.xml", methods=["GET"])

--- a/backend/app/services/agent_sparklines_service.py
+++ b/backend/app/services/agent_sparklines_service.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import os
 from typing import Any, Optional
 
+from ..utils.belief import avg_position as _avg_position
 from ..utils.json_io import safe_load_json as _safe_load_json
 
 
@@ -98,26 +99,6 @@ def _load_profile_names(sim_dir: str) -> dict[int, str]:
 
 
 # ── Stance helpers ─────────────────────────────────────────────────────────
-
-
-def _avg_position(positions: Any) -> Optional[float]:
-    """Mean of an agent's per-topic belief positions for one round.
-
-    ``positions`` is the ``{topic: float}`` dict from one agent's entry in
-    a snapshot's ``belief_positions``. Non-numeric / boolean values are
-    filtered out; returns ``None`` when no usable value remains so the
-    caller can skip the agent for that round.
-    """
-    if not isinstance(positions, dict) or not positions:
-        return None
-    values = [
-        float(v)
-        for v in positions.values()
-        if isinstance(v, (int, float)) and not isinstance(v, bool)
-    ]
-    if not values:
-        return None
-    return sum(values) / len(values)
 
 
 def _classify_stance(value: float) -> str:

--- a/backend/app/services/archive_service.py
+++ b/backend/app/services/archive_service.py
@@ -73,8 +73,9 @@ import io
 import json
 import logging
 import zipfile
-from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from ..utils.timeutils import utc_iso8601 as _utc_iso8601
 
 
 SCHEMA_VERSION = "1"
@@ -137,13 +138,6 @@ _URL_PATH_BY_FILENAME: Dict[str, str] = {
 
 
 logger = logging.getLogger(__name__)
-
-
-def _utc_iso8601() -> str:
-    """ISO-8601 UTC ``YYYY-MM-DDTHH:MM:SSZ`` — same shape every other
-    export module uses (``repro_export``, ``signal_service``, the
-    webhook log)."""
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _sha256_hex(content: bytes) -> str:

--- a/backend/app/services/dkg_publisher.py
+++ b/backend/app/services/dkg_publisher.py
@@ -79,10 +79,10 @@ import os
 import threading
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 
 from ..utils.logger import get_logger
+from ..utils.timeutils import utc_iso8601 as _now_iso
 
 logger = get_logger("miroshark.dkg")
 
@@ -455,10 +455,6 @@ def build_turtle(
     lines.append(f'  mir:publishedAt "{_now_iso()}"^^xsd:dateTime .')
 
     return "\n".join(lines) + "\n", repro_sha
-
-
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 # ---- Citation file --------------------------------------------------------

--- a/backend/app/services/notebook_export.py
+++ b/backend/app/services/notebook_export.py
@@ -67,8 +67,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+
+from ..utils.timeutils import utc_iso8601 as _utc_iso8601
 
 
 # Schema versioning — bumping is a deliberate wire-contract break, not a
@@ -91,17 +92,6 @@ CELL_ORDER: tuple[str, ...] = (
 
 
 # ── Helpers ────────────────────────────────────────────────────────────
-
-
-def _utc_iso8601() -> str:
-    """Return UTC ``YYYY-MM-DDTHH:MM:SSZ`` matching the repro-export
-    timestamp grammar.
-
-    Same shape the webhook delivery log + reproduce.json export use so
-    downstream parsers see a single timestamp grammar across every
-    artifact.
-    """
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _safe_str(value: Any, default: str = "") -> str:

--- a/backend/app/services/outcome_distribution.py
+++ b/backend/app/services/outcome_distribution.py
@@ -72,11 +72,11 @@ from __future__ import annotations
 import os
 import threading
 import time
-from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 from . import signal_service
 from ..utils.json_io import safe_load_json as _safe_load_json
+from ..utils.timeutils import utc_iso8601 as _iso_utc_now
 
 
 # ── Configuration ─────────────────────────────────────────────────────────
@@ -255,12 +255,6 @@ def _round_count_bucket(total_rounds: int) -> str:
     if total_rounds > _LONG_ROUND_MIN_EXCLUSIVE:
         return "long"
     return "medium"
-
-
-def _iso_utc_now() -> str:
-    """ISO-8601 UTC ``"YYYY-MM-DDTHH:MM:SSZ"`` — same shape as
-    ``signal_service._iso_utc_now`` and the webhook timestamp."""
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _bucket_with_pcts(counts: Dict[str, int], total: int) -> Dict[str, Any]:

--- a/backend/app/services/repro_export.py
+++ b/backend/app/services/repro_export.py
@@ -74,8 +74,9 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+
+from ..utils.timeutils import utc_iso8601 as _utc_iso8601
 
 
 SCHEMA_VERSION = "1"
@@ -99,16 +100,6 @@ REQUIRED_KEYS: frozenset[str] = frozenset(
         "config_reasoning",
     }
 )
-
-
-def _utc_iso8601() -> str:
-    """Return the current UTC time as an ISO-8601 ``Z``-suffixed string.
-
-    Matches the timestamp shape used by the webhook delivery log + the
-    transcript front matter so downstream parsers see one timestamp
-    grammar across every export.
-    """
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _safe_int(value: Any, default: int = 0) -> int:

--- a/backend/app/services/signal_service.py
+++ b/backend/app/services/signal_service.py
@@ -43,8 +43,9 @@ Design notes
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, Literal, Optional
+
+from ..utils.timeutils import utc_iso8601 as _iso_utc_now
 
 
 # ── Bucket thresholds ─────────────────────────────────────────────────────
@@ -155,16 +156,6 @@ def _compute_confidence(leading_pct: float) -> float:
     if confidence > 100.0:
         confidence = 100.0
     return round(confidence, 1)
-
-
-def _iso_utc_now() -> str:
-    """ISO-8601 UTC ``"YYYY-MM-DDTHH:MM:SSZ"`` for the response.
-
-    Same shape as the webhook delivery log's ``timestamp`` field and
-    the reproduce.json blob's ``exported_at`` field — every export
-    surface that timestamps anything uses this format.
-    """
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def compute_signal(summary: Any) -> Optional[dict[str, Any]]:

--- a/backend/app/services/signed_result.py
+++ b/backend/app/services/signed_result.py
@@ -58,8 +58,9 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-from datetime import datetime, timezone
 from typing import Any, Dict, Optional
+
+from ..utils.timeutils import utc_iso8601 as _iso_utc_now
 
 
 SCHEMA_VERSION = "1"
@@ -73,15 +74,6 @@ ALGORITHM = "hmac-sha256"
 # JSON-Web-Signature-ish primitive uses. Recipients verify by recomputing
 # the hex digest and ``hmac.compare_digest``-ing against this field.
 _KEY_HINT_LENGTH = 8
-
-
-def _iso_utc_now() -> str:
-    """ISO-8601 UTC ``"YYYY-MM-DDTHH:MM:SSZ"`` for the envelope timestamp.
-
-    Same shape every other export surface uses (signal_service,
-    webhook_service log, reproduce.json's ``exported_at``).
-    """
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def canonical_json(payload: Dict[str, Any]) -> bytes:

--- a/backend/app/services/thread_formatter.py
+++ b/backend/app/services/thread_formatter.py
@@ -28,6 +28,7 @@ import json
 import os
 from typing import Optional
 
+from ..utils.belief import avg_position as _avg_position
 from ..utils.json_io import safe_load_json as _safe_load_json
 
 
@@ -56,24 +57,6 @@ TRUNCATED_HEAD_TAIL = 3
 
 
 # ── Stance computation ────────────────────────────────────────────────────
-
-
-def _avg_position(positions: dict | None) -> Optional[float]:
-    """Mean of an agent's per-topic belief positions for one round.
-
-    Filters non-numeric values so a snapshot mid-write doesn't crash the
-    build. Returns ``None`` when no usable values remain.
-    """
-    if not positions:
-        return None
-    values = [
-        float(v)
-        for v in positions.values()
-        if isinstance(v, (int, float)) and not isinstance(v, bool)
-    ]
-    if not values:
-        return None
-    return sum(values) / len(values)
 
 
 def _round_stance_split(snapshot: dict) -> dict[str, float]:

--- a/backend/app/services/trajectory_export.py
+++ b/backend/app/services/trajectory_export.py
@@ -29,6 +29,7 @@ import json
 import os
 from typing import Any, Optional
 
+from ..utils.belief import avg_position as _avg_position
 from ..utils.json_io import safe_load_json as _safe_load_json
 
 
@@ -59,25 +60,6 @@ CSV_COLUMNS: tuple[str, ...] = (
 
 
 # ── Stance computation ────────────────────────────────────────────────────
-
-
-def _avg_position(positions: dict | None) -> Optional[float]:
-    """Mean of an agent's per-topic belief positions for one round.
-
-    The per-topic dict can be empty or contain non-numeric values when
-    a snapshot is mid-write; we filter those out and return ``None`` if
-    no usable values remain.
-    """
-    if not positions:
-        return None
-    values = [
-        float(v)
-        for v in positions.values()
-        if isinstance(v, (int, float)) and not isinstance(v, bool)
-    ]
-    if not values:
-        return None
-    return sum(values) / len(values)
 
 
 def compute_stance_split(

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -23,6 +23,7 @@ import json
 import os
 from typing import Any, Optional
 
+from ..utils.belief import avg_position as _avg_position
 from ..utils.json_io import safe_load_json as _safe_load_json
 
 
@@ -63,21 +64,6 @@ def _classify_stance(value: float) -> str:
     if v < -STANCE_THRESHOLD:
         return "bearish"
     return "neutral"
-
-
-def _avg_position(positions: dict | None) -> Optional[float]:
-    """Mean of an agent's per-topic belief positions for one round.
-
-    ``positions`` is a ``{topic: float}`` dict; we collapse to one
-    scalar so the transcript can label the agent's stance without
-    listing every topic.
-    """
-    if not positions:
-        return None
-    values = [float(v) for v in positions.values() if isinstance(v, (int, float))]
-    if not values:
-        return None
-    return sum(values) / len(values)
 
 
 # ── On-disk artifact loaders ──────────────────────────────────────────────

--- a/backend/app/services/waybackclaw_publisher.py
+++ b/backend/app/services/waybackclaw_publisher.py
@@ -84,10 +84,10 @@ import os
 import threading
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..utils.logger import get_logger
+from ..utils.timeutils import utc_iso8601 as _now_iso
 
 logger = get_logger("miroshark.waybackclaw")
 
@@ -364,10 +364,6 @@ def _write_record(sim_dir: str, payload: Dict[str, Any]) -> None:
 
 def _sha256_hex(payload_bytes: bytes) -> str:
     return "sha256:" + hashlib.sha256(payload_bytes).hexdigest()
-
-
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _derive_capabilities(repro_blob: Dict[str, Any]) -> List[str]:

--- a/backend/app/utils/base_url.py
+++ b/backend/app/utils/base_url.py
@@ -1,0 +1,32 @@
+"""Shared canonical base-URL resolution for public-facing surfaces."""
+
+from flask import request
+
+from ..config import Config
+
+
+def resolve_public_base_url() -> str:
+    """Absolute origin (no trailing slash) for public absolute URLs.
+
+    Prefers the operator-set ``Config.PUBLIC_BASE_URL`` (the single source of
+    truth across the feed / sitemap / share-card / oEmbed surfaces) so a
+    service reached on ``localhost`` but configured for a public host still
+    emits public URLs. Falls back to the request host with
+    ``X-Forwarded-Proto`` / ``X-Forwarded-Host`` honoured for reverse-proxy
+    deployments. Requires an active Flask request context for the fallback.
+
+    Note: ``watch.py`` and ``webhook_service.py`` deliberately keep their own
+    resolvers — the former never prefers ``PUBLIC_BASE_URL``, the latter runs
+    without a request context — so they are not consolidated here.
+    """
+    explicit = (Config.PUBLIC_BASE_URL or "").strip()
+    if explicit:
+        return explicit.rstrip("/")
+
+    base = (request.host_url or "").rstrip("/")
+    forwarded_proto = request.headers.get("X-Forwarded-Proto")
+    forwarded_host = request.headers.get("X-Forwarded-Host")
+    if forwarded_host:
+        proto = forwarded_proto or ("https" if request.is_secure else "http")
+        base = f"{proto}://{forwarded_host}"
+    return base

--- a/backend/app/utils/belief.py
+++ b/backend/app/utils/belief.py
@@ -1,0 +1,24 @@
+"""Shared belief-position helpers."""
+
+from typing import Any, Optional
+
+
+def avg_position(positions: Any) -> Optional[float]:
+    """Mean of an agent's per-topic belief positions for one round.
+
+    ``positions`` is the ``{topic: float}`` dict from one agent's entry in a
+    snapshot's ``belief_positions``. Non-numeric and boolean values are
+    filtered out (a snapshot can be mid-write, and ``bool`` is a numeric
+    subtype we never want averaged in); returns ``None`` when no usable value
+    remains so the caller can skip that agent for the round.
+    """
+    if not isinstance(positions, dict) or not positions:
+        return None
+    values = [
+        float(v)
+        for v in positions.values()
+        if isinstance(v, (int, float)) and not isinstance(v, bool)
+    ]
+    if not values:
+        return None
+    return sum(values) / len(values)

--- a/backend/app/utils/timeutils.py
+++ b/backend/app/utils/timeutils.py
@@ -1,0 +1,13 @@
+"""Shared time-formatting helpers."""
+
+from datetime import datetime, timezone
+
+
+def utc_iso8601() -> str:
+    """Current UTC time as an ISO-8601 ``YYYY-MM-DDTHH:MM:SSZ`` string.
+
+    The canonical timestamp grammar shared by every export/publish surface
+    (repro, archive, notebook, signal, outcome-distribution, signed-result,
+    and the dkg / waybackclaw publishers) and the webhook delivery log.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
Follow-up to #163 — implements the high-confidence DRY items deferred in `docs/cleanup/round2-00-SUMMARY.md`, each verified byte-identical before consolidating.

## Changes
- **`utc_iso8601()`** (`app/utils/timeutils.py`) — replaces **8 byte-identical** local ISO-8601 timestamp helpers (under 3 different names) across repro / archive / notebook / signal / outcome-distribution / signed-result / dkg / waybackclaw.
- **`avg_position()`** (`app/utils/belief.py`) — replaces 4 near-identical belief-average helpers, and **fixes a latent bug**: `transcript.py`'s copy was missing the `not isinstance(v, bool)` filter, so `True` counted as `1.0`. It now matches the other three (bool excluded).
- **`resolve_public_base_url()`** (`app/utils/base_url.py`) — replaces 3 byte-identical resolvers in feed / sitemap / share-oembed. `watch.py` and `webhook_service.py` keep their own (deliberately different — no `PUBLIC_BASE_URL` preference / no request context).
- Dropped a dead `from ..services import webhook_service  # noqa: F401` namespace import in `settings.py` (nothing used it), and cleaned the now-orphaned `datetime` / `request` imports.

Call sites are unchanged — each canonical function is alias-imported to its old local name, matching the `safe_load_json` pattern from #163.

## Verification
- `pytest`: **1370 passed / 2 failed / 17 skipped** — unchanged. The 2 failures are the pre-existing `demographic_grounding` cases (`LLM_API_KEY` not configured), red on `main` too.
- `ruff check backend`: **156 → 156** (zero new errors).
- Net **+90 / −209** (−119 lines) across 19 files; ISO grammar byte-identical, `avg_position` bool-fix unit-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
