### PR TITLE
docs: single animated hero + rebalance icon padding

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,9 +1,5 @@
 <p align="center">
-  <img src="../docs/images/simulate-anything-hero-v2.jpg" alt="MiroShark — Simulate anything for $1 in under 10 minutes. Drop in a document, headline, policy draft, or a what-if question and MiroShark spawns 100+ grounded AI agents that post, argue, and trade across Twitter, Reddit, and a prediction market hour by hour, then writes a report citing the actual posts and trades. Pipeline: input, build world, swarm, report. Keywords: multi-agent simulation, social simulation, swarm intelligence, agent-based modeling, LLM agents, prediction market, scenario testing." width="100%" />
-</p>
-
-<p align="center">
-  <img src="../docs/images/hero-animated.svg" alt="Animated overview — Simulate anything for $1, 10 min first result, 100 agents. The pipeline flows input → build world → swarm → report." width="100%" />
+  <img src="../docs/images/hero-animated.svg" alt="MiroShark — Simulate anything for $1 in under 10 minutes with 100+ grounded agents. The pipeline flows input → build world → swarm → report. Keywords: multi-agent simulation, social simulation, swarm intelligence, agent-based modeling, LLM agents, prediction market, scenario testing." width="100%" />
 </p>
 
 <h1 align="center">Simulate <em>anything.</em></h1>

--- a/docs/images/hero-animated.svg
+++ b/docs/images/hero-animated.svg
@@ -96,13 +96,13 @@
     <rect x="1055" y="478" width="120" height="120" rx="20" fill="none" stroke="#a855f7" stroke-width="2" class="breathe" style="animation-delay:3s"/>
 
     <!-- icon 1: document -->
-    <g transform="translate(485,538) scale(1.28)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
+    <g transform="translate(485,538) scale(1.14)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
       <path d="M-15 -22 h22 l10 10 v34 h-32 z"/>
       <path d="M7 -22 v10 h10"/>
       <line x1="-9" y1="-2" x2="9" y2="-2"/><line x1="-9" y1="8" x2="9" y2="8"/><line x1="-9" y1="18" x2="3" y2="18"/>
     </g>
     <!-- icon 2: build world (globe+nodes) -->
-    <g transform="translate(695,538) scale(1.28)" fill="none" stroke="#dcdcec" stroke-width="2.2" stroke-linecap="round">
+    <g transform="translate(695,538) scale(1.14)" fill="none" stroke="#dcdcec" stroke-width="2.2" stroke-linecap="round">
       <circle cx="0" cy="0" r="24"/>
       <ellipse cx="0" cy="0" rx="10" ry="24"/>
       <line x1="-24" y1="0" x2="24" y2="0"/>
@@ -112,7 +112,7 @@
       <circle cx="-15" cy="9" r="3.2" fill="#3fd0e0" stroke="none"/>
     </g>
     <!-- icon 3: swarm (twinkling cloud) -->
-    <g transform="translate(905,538) scale(1.28)" fill="#e2e2f0">
+    <g transform="translate(905,538) scale(1.14)" fill="#e2e2f0">
       <circle cx="-18" cy="-14" r="3.2"><animate attributeName="opacity" values=".25;1;.25" dur="1.5s" repeatCount="indefinite"/></circle>
       <circle cx="-4" cy="-20" r="3.6"><animate attributeName="opacity" values=".3;1;.3" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></circle>
       <circle cx="12" cy="-16" r="3.0"><animate attributeName="opacity" values=".25;1;.25" dur="1.6s" begin="0.5s" repeatCount="indefinite"/></circle>
@@ -127,7 +127,7 @@
       <circle cx="-6" cy="9" r="2.6"><animate attributeName="opacity" values=".3;1;.3" dur="1.45s" begin="0.25s" repeatCount="indefinite"/></circle>
     </g>
     <!-- icon 4: report -->
-    <g transform="translate(1115,538) scale(1.28)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
+    <g transform="translate(1115,538) scale(1.14)" fill="none" stroke="#dcdcec" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
       <path d="M-16 -22 h24 l8 8 v36 h-32 z"/>
       <line x1="-9" y1="16" x2="-9" y2="4"/><line x1="-1" y1="16" x2="-1" y2="-4"/><line x1="7" y1="16" x2="7" y2="-1"/>
       <path d="M-11 -8 l6 -6 5 4 7 -8" stroke="#F97316"/>


### PR DESCRIPTION
- Remove the duplicate static hero jpg; keep only the animated SVG hero
- Rebalance pipeline icon scale (1.14x) for comfortable tile padding