### PR TITLE
fix(deps): pin mcp<2.0.0 so the camel smoke test passes

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,6 +25,10 @@ requests>=2.31.0
 # Wonderwall (wonderwall package) is bundled directly in backend/wonderwall/
 # No separate install needed — camel-oasis is no longer a pip dependency
 camel-ai==0.2.90
+# camel-ai 0.2.90 allows mcp>=1.3.0, but mcp 2.0.0 relocated FastMCP and breaks
+# camel's import. uv.lock resolves 1.28.1; pin the pip install to match so the
+# camel smoke test does not pull the incompatible 2.x.
+mcp>=1.3.0,<2.0.0
 
 # ============= File Processing =============
 PyMuPDF>=1.24.0


### PR DESCRIPTION
## Problem

The `camel-smoke` CI job (`Camel agent smoke test`) has been failing on `main`, unrelated to any product change. It installs the real `camel-ai` via `pip install -r requirements.txt`, which does **not** honor `uv.lock`. `requirements.txt` left `mcp` unpinned, so pip resolves `mcp 2.0.0` (released 2026-07-28). `mcp 2.0.0` relocated `FastMCP`, which breaks `camel-ai==0.2.90`'s import and fails the smoke test at collection.

## Fix

Pin `mcp>=1.3.0,<2.0.0` in `requirements.txt`, right next to `camel-ai`:
- `camel-ai 0.2.90` already requires `mcp>=1.3.0`.
- `uv.lock` already resolves `mcp 1.28.1`, so the pip range now matches the lock.
- One-line, dependency-only; no runtime code touched.

Green CI here confirms the smoke test is unblocked.
