### PR TITLE
chore(deps): bump mcp 1.27.2 → 1.28.1 (CVE-2026-59950)

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1259,7 +1259,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1277,9 +1277,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the HIGH Dependabot alert for `mcp` (CVE-2026-59950 / GHSA-vj7q-gjh5-988w): *MCP Python SDK WebSocket server transport does not support Host/Origin validation.*

**This is alert hygiene, not an incident — the CVE is not reachable in this repo.**

## Why it isn't exploitable here

The CVE affects only the SDK's **WebSocket server transport**. This project is stdio-only:

```python
# backend/mcp_server.py:346-349
logger.info("MiroShark MCP server starting (stdio)")
async with stdio_server() as (read, write):
    await server.run(read, write, server.create_initialization_options())
```

- The only `mcp` SDK import in the repo is `mcp.server.Server`, `mcp.server.stdio.stdio_server`, `mcp.types` (`backend/mcp_server.py:58-60`).
- Repo-wide grep for `websocket_server`, `mcp.server.websocket`, `run_sse_async`, `streamable_http`, `sse_app`, `SseServerTransport`, `FastMCP` → **zero hits**. Grep for `websocket|ws://|wss://` across all Python → **zero hits** (the `websockets` package is present only transitively via `camel-ai`).
- `backend/app/api/mcp.py` is a read-only Flask endpoint rendering copy-paste client config; its docstring notes "The MCP server itself runs over stdio — this endpoint never spawns or talks to it."
- `backend/scripts/mcp_agent_bridge.py` is the *client* side and hand-rolls stdio JSON-RPC over `subprocess`; it doesn't use the SDK.
- No MCP listener binds to any interface, and `mcp_server.py` is referenced by no Dockerfile, CI job, or entrypoint — it's a local Claude Desktop / Cursor integration.

## The change

3 lines in `backend/uv.lock` — version + sdist/wheel URL and hash. **No transitive dependency changed**; mcp 1.28.1's dependency list is byte-identical to 1.27.2's.

`mcp` is transitive only (not in `pyproject.toml`), arriving via `camel-ai==0.2.90` whose constraint is `mcp>=1.3.0` — so no manifest change is needed.

> Note: the lock was regenerated with uv 0.9.7. The uv 0.7.9 in PATH writes lock `revision = 2` and would have silently downgraded this repo's `revision = 3` format.

## Verification

- `uv sync --frozen` succeeds → mcp 1.28.1, torch 2.12.1, camel-ai 0.2.90, sentence-transformers 5.3.0
- `backend/mcp_server.py` imports cleanly and registers all 8 tools
- API-surface diff 1.27.2 → 1.28.1 for every symbol used (`stdio_server`, `Server.run`, `Server.call_tool`, `Server.list_tools`, `Tool`, `TextContent`) — **identical**, no breaking changes on the used path
- Full backend unit suite: **1435 passed, 17 skipped** (skips need live backend + Neo4j)
- MCP-specific tests pass standalone: `test_unit_mcp_api.py`, `test_unit_mcp_bridge.py`, `test_unit_mcp_registry.py` → 32 passed

Not verified: integration/Neo4j tests, frontend build, Docker image build.

## Deliberately not included: torch

The LOW alert (`torch` CVE-2025-3000, `torch.jit.script` memory corruption) is **also unreachable** — repo-wide grep for `torch.jit`, `jit.script`, `jit.trace`, `torch.load`, `load_state_dict`, `.pt`/`.pth` returns zero hits. All four torch sites are plain tensor math or HF-hub loads of hard-coded model names.

Bumping 2.12.1 → 2.13.0 cascades the CUDA stack (`cuda-toolkit`, `nvidia-cublas`), ~93 lock lines and roughly a gigabyte of image churn, plus revalidation risk against sentence-transformers/transformers — disproportionate for an unreachable LOW. Recommend dismissing that alert as "vulnerable code not in path" and folding the bump into the next planned ML dependency refresh.