### PR TITLE
docs: add an animated SVG hero

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -2,6 +2,10 @@
   <img src="../docs/images/simulate-anything-hero-v2.jpg" alt="MiroShark — Simulate anything for $1 in under 10 minutes. Drop in a document, headline, policy draft, or a what-if question and MiroShark spawns 100+ grounded AI agents that post, argue, and trade across Twitter, Reddit, and a prediction market hour by hour, then writes a report citing the actual posts and trades. Pipeline: input, build world, swarm, report. Keywords: multi-agent simulation, social simulation, swarm intelligence, agent-based modeling, LLM agents, prediction market, scenario testing." width="100%" />
 </p>
 
+<p align="center">
+  <img src="../docs/images/hero-animated.svg" alt="Animated overview — Simulate anything for $1, 10 min first result, 100 agents. The pipeline flows input → build world → swarm → report." width="100%" />
+</p>
+
 <h1 align="center">Simulate <em>anything.</em></h1>
 
 <p align="center">

--- a/docs/images/hero-animated.svg
+++ b/docs/images/hero-animated.svg
@@ -1,0 +1,156 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="640" viewBox="0 0 1600 640" role="img" aria-label="MiroShark — Simulate anything. $1 per simulation, 10 min first result, 100 agents. Pipeline: input, build world, swarm, report.">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="42%" r="75%">
+      <stop offset="0%" stop-color="#2a1150"/>
+      <stop offset="55%" stop-color="#160a2c"/>
+      <stop offset="100%" stop-color="#080410"/>
+    </radialGradient>
+    <linearGradient id="chrome" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="46%" stop-color="#d3d4e0"/>
+      <stop offset="56%" stop-color="#9a9bad"/>
+      <stop offset="100%" stop-color="#eceef8"/>
+    </linearGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a1a48"/>
+      <stop offset="100%" stop-color="#140b28"/>
+    </linearGradient>
+    <filter id="glow" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="7" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softblur" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="18"/>
+    </filter>
+    <filter id="copperglow" x="-120%" y="-120%" width="340%" height="340%">
+      <feGaussianBlur stdDeviation="3" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <g id="arrow">
+      <path d="M0 -9 L14 -9 L14 -17 L30 0 L14 17 L14 9 L0 9 Z" fill="#F97316" opacity="0.85"/>
+    </g>
+    <style>
+      .title{font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-weight:800}
+      .num{font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-weight:800}
+      .lbl{font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-weight:700;letter-spacing:3px}
+      .cap{font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-weight:600}
+      .breathe{animation:breathe 4s ease-in-out infinite}
+      @keyframes breathe{0%,100%{opacity:.55}50%{opacity:.95}}
+    </style>
+  </defs>
+
+  <rect width="1600" height="640" fill="url(#bg)"/>
+
+  <!-- stars -->
+  <g fill="#ffffff">
+    <circle cx="120" cy="90" r="1.6"><animate attributeName="opacity" values=".2;1;.2" dur="3.1s" repeatCount="indefinite"/></circle>
+    <circle cx="300" cy="150" r="1.2"><animate attributeName="opacity" values=".3;.9;.3" dur="2.4s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="1480" cy="110" r="1.7"><animate attributeName="opacity" values=".2;1;.2" dur="3.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="1350" cy="220" r="1.2"><animate attributeName="opacity" values=".3;.9;.3" dur="2.8s" begin="1s" repeatCount="indefinite"/></circle>
+    <circle cx="90" cy="360" r="1.3"><animate attributeName="opacity" values=".2;.8;.2" dur="3.3s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="1520" cy="420" r="1.4"><animate attributeName="opacity" values=".2;.9;.2" dur="2.9s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="220" cy="470" r="1.1"><animate attributeName="opacity" values=".3;.9;.3" dur="3.4s" begin="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="1420" cy="520" r="1.2"><animate attributeName="opacity" values=".2;.8;.2" dur="2.6s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="760" cy="70" r="1.3"><animate attributeName="opacity" values=".2;.9;.2" dur="3.0s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="640" cy="120" r="1.0"><animate attributeName="opacity" values=".3;.8;.3" dur="2.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+  </g>
+
+  <!-- header -->
+  <text x="70" y="58" class="title" font-size="30" fill="url(#chrome)">MiroShark</text>
+  <text x="1530" y="56" class="cap" font-size="22" fill="#b9a9e0" text-anchor="end" opacity="0.85">Universal Swarm Intelligence Engine</text>
+
+  <!-- title with purple glow behind -->
+  <text x="800" y="212" class="title" font-size="112" fill="#7c3aed" text-anchor="middle" filter="url(#softblur)" opacity="0.6">Simulate anything.</text>
+  <text x="800" y="212" class="title" font-size="112" fill="url(#chrome)" text-anchor="middle" filter="url(#glow)">Simulate anything.</text>
+
+  <!-- stats -->
+  <g text-anchor="middle">
+    <text x="400" y="372" class="num" font-size="88" fill="url(#chrome)" filter="url(#glow)">$1</text>
+    <text x="400" y="420" class="lbl" font-size="21" fill="#9d8fc4">PER SIMULATION</text>
+    <line x1="600" y1="320" x2="600" y2="420" stroke="#ffffff" stroke-opacity="0.14"/>
+    <text x="800" y="372" class="num" font-size="88" fill="url(#chrome)" filter="url(#glow)">10 min</text>
+    <text x="800" y="420" class="lbl" font-size="21" fill="#9d8fc4">FIRST RESULT</text>
+    <line x1="1000" y1="320" x2="1000" y2="420" stroke="#ffffff" stroke-opacity="0.14"/>
+    <text x="1200" y="372" class="num" font-size="88" fill="url(#chrome)" filter="url(#glow)">100</text>
+    <text x="1200" y="420" class="lbl" font-size="21" fill="#9d8fc4">AGENTS</text>
+  </g>
+
+  <!-- pipeline tiles -->
+  <g>
+    <!-- tile backdrops -->
+    <rect x="425" y="478" width="120" height="120" rx="20" fill="url(#tile)" stroke="#8B5CF6" stroke-opacity="0.4"/>
+    <rect x="635" y="478" width="120" height="120" rx="20" fill="url(#tile)" stroke="#8B5CF6" stroke-opacity="0.4"/>
+    <rect x="845" y="478" width="120" height="120" rx="20" fill="url(#tile)" stroke="#8B5CF6" stroke-opacity="0.4"/>
+    <rect x="1055" y="478" width="120" height="120" rx="20" fill="url(#tile)" stroke="#8B5CF6" stroke-opacity="0.4"/>
+    <!-- glow pulse on tiles -->
+    <rect x="425" y="478" width="120" height="120" rx="20" fill="none" stroke="#a855f7" stroke-width="2" class="breathe"/>
+    <rect x="635" y="478" width="120" height="120" rx="20" fill="none" stroke="#a855f7" stroke-width="2" class="breathe" style="animation-delay:1s"/>
+    <rect x="845" y="478" width="120" height="120" rx="20" fill="none" stroke="#a855f7" stroke-width="2" class="breathe" style="animation-delay:2s"/>
+    <rect x="1055" y="478" width="120" height="120" rx="20" fill="none" stroke="#a855f7" stroke-width="2" class="breathe" style="animation-delay:3s"/>
+
+    <!-- icon 1: document -->
+    <g transform="translate(485,522)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
+      <path d="M-15 -22 h22 l10 10 v34 h-32 z"/>
+      <path d="M7 -22 v10 h10"/>
+      <line x1="-9" y1="-2" x2="9" y2="-2"/><line x1="-9" y1="8" x2="9" y2="8"/><line x1="-9" y1="18" x2="3" y2="18"/>
+    </g>
+    <!-- icon 2: build world (globe+nodes) -->
+    <g transform="translate(695,522)" fill="none" stroke="#dcdcec" stroke-width="2.2" stroke-linecap="round">
+      <circle cx="0" cy="0" r="24"/>
+      <ellipse cx="0" cy="0" rx="10" ry="24"/>
+      <line x1="-24" y1="0" x2="24" y2="0"/>
+      <line x1="-20" y1="-13" x2="20" y2="-13"/><line x1="-20" y1="13" x2="20" y2="13"/>
+      <circle cx="0" cy="-13" r="3.2" fill="#3fd0e0" stroke="none"/>
+      <circle cx="17" cy="6" r="3.2" fill="#3fd0e0" stroke="none"/>
+      <circle cx="-15" cy="9" r="3.2" fill="#3fd0e0" stroke="none"/>
+    </g>
+    <!-- icon 3: swarm (twinkling cloud) -->
+    <g transform="translate(905,522)" fill="#e2e2f0">
+      <circle cx="-18" cy="-14" r="3.2"><animate attributeName="opacity" values=".25;1;.25" dur="1.5s" repeatCount="indefinite"/></circle>
+      <circle cx="-4" cy="-20" r="3.6"><animate attributeName="opacity" values=".3;1;.3" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></circle>
+      <circle cx="12" cy="-16" r="3.0"><animate attributeName="opacity" values=".25;1;.25" dur="1.6s" begin="0.5s" repeatCount="indefinite"/></circle>
+      <circle cx="20" cy="-2" r="3.4"><animate attributeName="opacity" values=".3;1;.3" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+      <circle cx="-20" cy="2" r="3.4"><animate attributeName="opacity" values=".3;1;.3" dur="1.55s" begin="0.35s" repeatCount="indefinite"/></circle>
+      <circle cx="-9" cy="-4" r="4.2" fill="#f0f0fa"><animate attributeName="opacity" values=".4;1;.4" dur="1.4s" begin="0.1s" repeatCount="indefinite"/></circle>
+      <circle cx="5" cy="-2" r="4.0" fill="#f0f0fa"><animate attributeName="opacity" values=".4;1;.4" dur="1.65s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="-14" cy="14" r="3.0"><animate attributeName="opacity" values=".25;1;.25" dur="1.75s" begin="0.8s" repeatCount="indefinite"/></circle>
+      <circle cx="0" cy="16" r="3.4"><animate attributeName="opacity" values=".3;1;.3" dur="1.5s" begin="1.1s" repeatCount="indefinite"/></circle>
+      <circle cx="15" cy="13" r="3.0"><animate attributeName="opacity" values=".25;1;.25" dur="1.6s" begin="0.45s" repeatCount="indefinite"/></circle>
+      <circle cx="9" cy="9" r="2.6"><animate attributeName="opacity" values=".3;1;.3" dur="1.7s" begin="1.3s" repeatCount="indefinite"/></circle>
+      <circle cx="-6" cy="9" r="2.6"><animate attributeName="opacity" values=".3;1;.3" dur="1.45s" begin="0.25s" repeatCount="indefinite"/></circle>
+    </g>
+    <!-- icon 4: report -->
+    <g transform="translate(1115,522)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
+      <path d="M-16 -22 h24 l8 8 v36 h-32 z"/>
+      <line x1="-9" y1="16" x2="-9" y2="4"/><line x1="-1" y1="16" x2="-1" y2="-4"/><line x1="7" y1="16" x2="7" y2="-1"/>
+      <path d="M-11 -8 l6 -6 5 4 7 -8" stroke="#F97316"/>
+    </g>
+
+    <!-- labels -->
+    <g text-anchor="middle" class="cap" font-size="19" fill="#c9c2e4">
+      <text x="485" y="632">input</text>
+      <text x="695" y="632">build world</text>
+      <text x="905" y="632">swarm</text>
+      <text x="1115" y="632">report</text>
+    </g>
+
+    <!-- arrows + comet dots -->
+    <use href="#arrow" x="575" y="538"/>
+    <use href="#arrow" x="785" y="538"/>
+    <use href="#arrow" x="995" y="538"/>
+    <g fill="#F97316" filter="url(#copperglow)">
+      <circle cy="538" r="4">
+        <animate attributeName="cx" values="548;632" dur="1.5s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0;1;1;0" dur="1.5s" repeatCount="indefinite"/>
+      </circle>
+      <circle cy="538" r="4">
+        <animate attributeName="cx" values="758;842" dur="1.5s" begin="0.5s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0;1;1;0" dur="1.5s" begin="0.5s" repeatCount="indefinite"/>
+      </circle>
+      <circle cy="538" r="4">
+        <animate attributeName="cx" values="968;1052" dur="1.5s" begin="1s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0;1;1;0" dur="1.5s" begin="1s" repeatCount="indefinite"/>
+      </circle>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Adds a self-contained animated SVG hero (comet-dot pipeline flow, twinkling swarm, pulsing stars, chrome title glow) directly under the existing static hero. ~9KB, loops in the README.