### PR TITLE
chore(config): switch default model lineup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 # Copy this file to .env and paste your OpenRouter key into the
 # blank API_KEY slots below.
 #
-# Default = Cloud (OpenRouter, Mimo V2.5 + Gemini 3 Flash).
+# Default = Cloud (OpenRouter, Mercury 2 + Gemini 3 Flash + DeepSeek V4 Flash).
 # To run fully locally with Ollama, see the "Alternatives" block
 # further down.
 # =============================================================
@@ -14,7 +14,7 @@
 LLM_PROVIDER=openai
 LLM_API_KEY=                          # ← paste your OpenRouter key (sk-or-v1-...)
 LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_MODEL_NAME=xiaomi/mimo-v2.5
+LLM_MODEL_NAME=inception/mercury-2:nitro
 
 # ===== Smart Model (reports, ontology, graph reasoning — #1 quality lever) =====
 # Only ~19 calls per run, so investing here is the cheapest quality upgrade.
@@ -30,7 +30,7 @@ NER_MODEL_NAME=google/gemini-3-flash-preview
 
 # ===== Wonderwall Model (agent simulation loop — #1 cost driver) =====
 # 850+ calls, 7M+ tokens per run. Verbosity matters more than $/M token.
-WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
+WONDERWALL_MODEL_NAME=deepseek/deepseek-v4-flash:nitro
 #
 # Optional: route Wonderwall to a custom OpenAI-compatible endpoint
 # (self-hosted vLLM, Modal, fine-tuned model, Ollama on a different host…)
@@ -59,7 +59,7 @@ EMBEDDING_DIMENSIONS=768
 # ===== Web Search Model =====
 # Dedicated model for web enrichment (persona research for public figures).
 # Append ":online" to any OpenRouter model for Exa-powered web results.
-WEB_SEARCH_MODEL=google/gemini-3-flash-preview:online
+WEB_SEARCH_MODEL=deepseek/deepseek-v4-flash:online
 
 # ===== SearXNG (self-hosted web search) =====
 # When set, web enrichment searches SearXNG and synthesizes the snippets with
@@ -78,7 +78,7 @@ MIROSHARK_FIRECRAWL_BASE_URL=
 MIROSHARK_FIRECRAWL_API_KEY=
 
 # ===== Disable chain-of-thought on reasoning-capable OpenRouter models =====
