### PR TITLE
chore(models): switch default model from mimo-v2-flash to mimo-v2.5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 # Copy this file to .env and paste your OpenRouter key into the
 # blank API_KEY slots below.
 #
-# Default = Cloud (OpenRouter, Mimo V2 Flash + Gemini 3 Flash).
+# Default = Cloud (OpenRouter, Mimo V2.5 + Gemini 3 Flash).
 # To run fully locally with Ollama, see the "Alternatives" block
 # further down.
 # =============================================================
@@ -14,7 +14,7 @@
 LLM_PROVIDER=openai
 LLM_API_KEY=                          # ← paste your OpenRouter key (sk-or-v1-...)
 LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_MODEL_NAME=xiaomi/mimo-v2-flash
+LLM_MODEL_NAME=xiaomi/mimo-v2.5
 
 # ===== Smart Model (reports, ontology, graph reasoning — #1 quality lever) =====
 # Only ~19 calls per run, so investing here is the cheapest quality upgrade.
@@ -30,7 +30,7 @@ NER_MODEL_NAME=google/gemini-3-flash-preview
 
 # ===== Wonderwall Model (agent simulation loop — #1 cost driver) =====
 # 850+ calls, 7M+ tokens per run. Verbosity matters more than $/M token.
-WONDERWALL_MODEL_NAME=xiaomi/mimo-v2-flash
+WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
 #
 # Optional: route Wonderwall to a custom OpenAI-compatible endpoint
 # (self-hosted vLLM, Modal, fine-tuned model, Ollama on a different host…)
@@ -78,7 +78,7 @@ MIROSHARK_FIRECRAWL_BASE_URL=
 MIROSHARK_FIRECRAWL_API_KEY=
 
 # ===== Disable chain-of-thought on reasoning-capable OpenRouter models =====
-# ~3x lower latency on Qwen3-Flash / Gemini-3-Flash / Mimo-V2-Flash. Flip to
+# ~3x lower latency on Qwen3-Flash / Gemini-3-Flash / Mimo-V2.5. Flip to
 # false per-deployment if a slot benefits from CoT (rare for MiroShark's
 # short, structured prompts).
 LLM_DISABLE_REASONING=true

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ backend/pipeline_test_output/
 # Log files
 backend/logs/
 *.log
+backend/events.jsonl
 
 # Uploaded files
 backend/uploads/

--- a/README.fr.md
+++ b/README.fr.md
@@ -60,7 +60,7 @@ cp .env.example .env
 # Collez votre clé OpenRouter dans les emplacements LLM_API_KEY /
 # SMART_API_KEY / NER_API_KEY / OPENAI_API_KEY / EMBEDDING_API_KEY
 # (la même clé, à 5 endroits). Le duo par défaut est
-# Mimo V2 Flash + Gemini 3 Flash.
+# Mimo V2.5 + Gemini 3 Flash.
 ./miroshark
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -60,7 +60,7 @@ cp .env.example .env
 # OpenRouter のキーを LLM_API_KEY / SMART_API_KEY /
 # NER_API_KEY / OPENAI_API_KEY / EMBEDDING_API_KEY の
 # 5 か所に貼り付けてください(同じキーを 5 か所に)。
-# 既定の組み合わせは Mimo V2 Flash + Gemini 3 Flash です。
+# 既定の組み合わせは Mimo V2.5 + Gemini 3 Flash です。
 ./miroshark
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
 cp .env.example .env
 # Paste your OpenRouter key into the LLM_API_KEY / SMART_API_KEY /
 # NER_API_KEY / OPENAI_API_KEY / EMBEDDING_API_KEY slots (same key,
-# 5 places). Default lineup is Mimo V2 Flash + Gemini 3 Flash.
+# 5 places). Default lineup is Mimo V2.5 + Gemini 3 Flash.
 ./miroshark
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -59,7 +59,7 @@ git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
 cp .env.example .env
 # 将你的 OpenRouter 密钥粘贴到 LLM_API_KEY / SMART_API_KEY /
 # NER_API_KEY / OPENAI_API_KEY / EMBEDDING_API_KEY 五个字段
