### PR TITLE
fix(interview): Persona-interviews hang prevention, error surfacing, and…

### DIFF
--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -190,6 +190,20 @@ def _ensure_env_alive(simulation_id: str) -> bool:
         return False
 
     try:
+        # If a previous process crashed and left a stale RUNNING/STARTING state,
+        # reset it — we already know the env is not alive, so the state is stale.
+        existing_state = SimulationRunner.get_run_state(simulation_id)
+        if existing_state and existing_state.runner_status in [
+            RunnerStatus.RUNNING, RunnerStatus.STARTING, RunnerStatus.STOPPING
+        ]:
+            logger.info(
+                f"Resetting stale run state for {simulation_id} "
+                f"(was {existing_state.runner_status.value}) before env-only restart"
+            )
+            existing_state.runner_status = RunnerStatus.FAILED
+            existing_state.error = "Process died unexpectedly; restarting in env-only mode for interviews"
+            SimulationRunner._save_run_state(existing_state)
+
         SimulationRunner.start_simulation(
             simulation_id=simulation_id,
             platform='parallel',
@@ -8492,8 +8506,8 @@ def interview_agent():
         agent_id = data.get('agent_id')
         prompt = data.get('prompt')
         platform = data.get('platform')  # Optional: twitter/reddit/None
-        timeout = data.get('timeout', 60)
-        
+        timeout = data.get('timeout', 240)
+
         if agent_id is None:
             return jsonify({
                 "success": False,
@@ -8529,6 +8543,7 @@ def interview_agent():
                     "Simulation environment could not be started. Please try again.",
                     "无法启动模拟环境,请重试。",
                     locale,
+                    de="Die Simulationsumgebung konnte nicht gestartet werden. Bitte versuche es erneut.",
                 )
             }), 400
 
@@ -8543,23 +8558,28 @@ def interview_agent():
             timeout=timeout
         )
 
+        if not result.get("success"):
+            return jsonify({
+                "success": False,
+                "error": result.get("error") or _t("Interview failed", "访谈失败", locale, de="Interviewanfrage fehlgeschlagen"),
+            }), 400
         return jsonify({
-            "success": result.get("success", False),
+            "success": True,
             "data": result
         })
-        
+
     except ValueError as e:
         return jsonify({
             "success": False,
             "error": str(e)
         }), 400
-        
+
     except TimeoutError as e:
         return jsonify({
             "success": False,
             "error": f"Timed out waiting for interview response: {str(e)}"
         }), 504
-        
+
     except Exception as e:
         logger.error(f"Interview failed: {str(e)}")
         return jsonify({
@@ -8622,7 +8642,7 @@ def interview_agents_batch():
             return err
         interviews = data.get('interviews')
         platform = data.get('platform')  # Optional: twitter/reddit/None
-        timeout = data.get('timeout', 120)
+        timeout = data.get('timeout', 240)
 
         if not interviews or not isinstance(interviews, list):
             return jsonify({
@@ -8685,6 +8705,7 @@ def interview_agents_batch():
                     "Simulation environment could not be started. Please try again.",
                     "无法启动模拟环境,请重试。",
                     locale,
+                    de="Die Simulationsumgebung konnte nicht gestartet werden. Bitte versuche es erneut.",
                 )
             }), 400
 
@@ -8702,8 +8723,13 @@ def interview_agents_batch():
             timeout=timeout
         )
 
+        if not result.get("success"):
+            return jsonify({
+                "success": False,
+                "error": result.get("error") or _t("Interview failed", "访谈失败", locale, de="Interviewanfrage fehlgeschlagen"),
+            }), 400
         return jsonify({
-            "success": result.get("success", False),
+            "success": True,
             "data": result
         })
 

