### PR TITLE
fix(compose): persist backend/data so Nemotron datasets survive recreation

### DIFF
--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -56,6 +56,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./backend/uploads:/app/backend/uploads
+      - ./backend/data:/app/backend/data
       - hf_cache:/root/.cache/huggingface
 
 volumes:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -67,6 +67,7 @@ services:
       - traefik.http.services.miroshark-api.loadbalancer.server.port=5001
     volumes:
       - ./backend/uploads:/app/backend/uploads
+      - ./backend/data:/app/backend/data
       - ./backend/logs:/app/backend/logs
       - hf_cache:/root/.cache/huggingface
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./backend/uploads:/app/backend/uploads
+      - ./backend/data:/app/backend/data
       - hf_cache:/root/.cache/huggingface
 
 volumes:


### PR DESCRIPTION
Fixes the persistence gap raised in #234.

**Problem:** the demographics sampler downloads Nemotron-Personas parquet files to `backend/data/nemotron/<country>/` on first run. That path wasn't mounted anywhere, so the datasets (hundreds of MB per country) lived only in the container's writable layer and were **re-downloaded on every `docker compose down`/recreate or image update**.

**Fix:** add a `./backend/data:/app/backend/data` bind-mount to the `miroshark` service in all three compose files (`docker-compose.yml`, `docker-compose.ollama.yml`, `docker-compose.traefik.yml`), alongside the existing `uploads` mount. A bind-mount (rather than a named volume) is used so the datasets can also be pre-seeded from the host for air-gapped setups.

The named-volume vs. host-bind split @dan-and asked about is otherwise intentional and unchanged — see the issue reply.

Closes #234