-# (同一个密钥,粘 5 处)。默认组合是 Mimo V2 Flash + Gemini 3 Flash。
+# (同一个密钥,粘 5 处)。默认组合是 Mimo V2.5 + Gemini 3 Flash。
 ./miroshark
 ```
 

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -34,17 +34,17 @@ def _mask_key(key: str) -> str:
 # copied into when the caller supplies `preset_api_key`.
 _PRESETS = {
     'cheap': {
-        'label': 'Cloud — ~$1/run (Mimo V2 Flash + Gemini 3 Flash)',
+        'label': 'Cloud — ~$1/run (Mimo V2.5 + Gemini 3 Flash)',
         'fields': {
             'LLM_PROVIDER': 'openai',
             'LLM_BASE_URL': 'https://openrouter.ai/api/v1',
-            'LLM_MODEL_NAME': 'xiaomi/mimo-v2-flash',
+            'LLM_MODEL_NAME': 'xiaomi/mimo-v2.5',
             'SMART_PROVIDER': 'openai',
             'SMART_BASE_URL': 'https://openrouter.ai/api/v1',
             'SMART_MODEL_NAME': 'google/gemini-3-flash-preview',
             'NER_BASE_URL': 'https://openrouter.ai/api/v1',
             'NER_MODEL_NAME': 'google/gemini-3-flash-preview',
-            'WONDERWALL_MODEL_NAME': 'xiaomi/mimo-v2-flash',
+            'WONDERWALL_MODEL_NAME': 'xiaomi/mimo-v2.5',
             'EMBEDDING_PROVIDER': 'openai',
             'EMBEDDING_BASE_URL': 'https://openrouter.ai/api',
             'EMBEDDING_MODEL': 'openai/text-embedding-3-large',

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,11 +30,11 @@ class Config:
     # LLM configuration (unified OpenAI format)
     # LLM_PROVIDER: "openai" (default, any OpenAI-compatible API) or "claude-code" (local CLI)
     # Default model is used for profile generation, sim config, memory compaction.
-    # Cloud preset: xiaomi/mimo-v2-flash (cheap personas + sim configs)
+    # Cloud preset: xiaomi/mimo-v2.5 (cheap personas + sim configs)
     LLM_PROVIDER = os.environ.get('LLM_PROVIDER', 'openai')
     LLM_API_KEY = os.environ.get('LLM_API_KEY')
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'https://api.openai.com/v1')
-    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'xiaomi/mimo-v2-flash')
+    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'xiaomi/mimo-v2.5')
 
     # Smart model — stronger model for intelligence-sensitive workflows
     # (report generation, ontology extraction, graph reasoning).
@@ -162,7 +162,7 @@ class Config:
 
     # Wonderwall model — model for Wonderwall/CAMEL agent simulation loop.
     # When not set, uses LLM_MODEL_NAME.
-    # Cloud preset: xiaomi/mimo-v2-flash (same as default to reuse quota)
+    # Cloud preset: xiaomi/mimo-v2.5 (same as default to reuse quota)
     # Wonderwall is the #1 cost driver — 850+ calls per run. Keep it cheap.
     WONDERWALL_MODEL_NAME = os.environ.get('WONDERWALL_MODEL_NAME', '')
     # Optional per-slot endpoint override — point Wonderwall at a different

--- a/backend/app/utils/run_summary.py
+++ b/backend/app/utils/run_summary.py
@@ -25,7 +25,7 @@ logger = get_logger('miroshark.run_summary')
 # ---------------------------------------------------------------------------
 MODEL_PRICING = {
     # Current Cloud preset (update as OpenRouter prices drift)
-    "xiaomi/mimo-v2-flash":              {"input": 0.10, "output": 0.40},
+    "xiaomi/mimo-v2.5":              {"input": 0.14, "output": 0.28},
     "google/gemini-3-flash-preview":     {"input": 0.50, "output": 3.00},
     # Tracked for mixed / legacy setups
     "qwen/qwen3.5-flash-02-23":          {"input": 0.065, "output": 0.26},

--- a/cloudrun.env.yaml.example
+++ b/cloudrun.env.yaml.example
@@ -24,7 +24,7 @@ SECRET_KEY: "your-flask-secret-key-here"
 LLM_PROVIDER: "openai"
 LLM_API_KEY: "your-llm-api-key-here"
 LLM_BASE_URL: "https://api.openai.com/v1"
-LLM_MODEL_NAME: "xiaomi/mimo-v2-flash"
+LLM_MODEL_NAME: "xiaomi/mimo-v2.5"
 
 # === Neo4j Configuration ===
 NEO4J_URI: "bolt://your-neo4j-host:7687"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,7 +10,7 @@ All settings live in `.env` (copy from `.env.example`). The full reference below
 # LLM
 LLM_API_KEY=your-api-key
 LLM_BASE_URL=https://openrouter.ai/api/v1     # or http://localhost:11434/v1 for Ollama
-LLM_MODEL_NAME=xiaomi/mimo-v2-flash
+LLM_MODEL_NAME=xiaomi/mimo-v2.5
 
 # Neo4j
 NEO4J_URI=bolt://localhost:7687
@@ -53,7 +53,7 @@ LLM_MODEL_NAME=qwen2.5:32b
 # SMART_MODEL_NAME=google/gemini-3-flash-preview          # Cloud preset
 
 # ─── Wonderwall (agent sim loop — #1 cost driver, use cheapest viable) ───
-# WONDERWALL_MODEL_NAME=xiaomi/mimo-v2-flash
+# WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
 # Optional: route Wonderwall to a custom OpenAI-compatible endpoint
 # (self-hosted vLLM, Modal, custom fine-tune…). Both fields are
 # optional — leaving either blank inherits LLM_BASE_URL / LLM_API_KEY.

--- a/docs/CONFIGURATION.zh-CN.md
+++ b/docs/CONFIGURATION.zh-CN.md
@@ -10,7 +10,7 @@
 # LLM
 LLM_API_KEY=your-api-key
 LLM_BASE_URL=https://openrouter.ai/api/v1     # or http://localhost:11434/v1 for Ollama
-LLM_MODEL_NAME=xiaomi/mimo-v2-flash
+LLM_MODEL_NAME=xiaomi/mimo-v2.5
 
 # Neo4j
 NEO4J_URI=bolt://localhost:7687
@@ -53,7 +53,7 @@ LLM_MODEL_NAME=qwen2.5:32b
 # SMART_MODEL_NAME=google/gemini-3-flash-preview          # Cloud preset
 
 # ─── Wonderwall (agent sim loop — #1 cost driver, use cheapest viable) ───
-# WONDERWALL_MODEL_NAME=xiaomi/mimo-v2-flash
+# WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
 # Optional: route Wonderwall to a custom OpenAI-compatible endpoint
 # (self-hosted vLLM, Modal, custom fine-tune…). Both fields are
 # optional — leaving either blank inherits LLM_BASE_URL / LLM_API_KEY.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,7 @@ git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
 cp .env.example .env
 ```
 
