### PR TITLE
test: fix 2 demographic-grounding tests that required LLM_API_KEY

### DIFF
--- a/backend/tests/test_unit_demographic_grounding.py
+++ b/backend/tests/test_unit_demographic_grounding.py
@@ -210,7 +210,10 @@ def test_generator_with_unknown_country_falls_back_to_graph_only():
 
     from app.services.wonderwall_profile_generator import WonderwallProfileGenerator
 
-    gen = WonderwallProfileGenerator(country_code="xx")
+    # __init__ eagerly builds an LLM client (needs LLM_API_KEY); that client is
+    # irrelevant to this demographic-wiring check, so stub its construction out.
+    with patch("app.services.wonderwall_profile_generator.create_llm_client"):
+        gen = WonderwallProfileGenerator(country_code="xx")
     assert gen.country_code == "xx"
     # The pre-sim map is populated only when the sampler returns rows.
     # With an unknown country it stays empty and the worker thread sees
@@ -228,6 +231,7 @@ def test_generator_no_country_means_feature_off():
         # Re-import config to pick up the env override.
         from app import config as _cfg
         _cfg.Config.DEMOGRAPHICS_COUNTRY = ""
-        gen = WonderwallProfileGenerator()
+        with patch("app.services.wonderwall_profile_generator.create_llm_client"):
+            gen = WonderwallProfileGenerator()
         assert gen.country_code is None
         assert gen._demographic_seeds_by_user_id == {}


### PR DESCRIPTION
The 2 `test_unit_demographic_grounding.py` generator tests have been red on `main` in any environment without `LLM_API_KEY` set.

**Root cause:** they build a real `WonderwallProfileGenerator`, whose `__init__` eagerly calls `create_llm_client(...)` → raises `ValueError: LLM_API_KEY is not configured`. The LLM client is irrelevant to what these tests verify (that `country_code` and the demographic-seed map are wired correctly for the unknown-country / feature-off paths).

**Fix:** mock `create_llm_client` inside each test (after `pytest.importorskip("camel")`, so clean-skip behavior is preserved). No production code touched.

**Result:** `pytest` → **1372 passed / 0 failed / 17 skipped** (was 1370 passed / 2 failed). Fully green locally with no API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