--- a/backend/app/services/graph_tools.py
+++ b/backend/app/services/graph_tools.py
@@ -1691,23 +1691,34 @@ class GraphToolsService:
         Matches against realname and username fields (case-insensitive, substring match).
         Falls back to LLM selection if no names match.
         """
+        import re as _re
         selected_agents = []
         selected_indices = []
-        names_lower = [n.lower() for n in agent_names]
+        # Strip parenthetical qualifiers like "(1.2M)" or "(800K)" that the LLM
+        # appends to archetype labels but never appear verbatim in profile fields.
+        names_lower = [
+            _re.sub(r'\s*\([^)]*\)', '', n).strip().lower()
+            for n in agent_names
+        ]
 
         for i, profile in enumerate(profiles):
             if len(selected_agents) >= max_agents:
                 break
-            realname = (profile.get("realname") or "").lower()
+            # Reddit profiles use 'name'; Twitter CSV mapping uses 'realname'.
+            realname = (profile.get("realname") or profile.get("name") or "").lower()
             username = (profile.get("username") or "").lower()
+            profession = (profile.get("profession") or "").lower()
             for name_query in names_lower:
-                if name_query in realname or name_query in username:
+                if name_query in realname or name_query in username or name_query in profession:
                     selected_agents.append(profile)
                     selected_indices.append(i)
                     break
 
         if selected_agents:
-            matched_names = [a.get("realname", a.get("username", "?")) for a in selected_agents]
+            matched_names = [
+                a.get("realname") or a.get("name") or a.get("username", "?")
+                for a in selected_agents
+            ]
             reasoning = f"Directly selected by name: {', '.join(matched_names)}"
             logger.info(f"Agent name match: {len(selected_agents)} of {len(agent_names)} requested names found")
             return selected_agents, selected_indices, reasoning

--- a/backend/app/services/simulation_ipc.py
+++ b/backend/app/services/simulation_ipc.py
@@ -270,10 +270,10 @@ class SimulationIPCClient:
         try:
             with open(status_file, 'r', encoding='utf-8') as f:
                 status = json.load(f)
+            pid = status.get("pid")
             if status.get("status") != "alive":
                 # Status says not alive — but check if the process is actually
                 # running (handles race where old process overwrites new status)
-                pid = status.get("pid")
                 if pid:
                     try:
                         os.kill(pid, 0)  # signal 0 = check if process exists
@@ -281,6 +281,13 @@ class SimulationIPCClient:
                     except OSError:
                         pass  # PID is dead
                 return False
+            # Status says "alive" — verify the PID is still running to catch
+            # the case where the worker crashed after writing the status file.
+            if pid:
+                try:
+                    os.kill(pid, 0)
+                except OSError:
+                    return False  # PID is gone — stale "alive" status
             return True
         except (json.JSONDecodeError, OSError):
             return False

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -559,15 +559,17 @@ class SimulationRunner:
                     state.error = f"Process exit code: {exit_code}, error: {error_info}"
                     logger.error(f"Simulation failed: {simulation_id}, error={state.error}")
 
-                # Same fan-out for the failure path — operators want to know either way.
-                _fan_out_notifications(
-                    simulation_id,
-                    "failed",
-                    sim_dir=sim_dir,
-                    state=state,
-                    completed_at=datetime.now().isoformat(),
-                    error=state.error,
-                )
+                    # Notify only on a genuine failure. An intentional stop
+                    # (STOPPED/STOPPING, handled in the branch above) is not a
+                    # failure and must not page operators with a "failed" alert.
+                    _fan_out_notifications(
+                        simulation_id,
+                        "failed",
+                        sim_dir=sim_dir,
+                        state=state,
+                        completed_at=datetime.now().isoformat(),
+                        error=state.error,
+                    )
             
             state.twitter_running = False
             state.reddit_running = False

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -537,18 +537,27 @@ class SimulationRunner:
                     completed_at=state.completed_at,
                 )
             else:
-                state.runner_status = RunnerStatus.FAILED
-                # Read error info from main log file
-                main_log_path = os.path.join(sim_dir, "simulation.log")
-                error_info = ""
-                try:
-                    if os.path.exists(main_log_path):
-                        with open(main_log_path, 'r', encoding='utf-8') as f:
-                            error_info = f.read()[-2000:]  # Take last 2000 characters
-                except (OSError, UnicodeDecodeError) as e:
-                    logger.debug(f"Could not read error info from {main_log_path}: {e}")
-                state.error = f"Process exit code: {exit_code}, error: {error_info}"
-                logger.error(f"Simulation failed: {simulation_id}, error={state.error}")
+                # An intentional stop (via stop_simulation()) already set the
+                # status to STOPPED/STOPPING before sending SIGKILL.  Don't
+                # overwrite that with FAILED just because the exit code is -9.
+                if state.runner_status in (RunnerStatus.STOPPED, RunnerStatus.STOPPING):
+                    logger.info(
+                        f"Simulation process exited with code {exit_code} after "
+                        f"intentional stop: {simulation_id}"
+                    )
+                else:
+                    state.runner_status = RunnerStatus.FAILED
+                    # Read error info from main log file
+                    main_log_path = os.path.join(sim_dir, "simulation.log")
+                    error_info = ""
+                    try:
+                        if os.path.exists(main_log_path):
+                            with open(main_log_path, 'r', encoding='utf-8') as f:
+                                error_info = f.read()[-2000:]  # Take last 2000 characters
+                    except (OSError, UnicodeDecodeError) as e:
+                        logger.debug(f"Could not read error info from {main_log_path}: {e}")
+                    state.error = f"Process exit code: {exit_code}, error: {error_info}"
+                    logger.error(f"Simulation failed: {simulation_id}, error={state.error}")
 
                 # Same fan-out for the failure path — operators want to know either way.
                 _fan_out_notifications(
@@ -792,7 +801,7 @@ class SimulationRunner:
         return twitter_enabled or reddit_enabled or polymarket_enabled
     
     @classmethod
-    def _terminate_process(cls, process: subprocess.Popen, simulation_id: str, timeout: int = 10):
+    def _terminate_process(cls, process: subprocess.Popen, simulation_id: str, timeout: int = 30):
         """
         Cross-platform termination of process and its child processes
         

