### PR TITLE
docs: fix hero shark fin + tighten pipeline label spacing

### DIFF
--- a/docs/images/hero-animated.svg
+++ b/docs/images/hero-animated.svg
@@ -59,7 +59,7 @@
 
   <!-- header -->
   <text x="70" y="58" class="title" font-size="30" fill="url(#chrome)">MiroShark</text>
-  <path transform="translate(233,35)" d="M0 21 C 5 8 17 -2 31 -5 C 23 6 19 15 9 21 Z" fill="url(#chrome)" stroke="#8a6bd0" stroke-width="0.7" stroke-opacity="0.45"/>
+  <path transform="translate(232,33)" d="M1 19 Q 12 -7 25 -9 Q 19 7 31 19 Q 16 14 1 19 Z" fill="url(#chrome)" stroke="#8a6bd0" stroke-width="0.7" stroke-opacity="0.4"/>
   <text x="1530" y="56" class="cap" font-size="22" fill="#b9a9e0" text-anchor="end" opacity="0.85">Universal Swarm Intelligence Engine</text>
 
   <!-- title with purple glow behind -->
@@ -92,13 +92,13 @@
     <rect x="1055" y="478" width="120" height="120" rx="20" fill="none" stroke="#a855f7" stroke-width="2" class="breathe" style="animation-delay:3s"/>
 
     <!-- icon 1: document -->
-    <g transform="translate(485,522)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
+    <g transform="translate(485,538)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
       <path d="M-15 -22 h22 l10 10 v34 h-32 z"/>
       <path d="M7 -22 v10 h10"/>
       <line x1="-9" y1="-2" x2="9" y2="-2"/><line x1="-9" y1="8" x2="9" y2="8"/><line x1="-9" y1="18" x2="3" y2="18"/>
     </g>
     <!-- icon 2: build world (globe+nodes) -->
-    <g transform="translate(695,522)" fill="none" stroke="#dcdcec" stroke-width="2.2" stroke-linecap="round">
+    <g transform="translate(695,538)" fill="none" stroke="#dcdcec" stroke-width="2.2" stroke-linecap="round">
       <circle cx="0" cy="0" r="24"/>
       <ellipse cx="0" cy="0" rx="10" ry="24"/>
       <line x1="-24" y1="0" x2="24" y2="0"/>
@@ -108,7 +108,7 @@
       <circle cx="-15" cy="9" r="3.2" fill="#3fd0e0" stroke="none"/>
     </g>
     <!-- icon 3: swarm (twinkling cloud) -->
-    <g transform="translate(905,522)" fill="#e2e2f0">
+    <g transform="translate(905,538)" fill="#e2e2f0">
       <circle cx="-18" cy="-14" r="3.2"><animate attributeName="opacity" values=".25;1;.25" dur="1.5s" repeatCount="indefinite"/></circle>
       <circle cx="-4" cy="-20" r="3.6"><animate attributeName="opacity" values=".3;1;.3" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></circle>
       <circle cx="12" cy="-16" r="3.0"><animate attributeName="opacity" values=".25;1;.25" dur="1.6s" begin="0.5s" repeatCount="indefinite"/></circle>
@@ -123,7 +123,7 @@
       <circle cx="-6" cy="9" r="2.6"><animate attributeName="opacity" values=".3;1;.3" dur="1.45s" begin="0.25s" repeatCount="indefinite"/></circle>
     </g>
     <!-- icon 4: report -->
-    <g transform="translate(1115,522)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
+    <g transform="translate(1115,538)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
       <path d="M-16 -22 h24 l8 8 v36 h-32 z"/>
       <line x1="-9" y1="16" x2="-9" y2="4"/><line x1="-1" y1="16" x2="-1" y2="-4"/><line x1="7" y1="16" x2="7" y2="-1"/>
       <path d="M-11 -8 l6 -6 5 4 7 -8" stroke="#F97316"/>
@@ -131,10 +131,10 @@
 
     <!-- labels -->
     <g text-anchor="middle" class="cap" font-size="19" fill="#c9c2e4">
-      <text x="485" y="632">input</text>
-      <text x="695" y="632">build world</text>
-      <text x="905" y="632">swarm</text>
-      <text x="1115" y="632">report</text>
+      <text x="485" y="614">input</text>
+      <text x="695" y="614">build world</text>
+      <text x="905" y="614">swarm</text>
+      <text x="1115" y="614">report</text>
     </g>
 
     <!-- arrows + comet dots -->


### PR DESCRIPTION
- Replace the feather-looking mark next to the MiroShark wordmark with a proper chrome shark dorsal fin
- Center the pipeline icons in their tiles and pull the input/build world/swarm/report labels up closer