### PR TITLE
docs: animate header pill icons + polish the animated hero

### DIFF
--- a/docs/images/btn-bankr.svg
+++ b/docs/images/btn-bankr.svg
@@ -4,10 +4,13 @@
       <stop offset="0" stop-color="#241640"/>
       <stop offset="1" stop-color="#160d2a"/>
     </linearGradient>
+    <style>@keyframes flip{0%,100%{transform:scaleX(1)}50%{transform:scaleX(0.16)}}.coin{transform-box:fill-box;transform-origin:center;animation:flip 3.4s ease-in-out infinite}</style>
   </defs>
   <rect x="0.5" y="0.5" width="145" height="39" rx="19.5" fill="url(#g)" stroke="#8B5CF6" stroke-opacity="0.5"/>
   <rect x="2" y="1.5" width="142" height="15" rx="12" fill="#ffffff" opacity="0.05"/>
+  <g class="coin">
   <circle cx="25" cy="20" r="8" fill="#2a2140" stroke="#F97316" stroke-width="1.6"/>
   <text x="25" y="24.5" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="12" font-weight="700" fill="#F97316">$</text>
+  </g>
   <text x="42" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#E8E6F5">$miroshark</text>
 </svg>

--- a/docs/images/btn-docs.svg
+++ b/docs/images/btn-docs.svg
@@ -4,10 +4,13 @@
       <stop offset="0" stop-color="#241640"/>
       <stop offset="1" stop-color="#160d2a"/>
     </linearGradient>
+    <style>@keyframes rock{0%,100%{transform:rotate(-6deg)}50%{transform:rotate(6deg)}}.bk{transform-box:fill-box;transform-origin:center;animation:rock 3.2s ease-in-out infinite}</style>
   </defs>
   <rect x="0.5" y="0.5" width="101" height="39" rx="19.5" fill="url(#g)" stroke="#8B5CF6" stroke-opacity="0.5"/>
   <rect x="2" y="1.5" width="98" height="15" rx="12" fill="#ffffff" opacity="0.05"/>
+  <g class="bk">
   <path d="M17 13.5c-2 0-3.4.5-4 1v11c.6-.5 2-1 4-1s3.4.5 4 1c.6-.5 2-1 4-1s3.4.5 4 1v-11c-.6-.5-2-1-4-1s-3.4.5-4 1c-.6-.5-2-1-4-1z" fill="none" stroke="#A78BFA" stroke-width="1.5" stroke-linejoin="round"/>
   <line x1="25" y1="14.5" x2="25" y2="25.5" stroke="#A78BFA" stroke-width="1.5"/>
+  </g>
   <text x="42" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#E8E6F5">Docs</text>
 </svg>

--- a/docs/images/btn-site.svg
+++ b/docs/images/btn-site.svg
@@ -9,7 +9,7 @@
   <rect x="2" y="1.5" width="158" height="15" rx="12" fill="#ffffff" opacity="0.05"/>
   <g stroke="#A78BFA" stroke-width="1.5" fill="none">
     <circle cx="25" cy="20" r="8"/>
-    <ellipse cx="25" cy="20" rx="3.4" ry="8"/>
+    <ellipse cx="25" cy="20" rx="3.4" ry="8"><animate attributeName="rx" values="3.4;0.5;3.4" dur="3.4s" repeatCount="indefinite"/></ellipse>
     <line x1="17" y1="20" x2="33" y2="20"/>
     <line x1="18.5" y1="15" x2="31.5" y2="15"/>
     <line x1="18.5" y1="25" x2="31.5" y2="25"/>

--- a/docs/images/btn-star.svg
+++ b/docs/images/btn-star.svg
@@ -4,9 +4,10 @@
       <stop offset="0" stop-color="#241640"/>
       <stop offset="1" stop-color="#160d2a"/>
     </linearGradient>
+    <style>@keyframes tw{0%,100%{transform:scale(1)}50%{transform:scale(1.18)}}.ic{transform-box:fill-box;transform-origin:center;animation:tw 2.4s ease-in-out infinite}</style>
   </defs>
   <rect x="0.5" y="0.5" width="95" height="39" rx="19.5" fill="url(#g)" stroke="#8B5CF6" stroke-opacity="0.5"/>
   <rect x="2" y="1.5" width="92" height="15" rx="12" fill="#ffffff" opacity="0.05"/>
