### PR TITLE
docs: add Documentation badge to READMEs

### DIFF
--- a/.github/README.fr.md
+++ b/.github/README.fr.md
@@ -5,6 +5,7 @@
 <h1 align="center">MiroShark</h1>
 
 <p align="center">
+  <a href="https://www.miroshark.xyz/docs"><img src="https://img.shields.io/badge/Documentation-miroshark.xyz-blue?style=flat-square&logo=gitbook&logoColor=white&labelColor=1a1a2e" alt="Documentation"></a>
   <a href="https://github.com/aaronjmars/MiroShark/stargazers"><img src="https://img.shields.io/github/stars/aaronjmars/MiroShark?style=flat-square&logo=github" alt="GitHub stars"></a>
   <a href="https://github.com/aaronjmars/MiroShark/network/members"><img src="https://img.shields.io/github/forks/aaronjmars/MiroShark?style=flat-square&logo=github" alt="GitHub forks"></a>
   <a href="https://x.com/miroshark_"><img src="https://img.shields.io/badge/Follow-%40miroshark__-black?style=flat-square&logo=x&labelColor=000000" alt="Follow on X"></a>

--- a/.github/README.ja.md
+++ b/.github/README.ja.md
@@ -5,6 +5,7 @@
 <h1 align="center">MiroShark</h1>
 
 <p align="center">
+  <a href="https://www.miroshark.xyz/docs"><img src="https://img.shields.io/badge/Documentation-miroshark.xyz-blue?style=flat-square&logo=gitbook&logoColor=white&labelColor=1a1a2e" alt="ドキュメント"></a>
   <a href="https://github.com/aaronjmars/MiroShark/stargazers"><img src="https://img.shields.io/github/stars/aaronjmars/MiroShark?style=flat-square&logo=github" alt="GitHub stars"></a>
   <a href="https://github.com/aaronjmars/MiroShark/network/members"><img src="https://img.shields.io/github/forks/aaronjmars/MiroShark?style=flat-square&logo=github" alt="GitHub forks"></a>
   <a href="https://x.com/miroshark_"><img src="https://img.shields.io/badge/Follow-%40miroshark__-black?style=flat-square&logo=x&labelColor=000000" alt="Follow on X"></a>

--- a/.github/README.md
+++ b/.github/README.md
@@ -5,6 +5,7 @@
 <h1 align="center">MiroShark</h1>
 
 <p align="center">
+  <a href="https://www.miroshark.xyz/docs"><img src="https://img.shields.io/badge/Documentation-miroshark.xyz-blue?style=flat-square&logo=gitbook&logoColor=white&labelColor=1a1a2e" alt="Documentation"></a>
   <a href="https://github.com/MiroShark/MiroShark/stargazers"><img src="https://img.shields.io/github/stars/MiroShark/MiroShark?style=flat-square&logo=github" alt="GitHub stars"></a>
   <a href="https://github.com/MiroShark/MiroShark/network/members"><img src="https://img.shields.io/github/forks/MiroShark/MiroShark?style=flat-square&logo=github" alt="GitHub forks"></a>
   <a href="https://x.com/miroshark_"><img src="https://img.shields.io/badge/Follow-%40miroshark__-black?style=flat-square&logo=x&labelColor=000000" alt="Follow on X"></a>

--- a/.github/README.zh-CN.md
+++ b/.github/README.zh-CN.md
@@ -5,6 +5,7 @@
 <h1 align="center">MiroShark</h1>
 
 <p align="center">
+  <a href="https://www.miroshark.xyz/docs"><img src="https://img.shields.io/badge/Documentation-miroshark.xyz-blue?style=flat-square&logo=gitbook&logoColor=white&labelColor=1a1a2e" alt="文档"></a>
   <a href="https://github.com/aaronjmars/MiroShark/stargazers"><img src="https://img.shields.io/github/stars/aaronjmars/MiroShark?style=flat-square&logo=github" alt="GitHub stars"></a>
   <a href="https://github.com/aaronjmars/MiroShark/network/members"><img src="https://img.shields.io/github/forks/aaronjmars/MiroShark?style=flat-square&logo=github" alt="GitHub forks"></a>
   <a href="https://x.com/miroshark_"><img src="https://img.shields.io/badge/Follow-%40miroshark__-black?style=flat-square&logo=x&labelColor=000000" alt="Follow on X"></a>


### PR DESCRIPTION
Adds a Documentation badge linking to https://www.miroshark.xyz/docs across the English, French, Japanese, and Simplified Chinese READMEs (localized alt text).