### PR TITLE
fix(graph): restore semantic default fan-out in sub-query fallback

### DIFF
--- a/backend/app/services/graph_tools.py
+++ b/backend/app/services/graph_tools.py
@@ -1083,7 +1083,14 @@ class GraphToolsService:
         except Exception as e2:
             logger.warning(f"Failed to generate sub-questions: {e2}")
 
-        return [query][:max_queries]
+        # Total failure: fall back to the semantic default fan-out rather than a
+        # single bare query, so breadth search still explores participants/causes/process.
+        return [
+            query,
+            f"Main participants in {query}",
+            f"Causes and impacts of {query}",
+            f"Development process of {query}"
+        ][:max_queries]
 
     def panorama_search(
         self,


### PR DESCRIPTION
## What

Follow-up to #209. That PR added a useful intermediate plain-text-parse fallback in `GraphToolsService._generate_sub_queries`, but its **total-failure** path regressed from a 4-way semantic default to a single bare query:

```python
# before #209
return [query, f"Main participants in {query}", f"Causes and impacts of {query}", f"Development process of {query}"][:max_queries]
# after #209
return [query][:max_queries]
```

This narrows the breadth-search fan-out (`PanoramaSearch`) whenever the LLM fails to produce sub-questions.

## Change

Keeps #209's new plain-text-parse fallback intact and only restores the richer semantic default for the **total-failure** case, so breadth search still explores participants / causes & impacts / development process.

## Notes

- Flagged as a non-blocking nit during review of #209.
- One-spot change; `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)