### PR TITLE
docs: balance Docs pills, add Full-install button, drop Graph memory

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -57,7 +57,7 @@ cp .env.example .env    # paste one OpenRouter key
 ```
 
 <p align="center">
-  <a href="../docs/INSTALL.md"><img src="https://img.shields.io/badge/%F0%9F%93%96%20Full%20install-cloud%20·%20Docker%20·%20Ollama%20·%20Claude%20Code-8B5CF6?style=for-the-badge&labelColor=1a1a2e" alt="Full install guide"></a>
+  <a href="../docs/INSTALL.md"><img src="../docs/images/btn-install-full.svg" alt="Full install — cloud, Docker, Ollama, Claude Code" height="42"></a>
 </p>
 
 <br/><br/>
@@ -80,14 +80,6 @@ cp .env.example .env    # paste one OpenRouter key
 
 <p align="center">
   <img src="../docs/images/agent-grounding-v2.jpg" alt="Five layers of grounding per MiroShark agent: demographic seed, web enrichment, semantic search, relationships, and graph attributes." width="100%" />
-</p>
-
-<br/><br/>
-
-<h2 align="center">Graph memory</h2>
-
-<p align="center">
-  <img src="../docs/images/graph-memory-pipeline-v2.jpg" alt="MiroShark graph-memory pipeline. Ingestion: NER, embed, entity resolution, contradiction check, temporal edges. Retrieval: vector plus BM25 plus BFS, fused and reranked." width="100%" />
 </p>
 
 <br/><br/>
@@ -133,7 +125,10 @@ cp .env.example .env    # paste one OpenRouter key
   <a href="../docs/INSTALL.md"><img src="../docs/images/doc-install.svg" alt="Install" height="30" align="absmiddle"></a>&nbsp;
   <a href="../docs/CONFIGURATION.md"><img src="../docs/images/doc-config.svg" alt="Configuration" height="30" align="absmiddle"></a>&nbsp;
   <a href="../docs/MODELS.md"><img src="../docs/images/doc-models.svg" alt="Models" height="30" align="absmiddle"></a>&nbsp;
-  <a href="../docs/ARCHITECTURE.md"><img src="../docs/images/doc-arch.svg" alt="Architecture" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../docs/ARCHITECTURE.md"><img src="../docs/images/doc-arch.svg" alt="Architecture" height="30" align="absmiddle"></a>
+</p>
+
+<p align="center">
   <a href="../docs/API.md"><img src="../docs/images/doc-api.svg" alt="HTTP API" height="30" align="absmiddle"></a>&nbsp;
   <a href="../docs/CLI.md"><img src="../docs/images/doc-cli.svg" alt="CLI" height="30" align="absmiddle"></a>&nbsp;
   <a href="../docs/MCP.md"><img src="../docs/images/doc-mcp.svg" alt="MCP" height="30" align="absmiddle"></a>&nbsp;

--- a/docs/images/btn-install-full.svg
+++ b/docs/images/btn-install-full.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="588" height="46" viewBox="0 0 588 46" role="img" aria-label="Full install — Cloud, Docker, Ollama, Claude Code">
+  <defs>
+    <linearGradient id="dk" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#241640"/><stop offset="1" stop-color="#160d2a"/></linearGradient>
+    <linearGradient id="vi" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#9F7AEA"/><stop offset="1" stop-color="#7C3AED"/></linearGradient>
+    <clipPath id="pill"><rect x="0" y="0" width="588" height="46" rx="23"/></clipPath>
+  </defs>
+  <g clip-path="url(#pill)">
+    <rect x="0" y="0" width="196" height="46" fill="url(#dk)"/>
+    <rect x="196" y="0" width="392" height="46" fill="url(#vi)"/>
+    <rect x="0" y="0" width="588" height="16" fill="#ffffff" opacity="0.10"/>
+  </g>
+  <rect x="0.5" y="0.5" width="587" height="45" rx="22.5" fill="none" stroke="#8B5CF6" stroke-opacity="0.55"/>
+  <g stroke="#CFC9EA" stroke-width="1.9" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M26 13v12"/><path d="M20 20l6 6 6-6"/><path d="M19 31h14"/>
+  </g>
+  <text x="48" y="28.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="14.5" font-weight="700" letter-spacing="1.6" fill="#E8E6F5">FULL INSTALL</text>
+  <text x="392" y="28.5" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="14.5" font-weight="700" letter-spacing="1.2" fill="#FFFFFF">CLOUD · DOCKER · OLLAMA · CLAUDE CODE</text>
+</svg>


### PR DESCRIPTION
- Split the 9 Docs pills into two balanced centered rows (fixes the orphaned Ecosystem pill wrapping onto its own line)
- Replace the Full-install shields badge with a self-hosted two-tone SVG button (FULL INSTALL · cloud/Docker/Ollama/Claude Code)
- Remove the Graph memory section