### PR TITLE
feat(llm): separate thinking-token budget from response budget for reasoning models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,17 @@ MIROSHARK_FIRECRAWL_API_KEY=
 # short, structured prompts).
 LLM_DISABLE_REASONING=true
 
+# ===== Thinking-budget separation for reasoning-capable models =====
+# `max_tokens` is the response budget; on a reasoning model extended thinking
+# shares that same pool unless you size it separately. These map to
+# OpenRouter's unified `reasoning` field. Set EITHER (a token count wins):
+#   LLM_REASONING_MAX_TOKENS — int thinking budget (Anthropic/Gemini style).
+#   LLM_REASONING_EFFORT     — low|medium|high (OpenAI o-series style).
+# Setting either turns reasoning ON for that budget even with
+# LLM_DISABLE_REASONING=true. Unset (0/empty) → follows the flag above.
+# LLM_REASONING_MAX_TOKENS=2000
+# LLM_REASONING_EFFORT=
+
 # =============================================================
 # Alternatives — comment out the Cloud block above and paste one
 # of these in if you'd rather run locally or via Claude Code.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -198,6 +198,24 @@ class Config:
     # MiroShark's short, structured prompts).
     LLM_DISABLE_REASONING = os.environ.get('LLM_DISABLE_REASONING', 'true').lower() == 'true'
 
+    # Thinking-budget separation for reasoning-capable models.
+    # The top-level `max_tokens` we pass is the *response* budget; on a
+    # reasoning model that single pool silently has to cover extended
+    # thinking too, so a verbose <think> trace eats into the answer (the
+    # same truncation class that bit suggest_scenarios in #187/#188). These
+    # two knobs map to OpenRouter's unified `reasoning` field, which sizes
+    # the thinking budget independently of `max_tokens`:
+    #   * LLM_REASONING_MAX_TOKENS — int token budget for extended thinking
+    #     (Anthropic / Gemini style; maps to Anthropic `thinking.budget_tokens`).
+    #   * LLM_REASONING_EFFORT — "low" | "medium" | "high" for OpenAI o-series
+    #     style models that take an effort level instead of a token count.
+    # Setting either one turns reasoning ON for that budget even if
+    # LLM_DISABLE_REASONING is left at its default — asking for a thinking
+    # budget implies wanting the model to think. Left unset (0 / empty),
+    # reasoning falls back to the LLM_DISABLE_REASONING flag above.
+    LLM_REASONING_MAX_TOKENS = int(os.environ.get('LLM_REASONING_MAX_TOKENS', '0') or '0')
+    LLM_REASONING_EFFORT = os.environ.get('LLM_REASONING_EFFORT', '').strip().lower()
+
     # Report Agent configuration
     REPORT_AGENT_MAX_TOOL_CALLS = int(os.environ.get('REPORT_AGENT_MAX_TOOL_CALLS', '5'))
     REPORT_AGENT_MAX_REFLECTION_ROUNDS = int(os.environ.get('REPORT_AGENT_MAX_REFLECTION_ROUNDS', '2'))

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -179,6 +179,35 @@ class LLMClient:
         return ("claude" in m) or ("anthropic" in m)
 
     @staticmethod
+    def _resolve_reasoning_directive() -> Optional[Dict[str, Any]]:
+        """Build the OpenRouter ``reasoning`` extra_body directive from config.
+
+        Returns the dict to attach under ``extra_body["reasoning"]``, or
+        ``None`` to leave the key unset (model default). OpenRouter's unified
+        ``reasoning`` field sizes the thinking budget independently of the
+        top-level ``max_tokens`` response budget — see
+        https://openrouter.ai/docs/use-cases/reasoning-tokens.
+
+        Precedence:
+          1. An explicit thinking budget — ``LLM_REASONING_MAX_TOKENS`` > 0 or
+             ``LLM_REASONING_EFFORT`` set — enables reasoning with that budget.
+             A token count wins over an effort level when both are given.
+             Setting a budget overrides ``LLM_DISABLE_REASONING`` (asking for a
+             thinking budget implies wanting the model to think).
+          2. ``LLM_DISABLE_REASONING`` (default) → ``{"enabled": False}``.
+          3. Otherwise ``None`` (model default).
+        """
+        budget = getattr(Config, "LLM_REASONING_MAX_TOKENS", 0) or 0
+        if budget > 0:
+            return {"max_tokens": int(budget)}
+        effort = (getattr(Config, "LLM_REASONING_EFFORT", "") or "").strip().lower()
+        if effort:
+            return {"effort": effort}
+        if getattr(Config, "LLM_DISABLE_REASONING", False):
+            return {"enabled": False}
+        return None
+
+    @staticmethod
     def _maybe_cache_wrap_messages(
         messages: List[Dict[str, Any]],
     ) -> List[Dict[str, Any]]:
