### PR TITLE
docs: add OrcaRouter cloud preset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,38 @@ LLM_DISABLE_REASONING=true
 # WEB_SEARCH_MODEL=
 
 # =============================================================
+# OrcaRouter preset — alternative OpenAI-compatible gateway
+# =============================================================
+# One key covers every slot plus embeddings. Model IDs are namespaced
+# (openai/gpt-5.5, anthropic/claude-sonnet-5, google/gemini-3.5-flash).
+# No ":online" web-search variants — leave WEB_SEARCH_MODEL blank and
+# use SearXNG (MIROSHARK_SEARXNG_BASE_URL) for web enrichment, or the
+# default model is used as a fallback. See docs/INSTALL.md → Option A.4.
+#
+# LLM_PROVIDER=openai
+# LLM_API_KEY=sk-orca-YOUR_KEY
+# LLM_BASE_URL=https://api.orcarouter.ai/v1
+# LLM_MODEL_NAME=openai/gpt-5.5
+# SMART_PROVIDER=openai
+# SMART_API_KEY=sk-orca-YOUR_KEY
+# SMART_BASE_URL=https://api.orcarouter.ai/v1
+# SMART_MODEL_NAME=anthropic/claude-sonnet-5
+# NER_API_KEY=sk-orca-YOUR_KEY
+# NER_BASE_URL=https://api.orcarouter.ai/v1
+# NER_MODEL_NAME=google/gemini-3.5-flash
+# WONDERWALL_API_KEY=sk-orca-YOUR_KEY
+# WONDERWALL_BASE_URL=https://api.orcarouter.ai/v1
+# WONDERWALL_MODEL_NAME=openai/gpt-4o-mini
+# WEB_SEARCH_MODEL=
+# OPENAI_API_KEY=sk-orca-YOUR_KEY
+# OPENAI_API_BASE_URL=https://api.orcarouter.ai/v1
+# EMBEDDING_PROVIDER=openai
+# EMBEDDING_MODEL=openai/text-embedding-3-large
+# EMBEDDING_BASE_URL=https://api.orcarouter.ai
+# EMBEDDING_API_KEY=sk-orca-YOUR_KEY
+# EMBEDDING_DIMENSIONS=768
+
+# =============================================================
 # Alternatives — comment out the Cloud block above and paste one
 # of these in if you'd rather run locally or via Claude Code.
 # =============================================================

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,7 +9,7 @@ All settings live in `.env` (copy from `.env.example`). The full reference below
 ```bash
 # LLM
 LLM_API_KEY=your-api-key
-LLM_BASE_URL=https://openrouter.ai/api/v1     # or http://localhost:11434/v1 for Ollama
+LLM_BASE_URL=https://openrouter.ai/api/v1     # or https://api.orcarouter.ai/v1 for OrcaRouter, http://localhost:11434/v1 for Ollama
 LLM_MODEL_NAME=inception/mercury-2:nitro
 
 # Neo4j

--- a/docs/CONFIGURATION.zh-CN.md
+++ b/docs/CONFIGURATION.zh-CN.md
@@ -9,7 +9,7 @@
 ```bash
 # LLM
 LLM_API_KEY=your-api-key
