### PR TITLE
test: assert camel smoke test produces real agent output

### DIFF
--- a/backend/tests/test_smoke_camel_agent.py
+++ b/backend/tests/test_smoke_camel_agent.py
@@ -76,3 +76,24 @@ def test_socialagent_step_drives_aget_model_response_without_signature_error():
     assert response is not None
     # A wrong override signature would have raised TypeError above before
     # returning a response.
+
+    # Guard the *silent-empty-output* failure mode. #181 swallowed per-agent
+    # exceptions and let simulations "complete" with zero actions; the signature
+    # check above stops that exact reintroduction, but a future camel-ai change
+    # could break the loop in a quieter way — returning a structurally valid
+    # response that carries no actual model output (an empty ``msgs`` list, or a
+    # message whose content is empty/whitespace). The simulation loop reads that
+    # as a healthy step (see agent.py: ``response.msgs[0].content`` is what gets
+    # logged), so a dead agent looks alive. Asserting real content makes that
+    # class of regression fail loudly here instead of shipping zero-action runs.
+    assert response.msgs, (
+        "astep() returned no messages — the model-response path produced an "
+        "empty result, which the simulation loop would mis-read as a healthy "
+        "zero-action step (the silent-failure class behind #181)"
+    )
+    content = response.msgs[0].content
+    assert isinstance(content, str) and content.strip(), (
+        "astep() returned a message with empty content — a silently broken "
+        "agent step. Real model output (the STUB model included) is always a "
+        "non-empty string"
+    )


### PR DESCRIPTION
## What
Strengthen `backend/tests/test_smoke_camel_agent.py` so the end-to-end smoke test asserts the agent actually produces output, not just that `astep()` returns a non-`None` response. It now checks that the response carries at least one message and that the message content is a non-empty string.

## Why
The camel agent smoke test (PR #183) was added after the camel-ai 0.2.90 regression (#181), where a dropped positional argument made every `_aget_model_response` call raise `TypeError`, the exception was swallowed per agent, and simulations "completed" with **zero actions** — undetected for ~2 months because a dead run read as healthy.

The signature-compat test guards that *exact* reintroduction. But a future camel-ai bump could break the loop more quietly: return a structurally valid `ChatAgentResponse` that carries no actual model output (empty `msgs`, or a message whose content is empty/whitespace). The simulation loop reads `response.msgs[0].content` as a healthy step (see `wonderwall/social_agent/agent.py`), so a silently-dead agent would still look alive. `assert response is not None` does not catch that.

## Changes
- `backend/tests/test_smoke_camel_agent.py`: in `test_socialagent_step_drives_aget_model_response_without_signature_error`, after the existing non-`None` check, assert `response.msgs` is non-empty and `response.msgs[0].content` is a non-empty (stripped) string. Added a comment tying the new assertions to the #181 silent-failure class.

## Validation
Local test execution is blocked in the autonomous sandbox (Python/pytest disabled), so the test was not run here — it is exercised by the existing `camel-smoke` CI job, which installs real camel-ai + torch and runs this file on every PR. The STUB model used by the test returns a fixed non-empty string, so the new content assertions pass on a healthy loop and fail only on the empty-output regression they guard.

---
*Built autonomously by Aeon*
