### PR TITLE
fix(social-agent): preserve tool_calls when filtering empty LLM messages

### DIFF
--- a/backend/app/utils/llm_message_filter.py
+++ b/backend/app/utils/llm_message_filter.py
@@ -1,0 +1,36 @@
+"""Message filtering for OpenAI-compatible chat calls.
+
+Kept dependency-free (stdlib typing only) and outside the ``wonderwall``
+package so the offline unit-test job — which does not install camel-ai/numpy
+— can exercise it without importing the wonderwall package's heavy runtime
+chain (see ``wonderwall/__init__.py`` -> ``recsys.py`` -> numpy).
+"""
+
+from typing import Any, Dict, List
+
+
+def filter_openai_messages_for_api(
+    openai_messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Prepare CAMEL memory messages for an OpenAI-compatible chat call.
+
+    Gemini rejects assistant/user turns whose ``content`` is empty
+    (INVALID_ARGUMENT).  Drop those, but **keep** assistant turns that only
+    carry ``tool_calls`` (empty content is normal) and their ``tool`` /
+    ``function`` results — Azure returns 400 if a ``tool`` message is not
+    immediately preceded by an assistant message with ``tool_calls``.
+    """
+    filtered: List[Dict[str, Any]] = []
+    for msg in openai_messages:
+        content = msg.get("content")
+        has_content = content is not None and str(content).strip()
+        role = msg.get("role")
+        if has_content:
+            filtered.append(msg)
+        elif role == "assistant" and msg.get("tool_calls"):
+            filtered.append(msg)
+        elif role in ("tool", "function"):
+            filtered.append(msg)
+    if not filtered:
+        filtered = [{"role": "user", "content": "(empty context)"}]
+    return filtered

--- a/backend/tests/test_unit_social_agent_messages.py
+++ b/backend/tests/test_unit_social_agent_messages.py
@@ -1,6 +1,6 @@
 """Unit tests for Wonderwall SocialAgent OpenAI message filtering."""
 
-from wonderwall.social_agent.agent import filter_openai_messages_for_api
+from app.utils.llm_message_filter import filter_openai_messages_for_api
 
 
 def test_filter_drops_empty_user_turns():

--- a/backend/tests/test_unit_social_agent_messages.py
+++ b/backend/tests/test_unit_social_agent_messages.py
@@ -1,0 +1,56 @@
+"""Unit tests for Wonderwall SocialAgent OpenAI message filtering."""
+
+from wonderwall.social_agent.agent import filter_openai_messages_for_api
+
+
+def test_filter_drops_empty_user_turns():
+    messages = [
+        {"role": "system", "content": "You are an agent."},
+        {"role": "user", "content": ""},
+        {"role": "user", "content": "Observe the platform."},
+    ]
+    filtered = filter_openai_messages_for_api(messages)
+    assert filtered == [
+        {"role": "system", "content": "You are an agent."},
+        {"role": "user", "content": "Observe the platform."},
+    ]
+
+
+def test_filter_keeps_assistant_tool_calls_with_empty_content():
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "create_post", "arguments": "{}"},
+        }
+    ]
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": None, "tool_calls": tool_calls},
+        {"role": "tool", "tool_call_id": "call_1", "content": '{"ok": true}'},
+    ]
+    filtered = filter_openai_messages_for_api(messages)
+    assert filtered == messages
+
+
+def test_filter_keeps_multi_iteration_tool_chain():
+    """Regression: stripping empty assistant tool_calls caused Azure 400s."""
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "round 1"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "a", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "result"},
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "b", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c2", "content": "result2"},
+    ]
+    filtered = filter_openai_messages_for_api(messages)
+    assert len(filtered) == 6
+    assert filtered[2]["role"] == "assistant" and filtered[2]["tool_calls"]
+    assert filtered[4]["role"] == "assistant" and filtered[4]["tool_calls"]
+
+
+def test_filter_empty_context_fallback():
+    assert filter_openai_messages_for_api([]) == [
+        {"role": "user", "content": "(empty context)"}
+    ]

--- a/backend/wonderwall/social_agent/agent.py
+++ b/backend/wonderwall/social_agent/agent.py
@@ -17,7 +17,7 @@ import inspect
 import logging
 import sys
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 
 from camel.agents import ChatAgent
 from camel.messages import BaseMessage
@@ -27,6 +27,7 @@ from camel.toolkits import FunctionTool
 from camel.types import OpenAIBackendRole
 
 from app.utils.i18n import get_active_locale, t as _t
+from app.utils.llm_message_filter import filter_openai_messages_for_api
 from wonderwall.social_agent.agent_action import SocialAction
 from wonderwall.social_agent.agent_environment import SocialEnvironment
 from wonderwall.social_platform import Channel
@@ -51,33 +52,6 @@ if "sphinx" not in sys.modules:
         agent_log.addHandler(file_handler)
 
 ALL_SOCIAL_ACTIONS = [action.value for action in ActionType]
-
-
-def filter_openai_messages_for_api(
-    openai_messages: List[Dict[str, Any]],
-) -> List[Dict[str, Any]]:
-    """Prepare CAMEL memory messages for an OpenAI-compatible chat call.
-
-    Gemini rejects assistant/user turns whose ``content`` is empty
-    (INVALID_ARGUMENT).  Drop those, but **keep** assistant turns that only
-    carry ``tool_calls`` (empty content is normal) and their ``tool`` /
-    ``function`` results — Azure returns 400 if a ``tool`` message is not
-    immediately preceded by an assistant message with ``tool_calls``.
-    """
-    filtered: List[Dict[str, Any]] = []
-    for msg in openai_messages:
-        content = msg.get("content")
-        has_content = content is not None and str(content).strip()
-        role = msg.get("role")
-        if has_content:
-            filtered.append(msg)
-        elif role == "assistant" and msg.get("tool_calls"):
-            filtered.append(msg)
-        elif role in ("tool", "function"):
-            filtered.append(msg)
-    if not filtered:
-        filtered = [{"role": "user", "content": "(empty context)"}]
-    return filtered
 
 
 class SocialAgent(ChatAgent):

--- a/backend/wonderwall/social_agent/agent.py
+++ b/backend/wonderwall/social_agent/agent.py
@@ -17,7 +17,7 @@ import inspect
 import logging
 import sys
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from camel.agents import ChatAgent
 from camel.messages import BaseMessage
@@ -51,6 +51,33 @@ if "sphinx" not in sys.modules:
         agent_log.addHandler(file_handler)
 
 ALL_SOCIAL_ACTIONS = [action.value for action in ActionType]
+
+
+def filter_openai_messages_for_api(
+    openai_messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Prepare CAMEL memory messages for an OpenAI-compatible chat call.
+
+    Gemini rejects assistant/user turns whose ``content`` is empty
+    (INVALID_ARGUMENT).  Drop those, but **keep** assistant turns that only
+    carry ``tool_calls`` (empty content is normal) and their ``tool`` /
+    ``function`` results — Azure returns 400 if a ``tool`` message is not
+    immediately preceded by an assistant message with ``tool_calls``.
+    """
+    filtered: List[Dict[str, Any]] = []
+    for msg in openai_messages:
+        content = msg.get("content")
+        has_content = content is not None and str(content).strip()
+        role = msg.get("role")
+        if has_content:
+            filtered.append(msg)
+        elif role == "assistant" and msg.get("tool_calls"):
+            filtered.append(msg)
+        elif role in ("tool", "function"):
+            filtered.append(msg)
+    if not filtered:
+        filtered = [{"role": "user", "content": "(empty context)"}]
+    return filtered
 
 
 class SocialAgent(ChatAgent):
@@ -176,12 +203,7 @@ class SocialAgent(ChatAgent):
         import os as _os
         import time as _time
 
-        filtered = [
-            msg for msg in openai_messages
-            if msg.get("content") is not None and str(msg["content"]).strip()
-        ]
-        if not filtered:
-            filtered = [{"role": "user", "content": "(empty context)"}]
+        filtered = filter_openai_messages_for_api(openai_messages)
 
         # Inject OpenRouter metadata per-call so each generation is tagged.
         # Structured for Langfuse: `user` becomes the Langfuse sessionId,


### PR DESCRIPTION
Gemini (and Deepseek & GPT-5.4) rejects empty user/assistant content; Azure requires assistant tool_calls to precede tool results. Extract filter_openai_messages_for_api with unit tests covering both providers.



SocialAgent._aget_model_response (backend/wonderwall/social_agent/agent.py) filters CAMEL's message history before every LLM call. The old filter was:

```
  filtered = [
      msg for msg in openai_messages
      if msg.get("content") is not None and str(msg["content"]).strip()
  ]
```

  It drops any message with empty/None content. That rule existed for a real reason: Gemini rejects assistant/user turns with empty content (INVALID_ARGUMENT).

  But perform_action_by_llm runs a ReAct-style tool-calling loop, and a normal turn in that loop looks like:

  1. user — environment observation
  2. assistant — content is empty/None, the payload lives entirely in tool_calls
  3. tool — the tool result, tagged with tool_call_id

  The blanket content-emptiness filter stripped message (2) , because an assistant message that only carries tool_calls has no content — that's expected, not "empty" in any meaningful sense. That left the tool result message (3) in the array with no preceding assistant message declaring the tool_calls it's
  responding to.

  Azure's Chat Completions API validates this adjacency strictly: a role: "tool" message must immediately follow an assistant message containing the matching tool_calls entry. With that assistant message missing, Azure returns a 400 ("orphaned tool message" / unrecognized tool_call_id), which surfaced as an
  LLM-call error in the run summary. It only hit SocialAgent.perform_action_by_llm (the only caller that does tool-calling) — every other caller (NER extraction, memory compaction, belief tracking) doesn't use tools and was unaffected, which matches the pre-fix data exactly: 153 of 219 errors, 100% on gpt-5.4-mini and deepseek-v4, 100% in the Wonderwall Simulation phase, 0 elsewhere.

  The fix

  filter_openai_messages_for_api keeps the same Gemini-safety goal but narrows what counts as "droppable":

  - Still drops a message if content is truly empty and it's not one of the two cases below.
  - Keeps assistant messages with empty/None content when they carry tool_calls — that's the message Azure needs immediately before the tool result.
  - Keeps all tool/function role messages regardless of content — those are the tool results themselves; dropping them would leave a dangling tool_calls with no matching result, which providers also reject.

  So the assistant→tool_calls→tool adjacency Azure requires is preserved, while genuinely empty chat turns (plain empty user/assistant text messages) are still stripped for Gemini's benefit. Added test_unit_social_agent_messages.py with 4 cases covering both the Gemini empty-turn behavior and the Azure
  tool-chain regression (including multi-iteration chains, since a round can have more than one tool call).
