### PR TITLE
fix(llm): thinking model robustness — budget, JSON repair, None guards

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -191,6 +191,13 @@ class Config:
     # Silently no-ops for non-Anthropic models.
     LLM_PROMPT_CACHING_ENABLED = os.environ.get('LLM_PROMPT_CACHING_ENABLED', 'true').lower() == 'true'
 
+    # Extra token budget added transparently to every API call for thinking/reasoning
+    # models (e.g. deepseek-v4-flash, Qwen3) whose <think> blocks consume tokens
+    # from the same max_tokens pool as the actual response. Callers continue to
+    # specify only their response budget; LLMClient adds this value so both fit.
+    # 0 = safe default for non-thinking models (no change in behaviour).
+    THINKING_BUDGET_TOKENS = int(os.environ.get('THINKING_BUDGET_TOKENS', '0'))
+
     # Disable chain-of-thought on reasoning-capable OpenRouter models by default.
     # Passes `reasoning: {enabled: false}` in extra_body — huge latency win
     # (~3x on Qwen3-Flash, ~3x on Gemini-3-Flash) and zero-op on models that
@@ -305,5 +312,14 @@ class Config:
             errors.append("NEO4J_URI is not configured")
         if not cls.NEO4J_PASSWORD:
             errors.append("NEO4J_PASSWORD is not configured")
+        if cls.THINKING_BUDGET_TOKENS > 0 and cls.LLM_DISABLE_REASONING:
+            import warnings
+            warnings.warn(
+                "THINKING_BUDGET_TOKENS is set but LLM_DISABLE_REASONING=true (default) "
+                "will suppress <think> blocks via reasoning:{enabled:false} — the extra "
+                "token budget is wasted. Set LLM_DISABLE_REASONING=false to use thinking "
+                "models, or remove THINKING_BUDGET_TOKENS for non-thinking models.",
+                stacklevel=2,
+            )
         return errors
 

--- a/backend/app/services/graph_tools.py
+++ b/backend/app/services/graph_tools.py
@@ -1049,26 +1049,41 @@ class GraphToolsService:
             query=query,
         )
 
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt}
+        ]
         try:
             response = self.fast_llm.chat_json(
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt}
-                ],
-                temperature=0.3
+                messages=messages,
+                temperature=0.3,
+                repair_truncated=True,
             )
-
             sub_queries = response.get("sub_queries", [])
-            return [str(sq) for sq in sub_queries[:max_queries]]
-
+            if sub_queries:
+                return [str(sq) for sq in sub_queries[:max_queries]]
         except Exception as e:
-            logger.warning(f"Failed to generate sub-questions: {str(e)}, using default sub-questions")
-            return [
-                query,
-                f"Main participants in {query}",
-                f"Causes and impacts of {query}",
-                f"Development process of {query}"
-            ][:max_queries]
+            logger.debug(f"Sub-question JSON parse failed ({e}), trying plain-text parse")
+
+        # Fallback: the model returned a numbered/bulleted plain-text list
+        # instead of JSON (common with thinking models). Extract lines.
+        try:
+            raw = self.fast_llm.chat(messages=messages, temperature=0.3)
+            if raw:
+                import re as _re
+                lines = [
+                    _re.sub(r'^[\d]+[\.\)]\s*|\*+\s*|-\s*', '', ln).strip()
+                    for ln in raw.splitlines()
+                    if ln.strip() and not ln.strip().startswith('#')
+                ]
+                candidates = [ln for ln in lines if len(ln) > 10]
+                if candidates:
+                    logger.debug(f"Extracted {len(candidates)} sub-questions from plain-text response")
+                    return candidates[:max_queries]
+        except Exception as e2:
+            logger.warning(f"Failed to generate sub-questions: {e2}")
+
+        return [query][:max_queries]
 
     def panorama_search(
         self,
@@ -1793,13 +1808,14 @@ class GraphToolsService:
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt}
                 ],
-                temperature=0.5
+                temperature=0.5,
+                repair_truncated=True,
             )
 
             return response.get("questions", [default_q])
 
         except Exception as e:
-            logger.warning(f"Failed to generate interview questions: {e}")
+            logger.debug(f"Failed to generate interview questions (using defaults): {e}")
             return [
                 default_q,
                 get_prompt("graph_tools.interview_questions_default_impact", locale),

--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -503,6 +503,11 @@ class SimulationConfigGenerator:
                     response_format={"type": "json_object"},
                 )
 
+                if content is None:
+                    logger.warning(f"LLM returned empty response (attempt {attempt+1}), retrying")
+                    last_error = ValueError("LLM returned empty response")
+                    continue
+
                 # Try to parse JSON
                 try:
                     return json.loads(content)

--- a/backend/app/services/wonderwall_profile_generator.py
+++ b/backend/app/services/wonderwall_profile_generator.py
@@ -679,6 +679,11 @@ class WonderwallProfileGenerator:
                     response_format={"type": "json_object"},
                 )
 
+                if content is None:
+                    logger.warning(f"LLM returned empty response (attempt {attempt+1}), skipping to fallback")
+                    last_error = ValueError("LLM returned empty response")
+                    continue
+
                 # Try to parse JSON
                 try:
                     result = json.loads(content)

--- a/backend/app/storage/contradiction_detector.py
+++ b/backend/app/storage/contradiction_detector.py
@@ -169,6 +169,7 @@ class ContradictionDetector:
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.0,
                 max_tokens=512,
+                repair_truncated=True,
             )
             raw = response.get("results", {}) if isinstance(response, dict) else {}
         except Exception as e:

