### PR TITLE
feat(cli): add stop subcommand to cancel a running simulation

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -5,6 +5,7 @@ Run the server first (`./miroshark` from the repo root), then drive it with::
     python -m cli ask "Will the EU AI Act survive trilogue?"
     python -m cli list
     python -m cli status sim_abc123
+    python -m cli wait sim_abc123 || python -m cli stop sim_abc123
     python -m cli report sim_abc123
     python -m cli publish sim_abc123 --public
 
@@ -193,6 +194,23 @@ def cmd_wait(args: argparse.Namespace) -> int:
         time.sleep(min(args.interval, max(0.0, deadline - time.monotonic())))
 
 
+def cmd_stop(args: argparse.Namespace) -> int:
+    res = _api(
+        "POST", "/api/simulation/stop", body={"simulation_id": args.simulation_id}
+    )
+    if args.json:
+        _print_json(res)
+        return 0
+    if not res.get("success"):
+        _die(res.get("error", "stop failed"))
+    d = res.get("data") or {}
+    # The /stop endpoint settles the run on "stopped" — echo whatever the runner
+    # reports so a forced/already-terminal run still prints its real state.
+    status = d.get("runner_status") or "stopped"
+    print(f"{args.simulation_id} {status}")
+    return 0
+
+
 def cmd_frame(args: argparse.Namespace) -> int:
     params = {}
     if args.platforms:
@@ -341,6 +359,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Max seconds to wait before giving up (default 600).",
     )
     p_wait.set_defaults(func=cmd_wait)
+
+    p_stop = sub.add_parser(
+        "stop", help="Stop a running simulation (the escape hatch for `wait`)."
+    )
+    p_stop.add_argument("simulation_id")
+    p_stop.set_defaults(func=cmd_stop)
 
     p_frame = sub.add_parser("frame", help="Compact snapshot for one round.")
     p_frame.add_argument("simulation_id")

--- a/backend/tests/test_unit_cli.py
+++ b/backend/tests/test_unit_cli.py
@@ -9,7 +9,7 @@ def test_build_parser_known_subcommands():
     p = cli.build_parser()
     # Parsing --help would exit, but we can inspect subparser choices.
     sub = [a for a in p._subparsers._group_actions if a.choices][0]
-    expected = {"ask", "list", "status", "wait", "frame", "publish", "report", "cost", "trending", "health"}
+    expected = {"ask", "list", "status", "wait", "stop", "frame", "publish", "report", "cost", "trending", "health"}
     assert expected.issubset(set(sub.choices.keys()))
 
 
@@ -40,6 +40,14 @@ def test_cost_parses_positional():
     assert args.cmd == "cost"
     assert args.simulation_id == "sim_abc123"
     assert args.func is cli.cmd_cost
+
+
+def test_stop_parses_positional():
+    p = cli.build_parser()
+    args = p.parse_args(["stop", "sim_abc123"])
+    assert args.cmd == "stop"
+    assert args.simulation_id == "sim_abc123"
+    assert args.func is cli.cmd_stop
 
 
 def test_wait_defaults_and_overrides():

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -25,6 +25,7 @@ Set `MIROSHARK_API_URL` to point at a remote deployment.
 | `list` | List simulations / projects |
 | `status <sim_id>` | Runner status + round/total |
 | `wait <sim_id> [--interval N] [--timeout N]` | Block until the run finishes, then exit 0/1 |
+| `stop <sim_id>` | Cancel a running simulation |
 | `frame <sim_id> <round>` | Compact per-round snapshot |
 | `publish <sim_id> [--unpublish]` | Toggle the embed public flag |
 | `report <sim_id>` | Render the analytical report |
@@ -51,6 +52,21 @@ for `--json` piping. Exit codes: `0` when the run **completes**, `1` when it **f
 or is **stopped**, `2` on **timeout**. Tune the loop with `--interval` (seconds
 between polls, default `5`) and `--timeout` (max seconds to wait, default `600`).
 Add `--json` to print the final run-status payload on exit.