--- a/backend/scripts/run_parallel_simulation.py
+++ b/backend/scripts/run_parallel_simulation.py
@@ -522,7 +522,9 @@ class ParallelIPCHandler:
                 reddit_interviews.extend(both_platforms_interviews)
         
         results = {}
-        
+        twitter_error: str | None = None
+        reddit_error: str | None = None
+
         # Process Twitter platform interviews
         if twitter_interviews and self.twitter_env:
             try:
@@ -538,18 +540,27 @@ class ParallelIPCHandler:
                         )
                     except Exception as e:
                         print(f"  Warning: Unable to get Twitter Agent {agent_id}: {e}")
-                
+
                 if twitter_actions:
-                    await self.twitter_env.step(twitter_actions)
-                    
+                    print(f"  Twitter: starting {len(twitter_actions)} interview(s)...")
+                    await asyncio.wait_for(
+                        self.twitter_env.step(twitter_actions),
+                        timeout=220,
+                    )
+                    print(f"  Twitter: env.step() completed")
+
                     for interview in twitter_interviews:
                         agent_id = interview.get("agent_id")
                         result = self._get_interview_result(agent_id, "twitter")
                         result["platform"] = "twitter"
                         results[f"twitter_{agent_id}"] = result
+            except asyncio.TimeoutError:
+                twitter_error = "Twitter interview timed out after 220 s (thinking-model LLM too slow)"
+                print(f"  Twitter batch Interview timed out")
             except Exception as e:
+                twitter_error = str(e)
                 print(f"  Twitter batch Interview failed: {e}")
-        
+
         # Process Reddit platform interviews
         if reddit_interviews and self.reddit_env:
             try:
@@ -565,18 +576,27 @@ class ParallelIPCHandler:
                         )
                     except Exception as e:
                         print(f"  Warning: Unable to get Reddit Agent {agent_id}: {e}")
-                
+
                 if reddit_actions:
