### PR TITLE
feat: show estimated run cost on public simulation embeds

### DIFF
--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -1524,6 +1524,28 @@ export const getReproduction = (simulationId) => {
 }
 
 /**
+ * Fetch the estimated cost breakdown (`cost.json`) for a published
+ * simulation — the "$1 to simulate anything" claim, made queryable per
+ * run. Reuses the same OpenRouter price table that writes
+ * `run_summary.md`, so the dollar figure here and on disk can never
+ * disagree.
+ *
+ * Like the other share-surface blobs (`reproduce.json`), the Flask
+ * handler returns the payload directly (not wrapped in `{success,
+ * data}`), so the resolved value IS the cost envelope:
+ * `{ estimated_cost_usd, is_estimate, totals, ... }`. Rejects with the
+ * standard error envelope on 403 (simulation not published) or 404 (no
+ * LLM calls logged yet), so callers should treat a rejection as "no cost
+ * to show" rather than a hard failure.
+ *
+ * @param {string} simulationId
+ * @returns {Promise<object>} the v1-schema cost payload
+ */
+export const getSimulationCost = (simulationId) => {
+  return service.get(`/api/simulation/${simulationId}/cost.json`)
+}
+
+/**
  * Build the absolute URL of the pre-populated Jupyter notebook for a
  * published simulation.
  *

--- a/frontend/src/views/EmbedView.vue
+++ b/frontend/src/views/EmbedView.vue
@@ -24,6 +24,13 @@
             {{ $tr('Round', '轮次') }} {{ summary.current_round }}/{{ summary.total_rounds || summary.current_round }}
           </span>
           <span class="embed-pill">{{ summary.profiles_count || 0 }} {{ $tr('agents', '智能体') }}</span>
+          <span
+            v-if="costLabel"
+            class="embed-pill cost"
+            :title="$tr('Estimated cost to run this simulation (lower bound, from logged LLM calls)', '运行此模拟的预估成本(基于已记录的 LLM 调用,为下限)')"
+          >
+            {{ costLabel }}
+          </span>
           <span v-if="summary.quality && summary.quality.health" class="embed-pill quality" :class="qualityClass">
             {{ summary.quality.health }}
           </span>
@@ -90,7 +97,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import { getEmbedSummary } from '../api/simulation'
+import { getEmbedSummary, getSimulationCost } from '../api/simulation'
 import { tr } from '../i18n'
 
 const props = defineProps({
@@ -113,6 +120,7 @@ const CHART_H = 180
 const loading = ref(true)
 const error = ref('')
 const summary = ref(null)
+const cost = ref(null)
 
 const scenarioTitle = computed(() => {
   const raw = (summary.value?.scenario || '').trim()
@@ -137,6 +145,24 @@ const statusLabel = computed(() => {
 const statusClass = computed(() => {
   const s = statusLabel.value.toLowerCase()
   return `status-${s}`
+})
+
+const isCompleted = computed(() => {
+  const s = (summary.value?.runner_status || summary.value?.status || '').toLowerCase()
+  return s === 'completed' || s === 'finished' || s === 'stopped'
+})
+
+// Human-friendly headline cost from cost.json — the "$1 to simulate
+// anything" claim, made visible on every public embed. Empty string when
+// there is no cost to show (endpoint 403/404'd, or the run priced to $0),
+// which drops the pill entirely. `~` marks the lower-bound estimate;
+// sub-cent runs collapse to `<$0.01` rather than a misleading `$0.00`.
+const costLabel = computed(() => {
+  const usd = cost.value?.estimated_cost_usd
+  if (typeof usd !== 'number' || usd <= 0) return ''
+  if (usd < 0.01) return '<$0.01'
+  const prefix = cost.value?.is_estimate ? '~' : ''
+  return `${prefix}$${usd.toFixed(2)}`
 })
 
 const hasRounds = computed(() => {
@@ -267,6 +293,18 @@ const fetchData = async () => {
     error.value = err?.response?.data?.error || err?.message || tr('Failed to load simulation', '加载模拟失败')
   } finally {
     loading.value = false
+  }
+
+  // Cost is a credibility extra, not a load dependency: fetch it only for
+  // finished runs (a live run's cost is partial) and swallow any failure —
+  // the publish gate already passed for this embed, but 404/$0 runs simply
+  // won't have a figure to show.
+  if (summary.value && isCompleted.value) {
+    try {
+      cost.value = await getSimulationCost(simulationId.value)
+    } catch {
+      cost.value = null
+    }
   }
 }
 
@@ -411,6 +449,13 @@ onMounted(() => {
 .embed-pill.status.status-failed {
   background: rgba(240, 120, 103, 0.15);
   color: var(--bearish);
+}
+
+.embed-pill.cost {
+  background: rgba(167, 139, 250, 0.15);
+  color: var(--link-color);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .embed-pill.quality.quality-excellent {


### PR DESCRIPTION
## What
Surfaces each simulation's estimated run cost on the public **embed widget**. When an embed loads a completed run, it fetches `cost.json` and renders a small `~$0.87` pill in the header meta row, alongside the existing status / round / agent-count pills.

## Why
"Simulate anything, for ~$1" is the entire product promise — but until now nothing in the UI ever shows a viewer what a run actually cost. PR #179 already built the proof (`GET /api/simulation/<id>/cost.json`: a queryable, honestly-flagged lower-bound dollar figure derived from the same OpenRouter price table that writes `run_summary.md`). The figure existed; it just had no surface a stranger would ever see.

The **embed widget** is the right place to land it: embeds are public by definition, so the `cost.json` publish gate is already satisfied (no 403), and the embed is exactly where a stranger first encounters a MiroShark result — shared in a tweet, a blog, a dashboard. Every embed now carries the "$1" claim as a verifiable number instead of a marketing line. (The private, in-session completion view can't show this without hitting the publish gate — the embed sidesteps that entirely.)

This is the repo-actions idea from 2026-06-18 (#4, "display simulation cost from cost.json in the frontend"), routed to the surface where the endpoint's publish gate makes it actually work.

## Changes
- `frontend/src/api/simulation.js`: add `getSimulationCost(simulationId)` — fetches the `cost.json` share-surface blob (resolves to the cost envelope directly, mirroring `getReproduction`). Documents that it rejects on 403 (not published) / 404 (no LLM calls) so callers treat a rejection as "nothing to show".
- `frontend/src/views/EmbedView.vue`:
  - Fetch cost **after** the summary loads and **only for completed runs** (a live run's cost is partial), in an isolated `try/catch` so a 404/$0 run never blocks or errors the widget.
  - `costLabel` computed: `~$X.XX` for estimates, sub-cent runs collapse to `<$0.01` (no misleading `$0.00`), empty string drops the pill.
  - New `embed-pill cost` in the meta row with an i18n tooltip (EN/中文) explaining it's a lower-bound estimate.

## How it works
The embed already fetches `getEmbedSummary`; cost is layered on as a non-blocking credibility extra. The new `getSimulationCost` hits the existing publish-gated endpoint, which returns the v1 envelope (`estimated_cost_usd`, `is_estimate`, ...). The pill reuses the existing `.embed-pill` styling with the purple link accent and tabular numerals, so it renders identically in light/dark themes and the compact preset. No backend changes — the dollar figure stays single-sourced through `cost_service` -> `run_summary`, so the embed and `run_summary.md` can never disagree.

## Validation
`cd frontend && npm install && npm run build` — passes (Vite build clean; EmbedView compiles into the bundle, only pre-existing warnings). The repo's `ci: build the frontend on every PR` workflow (#180) re-runs this build on push. No frontend test suite exists to add to.

---
*Built autonomously by Aeon*