-`.env.example` ships with the Cloud preset (Mimo V2 Flash + Gemini 3 Flash) as the active default. Open `.env` and paste your OpenRouter key into the five blank `*_API_KEY=` lines (`LLM_`, `SMART_`, `NER_`, `OPENAI_`, `EMBEDDING_` — same key in all of them). No model edits needed unless you want a different lineup.
+`.env.example` ships with the Cloud preset (Mimo V2.5 + Gemini 3 Flash) as the active default. Open `.env` and paste your OpenRouter key into the five blank `*_API_KEY=` lines (`LLM_`, `SMART_`, `NER_`, `OPENAI_`, `EMBEDDING_` — same key in all of them). No model edits needed unless you want a different lineup.
 
 Then launch:
 
@@ -133,7 +133,7 @@ One key covers every slot, including embeddings. Easiest to set up and the path 
 ```bash
 LLM_API_KEY=sk-or-v1-YOUR_KEY
 LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_MODEL_NAME=xiaomi/mimo-v2-flash
+LLM_MODEL_NAME=xiaomi/mimo-v2.5
 
 SMART_PROVIDER=openai
 SMART_API_KEY=sk-or-v1-YOUR_KEY
@@ -144,7 +144,7 @@ NER_MODEL_NAME=google/gemini-3-flash-preview
 NER_BASE_URL=https://openrouter.ai/api/v1
 NER_API_KEY=sk-or-v1-YOUR_KEY
 
-WONDERWALL_MODEL_NAME=xiaomi/mimo-v2-flash
+WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
 WEB_SEARCH_MODEL=google/gemini-3-flash-preview:online
 
 OPENAI_API_KEY=sk-or-v1-YOUR_KEY

--- a/docs/INSTALL.zh-CN.md
+++ b/docs/INSTALL.zh-CN.md
@@ -93,7 +93,7 @@ git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
 cp .env.example .env
 ```
 
-`.env.example` 出厂自带云端预设(Mimo V2 Flash + Gemini 3 Flash)作为默认配置。打开 `.env`,把你的 OpenRouter 密钥粘贴进五行空白的 `*_API_KEY=`(`LLM_`、`SMART_`、`NER_`、`OPENAI_`、`EMBEDDING_` — 五行用同一把密钥)。除非你想换一套不同的模型组合,否则不需要修改任何模型字段。
+`.env.example` 出厂自带云端预设(Mimo V2.5 + Gemini 3 Flash)作为默认配置。打开 `.env`,把你的 OpenRouter 密钥粘贴进五行空白的 `*_API_KEY=`(`LLM_`、`SMART_`、`NER_`、`OPENAI_`、`EMBEDDING_` — 五行用同一把密钥)。除非你想换一套不同的模型组合,否则不需要修改任何模型字段。
 
 然后启动:
 