-                    await self.reddit_env.step(reddit_actions)
-                    
+                    print(f"  Reddit: starting {len(reddit_actions)} interview(s)...")
+                    await asyncio.wait_for(
+                        self.reddit_env.step(reddit_actions),
+                        timeout=220,
+                    )
+                    print(f"  Reddit: env.step() completed")
+
                     for interview in reddit_interviews:
                         agent_id = interview.get("agent_id")
                         result = self._get_interview_result(agent_id, "reddit")
                         result["platform"] = "reddit"
                         results[f"reddit_{agent_id}"] = result
+            except asyncio.TimeoutError:
+                reddit_error = "Reddit interview timed out after 220 s (thinking-model LLM too slow)"
+                print(f"  Reddit batch Interview timed out")
             except Exception as e:
+                reddit_error = str(e)
                 print(f"  Reddit batch Interview failed: {e}")
-        
+
         if results:
             self.send_response(command_id, "completed", result={
                 "interviews_count": len(results),
@@ -585,7 +605,9 @@ class ParallelIPCHandler:
             print(f"  Batch Interview completed: {len(results)} Agents")
             return True
         else:
-            self.send_response(command_id, "failed", error="No successful interviews")
+            error_parts = [e for e in [twitter_error, reddit_error] if e]
+            combined_error = "; ".join(error_parts) if error_parts else "No successful interviews"
+            self.send_response(command_id, "failed", error=combined_error)
             return False
     
     def _get_interview_result(self, agent_id: int, platform: str) -> Dict[str, Any]:

--- a/backend/wonderwall/environment/env.py
+++ b/backend/wonderwall/environment/env.py
@@ -49,7 +49,9 @@ env_log.addHandler(file_handler)
 
 def _is_interview_action(action) -> bool:
     """Check if an action is an interview, handling both enum and string."""
-    action_type = action.action_type
+    action_type = getattr(action, 'action_type', None)
+    if action_type is None:
+        return False
     if hasattr(action_type, "value"):
         return action_type.value == "interview"
     return action_type == "interview"
@@ -210,8 +212,15 @@ class WonderwallEnv:
             None
         """
         # Update the recommendation system (no-op for platforms that don't
-        # implement it).
-        if hasattr(self.platform, 'update_rec_table'):
+        # implement it). Skip for interview-only rounds: update_rec_table()
+        # runs synchronous PyTorch/twhin-bert embedding code that blocks the
+        # asyncio event loop, preventing asyncio.wait_for from firing its
+        # timeout. Rec-table state is irrelevant for interview responses.
+        all_interview = all(
+            _is_interview_action(a[0] if isinstance(a, list) else a)
+            for a in actions.values()
+        )
+        if not all_interview and hasattr(self.platform, 'update_rec_table'):
             await self.platform.update_rec_table()
             env_log.info("update rec table.")
 

--- a/backend/wonderwall/social_agent/agent.py
+++ b/backend/wonderwall/social_agent/agent.py
@@ -501,10 +501,16 @@ class SocialAgent(ChatAgent):
         # Camel can not stop updating the agents' memory after stop and astep
         # now.
 
+        agent_log.info(f"Agent {self.social_agent_id}: calling LLM for interview...")
         response = await self._aget_model_response(
             openai_messages=openai_messages, num_tokens=num_tokens)
 
+        if response is None or not response.output_messages:
+            raise RuntimeError(
+                f"Agent {self.social_agent_id}: LLM returned no response during interview"
+            )
         content = response.output_messages[0].content
+        agent_log.info(f"Agent {self.social_agent_id}: LLM response received, writing to platform...")
 
         if self.interview_record:
             # Test memory should not be writed to memory.
@@ -517,6 +523,7 @@ class SocialAgent(ChatAgent):
         interview_data = {"prompt": interview_prompt, "response": content}
         result = await self.env.action.perform_action(
             interview_data, ActionType.INTERVIEW.value)
+        agent_log.info(f"Agent {self.social_agent_id}: platform.perform_action completed")
 
         # Return the combined result
         return {

--- a/backend/wonderwall/social_platform/platform.py
+++ b/backend/wonderwall/social_platform/platform.py
@@ -130,7 +130,16 @@ class Platform:
             message_id, data = await self.channel.receive_from()
 
             agent_id, message, action = data
-            action = ActionType(action)
+            try:
+                action = ActionType(action)
+            except ValueError:
+                # Unknown action type — reply with an error so the caller's
+                # perform_action doesn't hang forever, then keep the loop alive.
+                import logging as _logging
+                _logging.getLogger(__name__).error(
+                    f"platform.running: unknown action type {action!r}")
+                await self.channel.send_to((message_id, agent_id, None))
+                continue
 
             if action == ActionType.EXIT:
                 # If the database is in-memory, save it to a file before
@@ -146,31 +155,43 @@ class Platform:
 
             # Retrieve the corresponding function using getattr
             action_function = getattr(self, action.value, None)
-            if action_function:
-                # Get the names of the parameters of the function
-                func_code = action_function.__code__
-                param_names = func_code.co_varnames[:func_code.co_argcount]
+            try:
+                if action_function:
+                    # Get the names of the parameters of the function
+                    func_code = action_function.__code__
+                    param_names = func_code.co_varnames[:func_code.co_argcount]
 
-                len_param_names = len(param_names)
-                if len_param_names > 3:
-                    raise ValueError(
-                        f"Functions with {len_param_names} parameters are not "
-                        f"supported.")
-                # Build a dictionary of parameters
-                params = {}
-                if len_param_names >= 2:
-                    params["agent_id"] = agent_id
-                if len_param_names == 3:
-                    # Assuming the second element in param_names is the name
-                    # of the second parameter you want to add
-                    second_param_name = param_names[2]
-                    params[second_param_name] = message
+                    len_param_names = len(param_names)
+                    if len_param_names > 3:
+                        raise ValueError(
+                            f"Functions with {len_param_names} parameters are not "
+                            f"supported.")
+                    # Build a dictionary of parameters
+                    params = {}
+                    if len_param_names >= 2:
+                        params["agent_id"] = agent_id
+                    if len_param_names == 3:
+                        # Assuming the second element in param_names is the name
+                        # of the second parameter you want to add
+                        second_param_name = param_names[2]
+                        params[second_param_name] = message
 
-                # Call the function with the parameters
-                result = await action_function(**params)
-                await self.channel.send_to((message_id, agent_id, result))
-            else:
-                raise ValueError(f"Action {action} is not supported")
+                    # Call the function with the parameters
+                    result = await action_function(**params)
+                    await self.channel.send_to((message_id, agent_id, result))
+                else:
+                    raise ValueError(f"Action {action} is not supported")
+            except Exception as _exc:
+                import logging as _logging
+                _logging.getLogger(__name__).error(
+                    f"platform.running: error handling action {action!r}: {_exc}",
+                    exc_info=True,
+                )
+                # Send None back so perform_action unblocks rather than hanging.
+                try:
+                    await self.channel.send_to((message_id, agent_id, None))
+                except Exception:
+                    pass
 
     def run(self):
         asyncio.run(self.running())

--- a/frontend/src/api/simulation.js
+++ b/frontend/src/api/simulation.js
@@ -222,7 +222,7 @@ export const exportSimulationData = (simulationId, format = 'json') => {
  * @param {Object} data - { simulation_id, interviews: [{ agent_id, prompt }] }
  */
 export const interviewAgents = (data) => {
-  return requestWithRetry(() => service.post('/api/simulation/interview/batch', data), 3, 1000)
+  return service.post('/api/simulation/interview/batch', data)
 }
 
 /**

--- a/frontend/src/components/Step5Interaction.vue
+++ b/frontend/src/components/Step5Interaction.vue
@@ -368,7 +368,7 @@
               ></textarea>
             </div>
 
-            <button 
+            <button
               class="survey-submit-btn"
               :disabled="selectedAgents.size === 0 || !surveyQuestion.trim() || isSurveying"
               @click="submitSurvey"
@@ -376,6 +376,7 @@
               <span v-if="isSurveying" class="loading-spinner"></span>
               <span v-else>{{ $tr('Send Question', '发送问题', { de: 'Umfrage senden' }) }}</span>
             </button>
+            <div v-if="surveyError" class="survey-error">{{ surveyError }}</div>
           </div>
 
           <!-- Results -->
@@ -568,6 +569,7 @@ const selectedAgents = ref(new Set())
 const surveyQuestion = ref('')
 const surveyResults = ref([])
 const isSurveying = ref(false)
+const surveyError = ref('')
 
 // Report Data
 const reportOutline = ref(null)
@@ -838,10 +840,11 @@ const clearAgentSelection = () => {
 
 const submitSurvey = async () => {
   if (selectedAgents.value.size === 0 || !surveyQuestion.value.trim()) return
-  
+
   isSurveying.value = true
+  surveyError.value = ''
   addLog(`${tr('Sending survey to', '正在向', { de: 'Sende Umfrage an' })} ${selectedAgents.value.size} ${tr('targets...', '个对象发送问卷...', { de: 'Ziele...' })}`)
-  
+
   try {
     const interviews = Array.from(selectedAgents.value).map(idx => ({
       agent_id: idx,
@@ -899,6 +902,7 @@ const submitSurvey = async () => {
       throw new Error(res.error || tr('Request failed', '请求失败', { de: 'Anfrage fehlgeschlagen' }))
     }
   } catch (err) {
+    surveyError.value = err.message
     addLog(`${tr('Survey send failed', '问卷发送失败', { de: 'Umfrage konnte nicht gesendet werden' })}: ${err.message}`)
   } finally {
     isSurveying.value = false
@@ -2481,6 +2485,18 @@ watch(() => props.simulationId, (newId) => {
   color: rgba(228,222,255,0.35);
   cursor: not-allowed;
   box-shadow: none;
+}
+
+.survey-error {
+  margin-top: 10px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: rgba(255, 68, 68, 0.12);
+  border: 1px solid rgba(255, 68, 68, 0.3);
+  color: #ff8080;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  line-height: 1.5;
 }
 
 .loading-spinner {


### PR DESCRIPTION
… stop-lifecycle fixes

Batch and Persona interviews with slow thinking models could hang silently or fail with opaque messages. This bundles the engine-, worker-, API-, and UI-level fixes plus two simulation stop-lifecycle corrections.

**Engine hang root-causes:**
- platform.running() wraps action dispatch in try/except and sends None back on error instead of dying (a dead loop blocked perform_action forever); unknown ActionType now continues instead of raising (#19)
- check_env_alive() verifies PID liveness even when the status file says "alive", so a crashed env_only worker is detected (#19)
- env.step() skips update_rec_table() on interview-only steps (the synchronous PyTorch call blocked the asyncio loop and defeated the worker timeout); _is_interview_action uses getattr to avoid AttributeError (#20)

**Worker reliability:**
- env.step() wrapped in asyncio.wait_for(220s) so the worker always sends a timely IPC response (#15)
- platform exceptions captured and joined into the IPC "failed" error instead of being lost to subprocess stdout (#13)
- perform_interview() raises a clear RuntimeError when the LLM returns None/empty, including the agent id (#14)

**API / UX:**
- interview endpoints return HTTP 400 with a top-level error so the frontend shows the real cause (#9)
- IPC poll timeout raised to 240s for slow thinking models (#10)
- _ensure_env_alive() resets a stale RUNNING/STARTING state before restart (#22)
- frontend interviewAgents drops requestWithRetry (retries just queue) (#11)
- survey submission shows a visible error box on failure (#12)

**Interview agent selection:**
- name matching also checks Reddit 'name' and 'profession' fields and strips parenthetical follower-count qualifiers (#28)

**Simulation stop lifecycle:**
- SIGTERM grace period 10s -> 30s so in-flight LLM calls can finish (#18)
- monitor no longer overwrites STOPPED with FAILED on the intentional -9 exit (#25)