### PR TITLE
docs: fix hero fin + enlarge pipeline icons

### DIFF
--- a/docs/images/hero-animated.svg
+++ b/docs/images/hero-animated.svg
@@ -17,6 +17,10 @@
       <stop offset="0%" stop-color="#2a1a48"/>
       <stop offset="100%" stop-color="#140b28"/>
     </linearGradient>
+    <linearGradient id="fin" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#b4b8cc"/>
+    </linearGradient>
     <filter id="glow" x="-60%" y="-60%" width="220%" height="220%">
       <feGaussianBlur stdDeviation="3.5" result="b"/>
       <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
@@ -59,7 +63,7 @@
 
   <!-- header -->
   <text x="70" y="58" class="title" font-size="30" fill="url(#chrome)">MiroShark</text>
-  <path transform="translate(232,33)" d="M1 19 Q 12 -7 25 -9 Q 19 7 31 19 Q 16 14 1 19 Z" fill="url(#chrome)" stroke="#8a6bd0" stroke-width="0.7" stroke-opacity="0.4"/>
+  <path transform="translate(232,34)" d="M2 20 C 7 3 17 -7 27 -6 C 24 3 25 12 31 20 Z" fill="url(#fin)" stroke="#6b4fa0" stroke-width="0.8" stroke-opacity="0.5"/>
   <text x="1530" y="56" class="cap" font-size="22" fill="#b9a9e0" text-anchor="end" opacity="0.85">Universal Swarm Intelligence Engine</text>
 
   <!-- title with purple glow behind -->
@@ -92,13 +96,13 @@
     <rect x="1055" y="478" width="120" height="120" rx="20" fill="none" stroke="#a855f7" stroke-width="2" class="breathe" style="animation-delay:3s"/>
 
     <!-- icon 1: document -->
-    <g transform="translate(485,538)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
+    <g transform="translate(485,538) scale(1.28)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
       <path d="M-15 -22 h22 l10 10 v34 h-32 z"/>
       <path d="M7 -22 v10 h10"/>
       <line x1="-9" y1="-2" x2="9" y2="-2"/><line x1="-9" y1="8" x2="9" y2="8"/><line x1="-9" y1="18" x2="3" y2="18"/>
     </g>
     <!-- icon 2: build world (globe+nodes) -->
-    <g transform="translate(695,538)" fill="none" stroke="#dcdcec" stroke-width="2.2" stroke-linecap="round">
+    <g transform="translate(695,538) scale(1.28)" fill="none" stroke="#dcdcec" stroke-width="2.2" stroke-linecap="round">
       <circle cx="0" cy="0" r="24"/>
       <ellipse cx="0" cy="0" rx="10" ry="24"/>
       <line x1="-24" y1="0" x2="24" y2="0"/>
@@ -108,7 +112,7 @@
       <circle cx="-15" cy="9" r="3.2" fill="#3fd0e0" stroke="none"/>
     </g>
     <!-- icon 3: swarm (twinkling cloud) -->
-    <g transform="translate(905,538)" fill="#e2e2f0">
+    <g transform="translate(905,538) scale(1.28)" fill="#e2e2f0">
       <circle cx="-18" cy="-14" r="3.2"><animate attributeName="opacity" values=".25;1;.25" dur="1.5s" repeatCount="indefinite"/></circle>
       <circle cx="-4" cy="-20" r="3.6"><animate attributeName="opacity" values=".3;1;.3" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></circle>
       <circle cx="12" cy="-16" r="3.0"><animate attributeName="opacity" values=".25;1;.25" dur="1.6s" begin="0.5s" repeatCount="indefinite"/></circle>
@@ -123,7 +127,7 @@
       <circle cx="-6" cy="9" r="2.6"><animate attributeName="opacity" values=".3;1;.3" dur="1.45s" begin="0.25s" repeatCount="indefinite"/></circle>
     </g>
     <!-- icon 4: report -->
-    <g transform="translate(1115,538)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
+    <g transform="translate(1115,538) scale(1.28)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
       <path d="M-16 -22 h24 l8 8 v36 h-32 z"/>
       <line x1="-9" y1="16" x2="-9" y2="4"/><line x1="-1" y1="16" x2="-1" y2="-4"/><line x1="7" y1="16" x2="7" y2="-1"/>
       <path d="M-11 -8 l6 -6 5 4 7 -8" stroke="#F97316"/>


### PR DESCRIPTION
- Give the shark fin a light-only gradient so the whole shape renders (was showing as a thin sliver where the chrome mid-band blended into the background)
- Scale the pipeline icons 1.28x so they fill their tiles instead of leaving padding