### PR TITLE
feat(i18n): generalize locale helpers + German/French foundation (#161, #95)

### DIFF
--- a/backend/app/prompts/locales/de/graph_tools.py
+++ b/backend/app/prompts/locales/de/graph_tools.py
@@ -1,0 +1,8 @@
+"""German translations for ``app.prompts.graph_tools``.
+
+Mirror the keys in ``app/prompts/locales/en/graph_tools.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/de/ner_extractor.py
+++ b/backend/app/prompts/locales/de/ner_extractor.py
@@ -1,0 +1,8 @@
+"""German translations for ``app.prompts.ner_extractor``.
+
+Mirror the keys in ``app/prompts/locales/en/ner_extractor.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/de/ontology.py
+++ b/backend/app/prompts/locales/de/ontology.py
@@ -1,0 +1,8 @@
+"""German translations for ``app.prompts.ontology``.
+
+Mirror the keys in ``app/prompts/locales/en/ontology.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/de/profile_generator.py
+++ b/backend/app/prompts/locales/de/profile_generator.py
@@ -1,0 +1,8 @@
+"""German translations for ``app.prompts.profile_generator``.
+
+Mirror the keys in ``app/prompts/locales/en/profile_generator.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/de/report_agent.py
+++ b/backend/app/prompts/locales/de/report_agent.py
@@ -1,0 +1,8 @@
+"""German translations for ``app.prompts.report_agent``.
+
+Mirror the keys in ``app/prompts/locales/en/report_agent.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/de/simulation_config.py
+++ b/backend/app/prompts/locales/de/simulation_config.py
@@ -1,0 +1,8 @@
+"""German translations for ``app.prompts.simulation_config``.
+
+Mirror the keys in ``app/prompts/locales/en/simulation_config.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/de/social_simulations.py
+++ b/backend/app/prompts/locales/de/social_simulations.py
@@ -1,0 +1,8 @@
+"""German translations for ``app.prompts.social_simulations``.
+
+Mirror the keys in ``app/prompts/locales/en/social_simulations.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/de/web_enrichment.py
+++ b/backend/app/prompts/locales/de/web_enrichment.py
@@ -1,0 +1,8 @@
+"""German translations for ``app.prompts.web_enrichment``.
+
+Mirror the keys in ``app/prompts/locales/en/web_enrichment.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/fr/graph_tools.py
+++ b/backend/app/prompts/locales/fr/graph_tools.py
@@ -1,0 +1,8 @@
+"""French translations for ``app.prompts.graph_tools``.
+
+Mirror the keys in ``app/prompts/locales/en/graph_tools.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/fr/ner_extractor.py
+++ b/backend/app/prompts/locales/fr/ner_extractor.py
@@ -1,0 +1,8 @@
+"""French translations for ``app.prompts.ner_extractor``.
+
+Mirror the keys in ``app/prompts/locales/en/ner_extractor.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/fr/ontology.py
+++ b/backend/app/prompts/locales/fr/ontology.py
@@ -1,0 +1,8 @@
+"""French translations for ``app.prompts.ontology``.
+
+Mirror the keys in ``app/prompts/locales/en/ontology.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/fr/profile_generator.py
+++ b/backend/app/prompts/locales/fr/profile_generator.py
@@ -1,0 +1,8 @@
+"""French translations for ``app.prompts.profile_generator``.
+
+Mirror the keys in ``app/prompts/locales/en/profile_generator.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/fr/report_agent.py
+++ b/backend/app/prompts/locales/fr/report_agent.py
@@ -1,0 +1,8 @@
+"""French translations for ``app.prompts.report_agent``.
+
+Mirror the keys in ``app/prompts/locales/en/report_agent.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/fr/simulation_config.py
+++ b/backend/app/prompts/locales/fr/simulation_config.py
@@ -1,0 +1,8 @@
+"""French translations for ``app.prompts.simulation_config``.
+
+Mirror the keys in ``app/prompts/locales/en/simulation_config.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/fr/social_simulations.py
+++ b/backend/app/prompts/locales/fr/social_simulations.py
@@ -1,0 +1,8 @@
+"""French translations for ``app.prompts.social_simulations``.
+
+Mirror the keys in ``app/prompts/locales/en/social_simulations.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/prompts/locales/fr/web_enrichment.py
+++ b/backend/app/prompts/locales/fr/web_enrichment.py
@@ -1,0 +1,8 @@
+"""French translations for ``app.prompts.web_enrichment``.
+
+Mirror the keys in ``app/prompts/locales/en/web_enrichment.py``. Any key left out of
+this dict falls back to the English source automatically — see
+``app/prompts/registry.py``.
+"""
+
+PROMPTS: dict[str, str] = {}

--- a/backend/app/utils/i18n.py
+++ b/backend/app/utils/i18n.py
@@ -16,7 +16,7 @@ import contextvars
 from typing import Any, Mapping, Optional
 
 
-SUPPORTED = ("en", "zh-CN")
+SUPPORTED = ("en", "zh-CN", "de", "fr")
 DEFAULT = "en"
 
 # Active locale for the current execution context. Set at the API entry
@@ -42,6 +42,10 @@ def normalize_locale(raw: Optional[str]) -> str:
         return "zh-CN"
     if head_lc.startswith("en"):
         return "en"
+    if head_lc.startswith("de"):
+        return "de"
+    if head_lc.startswith("fr"):
+        return "fr"
     return DEFAULT
 
 
@@ -116,14 +120,20 @@ class use_locale:
             self._token = None
 
 
-def t(en: str, zh: str, locale: str = DEFAULT) -> str:
-    """Pick a translation given a locale.
+def t(en: str, zh: str = "", locale: str = DEFAULT, *, de: str = "", fr: str = "") -> str:
+    """Pick a translation for ``locale``, falling back to the English source.
 
-    Falls back to the English source if no Chinese is provided.
+    ``en`` is the canonical source string. ``zh`` (kept positional for the
+    existing two-language call sites) / ``de`` / ``fr`` are optional per-locale
+    overrides; an empty or omitted override falls back to English — so a call
+    site that hasn't been translated yet stays English under any locale.
+
+    Adding a language: add a keyword here keyed to its BCP-47 code below,
+    append the code to :data:`SUPPORTED`, add a branch in
+    :func:`normalize_locale`, and create ``app/prompts/locales/<locale>/``.
     """
-    if locale == "zh-CN" and zh:
-        return zh
-    return en
+    overrides = {"zh-CN": zh, "de": de, "fr": fr}
+    return overrides.get(locale) or en
 
 
 def apply_i18n(payload: Any, locale: str) -> Any:

--- a/backend/tests/test_unit_i18n.py
+++ b/backend/tests/test_unit_i18n.py
@@ -129,8 +129,17 @@ def test_normalize_locale_picks_first_tag_from_accept_language_list():
     assert normalize_locale("en-US,en;q=0.9,zh;q=0.8") == "en"
 
 
+def test_normalize_locale_maps_de_and_fr_prefixes():
+    assert normalize_locale("de") == "de"
+    assert normalize_locale("de-DE") == "de"
+    assert normalize_locale("DE-at") == "de"
+    assert normalize_locale("fr") == "fr"
+    assert normalize_locale("fr-FR") == "fr"
+    assert normalize_locale("FR-ca") == "fr"
+
+
 def test_normalize_locale_unknown_tag_falls_back_to_default():
-    assert normalize_locale("fr-FR") == DEFAULT
+    assert normalize_locale("ja-JP") == DEFAULT
     assert normalize_locale("klingon") == DEFAULT
     assert normalize_locale("xx-YY,zz;q=0.9") == DEFAULT
 
@@ -213,9 +222,21 @@ def test_t_falls_back_to_english_when_zh_is_empty_under_zh_cn():
 
 
 def test_t_unknown_locale_falls_back_to_english():
-    """Adding a 3rd locale must not break callers that haven't migrated yet."""
+    """A call site that hasn't supplied a string for the active locale stays
+    English — so adding locales never breaks un-migrated callers."""
     assert t("hello", "你好", "fr") == "hello"
+    assert t("hello", "你好", "de") == "hello"
     assert t("hello", "你好", "klingon") == "hello"
+
+
+def test_t_returns_german_and_french_when_supplied():
+    assert t("hello", "你好", "de", de="hallo") == "hallo"
+    assert t("hello", "你好", "fr", fr="bonjour") == "bonjour"
+    # An empty override under its own locale still falls back to English.
+    assert t("hello", "你好", "de", de="") == "hello"
+    # Providing de/fr never disturbs the English or Chinese paths.
+    assert t("hello", "你好", "en", de="hallo", fr="bonjour") == "hello"
+    assert t("hello", "你好", "zh-CN", de="hallo", fr="bonjour") == "你好"
 
 
 # ── apply_i18n ──────────────────────────────────────────────────────────────

--- a/frontend/src/components/LocaleToggle.vue
+++ b/frontend/src/components/LocaleToggle.vue
@@ -1,32 +1,45 @@
 <template>
-  <button
-    class="locale-toggle"
-    :class="{ active: locale === 'zh-CN' }"
-    type="button"
-    :title="locale === 'zh-CN' ? 'Switch to English' : '切换到中文'"
-    :aria-label="locale === 'zh-CN' ? 'Switch to English' : 'Switch to Chinese'"
-    @click="toggleLocale"
-  >
-    <span class="locale-toggle-flag" aria-hidden="true">{{ locale === 'zh-CN' ? '中' : 'EN' }}</span>
-    <span class="locale-toggle-text">{{ locale === 'zh-CN' ? 'EN' : '中' }}</span>
-  </button>
+  <div class="locale-select-wrap">
+    <select
+      class="locale-select"
+      :value="locale"
+      aria-label="Select language"
+      title="Select language"
+      @change="onChange"
+    >
+      <option v-for="loc in locales" :key="loc" :value="loc">{{ labels[loc] }}</option>
+    </select>
+    <span class="locale-select-caret" aria-hidden="true">▾</span>
+  </div>
 </template>
 
 <script setup>
-import { useI18n } from '../i18n'
+import { useI18n, SUPPORTED_LOCALES, LOCALE_LABELS } from '../i18n'
 
-const { locale, toggleLocale } = useI18n()
+const { locale, setLocale } = useI18n()
+const locales = SUPPORTED_LOCALES
+const labels = LOCALE_LABELS
+
+function onChange(event) {
+  setLocale(event.target.value)
+}
 </script>
 
 <style scoped>
-/* Matches the dark glossy nav-pill family on the Home view. The
-   original orange Hyperstitions look is intentionally dropped. */
-.locale-toggle {
+/* Matches the dark glossy nav-pill family on the Home view. Replaces the old
+   binary EN/中 toggle with a selector now that more than two locales exist. */
+.locale-select-wrap {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+}
+
+.locale-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
   height: 36px;
-  padding: 0 10px;
+  padding: 0 26px 0 12px;
   font-family: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace;
   font-size: 11px;
   font-weight: 600;
@@ -44,32 +57,28 @@ const { locale, toggleLocale } = useI18n()
   transition: border-color 180ms ease, transform 180ms ease, color 180ms ease;
 }
 
-.locale-toggle:hover {
+.locale-select:hover {
   color: #ffffff;
   border-color: rgba(167, 139, 250, 0.55);
   transform: translateY(-1px);
 }
 
-.locale-toggle.active {
-  color: #ffffff;
-  border-color: rgba(167, 139, 250, 0.55);
+.locale-select:focus-visible {
+  outline: none;
+  border-color: rgba(167, 139, 250, 0.75);
 }
 
-.locale-toggle-flag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 22px;
-  padding: 2px 6px;
-  border-radius: 9999px;
-  font-size: 10px;
-  font-weight: 700;
-  color: #f4f1ff;
-  background: linear-gradient(180deg, rgba(167, 139, 250, 0.35) 0%, rgba(76, 29, 149, 0.55) 100%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+.locale-select option {
+  /* Native option lists render on the OS theme; keep them legible. */
+  color: #14122a;
+  background: #ece8ff;
 }
 
-.locale-toggle-text {
-  opacity: 0.65;
+.locale-select-caret {
+  position: absolute;
+  right: 10px;
+  font-size: 9px;
+  color: #cfc6ff;
+  pointer-events: none;
 }
 </style>

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -2,8 +2,11 @@ import { ref, computed } from 'vue'
 
 const STORAGE_KEY = 'miroshark.locale'
 const ZH_WARNING_KEY = 'miroshark.zh-warning-seen'
-const SUPPORTED = ['en', 'zh-CN']
+const SUPPORTED = ['en', 'zh-CN', 'de', 'fr']
 const DEFAULT_LOCALE = 'en'
+
+// Compact display labels for the language selector (sized for the nav pill).
+const LABELS = { 'en': 'EN', 'zh-CN': '中', 'de': 'DE', 'fr': 'FR' }
 
 function readInitial() {
   try {
@@ -57,11 +60,20 @@ export function dismissZhWarning() {
 }
 
 export function toggleLocale() {
-  setLocale(locale.value === 'zh-CN' ? 'en' : 'zh-CN')
+  // Cycle through the supported locales (kept for callers that used the old
+  // binary toggle; the nav now renders a full selector via setLocale).
+  const i = SUPPORTED.indexOf(locale.value)
+  setLocale(SUPPORTED[(i + 1) % SUPPORTED.length])
 }
 
-export function tr(en, zh) {
-  if (locale.value === 'zh-CN' && zh != null && zh !== '') return zh
+export function tr(en, zh, extra) {
+  const loc = locale.value
+  if (loc === 'zh-CN') return (zh != null && zh !== '') ? zh : en
+  // German / French (and any future locale) are supplied via an optional map
+  // keyed by locale code, e.g. tr('Hello', '你好', { de: 'Hallo', fr: 'Bonjour' }).
+  // Existing two-arg tr(en, zh) calls fall back to English under those locales
+  // until a string is added.
+  if (extra && extra[loc] != null && extra[loc] !== '') return extra[loc]
   return en
 }
 
@@ -89,3 +101,4 @@ export const i18nPlugin = {
 }
 
 export const SUPPORTED_LOCALES = SUPPORTED
+export const LOCALE_LABELS = LABELS


### PR DESCRIPTION
Lays the multi-language foundation so contributors can add German (#161, @dan-and) and French (#95) by just filling in strings — no further code changes.

## Backend — app/utils/i18n.py
- SUPPORTED -> (en, zh-CN, de, fr); normalize_locale maps de*/fr* prefixes.
- t() generalized from the hardcoded (en, zh) form to locale-keyed: en/zh stay positional so all 199 existing _t(en, zh, locale) call sites are unchanged, plus optional de=/fr= keywords. Empty/omitted overrides fall back to English.
- apply_i18n() and the prompt registry were already locale-generic; available_locales() auto-discovers the new dirs.

## Backend — prompt scaffold
- app/prompts/locales/{de,fr}/ mirroring en/ (one PROMPTS = {} module per prompt file). Missing keys fall back to English via the registry, so selecting de/fr is safe before translation lands.

## Frontend — src/i18n.js, components/LocaleToggle.vue
- SUPPORTED adds de/fr; tr() takes an optional third map arg, e.g. tr('Hi','你好',{de:'Hallo',fr:'Bonjour'}); existing two-arg calls fall back to English. toggleLocale() cycles all locales.
- LocaleToggle is now a language <select> (EN / 中 / DE / FR) instead of the binary EN<->中 button.

## Left for contributors (strings only)
- Backend: add de=/fr= to the ~199 _t(...) call sites.
- Prompts: fill the PROMPTS dicts in locales/de/ and locales/fr/.
- Frontend: add the third map arg at tr(...) call sites.

## Verification
- 32 i18n unit tests pass (incl. new de/fr cases + the fixed unknown-tag test).
- available_locales() -> [de, en, fr, zh-CN].
- Frontend builds; in-browser the selector renders EN/中/DE/FR and switching to de/fr updates value, persists to localStorage, sets <html lang>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)