@@ -133,7 +133,7 @@ cp .env.example .env
 ```bash
 LLM_API_KEY=sk-or-v1-YOUR_KEY
 LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_MODEL_NAME=xiaomi/mimo-v2-flash
+LLM_MODEL_NAME=xiaomi/mimo-v2.5
 
 SMART_PROVIDER=openai
 SMART_API_KEY=sk-or-v1-YOUR_KEY
@@ -144,7 +144,7 @@ NER_MODEL_NAME=google/gemini-3-flash-preview
 NER_BASE_URL=https://openrouter.ai/api/v1
 NER_API_KEY=sk-or-v1-YOUR_KEY
 
-WONDERWALL_MODEL_NAME=xiaomi/mimo-v2-flash
+WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
 WEB_SEARCH_MODEL=google/gemini-3-flash-preview:online
 
 OPENAI_API_KEY=sk-or-v1-YOUR_KEY

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -12,21 +12,21 @@ Each slot controls a different quality axis:
 
 | Slot | Controls | Key finding |
 |---|---|---|
-| **Default** | Persona richness, sim density | Mimo V2 Flash gives distinct voices at flash-tier price |
+| **Default** | Persona richness, sim density | Mimo V2.5 gives distinct voices at flash-tier price |
 | **Smart** | Report quality (#1 lever) | Gemini 3 Flash holds up on ReACT report loops with reasoning disabled |
 | **NER** | Extraction reliability | Needs deterministic JSON — pick a model that doesn't silently emit CoT |
 | **Wonderwall** | Cost (biggest consumer) | 850+ calls, 7M+ tokens. Verbosity matters more than $/M |
 
 ### Cloud mode — ~$1/run, ~10 min
 
-Mimo V2 Flash personas + Gemini 3 Flash smart/NER. Reasoning is disabled on every slot (`LLM_DISABLE_REASONING=true` sends `reasoning: {enabled: false}` in `extra_body`), which is the difference between a ~45s scenario-suggest call and a ~3s one.
+Mimo V2.5 personas + Gemini 3 Flash smart/NER. Reasoning is disabled on every slot (`LLM_DISABLE_REASONING=true` sends `reasoning: {enabled: false}` in `extra_body`), which is the difference between a ~45s scenario-suggest call and a ~3s one.
 
 | Slot | Model | Notes |
 |---|---|---|
-| Default | `xiaomi/mimo-v2-flash` | Persona generation, sim config, memory compaction |
+| Default | `xiaomi/mimo-v2.5` | Persona generation, sim config, memory compaction |
 | Smart | `google/gemini-3-flash-preview` | Report ReACT loop — only ~19 calls/run |
 | NER | `google/gemini-3-flash-preview` | Stable JSON with reasoning off |
-| Wonderwall | `xiaomi/mimo-v2-flash` | 850+ agent-action calls/run; keep verbosity low |
+| Wonderwall | `xiaomi/mimo-v2.5` | 850+ agent-action calls/run; keep verbosity low |
 
 Embeddings use `openai/text-embedding-3-large` (truncated to 768 dims via Matryoshka). Web enrichment uses `google/gemini-3-flash-preview:online`.
 

--- a/docs/MODELS.zh-CN.md
+++ b/docs/MODELS.zh-CN.md
@@ -12,21 +12,21 @@
 
 | 槽位 | 控制的内容 | 关键发现 |
 |---|---|---|
-| **Default** | 人设丰富度、模拟密度 | Mimo V2 Flash 在 flash 价位上能给出辨识度高的人物声音 |
+| **Default** | 人设丰富度、模拟密度 | Mimo V2.5 在 flash 价位上能给出辨识度高的人物声音 |
 | **Smart** | 报告质量(头号杠杆) | Gemini 3 Flash 在关闭 reasoning 的 ReACT 报告循环中表现稳定 |
 | **NER** | 抽取可靠性 | 需要确定性的 JSON — 选一个不会暗中输出 CoT 的模型 |
 | **Wonderwall** | 成本(最大消费方) | 850+ 次调用、7M+ tokens。冗长程度比 $/M 更重要 |
 
 ### 云端模式 — 约 1 美元/次,约 10 分钟
 
-Mimo V2 Flash 做人设 + Gemini 3 Flash 做 smart/NER。每个槽位都关闭了 reasoning(`LLM_DISABLE_REASONING=true` 会在 `extra_body` 里发送 `reasoning: {enabled: false}`),这就是一次场景建议从约 45 秒变成约 3 秒的差别。
+Mimo V2.5 做人设 + Gemini 3 Flash 做 smart/NER。每个槽位都关闭了 reasoning(`LLM_DISABLE_REASONING=true` 会在 `extra_body` 里发送 `reasoning: {enabled: false}`),这就是一次场景建议从约 45 秒变成约 3 秒的差别。
 
 | 槽位 | 模型 | 备注 |
 |---|---|---|
-| Default | `xiaomi/mimo-v2-flash` | 画像生成、模拟配置、记忆压缩 |
+| Default | `xiaomi/mimo-v2.5` | 画像生成、模拟配置、记忆压缩 |
 | Smart | `google/gemini-3-flash-preview` | 报告 ReACT 循环 — 每次运行只有约 19 次调用 |
 | NER | `google/gemini-3-flash-preview` | 关闭 reasoning 后输出稳定 JSON |
-| Wonderwall | `xiaomi/mimo-v2-flash` | 每次运行 850+ 次智能体动作调用;保持低冗长度 |
+| Wonderwall | `xiaomi/mimo-v2.5` | 每次运行 850+ 次智能体动作调用;保持低冗长度 |
 
 嵌入用 `openai/text-embedding-3-large`(通过 Matryoshka 截断到 768 维)。Web 增强用 `google/gemini-3-flash-preview:online`。
 

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -285,7 +285,7 @@
                   v-model="form.wonderwall.model_name"
                   class="field-input"
                   type="text"
-                  :placeholder="$tr('e.g. xiaomi/mimo-v2-flash', '例如 xiaomi/mimo-v2-flash', { de: 'z. B. xiaomi/mimo-v2-flash' })"
+                  :placeholder="$tr('e.g. xiaomi/mimo-v2.5', '例如 xiaomi/mimo-v2.5', { de: 'z. B. xiaomi/mimo-v2.5' })"
                 />
               </div>
               <div class="field-row">

--- a/railway.env.example
+++ b/railway.env.example
@@ -34,7 +34,7 @@ LLM_API_KEY=your-llm-api-key-here
 # Base URL for LLM API (default: https://api.openai.com/v1)
 LLM_BASE_URL=https://api.openai.com/v1
 # Model name for default LLM operations
-LLM_MODEL_NAME=xiaomi/mimo-v2-flash
+LLM_MODEL_NAME=xiaomi/mimo-v2.5
 
 # === Smart Model Configuration ===
 # Stronger model for intelligence-sensitive workflows


### PR DESCRIPTION
## What

\`xiaomi/mimo-v2-flash\` is **delisted from OpenRouter**, so this swaps the Default + Wonderwall slot to \`xiaomi/mimo-v2.5\` everywhere it was referenced — leaving a dead model id in deploy templates / the in-app preset / the pricing table would otherwise break real runs.

| Group | Files |
|---|---|
| Code/config | \`config.py\` (default + comments), \`api/settings.py\` (Cloud preset + label), \`run_summary.py\` (id **+ corrected pricing**) |
| Deploy/env templates | \`.env.example\`, \`cloudrun.env.yaml.example\`, \`railway.env.example\` |
| Frontend | \`SettingsPanel.vue\` (placeholder × en/zh/de) |
| Docs (EN + zh) | \`MODELS\`, \`CONFIGURATION\`, \`INSTALL\` + \`.zh-CN\` |
| README prose | \`README\` + \`.fr\`/\`.ja\`/\`.zh-CN\` |

## Pricing

mimo-v2.5 is **\$0.14/M in, \$0.28/M out** (vs flash's \$0.10/\$0.40 — input up, output down). Net per-run cost is ~a wash given the token mix, so the "~\$1/run" / "flash-tier price" claims hold. \`run_summary.py\` now carries the real rates so cost estimates stay accurate.

## Notes

- The dated \`docs/plans/2026-05-24-railway-deployment-runbook.md\` keeps the old id as a point-in-time record.
- Also gitignores \`backend/events.jsonl\` (runtime EventLogger artifact).
- Verified locally: \`mimo-v2.5\` is live on OpenRouter and replied successfully through the real \`LLMClient\`; unit suite \`1424 passed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)