-  <path d="M25 12.5l2.2 4.9 5.3.5-4 3.6 1.2 5.2-4.7-2.8-4.7 2.8 1.2-5.2-4-3.6 5.3-.5z" fill="#FBBF24"/>
+  <path class="ic" d="M25 12.5l2.2 4.9 5.3.5-4 3.6 1.2 5.2-4.7-2.8-4.7 2.8 1.2-5.2-4-3.6 5.3-.5z" fill="#FBBF24"/>
   <text x="44" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#E8E6F5">Star</text>
 </svg>

--- a/docs/images/btn-x.svg
+++ b/docs/images/btn-x.svg
@@ -4,11 +4,12 @@
       <stop offset="0" stop-color="#241640"/>
       <stop offset="1" stop-color="#160d2a"/>
     </linearGradient>
+    <style>@keyframes xp{0%,100%{transform:scale(1)}50%{transform:scale(1.14)}}.xp{transform-box:fill-box;transform-origin:center;animation:xp 2.6s ease-in-out infinite}</style>
   </defs>
   <rect x="0.5" y="0.5" width="151" height="39" rx="19.5" fill="url(#g)" stroke="#8B5CF6" stroke-opacity="0.5"/>
   <rect x="2" y="1.5" width="148" height="15" rx="12" fill="#ffffff" opacity="0.05"/>
-  <g transform="translate(16,12) scale(0.667)" fill="#FFFFFF">
+  <g class="xp"><g transform="translate(16,12) scale(0.667)" fill="#FFFFFF">
     <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-  </g>
+  </g></g>
   <text x="42" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#E8E6F5">@miroshark_</text>
 </svg>

--- a/docs/images/hero-animated.svg
+++ b/docs/images/hero-animated.svg
@@ -7,20 +7,22 @@
     </radialGradient>
     <linearGradient id="chrome" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#ffffff"/>
-      <stop offset="46%" stop-color="#d3d4e0"/>
-      <stop offset="56%" stop-color="#9a9bad"/>
-      <stop offset="100%" stop-color="#eceef8"/>
+      <stop offset="42%" stop-color="#cccdd9"/>
+      <stop offset="50%" stop-color="#8d8fa4"/>
+      <stop offset="51%" stop-color="#83859a"/>
+      <stop offset="66%" stop-color="#c6c8d6"/>
+      <stop offset="100%" stop-color="#f3f4fb"/>
     </linearGradient>
     <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#2a1a48"/>
       <stop offset="100%" stop-color="#140b28"/>
     </linearGradient>
     <filter id="glow" x="-60%" y="-60%" width="220%" height="220%">
-      <feGaussianBlur stdDeviation="7" result="b"/>
+      <feGaussianBlur stdDeviation="3.5" result="b"/>
       <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
     <filter id="softblur" x="-80%" y="-80%" width="260%" height="260%">
-      <feGaussianBlur stdDeviation="18"/>
+      <feGaussianBlur stdDeviation="13"/>
     </filter>
     <filter id="copperglow" x="-120%" y="-120%" width="340%" height="340%">
       <feGaussianBlur stdDeviation="3" result="b"/>
@@ -57,10 +59,11 @@
 
   <!-- header -->
   <text x="70" y="58" class="title" font-size="30" fill="url(#chrome)">MiroShark</text>
+  <path transform="translate(233,35)" d="M0 21 C 5 8 17 -2 31 -5 C 23 6 19 15 9 21 Z" fill="url(#chrome)" stroke="#8a6bd0" stroke-width="0.7" stroke-opacity="0.45"/>
   <text x="1530" y="56" class="cap" font-size="22" fill="#b9a9e0" text-anchor="end" opacity="0.85">Universal Swarm Intelligence Engine</text>
 
   <!-- title with purple glow behind -->
-  <text x="800" y="212" class="title" font-size="112" fill="#7c3aed" text-anchor="middle" filter="url(#softblur)" opacity="0.6">Simulate anything.</text>
+  <text x="800" y="212" class="title" font-size="112" fill="#7c3aed" text-anchor="middle" filter="url(#softblur)" opacity="0.55">Simulate anything.<animate attributeName="opacity" values="0.4;0.72;0.4" dur="3.6s" repeatCount="indefinite"/></text>
   <text x="800" y="212" class="title" font-size="112" fill="url(#chrome)" text-anchor="middle" filter="url(#glow)">Simulate anything.</text>
 
   <!-- stats -->


### PR DESCRIPTION
- Header pill icons now animate: star twinkle, globe spin, book rock, X pulse, coin flip (CSS/SMIL, self-contained)
- Animated hero polish: stronger chrome bevel, tighter glow, breathing title glow, shark fin on the wordmark