### PR TITLE
fix(config): fall back to default when LLM_MODEL_NAME is blank

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,7 +34,7 @@ class Config:
     LLM_PROVIDER = os.environ.get('LLM_PROVIDER', 'openai')
     LLM_API_KEY = os.environ.get('LLM_API_KEY')
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'https://api.openai.com/v1')
-    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'xiaomi/mimo-v2.5')
+    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME') or 'xiaomi/mimo-v2.5'  # `or` so a blank LLM_MODEL_NAME= falls back instead of sending an empty model
 
     # Smart model — stronger model for intelligence-sensitive workflows
     # (report generation, ontology extraction, graph reasoning).


### PR DESCRIPTION
Hardens `Config.LLM_MODEL_NAME` so a present-but-empty `LLM_MODEL_NAME=` falls back to the `xiaomi/mimo-v2.5` default instead of resolving to an empty string (which makes the upstream API 400 with "no model provided").

```diff
-LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME', 'xiaomi/mimo-v2.5')
+LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME') or 'xiaomi/mimo-v2.5'
```

`os.environ.get(name, default)` only uses the default when the var is **absent** — a blank `LLM_MODEL_NAME=` slips through as `''`. `or` covers both. Scoped to `LLM_MODEL_NAME` only; the `SMART_`/`WONDERWALL_` slots intentionally default to `''` (= inherit), so they're left as-is.

This is the one genuinely net-new bit salvaged from #204 (the model-id rename in that PR was already on `main`). Credit to @tomer-liran for spotting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)