--- a/backend/app/storage/ner_extractor.py
+++ b/backend/app/storage/ner_extractor.py
@@ -58,6 +58,7 @@ class NERExtractor:
                     messages=messages,
                     temperature=0.1,  # Low temp for extraction precision
                     max_tokens=4096,
+                    repair_truncated=True,
                 )
                 return self._validate_and_clean(result, ontology)
 

--- a/backend/app/utils/json_repair.py
+++ b/backend/app/utils/json_repair.py
@@ -75,7 +75,13 @@ def _isolate_and_parse(text: str) -> Any:
     try:
         return json.loads(json_str)
     except json.JSONDecodeError:
+        # Strip remaining control characters (raw newlines not inside strings,
+        # stray NUL bytes, etc.) and fix invalid backslash escapes such as
+        # Windows paths (\U, \n used as path sep) or LaTeX (\f, \p, \.).
+        # Valid JSON escapes after \ are: " \ / b f n r t u — anything else
+        # is replaced with \\ so the parser sees an escaped backslash instead.
         json_str = re.sub(r'[\x00-\x1f\x7f-\x9f]', ' ', json_str)
+        json_str = re.sub(r'\\(?!["\\/bfnrtu])', r'\\\\', json_str)
         json_str = re.sub(r'\s+', ' ', json_str)
         return json.loads(json_str)  # raises JSONDecodeError on failure
 

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -158,6 +158,8 @@ class LLMClient:
 
         # Ollama context window size — prevents prompt truncation.
         self._num_ctx = int(os.environ.get('OLLAMA_NUM_CTX', '8192'))
+        # Extra tokens reserved for <think> blocks on reasoning-capable models.
+        self._thinking_budget = Config.THINKING_BUDGET_TOKENS
 
     def _is_ollama(self) -> bool:
         """Check if we're talking to an Ollama server."""
@@ -284,11 +286,13 @@ class LLMClient:
             else messages
         )
 
+        effective_max_tokens = max_tokens + self._thinking_budget
+
         kwargs = {
             "model": self.model,
             "messages": effective_messages,
             "temperature": temperature,
-            "max_tokens": max_tokens,
+            "max_tokens": effective_max_tokens,
         }
 
         if response_format:
@@ -387,7 +391,19 @@ class LLMClient:
             self._emit_llm_event(messages, None, t0, response=response, temperature=temperature)
             return None
         # Some models (e.g., MiniMax M2.5) include <think> reasoning content in the content field, which needs to be removed
-        content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
+        content = re.sub(r'<think>[\s\S]*?</think>', '', content)
+        # Also strip unclosed <think> blocks: when the response is truncated before
+        # </think> the regex above won't match, leaving raw <think>... as the payload.
+        content = re.sub(r'<think>[\s\S]*$', '', content)
+        content = content.strip()
+        # Thinking models sometimes emit only a <think> block with no actual
+        # response after it (the model "exhausted" its work inside the thinking
+        # block). Treat that as an empty response so callers' retry / fallback
+        # logic engages — an empty string would otherwise reach json.loads and
+        # produce a cryptic "Invalid JSON format returned by LLM: " error.
+        if not content:
+            self._emit_llm_event(messages, None, t0, response=response, temperature=temperature)
+            return None
 
         self._emit_llm_event(messages, content, t0, response=response, temperature=temperature)
         return content

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -1111,11 +1111,21 @@ def create_model(config: Dict[str, Any], use_boost: bool = False):
     if llm_base_url:
         os.environ["OPENAI_API_BASE_URL"] = llm_base_url
     
-    print(f"{config_label} model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}...")
-    
+    # When a thinking model is configured, the model spends its default token
+    # budget on the <think> block and has nothing left for the tool-call JSON.
+    # Explicitly set max_tokens = base response budget + thinking budget so
+    # CAMEL always has enough headroom for the actual response.
+    thinking_budget = int(os.environ.get("THINKING_BUDGET_TOKENS", "0"))
+    model_config_dict = {}
+    if thinking_budget > 0:
+        model_config_dict["max_tokens"] = 4096 + thinking_budget
+
+    print(f"{config_label} model={llm_model}, base_url={llm_base_url[:40] if llm_base_url else 'default'}, max_tokens={model_config_dict.get('max_tokens', 'default')}...")
+
     return ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
         model_type=llm_model,
+        model_config_dict=model_config_dict or None,
         default_headers={
             'HTTP-Referer': 'https://www.miroshark.xyz/',
             'X-OpenRouter-Title': 'MiroShark - Simulate anything, for $1 & less than 10 min.',


### PR DESCRIPTION
Harden the pipeline against reasoning/thinking models that emit <think> blocks and occasionally return empty or malformed JSON:

Made for Issue #193 


- config: add THINKING_BUDGET_TOKENS + validate() warning when it conflicts with LLM_DISABLE_REASONING=true (#1)
- llm_client: pad max_tokens with the thinking budget, return None on empty content after <think> stripping, strip unclosed <think> blocks (#1)
- json_repair: strip control chars + fix invalid escape sequences (#4)
- ner_extractor, contradiction_detector: repair_truncated=True on chat_json() calls (#5)
- graph_tools: repair_truncated + plain-text fallback for sub-queries and interview questions (#8)
- wonderwall_profile_generator, simulation_config_generator: guard against None chat() response before json.loads (#16)
- run_parallel_simulation: pass max_tokens (4096 + thinking budget) to CAMEL ModelFactory.create() (#17)