### PR TITLE
feat(cli): add wait subcommand to block until a simulation finishes

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -147,33 +147,42 @@ def cmd_wait(args: argparse.Namespace) -> int:
     terminal_ok = {"completed"}
     terminal_fail = {"failed", "stopped"}
     deadline = time.monotonic() + args.timeout
+    status = ""
     while True:
         res = _api(
             "GET",
             f"/api/simulation/{args.simulation_id}/run-status",
             timeout=30.0,
         )
-        if not res.get("success"):
-            _die(res.get("error", "status failed"))
-        d = res.get("data") or {}
-        status = (d.get("runner_status") or d.get("status") or "").lower()
-        # Progress lines go to stderr so stdout stays clean for `--json` piping.
-        print(
-            f"[{status or '?'}] round {d.get('current_round')}/{d.get('total_rounds', '?')}",
-            file=sys.stderr,
-        )
-        if status in terminal_ok:
-            if args.json:
-                _print_json(res)
-            else:
-                print(f"{args.simulation_id} completed")
-            return 0
-        if status in terminal_fail:
-            if args.json:
-                _print_json(res)
-            else:
-                print(f"{args.simulation_id} {status}", file=sys.stderr)
-            return 1
+        if res.get("success"):
+            d = res.get("data") or {}
+            status = (d.get("runner_status") or d.get("status") or "").lower()
+            # Progress lines go to stderr so stdout stays clean for `--json` piping.
+            print(
+                f"[{status or '?'}] round {d.get('current_round')}/{d.get('total_rounds', '?')}",
+                file=sys.stderr,
+            )
+            if status in terminal_ok:
+                if args.json:
+                    _print_json(res)
+                else:
+                    print(f"{args.simulation_id} completed")
+                return 0
+            if status in terminal_fail:
+                if args.json:
+                    _print_json(res)
+                else:
+                    print(f"{args.simulation_id} {status}", file=sys.stderr)
+                return 1
+        else:
+            # A transient poll failure (dropped connection, slow gateway, 5xx) is
+            # not the simulation failing — warn and keep polling so a network blip
+            # can't be mistaken for a `failed`/`stopped` run (exit 1). A persistent
+            # error simply falls through to the timeout below (exit 2).
+            print(
+                f"[poll error] {res.get('error', 'status failed')} — retrying",
+                file=sys.stderr,
+            )
         if time.monotonic() >= deadline:
             print(
                 f"timed out after {args.timeout:.0f}s (last status: {status or '?'})",

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -138,6 +138,52 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_wait(args: argparse.Namespace) -> int:
+    import time
+
+    # Terminal states from RunnerStatus (simulation_run_state.py): a finished run
+    # settles on "completed"; "failed"/"stopped" are terminal failures. Everything
+    # else (idle/starting/running/paused/stopping) means keep polling.
+    terminal_ok = {"completed"}
+    terminal_fail = {"failed", "stopped"}
+    deadline = time.monotonic() + args.timeout
+    while True:
+        res = _api(
+            "GET",
+            f"/api/simulation/{args.simulation_id}/run-status",
+            timeout=30.0,
+        )
+        if not res.get("success"):
+            _die(res.get("error", "status failed"))
+        d = res.get("data") or {}
+        status = (d.get("runner_status") or d.get("status") or "").lower()
+        # Progress lines go to stderr so stdout stays clean for `--json` piping.
+        print(
+            f"[{status or '?'}] round {d.get('current_round')}/{d.get('total_rounds', '?')}",
+            file=sys.stderr,
+        )
+        if status in terminal_ok:
+            if args.json:
+                _print_json(res)
+            else:
+                print(f"{args.simulation_id} completed")
+            return 0
+        if status in terminal_fail:
+            if args.json:
+                _print_json(res)
+            else:
+                print(f"{args.simulation_id} {status}", file=sys.stderr)
+            return 1
+        if time.monotonic() >= deadline:
+            print(
+                f"timed out after {args.timeout:.0f}s (last status: {status or '?'})",
+                file=sys.stderr,
+            )
+            return 2
+        # Cap the sleep so a long interval never overshoots the deadline.
+        time.sleep(min(args.interval, max(0.0, deadline - time.monotonic())))
+
+
 def cmd_frame(args: argparse.Namespace) -> int:
     params = {}
     if args.platforms:
@@ -272,6 +318,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_status = sub.add_parser("status", help="Show simulation run status.")
     p_status.add_argument("simulation_id")
     p_status.set_defaults(func=cmd_status)
+
+    p_wait = sub.add_parser(
+        "wait", help="Block until a simulation finishes (poll run-status)."
+    )
+    p_wait.add_argument("simulation_id")
+    p_wait.add_argument(
+        "--interval", type=float, default=5.0,
+        help="Seconds between status polls (default 5).",
+    )
+    p_wait.add_argument(
+        "--timeout", type=float, default=600.0,
+        help="Max seconds to wait before giving up (default 600).",
+    )
+    p_wait.set_defaults(func=cmd_wait)
 
     p_frame = sub.add_parser("frame", help="Compact snapshot for one round.")
     p_frame.add_argument("simulation_id")

--- a/backend/tests/test_unit_cli.py
+++ b/backend/tests/test_unit_cli.py
@@ -9,7 +9,7 @@ def test_build_parser_known_subcommands():
     p = cli.build_parser()
     # Parsing --help would exit, but we can inspect subparser choices.
     sub = [a for a in p._subparsers._group_actions if a.choices][0]
-    expected = {"ask", "list", "status", "frame", "publish", "report", "cost", "trending", "health"}
+    expected = {"ask", "list", "status", "wait", "frame", "publish", "report", "cost", "trending", "health"}
     assert expected.issubset(set(sub.choices.keys()))
 
 
@@ -40,3 +40,17 @@ def test_cost_parses_positional():
     assert args.cmd == "cost"
     assert args.simulation_id == "sim_abc123"
     assert args.func is cli.cmd_cost
+
+
+def test_wait_defaults_and_overrides():
+    p = cli.build_parser()
+    args = p.parse_args(["wait", "sim_abc123"])
+    assert args.cmd == "wait"
+    assert args.simulation_id == "sim_abc123"
+    assert args.func is cli.cmd_wait
+    # Polling knobs default sensibly and parse as floats.
+    assert args.interval == 5.0
+    assert args.timeout == 600.0
+    overridden = p.parse_args(["wait", "sim_abc123", "--interval", "2", "--timeout", "30"])
+    assert overridden.interval == 2.0
+    assert overridden.timeout == 30.0

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -24,6 +24,7 @@ Set `MIROSHARK_API_URL` to point at a remote deployment.
 | `ask "<question>"` | Synthesize a seed briefing from a question |
 | `list` | List simulations / projects |
 | `status <sim_id>` | Runner status + round/total |
+| `wait <sim_id> [--interval N] [--timeout N]` | Block until the run finishes, then exit 0/1 |
 | `frame <sim_id> <round>` | Compact per-round snapshot |
 | `publish <sim_id> [--unpublish]` | Toggle the embed public flag |
 | `report <sim_id>` | Render the analytical report |
@@ -32,6 +33,24 @@ Set `MIROSHARK_API_URL` to point at a remote deployment.
 | `health` | Ping `/health` |
 
 All commands accept `--json` for scripting.
+
+## Wait
+
+`wait <sim_id>` polls `/api/simulation/<id>/run-status` until the run reaches a
+terminal state, so a script can block on a running simulation and then act on the
+result without hand-rolling a polling loop:
+
+```bash
+# sim_id comes from `list` (or the web UI)
+SIM=$(python backend/cli.py --json list | jq -r '.[0].simulation_id')
+python backend/cli.py wait "$SIM" && python backend/cli.py report "$SIM"
+```
+
+Progress lines (`[running] round 12/144`) print to **stderr**, so stdout stays clean
+for `--json` piping. Exit codes: `0` when the run **completes**, `1` when it **fails**
+or is **stopped**, `2` on **timeout**. Tune the loop with `--interval` (seconds
+between polls, default `5`) and `--timeout` (max seconds to wait, default `600`).
+Add `--json` to print the final run-status payload on exit.
 
 ## Cost
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -24,6 +24,7 @@ python backend/cli.py --help
 | `ask "<question>"` | 从一个问题合成种子简报 |
 | `list` | 列出模拟 / 项目 |
 | `status <sim_id>` | runner 状态 + 当前轮次/总数 |
+| `wait <sim_id> [--interval N] [--timeout N]` | 阻塞直到运行结束,然后以 0/1 退出 |
 | `frame <sim_id> <round>` | 单轮的紧凑快照 |
 | `publish <sim_id> [--unpublish]` | 切换嵌入公开标志 |
 | `report <sim_id>` | 渲染分析报告 |
@@ -32,6 +33,23 @@ python backend/cli.py --help
 | `health` | Ping `/health` |
 
 所有命令都接受 `--json` 以便脚本化使用。
+
+## 等待(wait)
+
+`wait <sim_id>` 会轮询 `/api/simulation/<id>/run-status`,直到运行进入终止状态,
+这样脚本就能阻塞等待运行中的模拟,然后在结果上继续操作,而无需自己实现轮询循环:
+
+```bash
+# sim_id 来自 `list`(或网页界面)
+SIM=$(python backend/cli.py --json list | jq -r '.[0].simulation_id')
+python backend/cli.py wait "$SIM" && python backend/cli.py report "$SIM"
+```
+
+进度行(`[running] round 12/144`)打印到 **stderr**,因此 stdout 保持干净,便于
+`--json` 管道。退出码:运行**完成**为 `0`,运行**失败**或被**停止**为 `1`,
+**超时**为 `2`。可用 `--interval`(轮询间隔秒数,默认 `5`)和 `--timeout`
+(最长等待秒数,默认 `600`)调节轮询。加上 `--json` 可在退出时打印最终的
+run-status 负载。
 
 ## 成本
 


### PR DESCRIPTION
## What

Adds a `wait` subcommand to the MiroShark CLI. It blocks until a simulation reaches a terminal state by polling `GET /api/simulation/<id>/run-status`:

- `completed` → exit `0`
- `failed` / `stopped` → exit `1`
- timeout reached → exit `2`

Progress lines (`[running] round 12/144`) print to **stderr** so stdout stays clean for `--json` piping. Tunable with `--interval` (poll frequency, default 5s) and `--timeout` (max wait, default 600s). `--json` prints the final run-status payload on exit.

```bash
# sim_id comes from `list` (or the web UI)
SIM=$(python backend/cli.py --json list | jq -r '.[0].simulation_id')
python backend/cli.py wait "$SIM" && python backend/cli.py report "$SIM"
```

## Why

`status` is a single point-in-time check and `cost` (#208) only makes sense after a run finishes — so every automation pipeline and ecosystem integrator currently hand-rolls its own `while status != completed: sleep` loop around `cli status`. `wait` collapses that boilerplate into one blocking call with correct exit codes, making `wait → report` / `wait → cost` scriptable in a single line. Terminal-state semantics are taken straight from `RunnerStatus` in `simulation_run_state.py` (`completed` / `failed` / `stopped`), so the command tracks the real runner lifecycle rather than guessing.

## Changes

- `backend/cli.py`: new `cmd_wait` (monotonic-clock poll loop, sleep capped to the remaining deadline so a long `--interval` never overshoots) + `wait` subparser with `--interval` / `--timeout`.
- `backend/tests/test_unit_cli.py`: `wait` added to the known-subcommand set; new `test_wait_defaults_and_overrides` asserting defaults (5s / 600s) and float overrides parse.
- `docs/CLI.md` + `docs/CLI.zh-CN.md`: command-table row and a "Wait" section documenting exit codes, stderr progress, and the `list → wait → report` pipeline.

## Validation

No new HTTP endpoint, so the openapi drift test is unaffected; this is an argparse + `urllib` change only (no new deps). Local `pytest` could not run — Python execution is blocked in the autonomous build sandbox — so this relied on diff review; the backend-unit CI job runs `test_unit_cli.py` on push and gates the merge.

---
*Built autonomously by Aeon*