-# ~3x lower latency on Qwen3-Flash / Gemini-3-Flash / Mimo-V2.5. Flip to
+# ~3x lower latency on Qwen3-Flash / Gemini-3-Flash / DeepSeek-V4-Flash. Flip to
 # false per-deployment if a slot benefits from CoT (rare for MiroShark's
 # short, structured prompts).
 LLM_DISABLE_REASONING=true

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -34,22 +34,22 @@ def _mask_key(key: str) -> str:
 # copied into when the caller supplies `preset_api_key`.
 _PRESETS = {
     'cheap': {
-        'label': 'Cloud — ~$1/run (Mimo V2.5 + Gemini 3 Flash)',
+        'label': 'Cloud — ~$1/run (Mercury 2 + Gemini 3 Flash + DeepSeek V4)',
         'fields': {
             'LLM_PROVIDER': 'openai',
             'LLM_BASE_URL': 'https://openrouter.ai/api/v1',
-            'LLM_MODEL_NAME': 'xiaomi/mimo-v2.5',
+            'LLM_MODEL_NAME': 'inception/mercury-2:nitro',
             'SMART_PROVIDER': 'openai',
             'SMART_BASE_URL': 'https://openrouter.ai/api/v1',
             'SMART_MODEL_NAME': 'google/gemini-3-flash-preview',
             'NER_BASE_URL': 'https://openrouter.ai/api/v1',
             'NER_MODEL_NAME': 'google/gemini-3-flash-preview',
-            'WONDERWALL_MODEL_NAME': 'xiaomi/mimo-v2.5',
+            'WONDERWALL_MODEL_NAME': 'deepseek/deepseek-v4-flash:nitro',
             'EMBEDDING_PROVIDER': 'openai',
             'EMBEDDING_BASE_URL': 'https://openrouter.ai/api',
             'EMBEDDING_MODEL': 'openai/text-embedding-3-large',
             'EMBEDDING_DIMENSIONS': 768,
-            'WEB_SEARCH_MODEL': 'google/gemini-3-flash-preview:online',
+            'WEB_SEARCH_MODEL': 'deepseek/deepseek-v4-flash:online',
         },
         'key_slots': ['LLM_API_KEY', 'SMART_API_KEY', 'NER_API_KEY', 'EMBEDDING_API_KEY'],
     },

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,20 +30,21 @@ class Config:
     # LLM configuration (unified OpenAI format)
     # LLM_PROVIDER: "openai" (default, any OpenAI-compatible API) or "claude-code" (local CLI)
     # Default model is used for profile generation, sim config, memory compaction.
-    # Cloud preset: xiaomi/mimo-v2.5 (cheap personas + sim configs)
+    # Cloud preset: inception/mercury-2:nitro (diffusion LLM — picked for speed;
+    # off the report's quality path. Fallback for any unset tier.)
     LLM_PROVIDER = os.environ.get('LLM_PROVIDER', 'openai')
     LLM_API_KEY = os.environ.get('LLM_API_KEY')
     LLM_BASE_URL = os.environ.get('LLM_BASE_URL', 'https://api.openai.com/v1')
-    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME') or 'xiaomi/mimo-v2.5'  # `or` so a blank LLM_MODEL_NAME= falls back instead of sending an empty model
+    LLM_MODEL_NAME = os.environ.get('LLM_MODEL_NAME') or 'inception/mercury-2:nitro'  # `or` so a blank LLM_MODEL_NAME= falls back instead of sending an empty model
 
     # Smart model — stronger model for intelligence-sensitive workflows
     # (report generation, ontology extraction, graph reasoning).
-    # When not set, these workflows use the default LLM config above.
-    # Cloud preset: google/gemini-3-flash-preview (stable JSON, fast reports)
+    # Defaults to google/gemini-3-flash-preview (stable JSON, fast reports);
+    # set SMART_MODEL_NAME= (empty) to inherit the default LLM config above.
     SMART_PROVIDER = os.environ.get('SMART_PROVIDER', '')   # "openai", "claude-code", or empty (inherit)
     SMART_API_KEY = os.environ.get('SMART_API_KEY', '')
     SMART_BASE_URL = os.environ.get('SMART_BASE_URL', '')
-    SMART_MODEL_NAME = os.environ.get('SMART_MODEL_NAME', '')
+    SMART_MODEL_NAME = os.environ.get('SMART_MODEL_NAME', 'google/gemini-3-flash-preview')
     
     # Neo4j configuration
     NEO4J_URI = os.environ.get('NEO4J_URI', 'bolt://localhost:7687')
@@ -143,9 +144,11 @@ class Config:
     # Web Enrichment — LLM-powered research for persona generation
     # Triggers for notable figures (politicians, CEOs, etc.) or when graph context is thin
     WEB_ENRICHMENT_ENABLED = os.environ.get('WEB_ENRICHMENT_ENABLED', 'true').lower() == 'true'
-    # Optional: dedicated model for web research (e.g. "perplexity/sonar-pro" on OpenRouter
-    # for grounded search, or "perplexity/sonar" for fast search). If empty, uses default LLM.
-    WEB_SEARCH_MODEL = os.environ.get('WEB_SEARCH_MODEL', '')
+    # Dedicated model for web research (web_research + deep_research + url_fetch).
+    # Defaults to deepseek/deepseek-v4-flash:online (bake-off value winner). Any
+    # ":online" OpenRouter variant works; set WEB_SEARCH_MODEL= (empty) to inherit
+    # the default LLM (only viable if the default model can browse).
+    WEB_SEARCH_MODEL = os.environ.get('WEB_SEARCH_MODEL', 'deepseek/deepseek-v4-flash:online')
 
     # SearXNG metasearch — when set, web enrichment does real search-then-
     # synthesize with the DEFAULT LLM instead of requiring a websearch-enabled
@@ -161,10 +164,10 @@ class Config:
     FIRECRAWL_API_KEY = os.environ.get('MIROSHARK_FIRECRAWL_API_KEY', '')
 
     # Wonderwall model — model for Wonderwall/CAMEL agent simulation loop.
-    # When not set, uses LLM_MODEL_NAME.
-    # Cloud preset: xiaomi/mimo-v2.5 (same as default to reuse quota)
+    # Defaults to deepseek/deepseek-v4-flash:nitro; set WONDERWALL_MODEL_NAME=
+    # (empty) to inherit LLM_MODEL_NAME.
     # Wonderwall is the #1 cost driver — 850+ calls per run. Keep it cheap.
-    WONDERWALL_MODEL_NAME = os.environ.get('WONDERWALL_MODEL_NAME', '')
+    WONDERWALL_MODEL_NAME = os.environ.get('WONDERWALL_MODEL_NAME', 'deepseek/deepseek-v4-flash:nitro')
     # Optional per-slot endpoint override — point Wonderwall at a different
     # OpenAI-compatible API (e.g. a self-hosted Modal/vLLM endpoint) without
     # affecting the Default/Smart/NER slots. When unset, the simulation
@@ -173,9 +176,9 @@ class Config:
     WONDERWALL_BASE_URL = os.environ.get('WONDERWALL_BASE_URL', '')
 
     # NER model — faster model for entity extraction (high-volume, mechanical task)
-    # When not set, NER uses the default LLM config above.
-    # Cloud preset: google/gemini-3-flash-preview (stable JSON with reasoning disabled)
-    NER_MODEL_NAME = os.environ.get('NER_MODEL_NAME', '')
+    # Defaults to google/gemini-3-flash-preview (stable JSON with reasoning disabled);
+    # set NER_MODEL_NAME= (empty) to inherit the default LLM config above.
+    NER_MODEL_NAME = os.environ.get('NER_MODEL_NAME', 'google/gemini-3-flash-preview')
     NER_BASE_URL = os.environ.get('NER_BASE_URL', '')
     NER_API_KEY = os.environ.get('NER_API_KEY', '')
 

--- a/backend/app/utils/run_summary.py
+++ b/backend/app/utils/run_summary.py
@@ -25,9 +25,11 @@ logger = get_logger('miroshark.run_summary')
 # ---------------------------------------------------------------------------
 MODEL_PRICING = {
     # Current Cloud preset (update as OpenRouter prices drift)
-    "xiaomi/mimo-v2.5":              {"input": 0.14, "output": 0.28},
-    "google/gemini-3-flash-preview":     {"input": 0.50, "output": 3.00},
+    "inception/mercury-2":               {"input": 0.25, "output": 0.75},    # Default (diffusion)
+    "google/gemini-3-flash-preview":     {"input": 0.50, "output": 3.00},    # Smart + NER
+    "deepseek/deepseek-v4-flash":        {"input": 0.098, "output": 0.196},  # Wonderwall + web search
     # Tracked for mixed / legacy setups
+    "xiaomi/mimo-v2.5":              {"input": 0.14, "output": 0.28},
     "qwen/qwen3.5-flash-02-23":          {"input": 0.065, "output": 0.26},
     "deepseek/deepseek-v3.2":            {"input": 0.252, "output": 0.378},
     "google/gemini-2.0-flash-001":       {"input": 0.10, "output": 0.40},

--- a/backend/app/utils/url_fetcher.py
+++ b/backend/app/utils/url_fetcher.py
@@ -6,7 +6,7 @@ scrapes the page via POST /v1/scrape and returns markdown — handles JS-heavy
 pages (automatic fetch → CycleTLS → Hero browser fallback) and PDFs/DOCX.
 
 Fallback path: ask the configured web-search LLM (WEB_SEARCH_MODEL, e.g.
-`google/gemini-3-flash-preview:online`) to read the URL and return the main
+`deepseek/deepseek-v4-flash:online`) to read the URL and return the main
 readable content. The model MUST have web access — use an `:online` variant
 on OpenRouter for any model without native browsing, otherwise it'll reject
 URLs dated past its training cutoff.
@@ -132,7 +132,7 @@ def _fetch_via_llm(url: str, timeout: int) -> tuple:
     if not model:
         raise ValueError(
             "No web-search model configured. Set WEB_SEARCH_MODEL in .env "
-            "(e.g. google/gemini-3-flash-preview:online)."
+            "(e.g. deepseek/deepseek-v4-flash:online)."
         )
 
     logger.info(f"Fetching URL via LLM ({model}): {url}")

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,7 +10,7 @@ All settings live in `.env` (copy from `.env.example`). The full reference below
 # LLM
 LLM_API_KEY=your-api-key
 LLM_BASE_URL=https://openrouter.ai/api/v1     # or http://localhost:11434/v1 for Ollama
-LLM_MODEL_NAME=xiaomi/mimo-v2.5
+LLM_MODEL_NAME=inception/mercury-2:nitro
 
 # Neo4j
 NEO4J_URI=bolt://localhost:7687
@@ -53,7 +53,7 @@ LLM_MODEL_NAME=qwen2.5:32b
 # SMART_MODEL_NAME=google/gemini-3-flash-preview          # Cloud preset
 
 # ─── Wonderwall (agent sim loop — #1 cost driver, use cheapest viable) ───
-# WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
+# WONDERWALL_MODEL_NAME=deepseek/deepseek-v4-flash:nitro
 # Optional: route Wonderwall to a custom OpenAI-compatible endpoint
 # (self-hosted vLLM, Modal, custom fine-tune…). Both fields are
 # optional — leaving either blank inherits LLM_BASE_URL / LLM_API_KEY.
@@ -110,7 +110,7 @@ REASONING_TRACE_ENABLED=true
 # Also powers the /api/graph/fetch-url URL importer — models without native
 # browsing must use an ":online" variant.
 WEB_ENRICHMENT_ENABLED=true
-# WEB_SEARCH_MODEL=google/gemini-3-flash-preview:online
+# WEB_SEARCH_MODEL=deepseek/deepseek-v4-flash:online
 
 # ─── Embedding batching ───
 # How many texts per HTTP request. Higher is faster on graph builds;

--- a/docs/CONFIGURATION.zh-CN.md
+++ b/docs/CONFIGURATION.zh-CN.md
@@ -10,7 +10,7 @@
 # LLM
 LLM_API_KEY=your-api-key
 LLM_BASE_URL=https://openrouter.ai/api/v1     # or http://localhost:11434/v1 for Ollama
-LLM_MODEL_NAME=xiaomi/mimo-v2.5
+LLM_MODEL_NAME=inception/mercury-2:nitro
 
 # Neo4j
 NEO4J_URI=bolt://localhost:7687
@@ -53,7 +53,7 @@ LLM_MODEL_NAME=qwen2.5:32b
 # SMART_MODEL_NAME=google/gemini-3-flash-preview          # Cloud preset
 
 # ─── Wonderwall (agent sim loop — #1 cost driver, use cheapest viable) ───
-# WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
+# WONDERWALL_MODEL_NAME=deepseek/deepseek-v4-flash:nitro
 # Optional: route Wonderwall to a custom OpenAI-compatible endpoint
 # (self-hosted vLLM, Modal, custom fine-tune…). Both fields are
 # optional — leaving either blank inherits LLM_BASE_URL / LLM_API_KEY.
@@ -110,7 +110,7 @@ REASONING_TRACE_ENABLED=true
 # Also powers the /api/graph/fetch-url URL importer — models without native
 # browsing must use an ":online" variant.
 WEB_ENRICHMENT_ENABLED=true
-# WEB_SEARCH_MODEL=google/gemini-3-flash-preview:online
+# WEB_SEARCH_MODEL=deepseek/deepseek-v4-flash:online
 
 # ─── Embedding batching ───
 # How many texts per HTTP request. Higher is faster on graph builds;

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,7 @@ git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
 cp .env.example .env
 ```
 
-`.env.example` ships with the Cloud preset (Mimo V2.5 + Gemini 3 Flash) as the active default. Open `.env` and paste your OpenRouter key into the five blank `*_API_KEY=` lines (`LLM_`, `SMART_`, `NER_`, `OPENAI_`, `EMBEDDING_` — same key in all of them). No model edits needed unless you want a different lineup.
+`.env.example` ships with the Cloud preset (Mercury 2 + Gemini 3 Flash + DeepSeek V4 Flash) as the active default. Open `.env` and paste your OpenRouter key into the five blank `*_API_KEY=` lines (`LLM_`, `SMART_`, `NER_`, `OPENAI_`, `EMBEDDING_` — same key in all of them). No model edits needed unless you want a different lineup.
 
 Then launch:
 
@@ -133,7 +133,7 @@ One key covers every slot, including embeddings. Easiest to set up and the path 
 ```bash
 LLM_API_KEY=sk-or-v1-YOUR_KEY
 LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_MODEL_NAME=xiaomi/mimo-v2.5
+LLM_MODEL_NAME=inception/mercury-2:nitro
 
 SMART_PROVIDER=openai
 SMART_API_KEY=sk-or-v1-YOUR_KEY
@@ -144,8 +144,8 @@ NER_MODEL_NAME=google/gemini-3-flash-preview
 NER_BASE_URL=https://openrouter.ai/api/v1
 NER_API_KEY=sk-or-v1-YOUR_KEY
 
-WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
-WEB_SEARCH_MODEL=google/gemini-3-flash-preview:online
+WONDERWALL_MODEL_NAME=deepseek/deepseek-v4-flash:nitro
+WEB_SEARCH_MODEL=deepseek/deepseek-v4-flash:online
 
 OPENAI_API_KEY=sk-or-v1-YOUR_KEY
 OPENAI_API_BASE_URL=https://openrouter.ai/api/v1

--- a/docs/INSTALL.zh-CN.md
+++ b/docs/INSTALL.zh-CN.md
@@ -93,7 +93,7 @@ git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
 cp .env.example .env
 ```
 
-`.env.example` 出厂自带云端预设(Mimo V2.5 + Gemini 3 Flash)作为默认配置。打开 `.env`,把你的 OpenRouter 密钥粘贴进五行空白的 `*_API_KEY=`(`LLM_`、`SMART_`、`NER_`、`OPENAI_`、`EMBEDDING_` — 五行用同一把密钥)。除非你想换一套不同的模型组合,否则不需要修改任何模型字段。
+`.env.example` 出厂自带云端预设(Mercury 2 + Gemini 3 Flash + DeepSeek V4 Flash)作为默认配置。打开 `.env`,把你的 OpenRouter 密钥粘贴进五行空白的 `*_API_KEY=`(`LLM_`、`SMART_`、`NER_`、`OPENAI_`、`EMBEDDING_` — 五行用同一把密钥)。除非你想换一套不同的模型组合,否则不需要修改任何模型字段。
 
 然后启动:
 
@@ -133,7 +133,7 @@ cp .env.example .env
 ```bash
 LLM_API_KEY=sk-or-v1-YOUR_KEY
 LLM_BASE_URL=https://openrouter.ai/api/v1
-LLM_MODEL_NAME=xiaomi/mimo-v2.5
+LLM_MODEL_NAME=inception/mercury-2:nitro
 
 SMART_PROVIDER=openai
 SMART_API_KEY=sk-or-v1-YOUR_KEY
@@ -144,8 +144,8 @@ NER_MODEL_NAME=google/gemini-3-flash-preview
 NER_BASE_URL=https://openrouter.ai/api/v1
 NER_API_KEY=sk-or-v1-YOUR_KEY
 
-WONDERWALL_MODEL_NAME=xiaomi/mimo-v2.5
-WEB_SEARCH_MODEL=google/gemini-3-flash-preview:online
+WONDERWALL_MODEL_NAME=deepseek/deepseek-v4-flash:nitro
+WEB_SEARCH_MODEL=deepseek/deepseek-v4-flash:online
 
 OPENAI_API_KEY=sk-or-v1-YOUR_KEY
 OPENAI_API_BASE_URL=https://openrouter.ai/api/v1

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -12,23 +12,23 @@ Each slot controls a different quality axis:
 
 | Slot | Controls | Key finding |
 |---|---|---|
-| **Default** | Persona richness, sim density | Mimo V2.5 gives distinct voices at flash-tier price |
+| **Default** | Persona richness, sim density | Mercury 2 — a diffusion LLM picked for speed; off the report's quality path |
 | **Smart** | Report quality (#1 lever) | Gemini 3 Flash holds up on ReACT report loops with reasoning disabled |
 | **NER** | Extraction reliability | Needs deterministic JSON — pick a model that doesn't silently emit CoT |
 | **Wonderwall** | Cost (biggest consumer) | 850+ calls, 7M+ tokens. Verbosity matters more than $/M |
 
 ### Cloud mode — ~$1/run, ~10 min
 
-Mimo V2.5 personas + Gemini 3 Flash smart/NER. Reasoning is disabled on every slot (`LLM_DISABLE_REASONING=true` sends `reasoning: {enabled: false}` in `extra_body`), which is the difference between a ~45s scenario-suggest call and a ~3s one.
+Mercury 2 personas + Gemini 3 Flash smart/NER + DeepSeek V4 Flash for the sim loop and web search. Reasoning is disabled on every slot (`LLM_DISABLE_REASONING=true` sends `reasoning: {enabled: false}` in `extra_body`), which is the difference between a ~45s scenario-suggest call and a ~3s one.
 
 | Slot | Model | Notes |
 |---|---|---|
-| Default | `xiaomi/mimo-v2.5` | Persona generation, sim config, memory compaction |
+| Default | `inception/mercury-2:nitro` | Persona generation, sim config, memory compaction |
 | Smart | `google/gemini-3-flash-preview` | Report ReACT loop — only ~19 calls/run |
 | NER | `google/gemini-3-flash-preview` | Stable JSON with reasoning off |
-| Wonderwall | `xiaomi/mimo-v2.5` | 850+ agent-action calls/run; keep verbosity low |
+| Wonderwall | `deepseek/deepseek-v4-flash:nitro` | 850+ agent-action calls/run; keep verbosity low |
 
-Embeddings use `openai/text-embedding-3-large` (truncated to 768 dims via Matryoshka). Web enrichment uses `google/gemini-3-flash-preview:online`.
+Embeddings use `openai/text-embedding-3-large` (truncated to 768 dims via Matryoshka). Web enrichment uses `deepseek/deepseek-v4-flash:online`.
 
 > **Latency note** — every OpenRouter call goes through `LLMClient`, which injects `reasoning: {enabled: false}` into `extra_body` by default. Turn it off with `LLM_DISABLE_REASONING=false` only if a specific slot benefits from chain-of-thought (rare for MiroShark's structured prompts).
 

--- a/docs/MODELS.zh-CN.md
+++ b/docs/MODELS.zh-CN.md
@@ -12,23 +12,23 @@
 
 | 槽位 | 控制的内容 | 关键发现 |
 |---|---|---|
-| **Default** | 人设丰富度、模拟密度 | Mimo V2.5 在 flash 价位上能给出辨识度高的人物声音 |
+| **Default** | 人设丰富度、模拟密度 | Mercury 2 —— 为速度挑选的扩散式(diffusion)LLM;不在报告的质量路径上 |
 | **Smart** | 报告质量(头号杠杆) | Gemini 3 Flash 在关闭 reasoning 的 ReACT 报告循环中表现稳定 |
 | **NER** | 抽取可靠性 | 需要确定性的 JSON — 选一个不会暗中输出 CoT 的模型 |
 | **Wonderwall** | 成本(最大消费方) | 850+ 次调用、7M+ tokens。冗长程度比 $/M 更重要 |
 
 ### 云端模式 — 约 1 美元/次,约 10 分钟
 
-Mimo V2.5 做人设 + Gemini 3 Flash 做 smart/NER。每个槽位都关闭了 reasoning(`LLM_DISABLE_REASONING=true` 会在 `extra_body` 里发送 `reasoning: {enabled: false}`),这就是一次场景建议从约 45 秒变成约 3 秒的差别。
+Mercury 2 做人设 + Gemini 3 Flash 做 smart/NER + DeepSeek V4 Flash 跑模拟循环和网络检索。每个槽位都关闭了 reasoning(`LLM_DISABLE_REASONING=true` 会在 `extra_body` 里发送 `reasoning: {enabled: false}`),这就是一次场景建议从约 45 秒变成约 3 秒的差别。
 
 | 槽位 | 模型 | 备注 |
 |---|---|---|
-| Default | `xiaomi/mimo-v2.5` | 画像生成、模拟配置、记忆压缩 |
+| Default | `inception/mercury-2:nitro` | 画像生成、模拟配置、记忆压缩 |
 | Smart | `google/gemini-3-flash-preview` | 报告 ReACT 循环 — 每次运行只有约 19 次调用 |
 | NER | `google/gemini-3-flash-preview` | 关闭 reasoning 后输出稳定 JSON |
-| Wonderwall | `xiaomi/mimo-v2.5` | 每次运行 850+ 次智能体动作调用;保持低冗长度 |
+| Wonderwall | `deepseek/deepseek-v4-flash:nitro` | 每次运行 850+ 次智能体动作调用;保持低冗长度 |
 
-嵌入用 `openai/text-embedding-3-large`(通过 Matryoshka 截断到 768 维)。Web 增强用 `google/gemini-3-flash-preview:online`。
+嵌入用 `openai/text-embedding-3-large`(通过 Matryoshka 截断到 768 维)。Web 增强用 `deepseek/deepseek-v4-flash:online`。
 
 > **延迟提示** — 每次 OpenRouter 调用都会经过 `LLMClient`,默认会在 `extra_body` 中注入 `reasoning: {enabled: false}`。仅当某个具体槽位从思维链中收益时才用 `LLM_DISABLE_REASONING=false` 关掉这个默认行为(对 MiroShark 的结构化提示词来说很罕见)。
 

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -285,7 +285,7 @@
                   v-model="form.wonderwall.model_name"
                   class="field-input"
                   type="text"
-                  :placeholder="$tr('e.g. xiaomi/mimo-v2.5', '例如 xiaomi/mimo-v2.5', { de: 'z. B. xiaomi/mimo-v2.5' })"
+                  :placeholder="$tr('e.g. inception/mercury-2:nitro', '例如 inception/mercury-2:nitro', { de: 'z. B. inception/mercury-2:nitro' })"
                 />
               </div>
               <div class="field-row">


### PR DESCRIPTION
Switches the default model lineup across every place it's encoded.

## Slots changed
| Slot | New default |
|---|---|
| Base `LLM_MODEL_NAME` | `inception/mercury-2:nitro` |
| Smart `SMART_MODEL_NAME` | `google/gemini-3-flash-preview` |
| NER `NER_MODEL_NAME` | `google/gemini-3-flash-preview` |
| Wonderwall `WONDERWALL_MODEL_NAME` | `deepseek/deepseek-v4-flash:nitro` |
| Web search `WEB_SEARCH_MODEL` | `deepseek/deepseek-v4-flash:online` |
| Embeddings `EMBEDDING_MODEL` | `openai/text-embedding-3-large` (unchanged) |

## Applied in
- `config.py` code fallbacks (Smart/NER/Wonderwall/WebSearch now carry explicit defaults; set the env var empty to restore inherit)
- `settings.py` 'cheap' Cloud preset + label
- `.env.example` active Cloud block
- docs: MODELS/INSTALL/CONFIGURATION (+ zh-CN) and the SettingsPanel placeholder
- `run_summary.py`: live-fetched OpenRouter pricing for mercury-2 ($0.25/$0.75 per M) and deepseek-v4-flash ($0.098/$0.196 per M)

## Not included
`FAST_SMART` and `TRANSLATION` slots — they don't exist in code yet and need wiring, not a value swap.

## Verify
- Backend unit suite: 1427 passed
- Frontend `npm run build`: succeeds