### PR TITLE
fix(ci): declare httpx explicitly so unit tests pass under openai 3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,8 @@ jobs:
             "pydantic>=2.0.0" \
             "requests>=2.31.0" \
             "neo4j>=5.26.0" \
-            "pillow>=12.0.0"
+            "pillow>=12.0.0" \
+            "httpx>=0.28,<1.0"
 
       - name: Run unit tests
         run: pytest -m "not integration"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,9 @@ flask-compress>=1.17
 # ============= LLM Related =============
 # OpenAI SDK (unified LLM calls using OpenAI format)
 openai>=1.0.0
+# HTTP client used directly by oracle_seed.py. openai 3.0 switched its own
+# transitive dep to httpx2, so pin classic httpx explicitly (matches camel-ai/mcp).
+httpx>=0.28,<1.0
 
 # ============= Neo4j =============
 neo4j>=5.26.0


### PR DESCRIPTION
## Problem

`tests` workflow went red on main (`test_unit_oracle_seed.py::test_formats_markdown_block`, `assert '## Oracle Evidence' in ''`). Not caused by the commit it landed on (#287 was docs-only) - it was **openai 3.0.0 releasing on PyPI**.

`openai 3.0.0` swapped its transitive HTTP dep from classic `httpx` to `httpx2`. The thin unit-test env installs an unpinned `openai>=1.0.0`, so CI resolved to 3.0.0 and stopped pulling classic `httpx`. `backend/app/services/oracle_seed.py` does `import httpx` directly - the import failed, `httpx` became `None`, `resolve_oracle_tools()` short-circuited to `""`, and the one test that drives a live client failed. Every other oracle test expects `""`, so only this one broke.

CI log evidence:
```
Collecting httpx2<3,>=2.7.0 (from openai>=1.0.0)
Downloading openai-3.0.0-py3-none-any.whl
```
(The full-deps Camel job stayed green - camel-ai/mcp still pull classic `httpx 0.28`.)

## Fix

Declare `httpx` explicitly - it is imported directly, so it should be a real dependency, not a transitive accident of the openai SDK.

- `.github/workflows/tests.yml`: add `httpx>=0.28,<1.0` to the unit-test install list.
- `backend/requirements.txt`: add `httpx>=0.28,<1.0`.

`<1.0` matches what camel-ai/mcp already pin, so no conflict in the full-deps job.

## Verify

Reproduced in a venv mirroring the thin CI deps:

- without classic httpx: `1 failed` (same `assert '## Oracle Evidence' in ''`)
- with the pin: `oracle_seed` 5/5 pass; full `pytest -m "not integration"` -> **1436 passed, 3 skipped, 17 deselected** (the 3 skips are the pre-existing camel imports; the lone warning is the pre-existing webhook-thread one).