### PR TITLE
chore: performance and robustness tuning for local llm usage

### DIFF
--- a/backend/app/services/simulation_config_generator.py
+++ b/backend/app/services/simulation_config_generator.py
@@ -234,13 +234,13 @@ class SimulationConfigGenerator:
     # Maximum context character count
     MAX_CONTEXT_LENGTH = 50000
     # Number of Agents per batch — keep small to avoid JSON truncation with local LLMs
-    AGENTS_PER_BATCH = 15
+    AGENTS_PER_BATCH = 7
 
     # Context truncation lengths for each step (characters)
     TIME_CONFIG_CONTEXT_LENGTH = 10000   # Time configuration
     EVENT_CONFIG_CONTEXT_LENGTH = 8000   # Event configuration
-    ENTITY_SUMMARY_LENGTH = 300          # Entity summary
-    AGENT_SUMMARY_LENGTH = 300           # Entity summary in Agent configuration
+    ENTITY_SUMMARY_LENGTH = 500          # Entity summary
+    AGENT_SUMMARY_LENGTH = 500           # Entity summary in Agent configuration
     ENTITIES_PER_TYPE_DISPLAY = 20       # Number of entities displayed per type
 
     def __init__(
@@ -756,13 +756,15 @@ Return JSON format (no markdown):
         if not event_config.initial_posts:
             return event_config
 
-        # Build agent index by entity type
+        # Build agent indices by entity type and by entity name
         agents_by_type: Dict[str, List[AgentActivityConfig]] = {}
+        agents_by_name: Dict[str, AgentActivityConfig] = {}
         for agent in agent_configs:
             etype = agent.entity_type.lower()
             if etype not in agents_by_type:
                 agents_by_type[etype] = []
             agents_by_type[etype].append(agent)
+            agents_by_name[agent.entity_name.lower()] = agent
 
         # Type alias mapping (handle different formats LLM might output)
         type_aliases = {
@@ -787,14 +789,18 @@ Return JSON format (no markdown):
             # Try to find matching agent
             matched_agent_id = None
 
-            # 1. Direct match
+            # 1. Direct type match
             if poster_type in agents_by_type:
                 agents = agents_by_type[poster_type]
                 idx = used_indices.get(poster_type, 0) % len(agents)
                 matched_agent_id = agents[idx].agent_id
                 used_indices[poster_type] = idx + 1
+            # 2. Name match — LLM sometimes outputs the entity name instead of type
+            elif poster_type in agents_by_name:
+                agent = agents_by_name[poster_type]
+                matched_agent_id = agent.agent_id
             else:
-                # 2. Use alias matching
+                # 3. Use alias matching
                 for alias_key, aliases in type_aliases.items():
                     if poster_type in aliases or alias_key == poster_type:
                         for alias in aliases:
@@ -807,7 +813,7 @@ Return JSON format (no markdown):
                     if matched_agent_id is not None:
                         break
 
-            # 3. If still not found, use agent with highest influence
+            # 4. If still not found, use agent with highest influence
             if matched_agent_id is None:
                 logger.warning(f"No matching Agent found for type '{poster_type}', using agent with highest influence")
                 if agent_configs:

--- a/backend/app/storage/neo4j_storage.py
+++ b/backend/app/storage/neo4j_storage.py
@@ -70,13 +70,28 @@ class Neo4jStorage(GraphStorage):
         self._driver.close()
 
     def _ensure_schema(self):
-        """Create indexes and constraints if they don't exist."""
-        with self._driver.session() as session:
-            for query in neo4j_schema.get_all_schema_queries():
-                try:
-                    session.run(query)
-                except Exception as e:
-                    logger.warning(f"Schema query warning (may already exist): {e}")
+        """Create indexes and constraints if they don't exist.
+
+        Retries with backoff because Neo4j may accept Bolt connections before its
+        index subsystem is fully ready (common on fresh container start).
+        """
+        max_attempts = 5
+        for attempt in range(max_attempts):
+            failures = []
+            with self._driver.session() as session:
+                for query in neo4j_schema.get_all_schema_queries():
+                    try:
+                        session.run(query).consume()
+                    except Exception as e:
+                        failures.append(e)
+                        logger.warning("Schema query failed (attempt %d): %s", attempt + 1, e)
+            if not failures:
+                return
+            if attempt < max_attempts - 1:
+                delay = 2 ** attempt
+                logger.info("Schema creation had %d failure(s); retrying in %ds…", len(failures), delay)
+                time.sleep(delay)
+        logger.error("Schema creation still failing after %d attempts; indexes may be missing", max_attempts)
 
     # ----------------------------------------------------------------
     # Retry wrapper

--- a/backend/app/utils/logger.py
+++ b/backend/app/utils/logger.py
@@ -81,11 +81,13 @@ def setup_logger(name: str = 'miroshark', level: int = logging.DEBUG) -> logging
     except OSError as e:
         print(f"[logger] File logging disabled ({e}); console only", file=sys.stderr)
 
-    # 2. Console handler - concise logs (INFO and above)
-    # Ensure UTF-8 encoding on Windows to avoid character encoding issues
+    # 2. Console handler - concise logs (INFO and above by default, or
+    # MIROSHARK_LOG_LEVEL if set — lets docker compose logs show DEBUG output)
     _ensure_utf8_stdout()
+    _env_level = os.environ.get('MIROSHARK_LOG_LEVEL', 'info').upper()
+    _console_level = getattr(logging, _env_level, logging.INFO)
     console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(logging.INFO)
+    console_handler.setLevel(_console_level)
     console_handler.setFormatter(simple_formatter)
 
     if file_handler is not None:

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -2368,6 +2368,16 @@ async def run_synchronized_simulation(
         )
         await twitter_result.env.reset()
         log_info("[Twitter] Environment ready")
+        try:
+            from wonderwall.social_platform.recsys import get_twhin_tokenizer, get_twhin_model
+            import torch as _torch
+            _device = 'cuda' if _torch.cuda.is_available() else 'cpu'
+            log_info("[Twitter] Loading twhin-bert-base recommendation model…")
+            get_twhin_tokenizer()
+            get_twhin_model(_device)
+            log_info("[Twitter] twhin-bert-base ready")
+        except Exception as _e:
+            log_info(f"[Twitter] twhin-bert pre-warm failed (non-fatal): {_e}")
 
     if has_reddit:
         reddit_result = PlatformSimulation()

--- a/backend/wonderwall/social_agent/agent.py
+++ b/backend/wonderwall/social_agent/agent.py
@@ -234,6 +234,11 @@ class SocialAgent(ChatAgent):
             except Exception:
                 pass
 
+        # CAMEL dropped `num_tokens` from _aget_model_response in newer versions
+        # (present in 0.2.x local .venv/py3.12, gone in Docker py3.14 build).
+        # Pop it here so we never pass an unexpected kwarg to super().
+        kwargs.pop("num_tokens", None)
+
         start = _time.time()
         error_msg = None
         result = None

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -6,12 +6,19 @@ services:
     container_name: miroshark-neo4j
     environment:
       - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set in .env}
+      - NEO4J_server_jvm_additional=--add-modules jdk.incubator.vector
     ports:
       - "7474:7474"
       - "7687:7687"
     volumes:
       - neo4j_data:/data
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:7474/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   ollama:
     image: ollama/ollama:latest
@@ -42,12 +49,16 @@ services:
       - "3000:3000"
       - "5001:5001"
     depends_on:
-      - neo4j
-      - ollama
+      neo4j:
+        condition: service_healthy
+      ollama:
+        condition: service_started
     restart: unless-stopped
     volumes:
       - ./backend/uploads:/app/backend/uploads
+      - hf_cache:/root/.cache/huggingface
 
 volumes:
   neo4j_data:
   ollama_data:
+  hf_cache:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -4,12 +4,19 @@ services:
     container_name: miroshark-neo4j
     environment:
       - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set in .env}
