### PR TITLE
fix(simulation): raise suggest-scenarios timeout and token limit 

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -512,7 +512,7 @@ def suggest_scenarios():
                 })
 
         try:
-            llm = create_llm_client(timeout=20.0)
+            llm = create_llm_client(timeout=40.0)
         except Exception as exc:
             logger.warning(f"suggest-scenarios: LLM client unavailable: {exc}")
             return jsonify({
@@ -540,7 +540,7 @@ def suggest_scenarios():
         ]
 
         try:
-            parsed = llm.chat_json(messages, temperature=0.4, max_tokens=700)
+            parsed = llm.chat_json(messages, temperature=0.4, max_tokens=1500)
         except Exception as exc:
             # Don't 500 — scenario auto-suggest is best-effort; the form still works.
             logger.warning(f"suggest-scenarios: LLM call failed: {exc}")


### PR DESCRIPTION
fixes #187 

Bump the LLM client timeout from 20s to 40s and max_tokens from 700 to 1500 in suggest_scenarios so responses in verbose languages (e.g. Chinese) aren't truncated and slower local LLMs have time to complete.