### PR TITLE
fix(wonderwall): camel-ai 0.2.90 _aget_model_response signature compat (unblocks #176)

### DIFF
--- a/backend/wonderwall/social_agent/agent.py
+++ b/backend/wonderwall/social_agent/agent.py
@@ -169,7 +169,7 @@ class SocialAgent(ChatAgent):
             "\n"
             "What do you think Helen should do?")
 
-    async def _aget_model_response(self, openai_messages, num_tokens, **kwargs):
+    async def _aget_model_response(self, openai_messages, *args, **kwargs):
         """Filter empty-content messages that Gemini rejects with INVALID_ARGUMENT,
         and emit llm_call observability events for Wonderwall subprocess visibility."""
         import os as _os
@@ -238,7 +238,7 @@ class SocialAgent(ChatAgent):
         error_msg = None
         result = None
         try:
-            result = await super()._aget_model_response(filtered, num_tokens, **kwargs)
+            result = await super()._aget_model_response(filtered, *args, **kwargs)
             return result
         except Exception as e:
             error_msg = str(e)


### PR DESCRIPTION
## TL;DR
The camel-ai **0.2.90** bump (#176) **silently breaks the entire agent simulation loop**. This 2-line change fixes it and is safe on the current 0.2.78 pin too, so it can land first and unblock #176.

## Root cause
`SocialAgent` (in `backend/wonderwall/social_agent/agent.py`) overrides camel's internal `ChatAgent._aget_model_response` to filter empty-content messages + emit `llm_call` observability events. camel-ai refactored that method between 0.2.78 and 0.2.90:

- **0.2.78:** `_aget_model_response(self, openai_messages, num_tokens, ...)`
- **0.2.90:** `_aget_model_response(self, openai_messages, current_iteration=0, response_format=None, tool_schemas=None, prev_num_openai_messages=0, ...)` — **`num_tokens` removed**, and it's called by keyword.

Our override still declares `num_tokens` as a required positional, so under 0.2.90 **every agent step** raises:

```
TypeError: SocialAgent._aget_model_response() missing 1 required positional argument: 'num_tokens'
```

`perform_action_by_llm` catches the exception per-agent, so the simulation runs to "completion" with **zero agent actions** and still emits a report (built from personas alone). It's a silent failure — and backend CI can't catch it because CI doesn't install camel-ai.

## Fix
Accept/forward the response args via `*args` instead of the removed `num_tokens`. Works on **both** versions (0.2.78 captures `num_tokens` in `*args`; 0.2.90 passes its kwargs straight through).

```diff
-    async def _aget_model_response(self, openai_messages, num_tokens, **kwargs):
+    async def _aget_model_response(self, openai_messages, *args, **kwargs):
...
-            result = await super()._aget_model_response(filtered, num_tokens, **kwargs)
+            result = await super()._aget_model_response(filtered, *args, **kwargs)
```

## Verification
Ran a real 1-round, 3-platform simulation locally on **camel-ai 0.2.90** (OpenRouter backend, Neo4j):

| | result | persisted to platform DBs |
|---|---|---|
| 0.2.90, unmodified | `TypeError` every step → **0 actions** | nothing |
| 0.2.90 + this fix | agents act in-character | **twitter: 7 posts · reddit: 5 posts + 22 comments · polymarket: 8 trades** |

## Follow-ups (out of scope here)
- The runner's `total_actions_count` logs `0` even when actions land in the platform DBs — a metrics bug that's *what lets a dead agent loop look like a healthy run*. Worth a separate fix.
- Consider a CI smoke job that installs camel-ai and asserts a tiny sim produces >0 actions, so a future camel bump can't silently break the loop again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)