### PR TITLE
chore: migrate GitHub links to MiroShark org, fix stale ecosystem slugs

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -18,7 +18,7 @@ These are the projects we know of that run MiroShark, extend it, or integrate wi
 
 | Logo | Project | Links |
 |------|---------|-------|
-| <img src="https://pbs.twimg.com/profile_images/2055896281751633920/NeawiT3G_400x400.png" alt="AntFleet" width="40" /> | AntFleet | [@AntFleetDev](https://x.com/AntFleetDev) · [miroshark-bench](https://github.com/AntFleet/miroshark-bench) |
+| <img src="https://pbs.twimg.com/profile_images/2055896281751633920/NeawiT3G_400x400.png" alt="AntFleet" width="40" /> | AntFleet | [@AntFleetDev](https://x.com/AntFleetDev) · [bench-miroshark](https://github.com/AntFleet/bench-miroshark) |
 | <img src="https://pbs.twimg.com/profile_images/2047719472455438336/CFrEyoNZ_400x400.jpg" alt="Blue Agent" width="40" /> | Blue Agent | [@blueagent_](https://x.com/blueagent_) · [blue-agent](https://github.com/madebyshun/blue-agent) |
 | <img src="https://pbs.twimg.com/profile_images/2040249335284387840/hIisggkp_400x400.png" alt="Capacitr" width="40" /> | Capacitr | [capacitr.xyz](https://capacitr.xyz/) · [MiroShark integration spec](https://spec.capacitr.xyz/#miroshark) · [@capacitr_xyz](https://x.com/capacitr_xyz) |
 | <img src="https://upload.wikimedia.org/wikipedia/en/2/2e/Tianjin_Normal_University_logo_2.png" alt="Crucible Sim" width="40" /> | Crucible Sim | [crucible-sim](https://github.com/wshuyi/crucible-sim) |

--- a/backend/app/api/docs.py
+++ b/backend/app/api/docs.py
@@ -170,8 +170,8 @@ def _swagger_ui_html(spec_url: str) -> str:
     <nav>
       <a href="/api/openapi.yaml">openapi.yaml</a>
       <a href="/api/openapi.json">openapi.json</a>
-      <a href="https://github.com/aaronjmars/MiroShark/blob/main/docs/API.md" target="_blank" rel="noopener">docs/API.md</a>
-      <a href="https://github.com/aaronjmars/MiroShark" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://github.com/MiroShark/MiroShark/blob/main/docs/API.md" target="_blank" rel="noopener">docs/API.md</a>
+      <a href="https://github.com/MiroShark/MiroShark" target="_blank" rel="noopener">GitHub</a>
     </nav>
   </header>
   <div id="swagger-ui"></div>

--- a/backend/app/api/mcp.py
+++ b/backend/app/api/mcp.py
@@ -288,7 +288,7 @@ def build_status_payload(
             'entity_count': None,
             'error': 'Neo4j probe skipped.',
         },
-        'docs_url': 'https://github.com/aaronjmars/MiroShark/blob/main/docs/MCP.md',
+        'docs_url': 'https://github.com/MiroShark/MiroShark/blob/main/docs/MCP.md',
     }
 
 

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -1044,7 +1044,7 @@ def _trending_fetch_one(feed_url: str) -> "list[dict]":
         req = Request(
             feed_url,
             headers={
-                'User-Agent': 'MiroShark/1.0 (+https://github.com/aaronjmars/MiroShark)',
+                'User-Agent': 'MiroShark/1.0 (+https://github.com/MiroShark/MiroShark)',
                 'Accept': 'application/rss+xml, application/atom+xml, application/xml;q=0.9, */*;q=0.8',
             },
         )

--- a/backend/app/services/ecosystem_catalog.py
+++ b/backend/app/services/ecosystem_catalog.py
@@ -102,11 +102,11 @@ ECOSYSTEM_CATEGORIES: frozenset[str] = frozenset(
 _CATALOG: List[Dict[str, Any]] = [
     {
         "name": "AntFleet",
-        "url": "https://github.com/AntFleet/miroshark-bench",
+        "url": "https://github.com/AntFleet/bench-miroshark",
         "description": "Security and capability benchmark suite over the MiroShark engine — first integrator-product feedback loop.",
         "category": "benchmark",
         "x_handle": "AntFleetDev",
-        "repo": "https://github.com/AntFleet/miroshark-bench",
+        "repo": "https://github.com/AntFleet/bench-miroshark",
     },
     {
         "name": "Blue Agent",

--- a/backend/app/services/feed.py
+++ b/backend/app/services/feed.py
@@ -275,7 +275,7 @@ def render_atom(
     ET.SubElement(feed, f"{{{_ATOM_NS}}}updated").text = most_recent or _now_z()
 
     generator = ET.SubElement(feed, f"{{{_ATOM_NS}}}generator")
-    generator.set("uri", "https://github.com/aaronjmars/MiroShark")
+    generator.set("uri", "https://github.com/MiroShark/MiroShark")
     generator.text = FEED_GENERATOR_NAME
 
     author = ET.SubElement(feed, f"{{{_ATOM_NS}}}author")
@@ -415,7 +415,7 @@ def render_rss(
     )
 
     ET.SubElement(channel, "generator").text = (
-        f"{FEED_GENERATOR_NAME} (https://github.com/aaronjmars/MiroShark)"
+        f"{FEED_GENERATOR_NAME} (https://github.com/MiroShark/MiroShark)"
     )
     ET.SubElement(channel, "language").text = "zh-CN" if locale == "zh-CN" else "en"
 

--- a/backend/app/services/replay_gif.py
+++ b/backend/app/services/replay_gif.py
@@ -357,7 +357,7 @@ def _render_frame(scenario: str, frame: dict, total_rounds: int, fonts: dict) ->
     draw.rectangle((0, CARD_H - FOOTER_H, CARD_W, CARD_H), fill=PANEL)
     draw.text(
         (PAD_X, CARD_H - FOOTER_H + 24),
-        "github.com/aaronjmars/MiroShark",
+        "github.com/MiroShark/MiroShark",
         fill=INK_MUTED,
         font=fonts["footer"],
     )
@@ -404,7 +404,7 @@ def _render_empty_frame(scenario: str, fonts: dict) -> Image.Image:
     draw.rectangle((0, CARD_H - FOOTER_H, CARD_W, CARD_H), fill=PANEL)
     draw.text(
         (PAD_X, CARD_H - FOOTER_H + 24),
-        "github.com/aaronjmars/MiroShark",
+        "github.com/MiroShark/MiroShark",
         fill=INK_MUTED,
         font=fonts["footer"],
     )

--- a/backend/app/services/share_card.py
+++ b/backend/app/services/share_card.py
@@ -369,7 +369,7 @@ def render_share_card(summary: dict) -> bytes:
 
     # ── Footer band ────────────────────────────────────────────────────────
     draw.rectangle((0, BODY_Y1, CARD_W, CARD_H), fill=INK)
-    repo_text = "github.com/aaronjmars/MiroShark"
+    repo_text = "github.com/MiroShark/MiroShark"
     draw.text((PAD_X, BODY_Y1 + 24), repo_text, fill=(220, 220, 220), font=f_footer)
 
     date_text = _format_date(summary.get("created_date") or "")

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -38,10 +38,10 @@ info:
 
   contact:
     name: MiroShark on GitHub
-    url: https://github.com/aaronjmars/MiroShark
+    url: https://github.com/MiroShark/MiroShark
   license:
     name: AGPL-3.0
-    url: https://github.com/aaronjmars/MiroShark/blob/main/LICENSE
+    url: https://github.com/MiroShark/MiroShark/blob/main/LICENSE
 
 servers:
   - url: http://localhost:5001
@@ -8066,7 +8066,7 @@ components:
           type: [integer, "null"]
           minimum: 1
           description: |
-            PR number on `aaronjmars/MiroShark` that introduced the
+            PR number on `MiroShark/MiroShark` that introduced the
             surface, or `null` for surfaces that predate per-PR
             instrumentation. Nullable so a consumer can sort or filter
             by "shipped after PR N" without special-casing absence.

--- a/docs/DKG.md
+++ b/docs/DKG.md
@@ -233,7 +233,7 @@ public probe reports `dkg_configured: false`, and existing
 
 ## See also
 
-* [OriginTrail/dkg-v9 — official daemon repo](https://github.com/OriginTrail/dkg-v9)
+* [OriginTrail/dkg — official daemon repo](https://github.com/OriginTrail/dkg)
 * [OriginTrail DKG documentation](https://docs.origintrail.io/)
 * [`backend/app/services/dkg_publisher.py`](../backend/app/services/dkg_publisher.py)
 * [`backend/app/services/repro_export.py`](../backend/app/services/repro_export.py) — the reproduce.json builder whose bytes get hashed

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -707,11 +707,11 @@ Sits alongside `/api/surfaces.json` on the same blueprint. Together the two endp
     "ecosystem": [
       {
         "name": "AntFleet",
-        "url": "https://github.com/AntFleet/miroshark-bench",
+        "url": "https://github.com/AntFleet/bench-miroshark",
         "description": "Security and capability benchmark suite over the MiroShark engine — first integrator-product feedback loop.",
         "category": "benchmark",
         "x_handle": "AntFleetDev",
-        "repo": "https://github.com/AntFleet/miroshark-bench"
+        "repo": "https://github.com/AntFleet/bench-miroshark"
       },
       {
         "name": "Capacitr",

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -60,7 +60,7 @@ Deploy to the cloud in under 3 minutes — no local setup required.
 
 ### Railway (recommended — persistent storage, free trial)
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/new/template?template=https://github.com/aaronjmars/MiroShark)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/new/template?template=https://github.com/MiroShark/MiroShark)
 
 After clicking, set these environment variables in the Railway dashboard:
 
@@ -74,7 +74,7 @@ After clicking, set these environment variables in the Railway dashboard:
 
 ### Render (free tier — 750 hrs/month, spins down after 15 min idle)
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/aaronjmars/MiroShark)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/MiroShark/MiroShark)
 
 Render reads `render.yaml` automatically. Set the same env vars above when prompted.
 
@@ -89,7 +89,7 @@ Render reads `render.yaml` automatically. Set the same env vars above when promp
 **Prereqs** — Python 3.11+, Node 18+, Neo4j (`brew install neo4j` / `sudo apt install neo4j`), and an OpenRouter key.
 
 ```bash
-git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
+git clone https://github.com/MiroShark/MiroShark.git && cd MiroShark
 cp .env.example .env
 ```
 
@@ -249,7 +249,7 @@ Open `http://localhost:3000`. Backend API at `http://localhost:5001`.
 ## Option B: Docker — local Ollama
 
 ```bash
-git clone https://github.com/aaronjmars/MiroShark.git
+git clone https://github.com/MiroShark/MiroShark.git
 cd MiroShark
 docker compose up -d
 

--- a/docs/INSTALL.zh-CN.md
+++ b/docs/INSTALL.zh-CN.md
@@ -60,7 +60,7 @@ neo4j-admin dbms set-initial-password miroshark
 
 ### Railway(推荐 — 持久化存储,免费试用)
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/new/template?template=https://github.com/aaronjmars/MiroShark)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/new/template?template=https://github.com/MiroShark/MiroShark)
 
 点击之后,在 Railway 控制台中设置以下环境变量:
 
@@ -74,7 +74,7 @@ neo4j-admin dbms set-initial-password miroshark
 
 ### Render(免费套餐 — 750 小时/月,闲置 15 分钟后会自动停机)
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/aaronjmars/MiroShark)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/MiroShark/MiroShark)
 
 Render 会自动读取 `render.yaml`。提示时设置上面相同的环境变量即可。
 
@@ -89,7 +89,7 @@ Render 会自动读取 `render.yaml`。提示时设置上面相同的环境变�
 **前置依赖** — Python 3.11+、Node 18+、Neo4j(`brew install neo4j` / `sudo apt install neo4j`),以及一把 OpenRouter 密钥。
 
 ```bash
-git clone https://github.com/aaronjmars/MiroShark.git && cd MiroShark
+git clone https://github.com/MiroShark/MiroShark.git && cd MiroShark
 cp .env.example .env
 ```
 
@@ -249,7 +249,7 @@ WONDERWALL_MODEL_NAME=your-model-id
 ## 方案 B: Docker — 本地 Ollama
 
 ```bash
-git clone https://github.com/aaronjmars/MiroShark.git
+git clone https://github.com/MiroShark/MiroShark.git
 cd MiroShark
 docker compose up -d
 

--- a/frontend/src/components/EmbedDialog.vue
+++ b/frontend/src/components/EmbedDialog.vue
@@ -2525,7 +2525,7 @@
                     <code class="signature-hint-code">WEBHOOK_SECRET=&lt;your 32+ char secret&gt;</code>
                     <p class="signature-hint-line">
                       <a
-                        href="https://github.com/aaronjmars/MiroShark/blob/main/docs/WEBHOOKS.md#verifying-webhook-signatures"
+                        href="https://github.com/MiroShark/MiroShark/blob/main/docs/WEBHOOKS.md#verifying-webhook-signatures"
                         target="_blank"
                         rel="noopener"
                       >{{ $tr('Verification snippets (Python / Node.js / curl)', '验证示例(Python / Node.js / curl)', { de: 'Verifizierungs-Snippets (Python / Node.js / curl)' , fr: 'Extraits de vérification (Python / Node.js / curl)'}) }} ↗</a>
@@ -2788,7 +2788,7 @@
               <div class="feed-callout-actions">
                 <a
                   class="feed-callout-link feed-callout-link-secondary"
-                  href="https://github.com/aaronjmars/MiroShark/blob/main/docs/NOTIFICATIONS.md"
+                  href="https://github.com/MiroShark/MiroShark/blob/main/docs/NOTIFICATIONS.md"
                   target="_blank"
                   rel="noopener"
                   :title="$tr('Channel setup guide on GitHub', 'GitHub 上的渠道接入指南', { de: 'Kanal-Einrichtungsanleitung auf GitHub' , fr: 'Guide de configuration du canal sur GitHub'})"

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -100,7 +100,7 @@
             </div>
             <div class="field-hint">
               {{ $tr('Applies the full set of model slots on save. See', '保存时将应用完整的模型槽配置。请参考', { de: 'Wendet beim Speichern alle Modell-Slots an. Siehe', fr: `Applique l'ensemble des slots de modèles à la sauvegarde. Voir` }) }}
-              <a href="https://github.com/aaronjmars/MiroShark/blob/main/.env.example"
+              <a href="https://github.com/MiroShark/MiroShark/blob/main/.env.example"
                  target="_blank" rel="noopener">.env.example</a>
               {{ $tr('for the exact values each preset uses.', '了解各预设使用的精确值。', { de: 'für die genauen Werte der jeweiligen Voreinstellung.', fr: 'pour les valeurs exactes de chaque préréglage.' }) }}
             </div>
@@ -466,7 +466,7 @@
               {{ $tr('e.g.', '例如', { de: 'z. B.', fr: 'ex.' }) }}
               <code>https://hooks.slack.com/services/T0…/B0…/abc</code>
               {{ $tr('or any URL that accepts a POST.', '或任何接受 POST 的 URL。', { de: 'oder jede URL, die POST akzeptiert.', fr: 'ou toute URL qui accepte un POST.' }) }}
-              {{ $tr('See', '参见', { de: 'Siehe', fr: 'Voir' }) }} <a href="https://github.com/aaronjmars/MiroShark/blob/main/docs/WEBHOOKS.md"
+              {{ $tr('See', '参见', { de: 'Siehe', fr: 'Voir' }) }} <a href="https://github.com/MiroShark/MiroShark/blob/main/docs/WEBHOOKS.md"
                      target="_blank" rel="noopener">{{ $tr('the webhook docs', 'Webhook 文档', { de: 'die Webhook-Dokumentation', fr: 'la doc du webhook' }) }}</a>
               {{ $tr('for the payload schema.', '了解负载结构。', { de: 'für das Payload-Schema.', fr: 'pour le schéma du payload.' }) }}
             </div>

--- a/frontend/src/components/SiteFooter.vue
+++ b/frontend/src/components/SiteFooter.vue
@@ -6,7 +6,7 @@
     <nav class="site-footer-nav">
       <a href="https://miroshark.xyz/docs" target="_blank" rel="noopener noreferrer">Docs</a>
       <span class="site-footer-sep" aria-hidden="true">·</span>
-      <a href="https://github.com/aaronjmars/MiroShark" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://github.com/MiroShark/MiroShark" target="_blank" rel="noopener noreferrer">GitHub</a>
       <span class="site-footer-sep" aria-hidden="true">·</span>
       <a href="https://x.com/miroshark_" target="_blank" rel="noopener noreferrer">X</a>
       <span class="site-footer-sep" aria-hidden="true">·</span>

--- a/frontend/src/views/ExploreView.vue
+++ b/frontend/src/views/ExploreView.vue
@@ -11,7 +11,7 @@
           <span class="arrow">←</span> {{ $tr('Home', '首页', { de: 'Startseite', fr: 'Accueil' }) }}
         </router-link>
         <a
-          href="https://github.com/aaronjmars/MiroShark"
+          href="https://github.com/MiroShark/MiroShark"
           target="_blank"
           rel="noopener"
           class="github-link"

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -13,7 +13,7 @@
         <router-link to="/explore" class="ms-nav-link" :title="$tr('Browse public simulations', '浏览公开模拟', { de: 'Öffentliche Simulationen durchsuchen', fr: 'Parcourir les simulations publiques' })">
           {{ $tr('Explore', '浏览', { de: 'Entdecken', fr: 'Explorer' }) }}
         </router-link>
-        <a href="https://github.com/aaronjmars/MiroShark" target="_blank" rel="noopener" class="ms-nav-link">
+        <a href="https://github.com/MiroShark/MiroShark" target="_blank" rel="noopener" class="ms-nav-link">
           GitHub <span class="ms-nav-arrow">↗</span>
         </a>
         <LocaleToggle />


### PR DESCRIPTION
Repo was transferred to the `MiroShark` org and two ecosystem repos were renamed. This updates all in-repo references to the canonical slugs — they previously worked only via GitHub's auto-redirect.

## Changes
- `aaronjmars/MiroShark` → `MiroShark/MiroShark` — 25 refs across 14 files (backend links/User-Agent/watermarks/feed URI, docs clone + deploy buttons, frontend links, `openapi.yaml`) **+ git remote**
- `AntFleet/miroshark-bench` → `AntFleet/bench-miroshark` — `ECOSYSTEM.md`, `ecosystem_catalog.py`, `docs/FEATURES.md`
- `OriginTrail/dkg-v9` → `OriginTrail/dkg` — `docs/DKG.md`

## Verification
- All 3 new slugs resolve **directly** (no redirect)
- Zero stale references remain
- `test_unit_openapi.py` + `test_unit_ecosystem_catalog.py` pass (26/26)
- Link-only change; no `@aaronjmars` handle/author refs touched