+
+## Stop
+
+`stop <sim_id>` POSTs to `/api/simulation/stop` to cancel a running simulation —
+the escape hatch `wait` was missing. `wait` blocks until a run reaches a terminal
+state, but had no way to *end* one that hangs, overruns its timeout, or is simply no
+longer needed. Pair them to bound a run and clean up on overrun:
+
+```bash
+# Wait up to 10 min; if it times out (or fails), stop it.
+python backend/cli.py wait "$SIM" --timeout 600 || python backend/cli.py stop "$SIM"
+```
+
+On success it prints `<sim_id> stopped` and exits `0`; on error (unknown id, server
+failure) it exits `1`. Add `--json` for the raw `/stop` payload.
 
 ## Cost
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -25,6 +25,7 @@ python backend/cli.py --help
 | `list` | 列出模拟 / 项目 |
 | `status <sim_id>` | runner 状态 + 当前轮次/总数 |
 | `wait <sim_id> [--interval N] [--timeout N]` | 阻塞直到运行结束,然后以 0/1 退出 |
+| `stop <sim_id>` | 取消正在运行的模拟 |
 | `frame <sim_id> <round>` | 单轮的紧凑快照 |
 | `publish <sim_id> [--unpublish]` | 切换嵌入公开标志 |
 | `report <sim_id>` | 渲染分析报告 |
@@ -50,6 +51,20 @@ python backend/cli.py wait "$SIM" && python backend/cli.py report "$SIM"
 **超时**为 `2`。可用 `--interval`(轮询间隔秒数,默认 `5`)和 `--timeout`
 (最长等待秒数,默认 `600`)调节轮询。加上 `--json` 可在退出时打印最终的
 run-status 负载。
+
+## 停止(stop)
+
+`stop <sim_id>` 会向 `/api/simulation/stop` 发送 POST 请求,取消正在运行的模拟 ——
+这正是 `wait` 此前缺失的退出口。`wait` 会阻塞直到运行进入终止状态,但无法**结束**
+一个卡住、超时或不再需要的运行。把两者配合使用,即可为运行设定上限并在超时后清理:
+
+```bash
+# 最多等待 10 分钟;若超时(或失败),则停止它。
+python backend/cli.py wait "$SIM" --timeout 600 || python backend/cli.py stop "$SIM"
+```
+
+成功时打印 `<sim_id> stopped` 并以 `0` 退出;出错(未知 id、服务器错误)时以 `1` 退出。
+加上 `--json` 可获取原始的 `/stop` 负载。
 
 ## 成本
 


### PR DESCRIPTION
## What
Adds a `stop` subcommand to the MiroShark CLI:

```bash
python backend/cli.py stop sim_abc123      # → "sim_abc123 stopped"
python backend/cli.py stop sim_abc123 --json
```

It POSTs `{"simulation_id": ...}` to the existing `POST /api/simulation/stop` endpoint, prints `<sim_id> <runner_status>` on success (exit 0), and `_die`s on error (exit 1). `--json` prints the raw payload.

## Why
`wait` (PR #215) blocks until a run reaches a terminal state — but had **no escape hatch**. If a simulation hangs, exhausts its timeout, or is simply no longer needed, there was no CLI command to cancel it; integrators had to raw-curl `/api/simulation/stop`. `stop` completes the automation lifecycle:

```bash
# bound the run; cancel it if it overruns
python backend/cli.py wait "$SIM" --timeout 600 || python backend/cli.py stop "$SIM"
```

The `/stop` endpoint already exists and terminates a running simulation — this just wires the missing CLI-to-API path.

## Changes
- `backend/cli.py`: add `cmd_stop()` (mirrors the `cmd_publish`/`cmd_cost` request + `--json` pattern); register the `stop` subparser in `build_parser()`; add the `wait || stop` idiom to the module docstring.
- `backend/tests/test_unit_cli.py`: add `test_stop_parses_positional` and include `"stop"` in the known-subcommand set (offline, no network).
- `docs/CLI.md` + `docs/CLI.zh-CN.md`: add the `stop` row to the command table and a `## Stop` section documenting the `wait || stop` recovery idiom.

## Validation
Local `pytest` could not run — the autonomous sandbox blocks Python execution. The change is pure-stdlib `argparse` mirroring existing subcommands; the added `test_unit_cli.py` cases are picked up by the repo's backend unit CI job on push (`pytest -m "not integration"`), which is the real gate here.

---
*Built autonomously by Aeon*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
