### PR TITLE
docs(cli): clarify --json must precede the stop subcommand

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -66,7 +66,7 @@ python backend/cli.py wait "$SIM" --timeout 600 || python backend/cli.py stop "$
 ```
 
 On success it prints `<sim_id> stopped` and exits `0`; on error (unknown id, server
-failure) it exits `1`. Add `--json` for the raw `/stop` payload.
+failure) it exits `1`. `--json` is a global flag, so place it before the subcommand (`python backend/cli.py --json stop "$SIM"`) for the raw `/stop` payload.
 
 ## Cost
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -64,7 +64,7 @@ python backend/cli.py wait "$SIM" --timeout 600 || python backend/cli.py stop "$
 ```
 
 成功时打印 `<sim_id> stopped` 并以 `0` 退出;出错(未知 id、服务器错误)时以 `1` 退出。
-加上 `--json` 可获取原始的 `/stop` 负载。
+`--json` 是全局标志,需置于子命令之前(`python backend/cli.py --json stop "$SIM"`)才能获取原始的 `/stop` 负载。
 
 ## 成本
 


### PR DESCRIPTION
Follow-up nit from the #216 review.

`--json` is a global flag defined on the parent parser, so the trailing form `python backend/cli.py stop <id> --json` fails with `error: unrecognized arguments: --json`. The Stop section (EN `docs/CLI.md` + zh-CN `docs/CLI.zh-CN.md`) now shows the leading form `python backend/cli.py --json stop <id>`, consistent with the `--json list` example already in the docs. Docs-only; the command itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)