### PR TITLE
feat(cli): add cost subcommand surfacing per-run USD estimate

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -198,6 +198,36 @@ def cmd_report(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_cost(args: argparse.Namespace) -> int:
+    res = _api("GET", f"/api/simulation/{args.simulation_id}/cost.json")
+    # cost.json returns the cost payload directly on success; the error path
+    # (private 403 / not-ready 404 / server error) returns {"success": False}.
+    if res.get("success") is False or "estimated_cost_usd" not in res:
+        if res.get("_http_status") == 404:
+            _die(
+                "cost not available yet — the simulation has logged no LLM "
+                "calls (still running?).",
+                code=2,
+            )
+        _die(res.get("error", "cost lookup failed"))
+    if args.json:
+        _print_json(res)
+        return 0
+    usd = res.get("estimated_cost_usd", 0.0)
+    totals = res.get("totals") or {}
+    # A "~" prefix mirrors the EmbedView cost pill: the figure is a lower-bound
+    # estimate (models absent from the price table count as $0).
+    prefix = "~$" if res.get("is_estimate") else "$"
+    print(
+        f"{prefix}{usd:.4f}  "
+        f"({totals.get('tokens_total', 0):,} tokens, "
+        f"{totals.get('llm_calls', 0)} LLM calls)"
+    )
+    for row in res.get("by_phase") or []:
+        print(f"  {row.get('phase', '?'):<16} {prefix}{row.get('estimated_cost_usd', 0.0):.4f}")
+    return 0
+
+
 def cmd_health(args: argparse.Namespace) -> int:
     try:
         with urlrequest.urlopen(_base_url() + "/health", timeout=5) as resp:
@@ -257,6 +287,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_report = sub.add_parser("report", help="Show rendered analytical report.")
     p_report.add_argument("simulation_id")
     p_report.set_defaults(func=cmd_report)
+
+    p_cost = sub.add_parser("cost", help="Show estimated USD cost for a simulation.")
+    p_cost.add_argument("simulation_id")
+    p_cost.set_defaults(func=cmd_cost)
 
     p_trend = sub.add_parser("trending", help="Pull trending topics from RSS feeds.")
     p_trend.set_defaults(func=cmd_trending)

--- a/backend/tests/test_unit_cli.py
+++ b/backend/tests/test_unit_cli.py
@@ -9,7 +9,7 @@ def test_build_parser_known_subcommands():
     p = cli.build_parser()
     # Parsing --help would exit, but we can inspect subparser choices.
     sub = [a for a in p._subparsers._group_actions if a.choices][0]
-    expected = {"ask", "list", "status", "frame", "publish", "report", "trending", "health"}
+    expected = {"ask", "list", "status", "frame", "publish", "report", "cost", "trending", "health"}
     assert expected.issubset(set(sub.choices.keys()))
 
 
@@ -32,3 +32,11 @@ def test_publish_unpublish_flag():
     p = cli.build_parser()
     args = p.parse_args(["publish", "sim_abc123", "--unpublish"])
     assert args.unpublish is True
+
+
+def test_cost_parses_positional():
+    p = cli.build_parser()
+    args = p.parse_args(["cost", "sim_abc123"])
+    assert args.cmd == "cost"
+    assert args.simulation_id == "sim_abc123"
+    assert args.func is cli.cmd_cost

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -27,7 +27,27 @@ Set `MIROSHARK_API_URL` to point at a remote deployment.
 | `frame <sim_id> <round>` | Compact per-round snapshot |
 | `publish <sim_id> [--unpublish]` | Toggle the embed public flag |
 | `report <sim_id>` | Render the analytical report |
+| `cost <sim_id>` | Estimated USD cost + token/call totals (the "$1" claim, per run) |
 | `trending` | Pull RSS/Atom trending items |
 | `health` | Ping `/health` |
 
 All commands accept `--json` for scripting.
+
+## Cost
+
+`cost <sim_id>` surfaces the per-run cost estimate (the `/api/simulation/<id>/cost.json`
+endpoint) at the command line, so the "$1 to simulate anything" claim is verifiable
+from a script:
+
+```bash
+$ python backend/cli.py cost sim_abc123
+~$0.9213  (1,284,902 tokens, 871 LLM calls)
+  graph_build      ~$0.1204
+  simulation       ~$0.7100
+  report           ~$0.0909
+```
+
+The `~` prefix marks the figure as a lower-bound estimate — calls on models absent
+from the price table count as `$0`. The simulation must be published (`publish <sim_id>`).
+Exit codes: `0` on success, `1` on private/server error, `2` when cost is not yet
+available (the run has logged no LLM calls). Add `--json` for the full breakdown.

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -27,7 +27,25 @@ python backend/cli.py --help
 | `frame <sim_id> <round>` | 单轮的紧凑快照 |
 | `publish <sim_id> [--unpublish]` | 切换嵌入公开标志 |
 | `report <sim_id>` | 渲染分析报告 |
+| `cost <sim_id>` | 预估美元成本 + token/调用次数(每次运行的「$1」主张) |
 | `trending` | 拉取 RSS/Atom 热门条目 |
 | `health` | Ping `/health` |
 
 所有命令都接受 `--json` 以便脚本化使用。
+
+## 成本
+
+`cost <sim_id>` 在命令行中展示单次运行的成本预估(对应 `/api/simulation/<id>/cost.json`
+端点),让「用 $1 模拟任何事」这一主张可以通过脚本核实:
+
+```bash
+$ python backend/cli.py cost sim_abc123
+~$0.9213  (1,284,902 tokens, 871 LLM calls)
+  graph_build      ~$0.1204
+  simulation       ~$0.7100
+  report           ~$0.0909
+```
+
+`~` 前缀表示该数字是下限预估 —— 价格表中缺失的模型调用按 `$0` 计算。该模拟必须已发布
+(`publish <sim_id>`)。退出码:成功为 `0`,私有/服务器错误为 `1`,成本尚不可用
+(运行尚未记录任何 LLM 调用)为 `2`。加上 `--json` 可获取完整明细。


### PR DESCRIPTION
## What
Adds a `cost` subcommand to the MiroShark CLI. `python -m cli cost <sim_id>` prints the per-run cost estimate at the command line:

```
$ python backend/cli.py cost sim_abc123
~$0.9213  (1,284,902 tokens, 871 LLM calls)
  graph_build      ~$0.1204
  simulation       ~$0.7100
  report           ~$0.0909
```

## Why
The `/api/simulation/<id>/cost.json` endpoint has shipped since #179, and the EmbedView shows a `~$X` cost pill (#190) — but neither is reachable from a script. Automation pipelines and ecosystem integrators running production workflows had no way to verify the "$1 to simulate anything" claim from the CLI. This closes that gap: cost observability becomes a one-line audit after any run, matching the existing `status` / `report` / `publish` command surface.

## Changes
- `backend/cli.py`: new `cmd_cost` + `cost` subparser. Calls `cost.json` via the existing `_api` helper. Prints `estimated_cost_usd` (with a `~` prefix when `is_estimate` is true, mirroring the EmbedView pill), token/call totals, and a per-phase breakdown. Honest about being a lower bound. Exit codes: `0` success, `1` private/server error, `2` when cost isn't available yet (404 — no LLM calls logged). `--json` emits the full payload.
- `backend/tests/test_unit_cli.py`: registers `cost` in the known-subcommands assertion and adds `test_cost_parses_positional`.
- `docs/CLI.md` + `docs/CLI.zh-CN.md`: documents the command, exit codes, and the lower-bound caveat (translations kept in sync).

## Validation
Offline unit tests (`pytest -m "not integration"` — includes `test_unit_cli.py`) could not be run locally: Python execution is blocked in the autonomous build sandbox. The change is argparse-only (no new HTTP endpoint, so the openapi drift test is unaffected) and is exercised by the repo's backend-unit CI job on push.

---
*Built autonomously by Aeon*
