### PR TITLE
deps: scoped override for shell-quote (CVE-2026-13311)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "concurrently": "^10.0.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "devDependencies": {
     "concurrently": "^10.0.3"
   },
+  "overrides": {
+    "shell-quote@<1.9.0": "^1.9.0"
+  },
   "engines": {
     "node": ">=22.0.0"
   },


### PR DESCRIPTION
Clears alert #66. `shell-quote` 1.8.4 → 1.10.0 via scoped override `"shell-quote@<1.9.0": "^1.9.0"`.

CVE-2026-13311, CVSS 7.5 — quadratic-complexity DoS **in `parse()`**.

## Three things worth knowing

**1. An override was mandatory.** `concurrently@10.0.3` pins every dependency exactly, including `"shell-quote": "1.8.4"`. Plain `npm audit fix` is a literal no-op, and `--force` would have *downgraded* concurrently 10.0.3→9.2.4. 10.0.3 is the latest concurrently, so there is no upstream fix yet.

**2. "It's just dev tooling" would have been the wrong verdict.** The `Dockerfile` is single-stage: it runs `npm ci` **without** `--omit=dev`, and its `CMD` is `npm run dev`. So concurrently is installed *and executing* in the shipped image.

**3. The vulnerability is still unreachable — for a better reason.** The only import of shell-quote in the entire tree is `node_modules/concurrently/dist/lib/command-parser/expand-arguments.js:1`:

```js
import { quote } from 'shell-quote'
```

concurrently imports **`quote` only and never calls `parse()`** — they're separate modules (`quote.js` / `parse.js`). The `parse` appearing in that file is concurrently's own method name, a red herring. And even setting that aside, the only strings that could reach it are the static command literals in `package.json`'s `dev` script.

**Verdict: not reachable, no urgency** — but taken because the override is clean and the alert is otherwise unfixable.

## Verification

- `npm audit` 2 high → **0 vulnerabilities**
- concurrently stays on 10.0.3 (no downgrade)
- Smoke-tested the `quote()` path with `--passthrough-arguments` and spaces/quotes — escaping correct on 1.10.0

Incidental: npm resynced a stale `engines.node` mirror in the lockfile (`>=18.0.0` → `>=22.0.0`) to match `package.json`. Unavoidable on any install.

## Stopgap, not a cure

The override self-deactivates once concurrently stops pinning `1.8.4` — which, as of now, it still does at latest.

## Not included

Alert #65 (`torch`, LOW) left untouched as previously decided: the CVE is unreachable (zero `torch.jit`/`torch.load` hits anywhere), and bumping 2.12.1→2.13.0 cascades the CUDA stack for ~1 GB of image churn plus revalidation risk against sentence-transformers/transformers. Better folded into the next planned ML dependency refresh.