### PR TITLE
ci: build the frontend on every PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,3 +44,25 @@ jobs:
       - name: Run unit tests
         run: pytest -m "not integration"
 
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+


### PR DESCRIPTION
## Why

PR CI only ran **backend unit tests** + GitGuardian — nothing compiled the frontend. That meant frontend dependency bumps (vite, vue-router, the frontend-minor-patch group) all showed green CI even though no build ever ran against them. The Dockerfile only runs `vite` in dev mode and the `docker-image.yml` job is tag-triggered, so a frontend build break would only surface at release time.

## What

Adds a `Frontend build` job to `tests.yml` that runs `npm ci && npm run build` on Node 22 with npm caching. A broken frontend now fails the PR instead of slipping through.

## Notes

- Node 22 is forward-compatible with the pending Vite 8 / Vue Router 5 bumps (both require Node ≥20.19/22.12), so this also gives those PRs a real signal.
- Runs in parallel with the existing backend `unit` job; no change to backend testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)