+      - NEO4J_server_jvm_additional=--add-modules jdk.incubator.vector
     ports:
       - "7474:7474"
       - "7687:7687"
     volumes:
       - neo4j_data:/data
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:7474/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     networks:
       - miroshark
 
@@ -23,7 +30,8 @@ services:
       NEO4J_URI: bolt://neo4j:7687
     # Host ports optional — Traefik routes :3000 (UI) and :5001 (API)
     depends_on:
-      - neo4j
+      neo4j:
+        condition: service_healthy
     restart: unless-stopped
     labels:
       - traefik.enable=true
@@ -60,6 +68,7 @@ services:
     volumes:
       - ./backend/uploads:/app/backend/uploads
       - ./backend/logs:/app/backend/logs
+      - hf_cache:/root/.cache/huggingface
     networks:
       - miroshark
       - docker-proxynet
@@ -67,6 +76,7 @@ services:
 
 volumes:
   neo4j_data:
+  hf_cache:
 
 networks:
   miroshark:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,19 @@ services:
     container_name: miroshark-neo4j
     environment:
       - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set in .env}
+      - NEO4J_server_jvm_additional=--add-modules jdk.incubator.vector
     ports:
       - "7474:7474"
       - "7687:7687"
     volumes:
       - neo4j_data:/data
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:7474/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   ollama:
     image: ollama/ollama:latest
@@ -40,12 +47,16 @@ services:
       - "3000:3000"
       - "5001:5001"
     depends_on:
-      - neo4j
-      - ollama
+      neo4j:
+        condition: service_healthy
+      ollama:
+        condition: service_started
     restart: unless-stopped
     volumes:
       - ./backend/uploads:/app/backend/uploads
+      - hf_cache:/root/.cache/huggingface
 
 volumes:
   neo4j_data:
   ollama_data:
+  hf_cache:


### PR DESCRIPTION

I found several issues - sometimes just low performing settings, which I had to change to get rid of WARNINGS and Timeouts.  

Operational tuning and reliability fixes, independent of the core simulation logic:

- simulation_config_generator: AGENTS_PER_BATCH 15 -> 7 and entity/agent summary lengths 300 -> 500 to avoid JSON truncation and give richer context with local LLMs; add name-based lookup in initial-post agent matching (type -> name -> alias -> highest-influence)
- run_parallel_simulation: pre-warm twhin-bert-base during setup so the ~3-5 min model load happens in the visible setup phase instead of Round 1
- agent: pop num_tokens before super()._aget_model_response() for CAMEL forward-compatibility (Docker py3.14 build dropped the kwarg)
- neo4j_storage: consume() schema DDL so failures surface, with a 5-attempt exponential-backoff retry for the Neo4j startup race
- logger: console handler now honors MIROSHARK_LOG_LEVEL
- docker-compose (x3): Neo4j healthcheck + service_healthy gating, persistent hf_cache volume for the HuggingFace model cache, and --add-modules jdk.incubator.vector for SIMD-accelerated Neo4j vectors