@@ -363,12 +392,16 @@ class LLMClient:
             if sim_id:
                 extra["user"] = sim_id
                 extra["session_id"] = sim_id
-            # Disable chain-of-thought on reasoning-capable models by default —
-            # we want short, deterministic outputs, not a 100-token <think>
-            # trace padding every call. Saves 50-80% latency on Qwen3/Gemini-3-Flash
-            # in benchmarks; no-ops on models that don't support the flag.
-            if Config.LLM_DISABLE_REASONING:
-                extra["reasoning"] = {"enabled": False}
+            # Reasoning directive. By default we disable chain-of-thought —
+            # short, deterministic outputs, not a 100-token <think> trace
+            # padding every call (saves 50-80% latency on Qwen3/Gemini-3-Flash;
+            # no-ops on models that don't support the flag). When a deployment
+            # sets a thinking budget (LLM_REASONING_MAX_TOKENS / _EFFORT),
+            # reasoning is enabled with that budget instead, sized separately
+            # from the `max_tokens` response cap above.
+            reasoning_directive = self._resolve_reasoning_directive()
+            if reasoning_directive is not None:
+                extra["reasoning"] = reasoning_directive
             kwargs["extra_body"] = extra
 
         t0 = time.perf_counter()

--- a/backend/tests/test_unit_reasoning_config.py
+++ b/backend/tests/test_unit_reasoning_config.py
@@ -1,0 +1,93 @@
+"""Unit tests for the LLM reasoning-budget directive resolver.
+
+Pure offline — no Flask, no network, no LLM. These cover
+``LLMClient._resolve_reasoning_directive``, which decides what (if
+anything) MiroShark attaches under OpenRouter's ``extra_body["reasoning"]``
+key. The directive sizes a reasoning model's *thinking* budget independently
+of the top-level ``max_tokens`` *response* budget (issue #193).
+
+Precedence under test:
+  1. ``LLM_REASONING_MAX_TOKENS`` > 0 → ``{"max_tokens": N}`` (and overrides
+     ``LLM_DISABLE_REASONING``).
+  2. ``LLM_REASONING_EFFORT`` set → ``{"effort": "..."}`` (token count wins
+     when both are set).
+  3. ``LLM_DISABLE_REASONING`` true → ``{"enabled": False}``.
+  4. Nothing set, reasoning not disabled → ``None`` (model default).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from app.config import Config
+from app.utils.llm_client import LLMClient
+
+
+@pytest.fixture(autouse=True)
+def _reset_reasoning_config(monkeypatch):
+    """Start each test from the documented defaults, then let it override."""
+    monkeypatch.setattr(Config, "LLM_DISABLE_REASONING", True, raising=False)
+    monkeypatch.setattr(Config, "LLM_REASONING_MAX_TOKENS", 0, raising=False)
+    monkeypatch.setattr(Config, "LLM_REASONING_EFFORT", "", raising=False)
+
+
+def test_default_disables_reasoning(monkeypatch):
+    # Out of the box LLM_DISABLE_REASONING=true → CoT off.
+    assert LLMClient._resolve_reasoning_directive() == {"enabled": False}
+
+
+def test_no_directive_when_reasoning_allowed_but_unbudgeted(monkeypatch):
+    # Reasoning allowed (flag off) but no explicit budget → leave the key
+    # unset so the model keeps its own default.
+    monkeypatch.setattr(Config, "LLM_DISABLE_REASONING", False)
+    assert LLMClient._resolve_reasoning_directive() is None
+
+
+def test_max_tokens_sets_thinking_budget(monkeypatch):
+    monkeypatch.setattr(Config, "LLM_DISABLE_REASONING", False)
+    monkeypatch.setattr(Config, "LLM_REASONING_MAX_TOKENS", 2000)
+    assert LLMClient._resolve_reasoning_directive() == {"max_tokens": 2000}
+
+
+def test_max_tokens_overrides_disable_flag(monkeypatch):
+    # Asking for a thinking budget implies wanting the model to think, even
+    # if the disable flag is left at its default.
+    monkeypatch.setattr(Config, "LLM_DISABLE_REASONING", True)
+    monkeypatch.setattr(Config, "LLM_REASONING_MAX_TOKENS", 1500)
+    assert LLMClient._resolve_reasoning_directive() == {"max_tokens": 1500}
+
+
+def test_effort_sets_reasoning_effort(monkeypatch):
+    monkeypatch.setattr(Config, "LLM_DISABLE_REASONING", False)
+    monkeypatch.setattr(Config, "LLM_REASONING_EFFORT", "high")
+    assert LLMClient._resolve_reasoning_directive() == {"effort": "high"}
+
+
+def test_effort_overrides_disable_flag(monkeypatch):
+    monkeypatch.setattr(Config, "LLM_DISABLE_REASONING", True)
+    monkeypatch.setattr(Config, "LLM_REASONING_EFFORT", "low")
+    assert LLMClient._resolve_reasoning_directive() == {"effort": "low"}
+
+
+def test_token_budget_wins_when_both_set(monkeypatch):
+    # A concrete token count is more specific than an effort level.
+    monkeypatch.setattr(Config, "LLM_DISABLE_REASONING", False)
+    monkeypatch.setattr(Config, "LLM_REASONING_MAX_TOKENS", 800)
+    monkeypatch.setattr(Config, "LLM_REASONING_EFFORT", "high")
+    assert LLMClient._resolve_reasoning_directive() == {"max_tokens": 800}
+
+
+def test_zero_and_empty_are_treated_as_unset(monkeypatch):
+    # The zero/empty sentinels must not be mistaken for an explicit budget.
+    monkeypatch.setattr(Config, "LLM_DISABLE_REASONING", False)
+    monkeypatch.setattr(Config, "LLM_REASONING_MAX_TOKENS", 0)
+    monkeypatch.setattr(Config, "LLM_REASONING_EFFORT", "")
+    assert LLMClient._resolve_reasoning_directive() is None

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -68,6 +68,14 @@ LLM_MODEL_NAME=qwen2.5:32b
 # per-deployment if a slot needs CoT.
 LLM_DISABLE_REASONING=true
 
+# ─── Thinking budget, sized separately from the response budget ───
+# `max_tokens` is the response budget; these size extended thinking on
+# their own (OpenRouter's unified `reasoning` field). Set EITHER — a token
+# count wins over an effort level. Setting either enables reasoning even
+# with LLM_DISABLE_REASONING=true.
+# LLM_REASONING_MAX_TOKENS=2000      # Anthropic/Gemini style token budget
+# LLM_REASONING_EFFORT=medium        # OpenAI o-series style: low|medium|high
+
 # ─── Claude Code mode (only when LLM_PROVIDER=claude-code) ───
 # CLAUDE_CODE_MODEL=claude-sonnet-4-20250514
 
@@ -202,6 +210,8 @@ All retrieval and memory features are on by default. Disable individually:
 | `WEB_ENRICHMENT_ENABLED` | `true` | Personas grounded only in the document |
 | `LLM_PROMPT_CACHING_ENABLED` | `true` | No Anthropic prompt caching on system messages |
 | `LLM_DISABLE_REASONING` | `true` | OpenRouter reasoning models emit CoT (~3× higher latency on Qwen3/Grok) |
+| `LLM_REASONING_MAX_TOKENS` | `0` | Thinking budget (tokens) sized separately from the `max_tokens` response budget — Anthropic/Gemini style. Maps to OpenRouter's `reasoning.max_tokens`; `> 0` enables reasoning even if `LLM_DISABLE_REASONING=true`. |
+| `LLM_REASONING_EFFORT` | `""` | Thinking effort `low`/`medium`/`high` for OpenAI o-series style models. Maps to OpenRouter's `reasoning.effort`; a `LLM_REASONING_MAX_TOKENS` token count takes precedence when both are set. |
 | `ORACLE_SEED_ENABLED` | `false` | Templates ignore `oracle_tools` |
 | `MCP_AGENT_TOOLS_ENABLED` | `false` | `tools_enabled` personas can't invoke MCP |
 | `DEMOGRAPHICS_COUNTRY` | `""` | Persona generator runs graph-only — no Nemotron demographic seed. Set to a code under `backend/app/countries/` (e.g. `sg`, `us`) to anchor each agent in a census-grounded row. See [DEMOGRAPHICS.md](DEMOGRAPHICS.md). |


### PR DESCRIPTION
## What
Adds two config knobs — `LLM_REASONING_MAX_TOKENS` and `LLM_REASONING_EFFORT` — that size a reasoning-capable model's **extended-thinking** budget independently of the top-level `max_tokens` **response** budget.

Both map to OpenRouter's unified [`reasoning`](https://openrouter.ai/docs/use-cases/reasoning-tokens) field and extend the existing `LLM_DISABLE_REASONING` path in `LLMClient.chat`:

- `LLM_REASONING_MAX_TOKENS` (int) → `reasoning: {max_tokens: N}` — Anthropic/Gemini style; maps to Anthropic's `thinking.budget_tokens`.
- `LLM_REASONING_EFFORT` (`low`/`medium`/`high`) → `reasoning: {effort: ...}` — OpenAI o-series style.

Precedence: a token budget wins over an effort level; setting either enables reasoning **even if** `LLM_DISABLE_REASONING=true` (asking for a thinking budget implies wanting the model to think). Unset (`0`/empty) → behavior falls back to the existing `LLM_DISABLE_REASONING` flag, so **default behavior is unchanged**.

## Why
Addresses #193. Today the top-level `max_tokens` we send is the *response* budget, but on a reasoning model that single pool silently has to cover extended thinking too — a verbose `<think>` trace eats into the answer. That's the same truncation class that bit `suggest_scenarios` in #187/#188. Separating the two makes per-run cost predictable per model tier, which is exactly the lever the "~$1 per simulation" promise needs: you can cap thinking spend without starving the response.

## Changes
- `backend/app/config.py`: add `LLM_REASONING_MAX_TOKENS` (int, default `0`) and `LLM_REASONING_EFFORT` (str, default `""`).
- `backend/app/utils/llm_client.py`: new `LLMClient._resolve_reasoning_directive()` staticmethod encapsulating the precedence; `chat()` now attaches its result under `extra_body["reasoning"]` (still only on the OpenRouter path, replacing the inline `LLM_DISABLE_REASONING` block).
- `backend/tests/test_unit_reasoning_config.py`: offline unit tests covering every precedence branch (default-disabled, unbudgeted-allowed, max_tokens, effort, override-of-disable-flag, token-wins-over-effort, zero/empty sentinels).
- `.env.example` + `docs/CONFIGURATION.md`: document both vars (commented examples + reference-table rows).

## Validation
Local `pytest` could not run — the autonomous build sandbox blocks Python execution. The new `test_unit_reasoning_config.py` follows the existing offline staticmethod-test pattern (`test_unit_prompt_cache.py` imports `LLMClient` the same way) and is discovered by `pytest -m "not integration"`, so CI's **Backend unit tests** job exercises it on push. No new dependencies; no HTTP surface change (no `openapi.yaml` impact).

---
*Built autonomously by Aeon*
