### PR TITLE
fix+ci: correct total_actions reporting + add camel agent smoke test (#181 follow-ups)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,3 +66,42 @@ jobs:
       - name: Build
         run: npm run build
 
+  camel-smoke:
+    name: Camel agent smoke test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # The unit job deliberately skips camel-ai/torch, so nothing else in CI
+      # exercises the camel <-> wonderwall integration. This job installs the
+      # REAL camel-ai (from requirements.txt, so a Dependabot bump re-triggers
+      # it) plus the wonderwall runtime deps that requirements.txt omits
+      # (torch/igraph/etc., kept in pyproject). A future camel-ai release that
+      # breaks the agent loop (see #181) then fails here instead of silently
+      # shipping a simulation that produces zero actions.
+      - name: Install camel + wonderwall runtime deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt
+          pip install \
+            "numpy>=1.26.0" \
+            "pandas>=2.0.0" \
+            "scikit-learn>=1.3.0" \
+            "igraph>=0.11.0" \
+            "sentence-transformers>=2.2.0" \
+            "pytest>=8.0.0" \
+            "pytest-asyncio>=0.23.0"
+
+      - name: Run camel agent smoke test
+        run: pytest tests/test_smoke_camel_agent.py -v
+

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -2800,10 +2800,20 @@ async def run_synchronized_simulation(
             log_info(f"[{name}] Trajectory saved: {traj_path}")
             log_info(f"[{name}] {tracker.get_summary()}")
 
-    # End loggers
-    for logger, name in [(twitter_logger, "Twitter"), (reddit_logger, "Reddit"), (polymarket_logger, "Polymarket")]:
+    # End loggers — report each platform's actual action count. The
+    # per-platform `*_result.total_actions` are accumulated every round (and
+    # surfaced in the progress line above); emitting a hardcoded 0 here made
+    # the runner log `total_actions=0` even on fully successful runs, masking
+    # whether the agent loop did anything.
+    for logger, name, result in [
+        (twitter_logger, "Twitter", twitter_result),
+        (reddit_logger, "Reddit", reddit_result),
+        (polymarket_logger, "Polymarket", polymarket_result),
+    ]:
         if logger:
-            logger.log_simulation_end(total_rounds, 0)
+            logger.log_simulation_end(
+                total_rounds, result.total_actions if result else 0
+            )
 
     return twitter_result, reddit_result, polymarket_result
 

--- a/backend/tests/test_smoke_camel_agent.py
+++ b/backend/tests/test_smoke_camel_agent.py
@@ -1,0 +1,78 @@
+"""Smoke test: the wonderwall ``SocialAgent`` must stay call-compatible with
+the installed ``camel-ai`` version.
+
+camel-ai periodically refactors ``ChatAgent`` internals. In 0.2.90 it changed
+how it invokes the overridable ``_aget_model_response`` (it dropped the
+``num_tokens`` positional argument), which silently broke **every** agent step
+in the simulation loop until the override was made signature-agnostic — every
+``perform_action_by_llm`` raised ``TypeError: _aget_model_response() missing 1
+required positional argument: 'num_tokens'``, the exception was swallowed per
+agent, and simulations "completed" with zero actions (see PR #181).
+
+The backend unit suite cannot catch this because it deliberately does not
+install camel-ai/torch. This module is run by the dedicated ``camel-smoke`` CI
+job, which installs them. It is driven by camel's STUB model, so it needs no
+API key and makes no network calls.
+"""
+import asyncio
+import inspect
+
+import pytest
+
+# Heavy deps (camel-ai, torch) are only present in the camel-smoke CI job.
+# Skip the whole module cleanly in the thin unit job instead of erroring.
+pytest.importorskip("camel")
+pytest.importorskip("torch")
+
+from camel.models import ModelFactory  # noqa: E402
+from camel.types import ModelPlatformType  # noqa: E402
+
+from wonderwall.social_agent.agent import SocialAgent  # noqa: E402
+from wonderwall.social_platform import Channel  # noqa: E402
+from wonderwall.social_platform.config import UserInfo  # noqa: E402
+
+
+def _make_stub_agent() -> SocialAgent:
+    """A SocialAgent backed by camel's STUB model — no API key, no network."""
+    model = ModelFactory.create(
+        model_platform=ModelPlatformType.STUB,
+        model_type="stub",
+    )
+    user_info = UserInfo(
+        is_controllable=False,
+        profile={"other_info": {"user_profile": "smoke-test persona"}},
+        recsys_type="twitter",
+    )
+    return SocialAgent(
+        agent_id=0,
+        user_info=user_info,
+        channel=Channel(),
+        model=model,
+    )
+
+
+def test_aget_model_response_is_signature_forward_compatible():
+    """The override must accept whatever args camel passes, so a future camel
+    signature change can't break it the way 0.2.90 did (#181)."""
+    kinds = {
+        p.kind
+        for p in inspect.signature(SocialAgent._aget_model_response).parameters.values()
+    }
+    assert inspect.Parameter.VAR_POSITIONAL in kinds, (
+        "_aget_model_response must forward *args — camel passes model-response "
+        "args positionally and hardcoding them broke the agent loop in #181"
+    )
+    assert inspect.Parameter.VAR_KEYWORD in kinds, (
+        "_aget_model_response must forward **kwargs to absorb new camel kwargs"
+    )
+
+
+def test_socialagent_step_drives_aget_model_response_without_signature_error():
+    """End-to-end: camel must be able to drive SocialAgent's overridden async
+    model-response path. Reproduces the exact code path #181 broke. astep()
+    (not step()) goes through the async ``_aget_model_response`` override."""
+    agent = _make_stub_agent()
+    response = asyncio.run(agent.astep("Say hello."))
+    assert response is not None
+    # A wrong override signature would have raised TypeError above before
+    # returning a response.


### PR DESCRIPTION
Closes the two follow-ups flagged during the camel-ai 0.2.90 investigation (#181).

## 1. `total_actions` metrics bug
`run_synchronized_simulation` accumulates each platform's count correctly into `*_result.total_actions` (it's even printed in the progress line — `X:4 R:4 PM:1`), but the end-of-run loop emitted:

```python
logger.log_simulation_end(total_rounds, 0)   # hardcoded 0
```

So the runner logged `total_actions=0` on **fully successful** runs where actions *did* land in the platform DBs. That's exactly what made the #181 dead-agent-loop look like a healthy run — `0` reads the same whether agents errored out or worked. Fixed to forward each platform's real `*_result.total_actions`.

## 2. Camel agent smoke test + CI job
The `Backend unit tests` job deliberately skips camel-ai/torch, so **nothing in CI exercised the camel ↔ wonderwall integration** — which is why the 0.2.90 `_aget_model_response` signature break shipped silently and only surfaced when running a real sim.

- New `backend/tests/test_smoke_camel_agent.py`: drives the **real** `SocialAgent` through camel's async model-response path using camel's **STUB** model (no API key, no network), and asserts the override stays signature-compatible.
- New `camel-smoke` CI job: installs the real camel-ai (from `requirements.txt`, so a Dependabot bump re-triggers it) + the wonderwall runtime deps, and runs the smoke test.
- The thin unit job skips the new test cleanly via `pytest.importorskip`.

## Verification
- `total_actions` fix: the per-platform counts were already correct (progress line); only the emission was `0`.
- Smoke test: **passes** on current code, and **fails** with the exact `TypeError: SocialAgent._aget_model_response() missing 1 required positional argument: 'num_tokens'` when the #181 fix is reverted — confirming it guards the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)