-LLM_BASE_URL=https://openrouter.ai/api/v1     # or http://localhost:11434/v1 for Ollama
+LLM_BASE_URL=https://openrouter.ai/api/v1     # or https://api.orcarouter.ai/v1 for OrcaRouter, http://localhost:11434/v1 for Ollama
 LLM_MODEL_NAME=inception/mercury-2:nitro
 
 # Neo4j

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,6 +11,7 @@ Pick one of the paths below.
 | [Cloud API — OpenRouter](#option-a1-openrouter) | No | One key covers every slot + embeddings |
 | [Cloud API — OpenAI](#option-a2-openai) | No | You already have an OpenAI key |
 | [Cloud API — Anthropic](#option-a3-anthropic) | No | You already have an Anthropic key |
+| [Cloud API — OrcaRouter](#option-a4-orcarouter) | No | One key covers every slot + embeddings |
 | [Docker + Ollama](#option-b-docker--local-ollama) | Yes | Fully self-hosted, one command |
 | [Manual + Ollama](#option-c-manual--local-ollama) | Yes | Fully self-hosted, manual control |
 | [Claude Code CLI](#option-d-claude-code-no-api-key) | No | Uses your Claude Pro/Max subscription |
@@ -118,10 +119,10 @@ Open `http://localhost:3000`. First simulation in ~10 min, ~$1. See [Models](MOD
 
 ## Option A: Cloud API (no GPU)
 
-Only Neo4j runs locally. LLM and embeddings use a cloud provider. Three flavours below — pick the one that matches the key you already have.
+Only Neo4j runs locally. LLM and embeddings use a cloud provider. Four flavours below — pick the one that matches the key you already have.
 
 ```bash
-# Common prep for all three flavours
+# Common prep for all four flavours
 brew install neo4j       # macOS  (Linux: sudo apt install neo4j)
 cp .env.example .env
 ```
@@ -219,7 +220,44 @@ EMBEDDING_DIMENSIONS=768
 
 > Prompt caching (`LLM_PROMPT_CACHING_ENABLED=true`) hits its sweet spot here — the ReACT report loop reuses the same system prompt across iterations, so caching meaningfully reduces the Sonnet bill.
 
-### Option A.4: Custom endpoint for Wonderwall
+### Option A.4: OrcaRouter
+
+One key covers every slot, including embeddings. [OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway with namespaced model IDs (`openai/…`, `anthropic/…`, `google/…`, `deepseek/…`) covering 190+ models in one catalog — so you can mix vendors per slot (e.g. Anthropic for the smart/report slot, OpenAI for the high-volume simulation loop). All models below were verified live against the OrcaRouter API.
+
+```bash
+LLM_API_KEY=sk-orca-YOUR_KEY
+LLM_BASE_URL=https://api.orcarouter.ai/v1
+LLM_MODEL_NAME=openai/gpt-5.5
+
+SMART_PROVIDER=openai
+SMART_API_KEY=sk-orca-YOUR_KEY
+SMART_BASE_URL=https://api.orcarouter.ai/v1
+SMART_MODEL_NAME=anthropic/claude-sonnet-5
+
+NER_MODEL_NAME=google/gemini-3.5-flash
+NER_BASE_URL=https://api.orcarouter.ai/v1
+NER_API_KEY=sk-orca-YOUR_KEY
+
+WONDERWALL_MODEL_NAME=openai/gpt-4o-mini
+
+# OrcaRouter has no ":online" web-search variants — leave blank and use
+# SearXNG (MIROSHARK_SEARXNG_BASE_URL) for web enrichment, or the default
+# model is used as a fallback.
+WEB_SEARCH_MODEL=
+
+OPENAI_API_KEY=sk-orca-YOUR_KEY
+OPENAI_API_BASE_URL=https://api.orcarouter.ai/v1
+
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=openai/text-embedding-3-large
+EMBEDDING_BASE_URL=https://api.orcarouter.ai
+EMBEDDING_API_KEY=sk-orca-YOUR_KEY
+EMBEDDING_DIMENSIONS=768
+```
+
+Note the embeddings base URL is `https://api.orcarouter.ai` — without `/v1` — because MiroShark appends `/v1/embeddings` itself (matching the OpenRouter layout above). Prompt caching also works here: OrcaRouter accepts Anthropic-style `cache_control` blocks on the `anthropic/claude-sonnet-5` smart model.
+
+### Option A.5: Custom endpoint for Wonderwall
 
 The Wonderwall slot (the per-agent simulation loop, ~850–1650 calls/run) accepts an independent endpoint override so you can route the volume hits to a self-hosted vLLM, Modal/Replicate deployment, fine-tuned model, or Ollama on a different host — while keeping graph build, reports, and NER on a hosted provider.
 

--- a/docs/INSTALL.zh-CN.md
+++ b/docs/INSTALL.zh-CN.md
@@ -11,6 +11,7 @@
 | [云端 API — OpenRouter](#方案-a1openrouter) | 否 | 一把密钥覆盖所有槽位与嵌入 |
 | [云端 API — OpenAI](#方案-a2openai) | 否 | 已有 OpenAI 密钥 |
 | [云端 API — Anthropic](#方案-a3anthropic) | 否 | 已有 Anthropic 密钥 |
+| [云端 API — OrcaRouter](#方案-a4orcarouter) | 否 | 一把密钥覆盖所有槽位与嵌入 |
 | [Docker + Ollama](#方案-bdocker--本地-ollama) | 是 | 完全自部署,一行命令 |
 | [手动 + Ollama](#方案-c手动--本地-ollama) | 是 | 完全自部署,手动控制 |
 | [Claude Code CLI](#方案-dclaude-code无需-api-密钥) | 否 | 使用你的 Claude Pro/Max 订阅 |
@@ -118,10 +119,10 @@ cp .env.example .env
 
 ## 方案 A: 云端 API(无需 GPU)
 
-只有 Neo4j 跑在本地。LLM 与嵌入都走云端提供商。下面三个口味 — 选一个匹配你已有密钥的。
+只有 Neo4j 跑在本地。LLM 与嵌入都走云端提供商。下面四个口味 — 选一个匹配你已有密钥的。
 
 ```bash
-# 三个口味通用的准备步骤
+# 四个口味通用的准备步骤
 brew install neo4j       # macOS  (Linux: sudo apt install neo4j)
 cp .env.example .env
 ```
@@ -219,7 +220,43 @@ EMBEDDING_DIMENSIONS=768
 
 > 提示词缓存(`LLM_PROMPT_CACHING_ENABLED=true`)在这条路径上收益最大 — ReACT 报告循环会在多轮迭代之间复用同一个系统提示词,所以缓存能显著降低 Sonnet 账单。
 
-### 方案 A.4:为 Wonderwall 配置自定义端点
+### 方案 A.4:OrcaRouter
+
+一把密钥覆盖所有槽位,包括嵌入。[OrcaRouter](https://www.orcarouter.ai) 是一个 OpenAI 兼容网关,模型 ID 带命名空间(`openai/…`、`anthropic/…`、`google/…`、`deepseek/…`),一个目录覆盖 190+ 模型 — 所以你可以按槽位混搭厂商(比如 smart/报告槽位用 Anthropic,高频模拟循环用 OpenAI)。下面所有模型都已在 OrcaRouter API 上实测可用。
+
+```bash
+LLM_API_KEY=sk-orca-YOUR_KEY
+LLM_BASE_URL=https://api.orcarouter.ai/v1
+LLM_MODEL_NAME=openai/gpt-5.5
+
+SMART_PROVIDER=openai
+SMART_API_KEY=sk-orca-YOUR_KEY
+SMART_BASE_URL=https://api.orcarouter.ai/v1
+SMART_MODEL_NAME=anthropic/claude-sonnet-5
+
+NER_MODEL_NAME=google/gemini-3.5-flash
+NER_BASE_URL=https://api.orcarouter.ai/v1
+NER_API_KEY=sk-orca-YOUR_KEY
+
+WONDERWALL_MODEL_NAME=openai/gpt-4o-mini
+
+# OrcaRouter 没有 ":online" 网络检索变体 — 留空并使用 SearXNG
+# (MIROSHARK_SEARXNG_BASE_URL) 做网络增强,或回退到默认模型。
+WEB_SEARCH_MODEL=
+
+OPENAI_API_KEY=sk-orca-YOUR_KEY
+OPENAI_API_BASE_URL=https://api.orcarouter.ai/v1
+
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=openai/text-embedding-3-large
+EMBEDDING_BASE_URL=https://api.orcarouter.ai
+EMBEDDING_API_KEY=sk-orca-YOUR_KEY
+EMBEDDING_DIMENSIONS=768
+```
+
+注意嵌入基址是 `https://api.orcarouter.ai` — 不带 `/v1` — 因为 MiroShark 会自己拼上 `/v1/embeddings`(与上面 OpenRouter 的布局一致)。提示词缓存在这里同样生效:OrcaRouter 接受 `anthropic/claude-sonnet-5` smart 模型上的 Anthropic 风格 `cache_control` 块。
+
+### 方案 A.5:为 Wonderwall 配置自定义端点
 
 Wonderwall 槽位(每个智能体的模拟循环,每次运行约 850–1650 次调用)允许独立的端点覆盖,这样你可以把高频调用路由到自部署的 vLLM、Modal/Replicate 部署、微调模型,或另一台主机上的 Ollama —— 同时把图谱构建、报告和 NER 留在托管提供商上。
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -44,6 +44,21 @@ WONDERWALL_MODEL_NAME=your-model-id
 
 Either field can be omitted — a blank `WONDERWALL_BASE_URL` reuses `LLM_BASE_URL`, a blank `WONDERWALL_API_KEY` reuses `LLM_API_KEY`. Useful for routing the 850+ agent-action calls per run to a vLLM / Modal / Ollama-on-a-server deployment while keeping the report and graph-build slots on a hosted provider.
 
+### OrcaRouter preset
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway with namespaced model IDs — one key covers every slot plus embeddings, and you can mix vendors per slot (e.g. Anthropic for the report slot, OpenAI for the high-volume sim loop). A ready-made block ships in [`.env.example`](../.env.example) and `docs/INSTALL.md` → [Option A.4](INSTALL.md#option-a4-orcarouter). All models below were verified live against the OrcaRouter API.
+
+| Slot | Model | Notes |
+|---|---|---|
+| Default | `openai/gpt-5.5` | Persona generation, sim config, memory compaction |
+| Smart | `anthropic/claude-sonnet-5` | Report ReACT loop; OrcaRouter accepts Anthropic `cache_control` blocks |
+| NER | `google/gemini-3.5-flash` | Deterministic JSON with no hidden CoT |
+| Wonderwall | `openai/gpt-4o-mini` | 850+ agent-action calls/run; keep verbosity low |
+
+Embeddings use `openai/text-embedding-3-large` at `https://api.orcarouter.ai` (truncated to 768 dims via Matryoshka — OrcaRouter honors the `dimensions` param). OrcaRouter has no `:online` web-search variants — leave `WEB_SEARCH_MODEL=` blank and use `MIROSHARK_SEARXNG_BASE_URL` for web enrichment, or the default model is used as a fallback.
+
+> **Latency note** — the OpenRouter-only `reasoning: {enabled: false}` injection does not apply to OrcaRouter base URLs, so keep the high-volume slots on the fast picks above (Wonderwall → `openai/gpt-4o-mini`, Default → `openai/gpt-5.5`).
+
 ## Local mode (Ollama)
 
 > **Context override required.** Ollama defaults to 4096 tokens, but MiroShark prompts need 10–30k. Create a custom Modelfile:

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -52,7 +52,7 @@ Either field can be omitted — a blank `WONDERWALL_BASE_URL` reuses `LLM_BASE_U
 |---|---|---|
 | Default | `openai/gpt-5.5` | Persona generation, sim config, memory compaction |
 | Smart | `anthropic/claude-sonnet-5` | Report ReACT loop; OrcaRouter accepts Anthropic `cache_control` blocks |
-| NER | `google/gemini-3.5-flash` | Deterministic JSON with no hidden CoT |
+| NER | `google/gemini-3.5-flash` | Deterministic JSON; reasoning is not force-disabled on OrcaRouter, so `LLMClient` strips any `<think>` blocks client-side |
 | Wonderwall | `openai/gpt-4o-mini` | 850+ agent-action calls/run; keep verbosity low |
 
 Embeddings use `openai/text-embedding-3-large` at `https://api.orcarouter.ai` (truncated to 768 dims via Matryoshka — OrcaRouter honors the `dimensions` param). OrcaRouter has no `:online` web-search variants — leave `WEB_SEARCH_MODEL=` blank and use `MIROSHARK_SEARXNG_BASE_URL` for web enrichment, or the default model is used as a fallback.

--- a/docs/MODELS.zh-CN.md
+++ b/docs/MODELS.zh-CN.md
@@ -44,6 +44,21 @@ WONDERWALL_MODEL_NAME=your-model-id
 
 任意一个字段都可以省略 — `WONDERWALL_BASE_URL` 留空则复用 `LLM_BASE_URL`,`WONDERWALL_API_KEY` 留空则复用 `LLM_API_KEY`。适合把每次运行 850+ 次智能体动作调用路由到 vLLM / Modal / 服务器上的 Ollama 部署,同时把报告和图谱构建槽位留在托管提供商上。
 
+### OrcaRouter 预设
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个 OpenAI 兼容网关,模型 ID 带命名空间 — 一把密钥覆盖所有槽位与嵌入,还能按槽位混搭厂商(比如报告槽位用 Anthropic,高频模拟循环用 OpenAI)。现成配置块已随 [`.env.example`](../.env.example) 与 `docs/INSTALL.md` → [方案 A.4](INSTALL.zh-CN.md#方案-a4orcarouter) 提供。下面所有模型都已在 OrcaRouter API 上实测可用。
+
+| 槽位 | 模型 | 备注 |
+|---|---|---|
+| Default | `openai/gpt-5.5` | 画像生成、模拟配置、记忆压缩 |
+| Smart | `anthropic/claude-sonnet-5` | 报告 ReACT 循环;OrcaRouter 接受 Anthropic 风格的 `cache_control` 块 |
+| NER | `google/gemini-3.5-flash` | 确定性 JSON,无隐藏 CoT |
+| Wonderwall | `openai/gpt-4o-mini` | 每次运行 850+ 次智能体动作调用;保持低冗长度 |
+
+嵌入用 `openai/text-embedding-3-large`(基址 `https://api.orcarouter.ai`,通过 Matryoshka 截断到 768 维 — OrcaRouter 支持 `dimensions` 参数)。OrcaRouter 没有 `:online` 网络检索变体 — 把 `WEB_SEARCH_MODEL=` 留空并配置 `MIROSHARK_SEARXNG_BASE_URL` 做网络增强,或回退到默认模型。
+
+> **延迟提示** — OpenRouter 专属的 `reasoning: {enabled: false}` 注入对 OrcaRouter 基址不生效,所以高频槽位请保持上面的快速选择(Wonderwall → `openai/gpt-4o-mini`,Default → `openai/gpt-5.5`)。
+
 ## 本地模式(Ollama)
 
 > **必须覆盖上下文长度。** Ollama 默认是 4096 tokens,但 MiroShark 的提示词需要 10–30k。创建一个自定义 Modelfile:

--- a/docs/MODELS.zh-CN.md
+++ b/docs/MODELS.zh-CN.md
@@ -52,7 +52,7 @@ WONDERWALL_MODEL_NAME=your-model-id
 |---|---|---|
 | Default | `openai/gpt-5.5` | 画像生成、模拟配置、记忆压缩 |
 | Smart | `anthropic/claude-sonnet-5` | 报告 ReACT 循环;OrcaRouter 接受 Anthropic 风格的 `cache_control` 块 |
-| NER | `google/gemini-3.5-flash` | 确定性 JSON,无隐藏 CoT |
+| NER | `google/gemini-3.5-flash` | 确定性 JSON;OrcaRouter 上不强制关闭 reasoning,因此 `LLMClient` 会在客户端剥离任何 `<think>` 块 |
 | Wonderwall | `openai/gpt-4o-mini` | 每次运行 850+ 次智能体动作调用;保持低冗长度 |
 
 嵌入用 `openai/text-embedding-3-large`(基址 `https://api.orcarouter.ai`,通过 Matryoshka 截断到 768 维 — OrcaRouter 支持 `dimensions` 参数)。OrcaRouter 没有 `:online` 网络检索变体 — 把 `WEB_SEARCH_MODEL=` 留空并配置 `MIROSHARK_SEARXNG_BASE_URL` 做网络增强,或回退到默认模型。


### PR DESCRIPTION
## Summary

Adds a named [OrcaRouter](https://www.orcarouter.ai) cloud preset to MiroShark, mirroring the existing OpenRouter and Atlas Cloud presets. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 190+ models from OpenAI, Anthropic, Google, DeepSeek and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `.env.example`: commented OrcaRouter preset block covering every slot plus embeddings, placed right after the existing Atlas Cloud preset.
- `docs/INSTALL.md` / `docs/INSTALL.zh-CN.md`: new "Option A.4: OrcaRouter" install path (one key covers every slot, including embeddings) with the full env block, a note on the embeddings base URL, and a note that prompt caching works on the `anthropic/claude-sonnet-5` smart model. The former "Option A.4: Custom endpoint for Wonderwall" is renumbered to A.5.
- `docs/MODELS.md` / `docs/MODELS.zh-CN.md`: new "OrcaRouter preset" subsection with the per-slot model table and the web-search caveat.
- `docs/CONFIGURATION.md` / `docs/CONFIGURATION.zh-CN.md`: the `LLM_BASE_URL` comment now lists the OrcaRouter endpoint alongside Ollama.

## Why a named preset rather than just the OpenAI-compatible escape hatch

MiroShark already ships named cloud presets for OpenRouter (active default) and Atlas Cloud (commented alternative). A named OrcaRouter preset gives users a copy-paste block with namespaced model IDs (`openai/...`, `anthropic/...`, `google/...`), so they can mix vendors per slot with a single key, and it keeps the docs consistent with how the other gateways are presented.

## How to use it

1. Get an API key at https://www.orcarouter.ai (keys start with `sk-orca-`).
2. Use the Option A.4 env block from `docs/INSTALL.md`, or uncomment the OrcaRouter preset in `.env.example`.
3. Pick model IDs such as `openai/gpt-5.5`, `anthropic/claude-sonnet-5`, `google/gemini-3.5-flash`. OrcaRouter has no `:online` web-search variants, so `WEB_SEARCH_MODEL=` stays blank and web enrichment falls back to SearXNG (`MIROSHARK_SEARXNG_BASE_URL`) or the default model.

## Verification

- Live API calls against `https://api.orcarouter.ai/v1` for every model in the preset returned 200: plain chat, tool calling, JSON mode, and embeddings (768 dims via the `dimensions` param). Anthropic-style `cache_control` blocks are accepted on the `anthropic/claude-sonnet-5` smart model.
- Docs/config only: no Python, frontend, or workflow files touched; existing env-var names are unchanged, so `Config` validation and the unit suite are unaffected.
